### PR TITLE
Upgrade/burn 0 21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -65,6 +67,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -123,7 +134,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -147,7 +158,7 @@ version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -160,6 +171,15 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -176,9 +196,9 @@ checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -216,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -230,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -252,7 +272,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -290,8 +310,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -321,7 +347,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -332,17 +358,32 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.2",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -351,10 +392,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -375,18 +428,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -402,21 +483,21 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "burn"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78ff10ed98b73e1d477ea6e6e1ec1b9cf9f71a17afc3fea9f4dca482d43dcd4"
+checksum = "39474be398d30e08681f1f6a8ff446b1e4f1403b5cf7749649a8871fd5945f3a"
 dependencies = [
  "burn-autodiff",
  "burn-candle",
@@ -424,23 +505,27 @@ dependencies = [
  "burn-core",
  "burn-cpu",
  "burn-cuda",
+ "burn-dispatch",
+ "burn-flex",
  "burn-ndarray",
  "burn-nn",
  "burn-optim",
  "burn-remote",
  "burn-rocm",
  "burn-router",
+ "burn-std",
  "burn-store",
  "burn-tch",
  "burn-train",
+ "burn-vision",
  "burn-wgpu",
 ]
 
 [[package]]
 name = "burn-autodiff"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f04955e9b4acd5e6a6229f80217dae79742975a97dc2253003f226333ad307"
+checksum = "3b93a80e43bfab909399444b29ce3894ff51f7e879720bfc75b6007ae6a01c3d"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -456,27 +541,30 @@ dependencies = [
 
 [[package]]
 name = "burn-backend"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a724a5d8d5865a1f6b304f629eb19f51489760689501c583b3e1f4209f067357"
+checksum = "64491519ac0867f550fa9c726cd443e5db94608c629050986cf2614c8c5ad39f"
 dependencies = [
  "burn-std",
  "bytemuck",
  "cubecl",
  "derive-new",
+ "enumset",
  "hashbrown 0.16.1",
  "num-traits",
- "rand 0.9.4",
- "rand_distr 0.5.1",
+ "portable-atomic-util",
+ "rand 0.10.1",
+ "rand_distr 0.6.0",
  "serde",
+ "spin",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "burn-candle"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c752d5008923eb9299783da5edae3242b94afdb956e88d2b37b025244b5071"
+checksum = "917fbbe1238d80ec1483c2c360ed9fa0146fdf57b2e66015c0824ccf5155276c"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -486,13 +574,13 @@ dependencies = [
 
 [[package]]
 name = "burn-collective"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b2199984291a0f3828d5ac04039fb864c56c3bdd9ee4172a63e457b668e4c"
+checksum = "427bdb9240bd1a41199066d44bc042341aa0cb0f46590d9af15eb88dd81066e7"
 dependencies = [
+ "burn-backend",
  "burn-communication",
  "burn-std",
- "burn-tensor",
  "bytes",
  "futures",
  "log",
@@ -504,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "burn-communication"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585526cd672adc35918d8aea9bcb50669067904f36090caaffa9573d22fc7ade"
+checksum = "0da93381634fb6ef2fbf9a19415439b1658bcdf2e044a8909caa54b8960e63bb"
 dependencies = [
  "axum",
  "burn-std",
@@ -520,7 +608,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-core",
@@ -529,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3634c3ba84397bcf2977ce746954d7e0a40e2d862e92362dd694c29e18df62"
+checksum = "5bde1e3b8e7e39b0aa71cd5905207ceea5c3478bec47bdb64acf72dcd0d6f978"
 dependencies = [
  "ahash",
  "bincode",
@@ -548,7 +636,7 @@ dependencies = [
  "num-traits",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "rmp-serde",
  "serde",
@@ -559,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "burn-cpu"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60aa53c4536719f1c91c250d4b4348daca473c44cf0c45b81096785f5510c192"
+checksum = "681478c5438ab6c753a55b85f5b42e5bd4c1f69a8564f2afa2f698ac396ba556"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -571,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6d13aff03fec966da4300459688883f8a1d741dddbf19d1bfc2562656a9a9b"
+checksum = "26efbec96ca3f691593c966fa90f98ef8a72867f62627904920b619ba3a9e6b6"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -591,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "burn-cubecl-fusion"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d25b2e9fb805931401f79782aabd92462d65e60bc207035a3e554de8d7cd9f"
+checksum = "6993d15b8ed588f55626e835ca768c1c3c7aa7a79d59beff4c987c40fc82d1f4"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -602,14 +690,16 @@ dependencies = [
  "cubecl",
  "cubek",
  "derive-new",
+ "hashbrown 0.16.1",
  "serde",
+ "spin",
 ]
 
 [[package]]
 name = "burn-cuda"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0c68cf653eb9c27dcbe046bb7b04cc18c6b33afda4c09317c102e6f4ae7cb6"
+checksum = "a6c66b49136fc11f59773054358f401fbec7fa0d69615f55ef22c29cf241c9b7"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -619,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "burn-dataset"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e87741e2ff9015845ed2b41b47f9e82795cf274bf2328a29619a2e6f662495c"
+checksum = "ba469fba38357c8bb65458873ddfd82aa97534aec0b3bae93d4c44604fc63839"
 dependencies = [
  "csv",
  "derive-new",
@@ -630,51 +720,90 @@ dependencies = [
  "image",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rmp-serde",
  "rusqlite",
  "sanitize-filename",
  "serde",
  "serde_json",
  "serde_rusqlite",
- "strum 0.27.2",
+ "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "burn-derive"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102d7e2f705b0cda2f89dd0e55e9bbfc6184029929d53487beb606c3303b29a5"
+checksum = "dce7be43cdfc9903c43dbaf3f4821543e0497d79047d8fc9ee9084e448844446"
 dependencies = [
  "derive-new",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "burn-dispatch"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2087b9e12323e0d25cc0ebdccfee40427dfdec4a23fa6d3f49ba2aa1f94ac17"
+dependencies = [
+ "burn-autodiff",
+ "burn-backend",
+ "burn-cpu",
+ "burn-cuda",
+ "burn-flex",
+ "burn-ndarray",
+ "burn-rocm",
+ "burn-tch",
+ "burn-wgpu",
+ "paste",
+]
+
+[[package]]
+name = "burn-flex"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0098bf6555c151517b4c98ca0e8ed1ab6a976e40f5f4e967c117b00eee21e192"
+dependencies = [
+ "aligned-vec",
+ "burn-backend",
+ "burn-ir",
+ "burn-std",
+ "bytemuck",
+ "gemm",
+ "half",
+ "libm",
+ "macerator",
+ "num-traits",
+ "rayon",
 ]
 
 [[package]]
 name = "burn-fusion"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea83d7f8574bcc07967291c5bb679ddc0a655c8db0642eca62755e2fffc8047"
+checksum = "95e58fcfd52a60cdf2f7da34fbebf0ed38f960fbd8675d384bacd5795cf2bdf2"
 dependencies = [
  "burn-backend",
  "burn-ir",
+ "burn-std",
  "derive-new",
  "hashbrown 0.16.1",
  "log",
  "serde",
+ "smallvec",
  "spin",
  "tracing",
 ]
 
 [[package]]
 name = "burn-ir"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2b1b37a7289bd85438800deaaebde50507336429b80f96a71730794db5bc31"
+checksum = "a81a55c32f35c2265d9e15ba2e796013d9780d5a49f9e21ea0ac4d29609dbf13"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -683,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96be578991cecef163e41a73bf985d8d7eb7fb8ef7bececf8d48523c481ecddf"
+checksum = "dceb9692e292782bab7ad0259e8e8f5ee80ba2b0329a78f0ba589a26a9633dd6"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -703,16 +832,16 @@ dependencies = [
  "paste",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rayon",
  "seq-macro",
 ]
 
 [[package]]
 name = "burn-nn"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8c6c14b94e5b1dddd68f8e6d669f20bac8f99fcb2e4f1a480212d1b598133"
+checksum = "93e4acd90806fa8663610f1071f3a8992eb98637d2d0816ee3062b334f61af00"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -720,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "burn-optim"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8c376d835d92ea363c05c6f48ac19bb687b683c7958c310a716ef8d5d77ba3"
+checksum = "4c5ea466ae0b85bf18f7656cdc152050dc8c581057fbbe33bbed267e22600228"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -734,17 +863,17 @@ dependencies = [
 
 [[package]]
 name = "burn-remote"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7238df1d59dcbb6880fe92ca0aa7b02b64d02394815e618da3d7933950bdaf39"
+checksum = "754cace9288e3927857ace69387eb5e4a8bc6eab3cb3ac00d4327cb30e4d2383"
 dependencies = [
  "async-channel",
  "axum",
+ "burn-backend",
  "burn-communication",
  "burn-ir",
  "burn-router",
  "burn-std",
- "burn-tensor",
  "bytes",
  "derive-new",
  "futures-util",
@@ -753,17 +882,30 @@ dependencies = [
  "serde",
  "serde_bytes",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing-core",
  "tracing-subscriber",
 ]
 
 [[package]]
-name = "burn-rocm"
-version = "0.20.1"
+name = "burn-rl"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2abda6ee63bdcb730f1a335349a9ff83f03048130d405b6ecdccd2df3ff23"
+checksum = "5d5bb875c36ddbb11f71a467bd6052d329d0ab78fbe79ab3777f4085e72290c4"
+dependencies = [
+ "burn-core",
+ "burn-optim",
+ "derive-new",
+ "log",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "burn-rocm"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66af82fdaaf2ad0fa4b0dae90119aa94f333105d76d520e0eb48917717c06fde"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -773,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "burn-router"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823ccb88484736a2861d53dc7f67db375ef050b0446bb02dd7cb8783ac6b69a2"
+checksum = "7960a5d43918c3158629da2bd7956e38dda16ef54de95cca83b4b7b1477e6185"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -787,27 +929,29 @@ dependencies = [
 
 [[package]]
 name = "burn-std"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a9ed8e34a4a49d3754586f306075d6b55a5e08343ac75c06f47e7d9f825271"
+checksum = "81c7eb60eb2c316854af5b214fd55f59fc7b0e25dfde7db671f09cc49f269048"
 dependencies = [
  "bytemuck",
  "bytes",
  "cubecl",
  "cubecl-common",
+ "cubecl-zspace",
  "half",
  "num-traits",
  "serde",
+ "smallvec",
+ "spin",
 ]
 
 [[package]]
 name = "burn-store"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be80a7b084a19901dc1d0a2e9b77e226c5c575879fe66de891c67062db41a6d"
+checksum = "2f64a4fe2a0616d18f07d1d0d19c79e655e70e1828cbcb5e9df7b52211091023"
 dependencies = [
  "burn-core",
- "burn-nn",
  "burn-tensor",
  "byteorder",
  "bytes",
@@ -821,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "burn-tch"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061cd3df7b4126949561185454b9b67623f6885657361cad2a07a2340b3b3108"
+checksum = "dfa36b630bd7a790395b4561f7d0e315c0d5e1c557db7dd4cf1b48d5c0d4aff2"
 dependencies = [
  "burn-backend",
  "cc",
@@ -835,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "burn-tensor"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3720e52e00ed0155ced4f8681d0e8a362e699cee36494ec5b97ad44fcc5194c0"
+checksum = "223ed3804bb9436e401fc57b87e44c86267070b870813520ed9f706c80c81442"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -849,21 +993,23 @@ dependencies = [
 
 [[package]]
 name = "burn-train"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3128c7571992c382a5ad057c72654c1048ea4dcf138d1f394313047e69803a"
+checksum = "fa65e2e569e571bb8dc9d37aa8fcf715f522f8159c6ee87f665c1961fee5259f"
 dependencies = [
  "async-channel",
  "burn-core",
- "burn-ndarray",
+ "burn-flex",
  "burn-optim",
+ "burn-rl",
  "derive-new",
  "log",
  "nvml-wrapper",
+ "rand 0.10.1",
  "ratatui",
  "rstest",
  "serde",
- "sysinfo 0.37.2",
+ "sysinfo",
  "systemstat",
  "thiserror 2.0.18",
  "tracing-appender",
@@ -872,10 +1018,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "burn-wgpu"
-version = "0.20.1"
+name = "burn-vision"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df78d62afc9b9fbb8ee4e49b72006485bb64f778a790e185a2d919479bcfc008"
+checksum = "38b5a3e9096977462cd22bf713087f9777e427f7693508871f86f5b1e8347a70"
+dependencies = [
+ "aligned-vec",
+ "bon",
+ "burn-cubecl",
+ "burn-flex",
+ "burn-ir",
+ "burn-tensor",
+ "bytemuck",
+ "cubecl",
+ "derive-new",
+ "half",
+ "image",
+ "macerator",
+ "ndarray 0.17.2",
+ "num-traits",
+ "paste",
+ "serde",
+]
+
+[[package]]
+name = "burn-wgpu"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eb009254af15922cb37814f3b3b61043046193ba2fde97c3879a25fbd51a92e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -900,7 +1070,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -952,12 +1122,12 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
  "byteorder",
- "float8 0.6.1",
+ "float8",
  "gemm",
  "half",
  "libm",
@@ -969,6 +1139,7 @@ dependencies = [
  "rayon",
  "safetensors 0.7.0",
  "thiserror 2.0.18",
+ "tokenizers",
  "yoke",
  "zip 7.2.0",
 ]
@@ -981,12 +1152,6 @@ checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
  "unicode-normalization",
 ]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
@@ -1005,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1092,7 +1257,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1122,13 +1287,13 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1148,15 +1313,16 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -1234,33 +1400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags",
- "core-foundation",
- "libc",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,25 +1428,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1315,12 +1453,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1365,15 +1503,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
@@ -1405,6 +1545,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053856efd5436224775b9423d43d86f53d5b1d3af9a6b9983d9a313a0922638f"
+checksum = "fd203fef6e359472e4cb8f6c0ef3eca062815a1edd560eb6d6c1d5c1397838d9"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1444,59 +1594,65 @@ dependencies = [
 
 [[package]]
 name = "cubecl-common"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bf8aaeb572c8cf2f2ffd07fa9bb1a2cf9336d1aa11ecd4d9a2f2e30c4be706"
+checksum = "cc956c2dcc993f16f748d03bfdbd900f75cab4d469f4e5d8924f8ee128e861ad"
 dependencies = [
  "backtrace",
  "bytemuck",
  "bytes",
  "cfg-if",
  "cfg_aliases",
+ "ciborium",
  "derive-new",
  "derive_more",
  "dirs",
  "embassy-futures",
  "embassy-time",
  "float4",
- "float8 0.4.2",
+ "float8",
  "futures-lite",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "log",
  "num-traits",
+ "oneshot",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.9.4",
+ "rand 0.10.1",
  "sanitize-filename",
  "serde",
  "serde_bytes",
  "serde_json",
  "spin",
+ "toml",
  "tracing",
+ "tynm",
  "wasm-bindgen-futures",
  "web-time",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "cubecl-core"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98374a31d2b68b55709891169832ccf205408c201c5e023964482441f213d0b9"
+checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytemuck",
  "cubecl-common",
  "cubecl-ir",
  "cubecl-macros",
  "cubecl-runtime",
+ "cubecl-zspace",
  "derive-new",
  "derive_more",
  "enumset",
  "float-ord",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "log",
  "num-traits",
  "paste",
@@ -1508,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb24d96c1ff84ab4def0a529e384311a15cb771310aaf2b640c312384c3bca23"
+checksum = "411af04828cbf4583ecd388579fb30cd7a644eec19a334bb8f0d9d08522e1458"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1525,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-cpu"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152588a6e16b6bda5e8216af7a6fad3d7de4697294b6ce0f6acbe3a9029ff674"
+checksum = "f572143f54e42a49ee0635a4ec36005f639e62be029e4f49890c808985981b35"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1540,23 +1696,22 @@ dependencies = [
  "log",
  "paste",
  "serde",
- "sysinfo 0.36.1",
+ "sysinfo",
  "tracel-llvm",
  "tracel-llvm-bundler",
 ]
 
 [[package]]
 name = "cubecl-cuda"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f74a5750c45090d1fc5ddf6a19fea9a099aa1f6800b78f1167a2d60182d1d96"
+checksum = "b6b0a69ff45688d322ad8e92c8bf645167b9ca490fa8fa087fc6adac8c5e46be"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
  "cubecl-runtime",
- "cubecl-zspace",
  "cudarc",
  "derive-new",
  "half",
@@ -1567,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-hip"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbae9bc7ee6093d0d7a549c05873dff3478f9087b59eb09b223a97d642c849aa"
+checksum = "3c6b510a9348f06ecd56b32cf10eb6241639e927a87f5c09ec61cc7a7610d5a3"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1577,7 +1732,6 @@ dependencies = [
  "cubecl-cpp",
  "cubecl-hip-sys",
  "cubecl-runtime",
- "cubecl-zspace",
  "derive-new",
  "half",
  "log",
@@ -1598,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-ir"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361b608ff9f05024c7a7e381852689acd95b6af5af956d68734692b27d5f75ef"
+checksum = "d28a897a40c8ee6c57a8b8d76d8823ba2e97f4c2b83db9338f17a0752132d486"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1609,8 +1763,9 @@ dependencies = [
  "enumset",
  "float-ord",
  "fnv",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "num-traits",
  "portable-atomic",
  "serde",
@@ -1619,37 +1774,38 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9a872d16207c6a27ed45942fd311a281394dd384b14a21f72131db1556a977"
+checksum = "77aa6df563e8e6a0926d2e9eeacb968737940a0e1ae9be819f6a65a341006e12"
 dependencies = [
  "cubecl-common",
- "darling 0.21.3",
+ "darling 0.23.0",
  "derive-new",
  "ident_case",
+ "inflections",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3fa0626cdf28b9c49084c2bb51493bfde44378e22d90624aacaafb81da3588"
+checksum = "a515651a5a91e25d87f71f311f80a088e6cf815798b9922560a97636da6b8740"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "cubecl-opt"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcff25fdcbd82ea4277c30a81e162722859f57c6ae105c0a3c53f8bb91154f6"
+checksum = "0a599c6c3efefdcee8636994c90e58ef696c7efbed2d18b5b5ad8d5f29923abb"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1665,22 +1821,23 @@ dependencies = [
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02e28997a8d75311afae4d2cea7b593eb125312f845874118a59d78c7a6b34c"
+checksum = "b68491bf5b3e997ae36bdc4e63b4ccd6d2f0e86b3b596a5d7a48d2b9e92622a0"
 dependencies = [
+ "ahash",
  "async-channel",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "cubecl-common",
  "cubecl-ir",
+ "cubecl-zspace",
  "derive-new",
  "derive_more",
  "dirs",
  "enumset",
- "foldhash 0.1.5",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "log",
  "md5",
  "serde",
@@ -1689,21 +1846,19 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tracing",
- "variadics_please",
  "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
 name = "cubecl-std"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ff5741c98b7a7a5944b4afb0b67dd7f5e0be41ce7f303b587f8b0d6430b29b"
+checksum = "b391b584a4897683dd9fc0767f96337ac712b733126ce0f68a9ee8a2df073d2d"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
  "cubecl-runtime",
- "foldhash 0.1.5",
  "half",
  "num-traits",
  "paste",
@@ -1714,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "cubecl-wgpu"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29787364632fc7ec6a11cf3d95187f82f6fcce17d6bb4f0fb0dde580b837631d"
+checksum = "4d3663c6e1a86187172b2cee495b6b533e7d91a2cb37e26f421649e315fe4c3a"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1729,59 +1884,68 @@ dependencies = [
  "derive-new",
  "derive_more",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "log",
  "sanitize-filename",
  "tracing",
+ "wasm-bindgen-futures",
  "wgpu",
 ]
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0f819071413b19a00b7105497e0f6d2cf3e7e9d65cbb8d4ecf1ddb29c61dc2"
+checksum = "04054d95698afab785a4dda9f949e297831dd9e4cc6d036a93e6603f88e88b07"
+dependencies = [
+ "derive-new",
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "cubek"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb1cce47db02017925301bedec92ae84628493df3f9761ea7ac42a60c6146f8"
+checksum = "ba62fb5043d5eb723017415eec57c541f41901beea984500e2e16b57d75fa717"
 dependencies = [
  "cubecl",
  "cubek-attention",
  "cubek-convolution",
+ "cubek-fft",
  "cubek-matmul",
  "cubek-quant",
  "cubek-random",
  "cubek-reduce",
+ "cubek-std",
 ]
 
 [[package]]
 name = "cubek-attention"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7278bd122b2428af479f9af05285160613733c33c93b63ab3c6d25cd0460c18b"
+checksum = "75ca5c363f05a9297b9d1c0e90959cc5f9fd90bc596e4e537f26f20602ec63a5"
 dependencies = [
  "bytemuck",
  "cubecl",
  "cubecl-common",
  "cubek-matmul",
- "cubek-random",
+ "cubek-std",
  "half",
  "serde",
 ]
 
 [[package]]
 name = "cubek-convolution"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eb04bca4ae104d62a56def04b04f3d079c42fe49aac62202c96876f90fa28b"
+checksum = "70f2755a8eb9ea5509c17edac78e4a9dc4be89c433d8e2ee709703a93b96f749"
 dependencies = [
  "bytemuck",
  "cubecl",
  "cubecl-common",
  "cubek-matmul",
+ "cubek-std",
  "derive-new",
  "enumset",
  "half",
@@ -1789,23 +1953,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "cubek-matmul"
-version = "0.1.1"
+name = "cubek-fft"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f3b04b113760e97c65a8a4dca9afc220744031eeecd5ad6cd0e3be91ba3a9"
+checksum = "8dd7c2972363332dc4609067a2ccc21856308d98089e676d3f0c52747ae61a5b"
+dependencies = [
+ "cubecl",
+]
+
+[[package]]
+name = "cubek-matmul"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a4cea5f0f439907dc953c7638a6204b3f055f1bcbd10db91dfc5faa030ac1c"
 dependencies = [
  "bytemuck",
  "cubecl",
  "cubecl-common",
+ "cubek-std",
  "half",
  "serde",
 ]
 
 [[package]]
 name = "cubek-quant"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ec3ae04af324df2d615c2b394e270d58d6f08cb833d67633e2ba794de75916"
+checksum = "802ff1b5f19597a7b7cb308c7c69e9eef28b78d57dab7794c816bb8f7d3d1b85"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1815,25 +1989,26 @@ dependencies = [
 
 [[package]]
 name = "cubek-random"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a34844d8b7f739185c1d24896137dcb73f458830444103b45f678585ad983e"
+checksum = "8dfecce959bdbeb3b355120e586d1ea9e45a0fc7f2ca354f4260a571952551be"
 dependencies = [
  "cubecl",
  "cubecl-common",
  "half",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
 ]
 
 [[package]]
 name = "cubek-reduce"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42397d9ed85bb3084dfb56ed26de75690b5b07caf42a32f4006b57eb23d5b6d6"
+checksum = "86758b84452b06e9121f25200da13b4909ecd6235cefb5f33f459bea24dac41a"
 dependencies = [
  "cubecl",
+ "cubek-std",
  "half",
  "num-traits",
  "serde",
@@ -1841,12 +2016,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "cudarc"
-version = "0.18.2"
+name = "cubek-std"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa12038120eb13347a6ae2ffab1d34efe78150125108627fd85044dd4d6ff1e"
+checksum = "a587d0a44b6f14f4c3711ac10717179b48adb59203b2b2bffe334876bf713187"
 dependencies = [
- "libloading",
+ "cubecl",
+ "cubecl-common",
+ "half",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
+dependencies = [
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -1890,7 +2076,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1903,8 +2089,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1917,7 +2102,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1928,7 +2113,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1939,7 +2124,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1950,14 +2135,23 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1969,9 +2163,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -1990,7 +2190,38 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2012,7 +2243,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -2055,6 +2286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,7 +2303,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2098,9 +2348,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embassy-futures"
@@ -2110,9 +2360,9 @@ checksum = "dc2d050bdc5c21e0862a89256ed8029ae6c290a93aecefc73084b3002cdebb01"
 
 [[package]]
 name = "embassy-time"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+checksum = "592b0c143ec626e821d4d90da51a2bd91d559d6c442b7c74a47d368c9e23d97a"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2121,7 +2371,7 @@ dependencies = [
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "futures-util",
+ "futures-core",
 ]
 
 [[package]]
@@ -2182,14 +2432,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
  "serde",
@@ -2197,14 +2447,14 @@ dependencies = [
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2224,7 +2474,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2241,6 +2491,21 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2292,6 +2557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,23 +2574,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2327,14 +2588,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
+name = "filedescriptor"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2344,10 +2615,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2367,24 +2650,15 @@ checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "float4"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5939bac0ef2ad7c83a53e4fb889c1d81f007b07061d648cd271071984d86f257"
+checksum = "9a5404bf31d22893d61cf24d4dda149d8e6b2ff07601c3cb3be651031f61a4ed"
 
 [[package]]
 name = "float8"
-version = "0.4.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4203231de188ebbdfb85c11f3c20ca2b063945710de04e7b59268731e728b462"
-dependencies = [
- "half",
-]
-
-[[package]]
-name = "float8"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
@@ -2409,33 +2683,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2515,7 +2762,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2532,9 +2779,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2741,9 +2988,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gix-features"
-version = "0.45.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56aad357ae016449434705033df644ac6253dfcf1281aad3af3af9e907560d1"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "gix-trace",
  "gix-utils",
@@ -2752,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.18.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785b9c499e46bc78d7b81c148c21b3fca18655379ee729a856ed19ce50d359ec"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
@@ -2766,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.22"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2778,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "20.0.1"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad89218e74850f42d364ed3877c7291f0474c8533502df91bb877ecc5cb0dd40"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -2793,15 +3040,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
  "fastrand",
  "unicode-normalization",
@@ -2809,12 +3056,11 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2961,9 +3207,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2981,34 +3227,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows",
 ]
 
 [[package]]
@@ -3017,7 +3246,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -3028,14 +3257,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3096,10 +3325,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -3117,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -3153,6 +3379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3247,7 +3479,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3256,7 +3488,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3380,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3424,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -3435,7 +3667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3448,6 +3680,12 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inout"
@@ -3468,7 +3706,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3479,7 +3717,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3487,36 +3725,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3567,7 +3775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3582,14 +3790,25 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3599,7 +3818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "pkg-config",
 ]
 
@@ -3608,6 +3827,12 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -3629,9 +3854,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3650,7 +3875,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -3686,10 +3921,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3704,10 +3936,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3738,9 +3973,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loop9"
@@ -3753,11 +3988,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3767,10 +4002,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "macerator"
-version = "0.2.10"
+name = "mac_address"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b0b2dbe8b22f9e96ba12e29964889010117f92e6bd006010887320ae58e2f0"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
+name = "macerator"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "508a2f720538bb7e3ea3cb6d098615b107cb82ae387d77d906276905e9ec894b"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -3784,24 +4029,31 @@ dependencies = [
 
 [[package]]
 name = "macerator-macros"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ee1819976b67f4d782390c55a75c13401c7a988517f7f8e60a33484dc2e00a"
+checksum = "ed5ce85961d618ce9794bdf822bfe96fe9dd341aa5b033b454f7a8d96e79b9b1"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
+name = "macro_rules_attribute"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
 dependencies = [
- "libc",
+ "macro_rules_attribute-proc_macro",
+ "paste",
 ]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "matchers"
@@ -3864,18 +4116,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.32.0"
+name = "memmem"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "bitflags",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
+ "autocfg",
 ]
 
 [[package]]
@@ -3919,6 +4171,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0b3262dc837d2513fe2ef31ff8461352ef932dcca31ba0c0abe33547cf6b9b"
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,18 +4204,18 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "26.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916cbc7cb27db60be930a4e2da243cf4bc39569195f22fd8ee419cd31d5b662c"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bitflags",
+ "bit-set 0.9.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
  "libm",
@@ -3996,7 +4270,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4061,10 +4335,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "no_std_io2"
-version = "0.9.3"
+name = "nix"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -4148,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4160,7 +4447,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4225,12 +4512,12 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
 dependencies = [
- "bitflags",
- "libloading",
+ "bitflags 2.11.1",
+ "libloading 0.8.9",
  "nvml-wrapper-sys",
  "static_assertions",
  "thiserror 1.0.69",
@@ -4243,16 +4530,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "malloc_buf",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -4261,7 +4548,26 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4272,6 +4578,31 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -4290,6 +4621,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4303,11 +4662,30 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.0.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4334,20 +4712,20 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "parry2d"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b05ce9599a62eec9f6b761cf32647ab1dee43477b5c00ff9221a4b7cb80c4b"
+checksum = "61cb992a61782917b0876f313fceec5f50470fcf8b0e59865db816ff68cd6287"
 dependencies = [
  "approx",
  "arrayvec",
- "bitflags",
+ "bitflags 2.11.1",
  "downcast-rs",
  "either",
  "ena",
@@ -4358,7 +4736,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "simba",
  "slab",
  "smallvec",
@@ -4368,13 +4746,13 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04d21bda5249438b5695e7f08f1655524a6025bcdb186c324b7a66562f2d61"
+checksum = "8598fd0fa548d469b6ca4f9e90b446434fb879c12494a91e41c341d8f0f558d8"
 dependencies = [
  "approx",
  "arrayvec",
- "bitflags",
+ "bitflags 2.11.1",
  "downcast-rs",
  "either",
  "ena",
@@ -4385,7 +4763,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "rstar",
  "simba",
  "slab",
@@ -4437,13 +4815,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
+name = "pest"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
- "fixedbitset",
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
  "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4457,12 +4932,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4498,7 +4967,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4516,9 +4985,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4560,7 +5029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4583,21 +5052,21 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4625,9 +5094,9 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -4744,9 +5213,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4852,15 +5321,15 @@ checksum = "73edcbebd2c2a9eb0041e40b046b5136da32990fcd2ac76b9414ebff45908e18"
 dependencies = [
  "approx",
  "arrayvec",
- "bit-vec",
- "bitflags",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.1",
  "downcast-rs",
  "glamx",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "parry2d",
  "profiling",
  "rustc-hash 2.1.2",
@@ -4879,15 +5348,15 @@ checksum = "a576251c9dc2d6aff08470b7433096a04019c8b7bea9bbb7087f092c180feaea"
 dependencies = [
  "approx",
  "arrayvec",
- "bit-vec",
- "bitflags",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.1",
  "downcast-rs",
  "glamx",
  "log",
  "nalgebra",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "parry3d",
  "profiling",
  "rustc-hash 2.1.2",
@@ -4900,24 +5369,87 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
 dependencies = [
- "bitflags",
- "cassowary",
- "compact_str",
- "crossterm",
- "indoc",
  "instability",
- "itertools 0.13.0",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.1",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
  "lru",
- "paste",
- "strum 0.26.3",
- "time",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4976,7 +5508,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4984,6 +5516,18 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
 
 [[package]]
 name = "rawpointer"
@@ -4999,6 +5543,17 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
 ]
 
 [[package]]
@@ -5023,16 +5578,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5093,7 +5639,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -5125,7 +5671,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5179,7 +5725,7 @@ dependencies = [
  "rlevo-core",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5192,7 +5738,7 @@ dependencies = [
  "rand 0.10.1",
  "rand_distr 0.6.0",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5223,7 +5769,7 @@ dependencies = [
  "rand_distr 0.6.0",
  "rlevo-core",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5252,7 +5798,7 @@ dependencies = [
  "rlevo-core",
  "rlevo-environments",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5317,7 +5863,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -5327,7 +5873,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5364,35 +5910,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -5405,9 +5938,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5415,9 +5948,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5548,14 +6081,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5714,6 +6247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5743,6 +6282,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -5778,11 +6320,23 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -5811,15 +6365,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -5828,16 +6373,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.26.4"
+name = "strum"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5849,7 +6390,19 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5857,6 +6410,23 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -5886,7 +6456,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5895,7 +6465,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -5905,30 +6475,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.36.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -5947,9 +6503,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5966,7 +6522,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "ndarray 0.16.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "safetensors 0.3.3",
  "thiserror 1.0.69",
  "torch-sys",
@@ -5982,7 +6538,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -5993,6 +6549,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset 0.4.2",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook 0.3.18",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -6038,7 +6657,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6049,7 +6668,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6162,10 +6781,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.52.0"
+name = "tokenizers"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6186,7 +6838,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6201,18 +6853,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -6220,7 +6860,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -6238,26 +6878,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -6276,9 +6907,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -6287,7 +6918,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -6329,20 +6960,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6408,7 +7039,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tracel-llvm-bundler",
  "tracel-tblgen-rs",
  "unindent",
@@ -6450,11 +7081,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -6468,7 +7100,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6518,23 +7150,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -6547,6 +7162,15 @@ dependencies = [
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tynm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21cdb0fc8f85c98b1ec812bc4cd69faf6c0fa2fc17d44ea3c2cdd38dc08e999"
+dependencies = [
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -6572,9 +7196,15 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -6592,6 +7222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6599,26 +7238,20 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -6656,7 +7289,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -6681,23 +7314,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.23.0"
+name = "utf8parse"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "rand 0.10.1",
@@ -6729,7 +7363,7 @@ checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6755,6 +7389,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -6783,11 +7426,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -6796,14 +7439,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6814,9 +7457,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6824,9 +7467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6834,22 +7477,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -6882,17 +7525,29 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.95"
+name = "wayland-sys"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6914,14 +7569,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6933,17 +7588,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "wgpu"
-version = "26.0.1"
+name = "wezterm-bidi"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b6ff82bbf6e9206828e1a3178e851f8c20f1c9028e74dd3a8090741ccd5798"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 2.11.1",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
  "naga",
@@ -6963,17 +7691,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "26.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f62f1053bd28c2268f42916f31588f81f64796e2ff91b81293515017ca8bd9"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
- "bitflags",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.11.1",
+ "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
@@ -6989,95 +7718,112 @@ dependencies = [
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "26.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae5fbde6a4cbebae38358aa73fcd6e0f15c6144b67ef5dc91ded0db125dbdf"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "26.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7670e390f416006f746b4600fdd9136455e3627f5bd763abf9a65daa216dd2d"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "26.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720a5cb9d12b3d337c15ff0e24d3e97ed11490ff3f7506e7f3d98c68fa5d6f14"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "26.0.6"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d0e67224cc7305b3b4eb2cc57ca4c4c3afc665c1d1bee162ea806e19c47bdd"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
- "bitflags",
- "block",
+ "bit-set 0.9.1",
+ "bitflags 2.11.1",
+ "block2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "log",
- "metal",
  "naga",
  "ndk-sys",
- "objc",
- "ordered-float",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float 5.3.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "26.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca7a8d8af57c18f57d393601a1fb159ace8b2328f1b6b5f80893f7d672c9ae2"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
+ "raw-window-handle",
  "web-sys",
 ]
 
@@ -7124,82 +7870,47 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -7210,18 +7921,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7232,14 +7932,8 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -7249,49 +7943,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7299,15 +7974,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7327,7 +7993,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7352,7 +8018,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -7365,11 +8031,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -7470,15 +8136,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7491,6 +8151,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -7513,7 +8179,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7529,7 +8195,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7541,7 +8207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -7580,7 +8246,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7596,7 +8262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -7604,6 +8270,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "y4m"
@@ -7630,7 +8302,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7651,14 +8323,14 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7671,7 +8343,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7711,7 +8383,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ categories = ["science", "algorithms", "simulation"]
 
 [workspace.dependencies]
 # Core ML and tensor computation
-burn = { version = "0.20.1", features = ["wgpu", "train", "tui", "metrics", "ndarray"] }
-cubecl = { version = "0.9.0", features = ["wgpu"] }
+burn = { version = "0.21.0", features = ["wgpu", "train", "tui", "metrics", "flex"] }
+cubecl = { version = "0.10.0", features = ["wgpu"] }
 
 # Utilities
 rand = "0.10.1"
@@ -33,15 +33,15 @@ ringbuffer = "0.16.0"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 
 # Benchmarking and profiling
-criterion = { version = "0.5", features = ["html_reports"] }
-pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
+criterion = { version = "0.8", features = ["html_reports"] }
+pprof = { version = "0.15", features = ["flamegraph", "criterion"] }
 
 # Logging (recommended for ML projects)
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Error handling
-thiserror = "1.0"
+thiserror = "2.0"
 anyhow = "1.0"
 
 # Physics (Box2D-style environments)

--- a/crates/rlevo-benchmarks/Cargo.toml
+++ b/crates/rlevo-benchmarks/Cargo.toml
@@ -18,8 +18,8 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { version = "1", optional = true }
-ratatui = { version = "0.29", optional = true }
-crossterm = { version = "0.28", optional = true }
+ratatui = { version = "0.30", optional = true }
+crossterm = { version = "0.29", optional = true }
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/rlevo-core/examples/grid_agent.rs
+++ b/crates/rlevo-core/examples/grid_agent.rs
@@ -24,14 +24,14 @@
 //! cargo run -p rlevo-core --example grid_agent
 //! ```
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rlevo_core::action::{DiscreteAction, MultiDiscreteAction};
 use rlevo_core::base::{Action, Observation, State, TensorConversionError, TensorConvertible};
 use serde::{Deserialize, Serialize};
 
 /// Concrete backend used for tensor demonstrations in `main`.
-type DemoBackend = NdArray;
+type DemoBackend = Flex;
 
 // ─── Facing ──────────────────────────────────────────────────────────────────
 
@@ -119,7 +119,7 @@ impl Observation<1> for AgentObservation {
 
 impl<B: Backend> TensorConvertible<1, B> for AgentObservation {
     #[allow(clippy::cast_precision_loss)]
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         let data = TensorData::new(
             vec![self.x as f32, self.y as f32, f32::from(self.facing.to_u8())],
             [3],
@@ -129,7 +129,7 @@ impl<B: Backend> TensorConvertible<1, B> for AgentObservation {
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims[0] != 3 {
             return Err(TensorConversionError {
                 message: format!("expected shape [3], got {dims:?}"),
@@ -370,7 +370,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         AgentObservation::shape()
     );
 
-    let device: <DemoBackend as Backend>::Device = Default::default();
+    let device: <DemoBackend as burn::tensor::backend::BackendTypes>::Device = Default::default();
     let tensor = <AgentObservation as TensorConvertible<1, DemoBackend>>::to_tensor(&obs, &device);
     println!(
         "tensor                       = {:?}",

--- a/crates/rlevo-core/src/base.rs
+++ b/crates/rlevo-core/src/base.rs
@@ -174,7 +174,7 @@ impl Error for TensorConversionError {}
 /// [`State::is_valid`] / [`Action::is_valid`]).
 pub trait TensorConvertible<const D: usize, B: Backend>: Sized {
     /// Converts `self` into a tensor on `device`.
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, D>;
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, D>;
 
     /// Reconstructs a value from a tensor.
     ///

--- a/crates/rlevo-environments/src/classic/acrobot.rs
+++ b/crates/rlevo-environments/src/classic/acrobot.rs
@@ -652,12 +652,12 @@ impl<D: AcrobotDynamicsFn + Default> Environment<1, 1, 1> for Acrobot<D> {
 // ---------------------------------------------------------------------------
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for AcrobotObservation {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats(self.to_array(), device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [6] {
             return Err(TensorConversionError {
                 message: format!("expected shape [6], got {dims:?}"),
@@ -681,14 +681,14 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for AcrobotObser
 }
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for AcrobotAction {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         let mut one_hot = [0.0_f32; 3];
         one_hot[self.to_index()] = 1.0;
         burn::tensor::Tensor::from_floats(one_hot, device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [3] {
             return Err(TensorConversionError {
                 message: format!("expected shape [3], got {dims:?}"),

--- a/crates/rlevo-environments/src/classic/bandit/contextual.rs
+++ b/crates/rlevo-environments/src/classic/bandit/contextual.rs
@@ -108,7 +108,7 @@ impl<const C: usize> State<1> for ContextualBanditState<C> {
 
 impl<const C: usize, B: Backend> TensorConvertible<1, B> for ContextualBanditObservation<C> {
     /// One-hot encoding of the current context as a rank-1 tensor of length `C`.
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         let mut one_hot = [0.0_f32; C];
         one_hot[self.context] = 1.0;
         Tensor::from_floats(one_hot, device)
@@ -120,7 +120,7 @@ impl<const C: usize, B: Backend> TensorConvertible<1, B> for ContextualBanditObs
     ///
     /// Returns [`TensorConversionError`] if the tensor shape is not `[C]`.
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [C] {
             return Err(TensorConversionError {
                 message: format!("expected shape [{C}], got {dims:?}"),
@@ -360,7 +360,7 @@ mod tests {
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::environment::Snapshot;
 
-    type TestBackend = burn::backend::NdArray;
+    type TestBackend = burn::backend::Flex;
     const C: usize = 4;
     const K: usize = 10;
 

--- a/crates/rlevo-environments/src/classic/bandit/k_armed.rs
+++ b/crates/rlevo-environments/src/classic/bandit/k_armed.rs
@@ -95,7 +95,7 @@ impl Display for KArmedBanditState {
 
 impl<B: Backend> TensorConvertible<1, B> for KArmedBanditState {
     /// Encodes the stateless bandit state as a 1-D tensor `[0.0]`.
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats([0.0_f32; 1], device)
     }
 
@@ -106,7 +106,7 @@ impl<B: Backend> TensorConvertible<1, B> for KArmedBanditState {
     ///
     /// Returns [`TensorConversionError`] if the tensor shape is not `[1]`.
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [1] {
             return Err(TensorConversionError {
                 message: format!("expected shape [1], got {dims:?}"),
@@ -226,7 +226,7 @@ impl<const K: usize> DiscreteAction<1> for KArmedBanditAction<K> {
 
 impl<const K: usize, B: Backend> TensorConvertible<1, B> for KArmedBanditAction<K> {
     /// One-hot encoding of the selected arm as a rank-1 tensor of length `K`.
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         let mut one_hot = [0.0_f32; K];
         one_hot[self.selected_arm] = 1.0;
         Tensor::from_floats(one_hot, device)
@@ -239,7 +239,7 @@ impl<const K: usize, B: Backend> TensorConvertible<1, B> for KArmedBanditAction<
     /// Returns [`TensorConversionError`] if the tensor shape is not `[K]` or
     /// the argmax falls outside the valid arm range.
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [K] {
             return Err(TensorConversionError {
                 message: format!("expected shape [{K}], got {dims:?}"),
@@ -537,7 +537,7 @@ mod tests {
     use super::*;
     use rlevo_core::environment::Snapshot;
 
-    type TestBackend = burn::backend::NdArray;
+    type TestBackend = burn::backend::Flex;
     const K: usize = 10;
 
     #[test]

--- a/crates/rlevo-environments/src/classic/cartpole.rs
+++ b/crates/rlevo-environments/src/classic/cartpole.rs
@@ -526,12 +526,12 @@ impl crate::render::AsciiRenderable for CartPole {
 // ---------------------------------------------------------------------------
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for CartPoleObservation {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats(self.to_array(), device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [4] {
             return Err(TensorConversionError {
                 message: format!("expected shape [4], got {dims:?}"),
@@ -553,14 +553,14 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for CartPoleObse
 }
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for CartPoleAction {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         let mut one_hot = [0.0_f32; 2];
         one_hot[self.to_index()] = 1.0;
         burn::tensor::Tensor::from_floats(one_hot, device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [2] {
             return Err(TensorConversionError {
                 message: format!("expected shape [2], got {dims:?}"),

--- a/crates/rlevo-environments/src/classic/mountain_car.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car.rs
@@ -370,12 +370,12 @@ impl crate::render::AsciiRenderable for MountainCar {
 // ---------------------------------------------------------------------------
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for MountainCarObservation {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats(self.to_array(), device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [2] {
             return Err(TensorConversionError {
                 message: format!("expected shape [2], got {dims:?}"),
@@ -395,14 +395,14 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for MountainCarO
 }
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for MountainCarAction {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         let mut one_hot = [0.0_f32; 3];
         one_hot[self.to_index()] = 1.0;
         burn::tensor::Tensor::from_floats(one_hot, device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [3] {
             return Err(TensorConversionError {
                 message: format!("expected shape [3], got {dims:?}"),

--- a/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
@@ -434,12 +434,12 @@ impl Environment<1, 1, 1> for MountainCarContinuous {
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B>
     for MountainCarContinuousObservation
 {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats(self.to_array(), device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [2] {
             return Err(TensorConversionError {
                 message: format!("expected shape [2], got {dims:?}"),
@@ -459,12 +459,12 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B>
 }
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for MountainCarContinuousAction {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats([self.0], device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [1] {
             return Err(TensorConversionError {
                 message: format!("expected shape [1], got {dims:?}"),

--- a/crates/rlevo-environments/src/classic/pendulum.rs
+++ b/crates/rlevo-environments/src/classic/pendulum.rs
@@ -418,12 +418,12 @@ impl crate::render::AsciiRenderable for Pendulum {
 // ---------------------------------------------------------------------------
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for PendulumObservation {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats(self.to_array(), device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [3] {
             return Err(TensorConversionError {
                 message: format!("expected shape [3], got {dims:?}"),
@@ -444,12 +444,12 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for PendulumObse
 }
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for PendulumAction {
-    fn to_tensor(&self, device: &B::Device) -> burn::tensor::Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> burn::tensor::Tensor<B, 1> {
         burn::tensor::Tensor::from_floats([self.0], device)
     }
 
     fn from_tensor(tensor: burn::tensor::Tensor<B, 1>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [1] {
             return Err(TensorConversionError {
                 message: format!("expected shape [1], got {dims:?}"),

--- a/crates/rlevo-environments/src/games/chess/observations.rs
+++ b/crates/rlevo-environments/src/games/chess/observations.rs
@@ -427,7 +427,7 @@ impl Default for ChessState {
 //     /// - Plane 118: No-progress count (normalized)
 //     ///
 //     /// All planes are from the perspective of the current player to move.
-//     fn to_tensor<B: Backend>(&self, device: &B::Device) -> Tensor<B, 3> {
+//     fn to_tensor<B: Backend>(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 3> {
 //         let mut data = Vec::with_capacity(self.numel());
 
 //         // Planes 0-111: Historical positions (8 time steps × 14 planes)
@@ -677,9 +677,9 @@ impl Default for ChessState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     #[test]
     fn test_state_creation() {

--- a/crates/rlevo-environments/src/grids/core/observation.rs
+++ b/crates/rlevo-environments/src/grids/core/observation.rs
@@ -55,7 +55,7 @@ impl Observation<3> for GridObservation {
 }
 
 impl<B: Backend> TensorConvertible<3, B> for GridObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 3> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 3> {
         let mut flat = Vec::with_capacity(VIEW_SIZE * VIEW_SIZE * OBS_CHANNELS);
         for row in &self.view {
             for cell in row {
@@ -81,7 +81,7 @@ impl<B: Backend> TensorConvertible<3, B> for GridObservation {
     /// `[VIEW_SIZE, VIEW_SIZE, OBS_CHANNELS]` or the backend fails to
     /// materialize its data.
     fn from_tensor(tensor: Tensor<B, 3>) -> Result<Self, TensorConversionError> {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         if dims.as_slice() != [VIEW_SIZE, VIEW_SIZE, OBS_CHANNELS] {
             return Err(TensorConversionError {
                 message: format!(
@@ -165,8 +165,8 @@ mod tests {
 
     #[test]
     fn view_round_trips_through_tensor() {
-        use burn::backend::NdArray;
-        type TestBackend = NdArray;
+        use burn::backend::Flex;
+        type TestBackend = Flex;
         let device = Default::default();
 
         let mut view = [[Entity::Empty; VIEW_SIZE]; VIEW_SIZE];
@@ -187,9 +187,9 @@ mod tests {
 
     #[test]
     fn from_tensor_rejects_wrong_shape() {
-        use burn::backend::NdArray;
+        use burn::backend::Flex;
         use burn::tensor::TensorData as TD;
-        type TestBackend = NdArray;
+        type TestBackend = Flex;
         let device = Default::default();
 
         let flat = vec![0.0f32; VIEW_SIZE * VIEW_SIZE * 2];

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/action.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/action.rs
@@ -46,7 +46,7 @@ impl ContinuousAction<1> for InvertedDoublePendulumAction {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for InvertedDoublePendulumAction {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/observation.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/observation.rs
@@ -66,7 +66,7 @@ impl Observation<1> for InvertedDoublePendulumObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for InvertedDoublePendulumObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/inverted_pendulum/action.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_pendulum/action.rs
@@ -47,7 +47,7 @@ impl ContinuousAction<1> for InvertedPendulumAction {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for InvertedPendulumAction {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/inverted_pendulum/observation.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_pendulum/observation.rs
@@ -45,7 +45,7 @@ impl Observation<1> for InvertedPendulumObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for InvertedPendulumObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/reacher/action.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/action.rs
@@ -49,7 +49,7 @@ impl ContinuousAction<1> for ReacherAction {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for ReacherAction {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/reacher/observation.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/observation.rs
@@ -63,7 +63,7 @@ impl Observation<1> for ReacherObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for ReacherObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/swimmer/action.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/action.rs
@@ -49,7 +49,7 @@ impl ContinuousAction<1> for SwimmerAction {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for SwimmerAction {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-environments/src/locomotion/swimmer/observation.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/observation.rs
@@ -69,7 +69,7 @@ impl Observation<1> for SwimmerObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for SwimmerObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats(self.0, device)
     }
 

--- a/crates/rlevo-evolution/benches/operators.rs
+++ b/crates/rlevo-evolution/benches/operators.rs
@@ -1,4 +1,4 @@
-//! Baseline micro-benchmarks for hot-path operators on the ndarray
+//! Baseline micro-benchmarks for hot-path operators on the flex
 //! backend.
 //!
 //! The numbers these benches produce are the reference point for the

--- a/crates/rlevo-evolution/benches/operators.rs
+++ b/crates/rlevo-evolution/benches/operators.rs
@@ -9,7 +9,7 @@
 //! `--save-baseline pre-kernel` before landing kernels and
 //! `--baseline pre-kernel` afterwards to get a side-by-side report.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use burn::tensor::{Distribution, Tensor, backend::Backend as _};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
@@ -20,16 +20,16 @@ use rlevo_evolution::fitness::BatchFitnessFn;
 use rlevo_evolution::ops::selection::tournament_select;
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
-type B = NdArray;
+type B = Flex;
 
 struct ZeroFitness;
 impl BatchFitnessFn<B, Tensor<B, 2>> for ZeroFitness {
     fn evaluate_batch(
         &mut self,
         population: &Tensor<B, 2>,
-        device: &<B as burn::tensor::backend::Backend>::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 1> {
-        let n = population.shape().dims[0];
+        let n = population.dims()[0];
         Tensor::<B, 1>::zeros([n], device)
     }
 }
@@ -56,7 +56,7 @@ fn bench_de_generation(c: &mut Criterion) {
     let mut group = c.benchmark_group("de_one_generation");
     group.sample_size(10);
     for &pop_size in &[64_usize, 256, 1024] {
-        let device: <B as burn::tensor::backend::Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         B::seed(&device, 42);
         let mut params = DeConfig::default_for(pop_size, 10);
         params.variant = DeVariant::Rand1Bin;

--- a/crates/rlevo-evolution/src/algorithms/de.rs
+++ b/crates/rlevo-evolution/src/algorithms/de.rs
@@ -518,7 +518,7 @@ mod tests {
 
     /// All five DE variants converge on Sphere-D10 within budget.
     ///
-    /// The Burn ndarray backend seeds its RNG through a process-wide
+    /// The Burn Flex backend seeds its RNG through a process-wide
     /// mutex, so separate `#[test]` functions that call `Tensor::random`
     /// race on seeding and produce non-deterministic trajectories. This
     /// single test runs the variants sequentially inside one function

--- a/crates/rlevo-evolution/src/algorithms/de.rs
+++ b/crates/rlevo-evolution/src/algorithms/de.rs
@@ -159,10 +159,10 @@ pub struct DeState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
 ///
-/// let strategy = DifferentialEvolution::<NdArray>::new();
+/// let strategy = DifferentialEvolution::<Flex>::new();
 /// let mut params = DeConfig::default_for(30, 10);
 /// params.variant = DeVariant::Rand1Bin;
 /// let _ = (strategy, params);
@@ -184,7 +184,7 @@ impl<B: Backend> DifferentialEvolution<B> {
     fn sample_initial_population(
         params: &DeConfig,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 2> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
@@ -231,7 +231,7 @@ where
     type State = DeState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &DeConfig, rng: &mut dyn Rng, device: &B::Device) -> DeState<B> {
+    fn init(&self, params: &DeConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> DeState<B> {
         let population = Self::sample_initial_population(params, rng, device);
         DeState {
             population,
@@ -249,7 +249,7 @@ where
         params: &DeConfig,
         state: &DeState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, DeState<B>) {
         // First call: evaluate the initial population.
         if state.fitness.is_empty() {
@@ -420,7 +420,7 @@ where
         let mask_int =
             Tensor::<B, 1, Int>::from_data(TensorData::new(replace_mask, [pop_size]), &device);
         let mask_bool_row = mask_int.equal_elem(1);
-        let genome_dim = state.population.shape().dims[1];
+        let genome_dim = state.population.dims()[1];
         let mask_bool = mask_bool_row
             .unsqueeze_dim::<2>(1)
             .expand([pop_size, genome_dim]);
@@ -480,9 +480,9 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -86,10 +86,10 @@ pub struct EpState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
 ///
-/// let strategy = EvolutionaryProgramming::<NdArray>::new();
+/// let strategy = EvolutionaryProgramming::<Flex>::new();
 /// let params = EpConfig::default_for(30, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -116,7 +116,7 @@ where
     type State = EpState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &EpConfig, rng: &mut dyn Rng, device: &B::Device) -> EpState<B> {
+    fn init(&self, params: &EpConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> EpState<B> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
         let parents = Tensor::<B, 2>::random(
@@ -143,7 +143,7 @@ where
         params: &EpConfig,
         state: &EpState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, EpState<B>) {
         // First call: evaluate the initial parents.
         if state.parent_fitness.is_empty() {
@@ -310,9 +310,9 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -121,10 +121,10 @@ pub struct EsState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrategy};
 ///
-/// let strategy = EvolutionStrategy::<NdArray>::new();
+/// let strategy = EvolutionStrategy::<Flex>::new();
 /// let params = EsConfig::default_for(EsKind::MuPlusLambda { mu: 5, lambda: 20 }, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -152,7 +152,7 @@ impl<B: Backend> EvolutionStrategy<B> {
     fn sample_initial_parents(
         params: &EsConfig,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, Tensor<B, 1>) {
         let mu = Self::mu(params.kind);
         let (lo, hi) = params.bounds;
@@ -178,7 +178,7 @@ where
     type State = EsState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &EsConfig, rng: &mut dyn Rng, device: &B::Device) -> EsState<B> {
+    fn init(&self, params: &EsConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> EsState<B> {
         let (parents, sigmas) = Self::sample_initial_parents(params, rng, device);
         EsState {
             parents,
@@ -197,7 +197,7 @@ where
         params: &EsConfig,
         state: &EsState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, EsState<B>) {
         // First call: evaluate the initial parents as the "offspring"
         // so fitness is populated in the subsequent `tell`.
@@ -465,9 +465,9 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn mu_plus_lambda_converges_on_sphere_d10() {
         // Convergence on Sphere (D=10) to best_fitness < 1e-6 within
-        // budget on ndarray. We allow a generous budget because the
+        // budget on Flex. We allow a generous budget because the
         // classical ES is slower than CMA-ES; the goal is to verify
         // convergence direction, not to optimize hyperparameters.
         let best = run_es(EsKind::MuPlusLambda { mu: 5, lambda: 20 }, 10, 1500, 42);

--- a/crates/rlevo-evolution/src/algorithms/ga.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga.rs
@@ -116,12 +116,12 @@ pub struct GaState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::ga::{
 ///     GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
 /// };
 ///
-/// let strategy = GeneticAlgorithm::<NdArray>::new();
+/// let strategy = GeneticAlgorithm::<Flex>::new();
 /// let params = GaConfig {
 ///     pop_size: 64,
 ///     genome_dim: 10,
@@ -150,7 +150,7 @@ impl<B: Backend> GeneticAlgorithm<B> {
     fn sample_initial_population(
         params: &GaConfig,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 2> {
         let (lo, hi) = params.bounds;
         let range = f64::from(hi - lo);
@@ -173,7 +173,7 @@ where
     type State = GaState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &GaConfig, rng: &mut dyn Rng, device: &B::Device) -> GaState<B> {
+    fn init(&self, params: &GaConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> GaState<B> {
         let population = Self::sample_initial_population(params, rng, device);
         GaState {
             population,
@@ -189,7 +189,7 @@ where
         params: &GaConfig,
         state: &GaState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, GaState<B>) {
         // On the first call, state.fitness is empty; the harness has not
         // evaluated anyone yet. Return the initial population unchanged.
@@ -350,10 +350,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/ga_binary.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga_binary.rs
@@ -79,10 +79,10 @@ pub struct BinaryGaState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::ga_binary::{BinaryGaConfig, BinaryGeneticAlgorithm};
 ///
-/// let strategy = BinaryGeneticAlgorithm::<NdArray>::new();
+/// let strategy = BinaryGeneticAlgorithm::<Flex>::new();
 /// let params = BinaryGaConfig::default_for(32, 16);
 /// let _ = (strategy, params);
 /// ```
@@ -103,7 +103,7 @@ impl<B: Backend> BinaryGeneticAlgorithm<B> {
     fn sample_initial_population(
         params: &BinaryGaConfig,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 2, Int> {
         B::seed(device, rng.next_u64());
         let u = Tensor::<B, 2>::random(
@@ -127,7 +127,7 @@ where
         &self,
         params: &BinaryGaConfig,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> BinaryGaState<B> {
         BinaryGaState {
             population: Self::sample_initial_population(params, rng, device),
@@ -143,7 +143,7 @@ where
         params: &BinaryGaConfig,
         state: &BinaryGaState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2, Int>, BinaryGaState<B>) {
         if state.fitness.is_empty() {
             return (state.population.clone(), state.clone());
@@ -294,8 +294,8 @@ mod tests {
     use super::*;
     use crate::fitness::BatchFitnessFn;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
-    type TestBackend = NdArray;
+    use burn::backend::Flex;
+    type TestBackend = Flex;
 
     /// `OneMax` phrased as minimization: `cost = D − count_ones`.
     struct OneMaxCost {
@@ -306,14 +306,14 @@ mod tests {
         fn evaluate_batch(
             &mut self,
             population: &Tensor<B, 2, Int>,
-            device: &B::Device,
+            device: &<B as burn::tensor::backend::BackendTypes>::Device,
         ) -> Tensor<B, 1> {
-            let dims = population.shape().dims;
+            let dims = population.dims();
             let pop_size = dims[0];
             let data = population
                 .clone()
                 .into_data()
-                .into_vec::<i64>()
+                .into_vec::<i32>()
                 .unwrap_or_default();
             let mut fitness = Vec::with_capacity(pop_size);
             for row in 0..pop_size {

--- a/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
+++ b/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
@@ -126,10 +126,10 @@ pub struct CgpState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::gp_cgp::{CartesianGeneticProgramming, CgpConfig};
 ///
-/// let strategy = CartesianGeneticProgramming::<NdArray>::new();
+/// let strategy = CartesianGeneticProgramming::<Flex>::new();
 /// let params = CgpConfig::default_for(1);
 /// assert!(params.genome_len() > 0);
 /// let _ = strategy;
@@ -171,8 +171,11 @@ impl<B: Backend> CartesianGeneticProgramming<B> {
         genome
             .clone()
             .into_data()
-            .into_vec::<i64>()
+            .into_vec::<i32>()
             .unwrap_or_default()
+            .into_iter()
+            .map(i64::from)
+            .collect()
     }
 }
 
@@ -310,7 +313,7 @@ where
     type State = CgpState<B>;
     type Genome = Tensor<B, 2, Int>;
 
-    fn init(&self, params: &CgpConfig, rng: &mut dyn Rng, device: &B::Device) -> CgpState<B> {
+    fn init(&self, params: &CgpConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> CgpState<B> {
         let genome_vec = Self::sample_initial_genome(params, rng);
         let parent = Tensor::<B, 2, Int>::from_data(
             TensorData::new(genome_vec, [1, params.genome_len()]),
@@ -330,7 +333,7 @@ where
         params: &CgpConfig,
         state: &CgpState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2, Int>, CgpState<B>) {
         // First call: evaluate the parent as "offspring" of size 1.
         if !state.parent_fitness.is_finite() {
@@ -350,8 +353,11 @@ where
             mutate_genome(&mut child, params, &mut mut_rng);
             offspring_genomes.extend(child);
         }
+        #[allow(clippy::cast_possible_truncation)]
+        let offspring_genomes_i32: Vec<i32> =
+            offspring_genomes.into_iter().map(|v| v as i32).collect();
         let offspring = Tensor::<B, 2, Int>::from_data(
-            TensorData::new(offspring_genomes, [params.lambda, params.genome_len()]),
+            TensorData::new(offspring_genomes_i32, [params.lambda, params.genome_len()]),
             device,
         );
         (offspring, state.clone())
@@ -392,9 +398,9 @@ where
         let best_off_fit = fitness_host[best_off_idx];
         if best_off_fit <= state.parent_fitness {
             let device = offspring.device();
-            #[allow(clippy::cast_possible_wrap)]
+            #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
             let idx = Tensor::<B, 1, Int>::from_data(
-                TensorData::new(vec![best_off_idx as i64], [1]),
+                TensorData::new(vec![best_off_idx as i32], [1]),
                 &device,
             );
             state.parent = offspring.clone().select(0, idx);
@@ -431,9 +437,9 @@ fn update_best<B: Backend>(state: &mut CgpState<B>, pop: &Tensor<B, 2, Int>, fit
     }
     if best_f < state.best_fitness {
         let device = pop.device();
-        #[allow(clippy::cast_possible_wrap)]
+        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
         let idx =
-            Tensor::<B, 1, Int>::from_data(TensorData::new(vec![best_idx as i64], [1]), &device);
+            Tensor::<B, 1, Int>::from_data(TensorData::new(vec![best_idx as i32], [1]), &device);
         state.best_genome = Some(pop.clone().select(0, idx));
         state.best_fitness = best_f;
     }
@@ -444,8 +450,8 @@ mod tests {
     use super::*;
     use crate::fitness::BatchFitnessFn;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
-    type TestBackend = NdArray;
+    use burn::backend::Flex;
+    type TestBackend = Flex;
 
     /// Symbolic regression on `x² + 1` over 20 evenly spaced x ∈ [−1, 1].
     struct SymRegression {
@@ -468,10 +474,17 @@ mod tests {
         fn evaluate_batch(
             &mut self,
             population: &Tensor<B, 2, Int>,
-            device: &B::Device,
+            device: &<B as burn::tensor::backend::BackendTypes>::Device,
         ) -> Tensor<B, 1> {
-            let pop_size = population.shape().dims[0];
-            let data = population.clone().into_data().into_vec::<i64>().unwrap();
+            let pop_size = population.dims()[0];
+            let data: Vec<i64> = population
+                .clone()
+                .into_data()
+                .into_vec::<i32>()
+                .unwrap()
+                .into_iter()
+                .map(i64::from)
+                .collect();
             let gl = self.params.genome_len();
             let inputs: Vec<Vec<f32>> = self.xs.iter().map(|&x| vec![x]).collect();
             let mut fitness = Vec::with_capacity(pop_size);

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
@@ -95,10 +95,10 @@ pub struct AbcState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::abc::{AbcConfig, ArtificialBeeColony};
 ///
-/// let strategy = ArtificialBeeColony::<NdArray>::new();
+/// let strategy = ArtificialBeeColony::<Flex>::new();
 /// let params = AbcConfig::default_for(30, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -125,7 +125,7 @@ impl<B: Backend> ArtificialBeeColony<B> {
         colony: &Tensor<B, 2>,
         pop_size: usize,
         genome_dim: usize,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 2> {
         // Base = copy of targets' rows (we only modify one dim each).
         #[allow(clippy::cast_possible_wrap)]
@@ -170,7 +170,7 @@ where
     type State = AbcState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &AbcConfig, rng: &mut dyn Rng, device: &B::Device) -> AbcState<B> {
+    fn init(&self, params: &AbcConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> AbcState<B> {
         assert!(params.pop_size >= 2, "ABC requires pop_size >= 2");
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
@@ -195,7 +195,7 @@ where
         params: &AbcConfig,
         state: &AbcState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, AbcState<B>) {
         if state.fitness.is_empty() {
             return (state.colony.clone(), state.clone());
@@ -414,10 +414,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_perm.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_perm.rs
@@ -67,10 +67,10 @@ pub struct AcoPermState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::aco_perm::{AntColonyPermutation, AcoPermConfig};
 ///
-/// let strategy = AntColonyPermutation::<NdArray>::new();
+/// let strategy = AntColonyPermutation::<Flex>::new();
 /// let params = AcoPermConfig::default_for(32, 20);
 /// let _ = (strategy, params);
 /// ```
@@ -98,7 +98,7 @@ impl<B: Backend> Strategy<B> for AntColonyPermutation<B> {
         &self,
         _params: &AcoPermConfig,
         _rng: &mut dyn Rng,
-        _device: &B::Device,
+        _device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> AcoPermState<B> {
         todo!(
             "permutation ACO is not yet implemented; \
@@ -111,7 +111,7 @@ impl<B: Backend> Strategy<B> for AntColonyPermutation<B> {
         _params: &AcoPermConfig,
         _state: &AcoPermState<B>,
         _rng: &mut dyn Rng,
-        _device: &B::Device,
+        _device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Self::Genome, AcoPermState<B>) {
         todo!("permutation ACO is not yet implemented")
     }
@@ -135,9 +135,9 @@ impl<B: Backend> Strategy<B> for AntColonyPermutation<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     #[test]
     fn stub_is_constructible() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -98,10 +98,10 @@ pub struct AcoRState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::aco_r::{AcoRConfig, AntColonyReal};
 ///
-/// let strategy = AntColonyReal::<NdArray>::new();
+/// let strategy = AntColonyReal::<Flex>::new();
 /// let params = AcoRConfig::default_for(50, 10, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -148,7 +148,7 @@ where
     type State = AcoRState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &AcoRConfig, rng: &mut dyn Rng, device: &B::Device) -> AcoRState<B> {
+    fn init(&self, params: &AcoRConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> AcoRState<B> {
         assert!(params.archive_size >= 2, "ACO_R requires archive_size >= 2");
         assert!(params.m >= 1, "ACO_R requires m >= 1");
         let (lo, hi) = params.bounds;
@@ -174,7 +174,7 @@ where
         params: &AcoRConfig,
         state: &AcoRState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, AcoRState<B>) {
         // First call: evaluate the initial archive.
         if state.archive_fitness.is_empty() {
@@ -330,10 +330,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -105,10 +105,10 @@ pub struct BatState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::bat::{BatAlgorithm, BatConfig};
 ///
-/// let strategy = BatAlgorithm::<NdArray>::new();
+/// let strategy = BatAlgorithm::<Flex>::new();
 /// let params = BatConfig::default_for(32, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -135,7 +135,7 @@ where
     type State = BatState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &BatConfig, rng: &mut dyn Rng, device: &B::Device) -> BatState<B> {
+    fn init(&self, params: &BatConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> BatState<B> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
         let positions = Tensor::<B, 2>::random(
@@ -162,7 +162,7 @@ where
         params: &BatConfig,
         state: &BatState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, BatState<B>) {
         if state.fitness.is_empty() {
             // Evaluate the initial colony first; the velocity update is
@@ -355,10 +355,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -18,7 +18,7 @@
 //! # Numerical parity caveat
 //!
 //! The fractional power `|v|^(1/β)` is FMA-reorder-sensitive — wgpu
-//! reductions can drift ~`1e-3` relative from ndarray on the same seed.
+//! reductions can drift ~`1e-3` relative from flex on the same seed.
 //! The backend-parity test relaxes tolerance for CS accordingly.
 //!
 //! # References

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -91,10 +91,10 @@ pub struct CuckooState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::cuckoo::{CuckooConfig, CuckooSearch};
 ///
-/// let strategy = CuckooSearch::<NdArray>::new();
+/// let strategy = CuckooSearch::<Flex>::new();
 /// let params = CuckooConfig::default_for(30, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -161,7 +161,7 @@ where
     type State = CuckooState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &CuckooConfig, rng: &mut dyn Rng, device: &B::Device) -> CuckooState<B> {
+    fn init(&self, params: &CuckooConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> CuckooState<B> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
         let nests = Tensor::<B, 2>::random(
@@ -183,7 +183,7 @@ where
         params: &CuckooConfig,
         state: &CuckooState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, CuckooState<B>) {
         if state.fitness.is_empty() {
             return (state.nests.clone(), state.clone());
@@ -341,10 +341,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -101,10 +101,10 @@ pub struct FireflyState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::firefly::{FireflyAlgorithm, FireflyConfig};
 ///
-/// let strategy = FireflyAlgorithm::<NdArray>::new();
+/// let strategy = FireflyAlgorithm::<Flex>::new();
 /// let params = FireflyConfig::default_for(32, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -132,11 +132,11 @@ impl<B: Backend> FireflyAlgorithm<B> {
         beta0: f32,
         gamma: f32,
         alpha: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
         noise_seed: u64,
     ) -> Tensor<B, 2> {
         let pop = fitness.len();
-        let shape = positions.shape().dims;
+        let shape = positions.dims();
         let d = shape[1];
 
         // Pairwise squared distances via (x·x^T + ||x||² - 2x·x^T).
@@ -187,7 +187,7 @@ where
         &self,
         params: &FireflyConfig,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> FireflyState<B> {
         #[cfg(not(feature = "custom-kernels"))]
         assert!(
@@ -228,7 +228,7 @@ where
         params: &FireflyConfig,
         state: &FireflyState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, FireflyState<B>) {
         if state.fitness.is_empty() {
             return (state.positions.clone(), state.clone());
@@ -312,10 +312,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -92,10 +92,10 @@ pub struct GwoState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::gwo::{GreyWolfOptimizer, GwoConfig};
 ///
-/// let strategy = GreyWolfOptimizer::<NdArray>::new();
+/// let strategy = GreyWolfOptimizer::<Flex>::new();
 /// let params = GwoConfig::default_for(32, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -113,7 +113,7 @@ impl<B: Backend> GreyWolfOptimizer<B> {
         }
     }
 
-    fn sample_initial(params: &GwoConfig, rng: &mut dyn Rng, device: &B::Device) -> Tensor<B, 2> {
+    fn sample_initial(params: &GwoConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 2> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
         Tensor::<B, 2>::random(
@@ -132,7 +132,7 @@ where
     type State = GwoState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &GwoConfig, rng: &mut dyn Rng, device: &B::Device) -> GwoState<B> {
+    fn init(&self, params: &GwoConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> GwoState<B> {
         assert!(params.pop_size >= 3, "GWO requires pop_size >= 3");
         let pack = Self::sample_initial(params, rng, device);
         GwoState {
@@ -149,7 +149,7 @@ where
         params: &GwoConfig,
         state: &GwoState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, GwoState<B>) {
         // First call: evaluate initial pack so `tell` can rank it.
         if state.fitness.is_empty() {
@@ -317,10 +317,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/kernels/levy_flight_cube.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/kernels/levy_flight_cube.rs
@@ -31,7 +31,7 @@
 //!
 //! The fractional-power step `|v|^(1/β)` is FMA-reorder-sensitive
 //! enough that wgpu reductions drift ~`1e-3` relative from the
-//! ndarray path on identical seeds (`tests/backend_parity.rs` pins
+//! flex path on identical seeds (`tests/backend_parity.rs` pins
 //! the cross-backend tolerance). The fusion win here is only "save
 //! two launches per generation"; unless profiling shows those launches
 //! dominate, the host-sampled path is both faster to ship and easier

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/kernels/pairwise_attract_cube.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/kernels/pairwise_attract_cube.rs
@@ -45,7 +45,7 @@
 //! tensor — ~10 MB at `N = 512, D = 10` in `f32`. The fused kernel
 //! eliminates that allocation and collapses three launches (pairwise
 //! diff, attractiveness `β`, weighted sum) into one, with a target of
-//! measurable speedup at `N ≥ 128` on both wgpu and ndarray.
+//! measurable speedup at `N ≥ 128` on both wgpu and flex.
 //!
 //! # Fallback
 //!

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
@@ -127,10 +127,10 @@ pub struct PsoState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::pso::{ParticleSwarm, PsoConfig};
 ///
-/// let strategy = ParticleSwarm::<NdArray>::new();
+/// let strategy = ParticleSwarm::<Flex>::new();
 /// let params = PsoConfig::default_for(32, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -148,7 +148,7 @@ impl<B: Backend> ParticleSwarm<B> {
         }
     }
 
-    fn sample_positions(params: &PsoConfig, rng: &mut dyn Rng, device: &B::Device) -> Tensor<B, 2> {
+    fn sample_positions(params: &PsoConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 2> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
         Tensor::<B, 2>::random(
@@ -167,7 +167,7 @@ where
     type State = PsoState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &PsoConfig, rng: &mut dyn Rng, device: &B::Device) -> PsoState<B> {
+    fn init(&self, params: &PsoConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> PsoState<B> {
         let positions = Self::sample_positions(params, rng, device);
         let velocities = Tensor::<B, 2>::zeros([params.pop_size, params.genome_dim], device);
         let personal_best = positions.clone();
@@ -188,7 +188,7 @@ where
         params: &PsoConfig,
         state: &PsoState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, PsoState<B>) {
         // First call: evaluate the initial positions so `tell` can
         // populate personal_best_fitness / global_best.
@@ -361,10 +361,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
@@ -93,10 +93,10 @@ pub struct SalpState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::salp::{SalpConfig, SalpSwarm};
 ///
-/// let strategy = SalpSwarm::<NdArray>::new();
+/// let strategy = SalpSwarm::<Flex>::new();
 /// let params = SalpConfig::default_for(32, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -123,7 +123,7 @@ where
     type State = SalpState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &SalpConfig, rng: &mut dyn Rng, device: &B::Device) -> SalpState<B> {
+    fn init(&self, params: &SalpConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> SalpState<B> {
         assert!(params.pop_size >= 2, "SSA requires pop_size >= 2");
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
@@ -146,7 +146,7 @@ where
         params: &SalpConfig,
         state: &SalpState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, SalpState<B>) {
         if state.fitness.is_empty() {
             return (state.positions.clone(), state.clone());
@@ -273,10 +273,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -88,10 +88,10 @@ pub struct WoaState<B: Backend> {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::metaheuristic::woa::{WhaleOptimization, WoaConfig};
 ///
-/// let strategy = WhaleOptimization::<NdArray>::new();
+/// let strategy = WhaleOptimization::<Flex>::new();
 /// let params = WoaConfig::default_for(32, 10);
 /// let _ = (strategy, params);
 /// ```
@@ -118,7 +118,7 @@ where
     type State = WoaState<B>;
     type Genome = Tensor<B, 2>;
 
-    fn init(&self, params: &WoaConfig, rng: &mut dyn Rng, device: &B::Device) -> WoaState<B> {
+    fn init(&self, params: &WoaConfig, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> WoaState<B> {
         let (lo, hi) = params.bounds;
         B::seed(device, rng.next_u64());
         let positions = Tensor::<B, 2>::random(
@@ -141,7 +141,7 @@ where
         params: &WoaConfig,
         state: &WoaState<B>,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2>, WoaState<B>) {
         // First call: evaluate initial whales so `tell` can record fitness.
         if state.fitness.is_empty() {
@@ -303,10 +303,10 @@ mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     struct Sphere;
     struct SphereFit;

--- a/crates/rlevo-evolution/src/fitness.rs
+++ b/crates/rlevo-evolution/src/fitness.rs
@@ -38,7 +38,7 @@ pub trait FitnessFn<G>: Send {
 /// individual at row `i` of `population`.
 pub trait BatchFitnessFn<B: Backend, G>: Send {
     /// Evaluates every member of `population` and stacks fitnesses.
-    fn evaluate_batch(&mut self, population: &G, device: &B::Device) -> Tensor<B, 1>;
+    fn evaluate_batch(&mut self, population: &G, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1>;
 }
 
 /// Adapter from `FitnessEvaluable` to [`BatchFitnessFn<B, Tensor<B, 2>>`].
@@ -93,8 +93,8 @@ where
     FE: FitnessEvaluable<Individual = Vec<f64>, Landscape = L> + Send,
     L: Send + Sync,
 {
-    fn evaluate_batch(&mut self, population: &Tensor<B, 2>, device: &B::Device) -> Tensor<B, 1> {
-        let dims = population.shape().dims;
+    fn evaluate_batch(&mut self, population: &Tensor<B, 2>, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
+        let dims = population.dims();
         assert_eq!(dims.len(), 2, "population tensor must be rank 2");
         let pop_size = dims[0];
         let genome_dim = dims[1];
@@ -160,8 +160,8 @@ where
     B: Backend,
     L: Landscape,
 {
-    fn evaluate_batch(&mut self, population: &Tensor<B, 2>, device: &B::Device) -> Tensor<B, 1> {
-        let dims = population.shape().dims;
+    fn evaluate_batch(&mut self, population: &Tensor<B, 2>, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
+        let dims = population.dims();
         assert_eq!(dims.len(), 2, "population tensor must be rank 2");
         let pop_size = dims[0];
         let genome_dim = dims[1];
@@ -196,8 +196,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
-    type TestBackend = NdArray;
+    use burn::backend::Flex;
+    type TestBackend = Flex;
 
     #[derive(Debug, Clone, Copy)]
     struct Sphere;

--- a/crates/rlevo-evolution/src/ops/crossover.rs
+++ b/crates/rlevo-evolution/src/ops/crossover.rs
@@ -30,11 +30,11 @@ pub fn blx_alpha<B: Backend>(
     parent_a: Tensor<B, 2>,
     parent_b: Tensor<B, 2>,
     alpha: f32,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     assert_eq!(
-        parent_a.shape().dims,
-        parent_b.shape().dims,
+        parent_a.dims(),
+        parent_b.dims(),
         "BLX-α: parents must have identical shapes"
     );
     let shape = parent_a.shape();
@@ -61,11 +61,11 @@ pub fn uniform_crossover<B: Backend>(
     parent_a: Tensor<B, 2>,
     parent_b: Tensor<B, 2>,
     p: f32,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     assert_eq!(
-        parent_a.shape().dims,
-        parent_b.shape().dims,
+        parent_a.dims(),
+        parent_b.dims(),
         "uniform crossover: parents must have identical shapes"
     );
     let shape = parent_a.shape();
@@ -87,11 +87,11 @@ pub fn binary_uniform_crossover<B: Backend>(
     parent_a: Tensor<B, 2, Int>,
     parent_b: Tensor<B, 2, Int>,
     p: f32,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2, Int> {
     assert_eq!(
-        parent_a.shape().dims,
-        parent_b.shape().dims,
+        parent_a.dims(),
+        parent_b.dims(),
         "binary uniform crossover: parents must have identical shapes"
     );
     let shape = parent_a.shape();
@@ -103,15 +103,15 @@ pub fn binary_uniform_crossover<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::{ndarray::NdArrayDevice, NdArray};
+    use burn::backend::{flex::FlexDevice, Flex};
     use burn::tensor::TensorData;
     #[allow(unused_imports)]
     use burn::tensor::backend::Backend as _;
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     #[test]
     fn blx_alpha_lies_between_bounds() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 13);
         let a = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![0.0_f32, 0.0, 0.0, 0.0], [2, 2]),
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn uniform_all_from_a_when_p_is_one() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 5);
         let a = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![7.0_f32, 7.0, 7.0, 7.0], [2, 2]),
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn uniform_all_from_b_when_p_is_zero() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 5);
         let a = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![7.0_f32, 7.0, 7.0, 7.0], [2, 2]),

--- a/crates/rlevo-evolution/src/ops/kernels/mod.rs
+++ b/crates/rlevo-evolution/src/ops/kernels/mod.rs
@@ -4,7 +4,7 @@
 //! only the pure-tensor operator baselines in [`crate::ops::selection`],
 //! [`crate::ops::crossover`], and [`crate::ops::mutation`]. Those
 //! compose from Burn tensor primitives and run on every backend Burn
-//! supports (ndarray, wgpu, …) with no extra work. The `custom-kernels`
+//! supports (flex, wgpu, …) with no extra work. The `custom-kernels`
 //! Cargo feature exists so downstream crates can pin the future ABI
 //! when kernels land.
 //!

--- a/crates/rlevo-evolution/src/ops/mutation.rs
+++ b/crates/rlevo-evolution/src/ops/mutation.rs
@@ -14,7 +14,7 @@ use burn::tensor::{backend::Backend, Distribution, Int, Tensor};
 pub fn gaussian_mutation<B: Backend>(
     population: Tensor<B, 2>,
     sigma: f32,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     let shape = population.shape();
     let noise = Tensor::<B, 2>::random(shape, Distribution::Normal(0.0, 1.0), device);
@@ -35,11 +35,10 @@ pub fn gaussian_mutation<B: Backend>(
 pub fn gaussian_mutation_per_row<B: Backend>(
     population: Tensor<B, 2>,
     sigmas: Tensor<B, 1>,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     let shape = population.shape();
-    let n = shape.dims[0];
-    let d = shape.dims[1];
+    let [n, d] = population.dims();
     let noise = Tensor::<B, 2>::random(shape, Distribution::Normal(0.0, 1.0), device);
     let sigmas_2d = sigmas.reshape([n, 1]).expand([n, d]);
     population + noise * sigmas_2d
@@ -55,7 +54,7 @@ pub fn uniform_reset<B: Backend>(
     lo: f32,
     hi: f32,
     p: f32,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     let shape = population.shape();
     let noise =
@@ -75,7 +74,7 @@ pub fn uniform_reset<B: Backend>(
 pub fn bit_flip_mutation<B: Backend>(
     population: Tensor<B, 2, Int>,
     p: f32,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2, Int> {
     let shape = population.shape();
     let coin = Tensor::<B, 2>::random(shape.clone(), Distribution::Uniform(0.0, 1.0), device);
@@ -89,17 +88,17 @@ pub fn bit_flip_mutation<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
-    use burn::backend::ndarray::NdArrayDevice;
+    use burn::backend::Flex;
+    use burn::backend::flex::FlexDevice;
     #[allow(unused_imports)]
     use burn::tensor::backend::Backend as _;
     use burn::tensor::TensorData;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     #[test]
     fn gaussian_with_zero_sigma_is_identity() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 3);
         let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![1.0_f32, 2.0, 3.0, 4.0], [2, 2]),
@@ -115,19 +114,19 @@ mod tests {
 
     #[test]
     fn gaussian_preserves_shape() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 3);
         let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![0.0_f32; 12], [3, 4]),
             &device,
         );
         let out = gaussian_mutation(input, 1.0, &device);
-        assert_eq!(out.shape().dims, vec![3, 4]);
+        assert_eq!(out.dims(), [3, 4]);
     }
 
     #[test]
     fn per_row_applies_distinct_sigmas() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 4);
         let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![0.0_f32; 4], [2, 2]),
@@ -146,7 +145,7 @@ mod tests {
 
     #[test]
     fn uniform_reset_with_p_zero_is_identity() {
-        let device: NdArrayDevice = Default::default();
+        let device: FlexDevice = Default::default();
         TestBackend::seed(&device, 9);
         let input = Tensor::<TestBackend, 2>::from_data(
             TensorData::new(vec![3.0_f32, 4.0, 5.0, 6.0], [2, 2]),

--- a/crates/rlevo-evolution/src/ops/replacement.rs
+++ b/crates/rlevo-evolution/src/ops/replacement.rs
@@ -38,7 +38,7 @@ pub fn elitist<B: Backend>(
     offspring_pop: Tensor<B, 2>,
     offspring_fitness: &[f32],
     k: usize,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> (Tensor<B, 2>, Vec<f32>) {
     let pop_size = current_fitness.len();
     assert!(k <= pop_size, "elite count must be <= population size");
@@ -86,7 +86,7 @@ pub fn mu_plus_lambda<B: Backend>(
     offspring: Tensor<B, 2>,
     offspring_fitness: &[f32],
     mu: usize,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> (Tensor<B, 2>, Vec<f32>) {
     let combined = Tensor::cat(vec![parents, offspring], 0);
     let combined_fitness: Vec<f32> = parent_fitness
@@ -117,7 +117,7 @@ pub fn mu_comma_lambda<B: Backend>(
     offspring: Tensor<B, 2>,
     offspring_fitness: &[f32],
     mu: usize,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> (Tensor<B, 2>, Vec<f32>) {
     assert!(
         mu <= offspring_fitness.len(),
@@ -138,8 +138,8 @@ pub fn mu_comma_lambda<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
-    type TestBackend = NdArray;
+    use burn::backend::Flex;
+    type TestBackend = Flex;
 
     #[test]
     fn generational_discards_current() {
@@ -207,7 +207,7 @@ mod tests {
             2,
             &device,
         );
-        assert_eq!(next.shape().dims, vec![2, 2]);
+        assert_eq!(next.dims(), [2, 2]);
         let mut fs = f;
         fs.sort_by(|a, b| a.partial_cmp(b).unwrap());
         approx::assert_relative_eq!(fs[0], 1.0, epsilon = 1e-6);

--- a/crates/rlevo-evolution/src/ops/selection.rs
+++ b/crates/rlevo-evolution/src/ops/selection.rs
@@ -29,7 +29,7 @@ pub fn tournament_indices_host(
     tournament_size: usize,
     n_winners: usize,
     rng: &mut dyn Rng,
-) -> Vec<i64> {
+) -> Vec<i32> {
     assert!(!fitness.is_empty(), "fitness must be non-empty");
     assert!(tournament_size >= 2, "tournament size must be >= 2");
     let pop_size = fitness.len();
@@ -44,8 +44,8 @@ pub fn tournament_indices_host(
                 best_idx = idx;
             }
         }
-        #[allow(clippy::cast_possible_wrap)]
-        winners.push(best_idx as i64);
+        #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+        winners.push(best_idx as i32);
     }
     winners
 }
@@ -66,7 +66,7 @@ pub fn tournament_select<B: Backend>(
     tournament_size: usize,
     n_winners: usize,
     rng: &mut dyn Rng,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     let winners = tournament_indices_host(fitness, tournament_size, n_winners, rng);
     let indices = Tensor::<B, 1, Int>::from_data(TensorData::new(winners, [n_winners]), device);
@@ -80,17 +80,17 @@ pub fn tournament_select<B: Backend>(
 ///
 /// Panics if `top_k > fitness.len()` or `fitness.is_empty()`.
 #[must_use]
-pub fn truncation_indices_host(fitness: &[f32], top_k: usize) -> Vec<i64> {
+pub fn truncation_indices_host(fitness: &[f32], top_k: usize) -> Vec<i32> {
     assert!(!fitness.is_empty(), "fitness must be non-empty");
     assert!(top_k <= fitness.len(), "top_k must be <= population size");
     let mut indexed: Vec<(usize, f32)> = fitness.iter().copied().enumerate().collect();
     indexed
         .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-    #[allow(clippy::cast_possible_wrap)]
+    #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
     indexed
         .into_iter()
         .take(top_k)
-        .map(|(i, _)| i as i64)
+        .map(|(i, _)| i as i32)
         .collect()
 }
 
@@ -105,7 +105,7 @@ pub fn truncation_select<B: Backend>(
     population: &Tensor<B, 2>,
     fitness: &[f32],
     top_k: usize,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
     let winners = truncation_indices_host(fitness, top_k);
     let indices = Tensor::<B, 1, Int>::from_data(TensorData::new(winners, [top_k]), device);
@@ -115,11 +115,11 @@ pub fn truncation_select<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     #[test]
     fn tournament_prefers_better_fitness_in_expectation() {
@@ -155,6 +155,6 @@ mod tests {
         let fitness = [10.0_f32, 0.0, 10.0];
         let mut rng = StdRng::seed_from_u64(2);
         let parents = tournament_select(&pop, &fitness, 2, 4, &mut rng, &device);
-        assert_eq!(parents.shape().dims, vec![4, 2]);
+        assert_eq!(parents.dims(), [4, 2]);
     }
 }

--- a/crates/rlevo-evolution/src/population.rs
+++ b/crates/rlevo-evolution/src/population.rs
@@ -6,7 +6,7 @@
 //!
 //! The wrapper exists so operators and strategies have a single shape
 //! contract to validate against (they check `pop_size` and `genome_dim`
-//! rather than repeatedly interrogating `tensor.shape().dims`).
+//! rather than repeatedly interrogating `tensor.dims()`).
 
 use std::marker::PhantomData;
 
@@ -59,7 +59,7 @@ impl<B: Backend> Population<B, Real> {
     /// Panics if the tensor is not rank 2.
     #[must_use]
     pub fn new_real(tensor: Tensor<B, 2>) -> Self {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         assert_eq!(dims.len(), 2, "population tensor must be rank 2");
         Self {
             pop_size: dims[0],
@@ -102,7 +102,7 @@ impl<B: Backend> Population<B, Binary> {
     /// Panics if the tensor is not rank 2.
     #[must_use]
     pub fn new_binary(tensor: Tensor<B, 2, Int>) -> Self {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         assert_eq!(dims.len(), 2, "population tensor must be rank 2");
         Self {
             pop_size: dims[0],
@@ -134,7 +134,7 @@ impl<B: Backend> Population<B, Integer> {
     /// Panics if the tensor is not rank 2.
     #[must_use]
     pub fn new_integer(tensor: Tensor<B, 2, Int>) -> Self {
-        let dims = tensor.shape().dims;
+        let dims = tensor.dims();
         assert_eq!(dims.len(), 2, "population tensor must be rank 2");
         Self {
             pop_size: dims[0],
@@ -161,9 +161,9 @@ impl<B: Backend> Population<B, Integer> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     #[test]
     fn real_population_reports_shape() {
@@ -173,7 +173,7 @@ mod tests {
         let pop = Population::<TestBackend, Real>::new_real(tensor);
         assert_eq!(pop.pop_size(), 2);
         assert_eq!(pop.genome_dim(), 2);
-        assert_eq!(pop.tensor().shape().dims, vec![2, 2]);
+        assert_eq!(pop.tensor().dims(), [2, 2]);
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/shaping.rs
+++ b/crates/rlevo-evolution/src/shaping.rs
@@ -17,7 +17,7 @@ use burn::tensor::{backend::Backend, Tensor};
 #[must_use]
 pub fn z_score<B: Backend>(fitness: Tensor<B, 1>) -> Tensor<B, 1> {
     let mean = fitness.clone().mean().into_scalar().elem::<f32>();
-    let n = fitness.shape().dims[0];
+    let n = fitness.dims()[0];
     #[allow(clippy::cast_precision_loss)]
     let n_f = n.max(1) as f32;
     let centered = fitness - mean;
@@ -42,7 +42,7 @@ pub fn z_score<B: Backend>(fitness: Tensor<B, 1>) -> Tensor<B, 1> {
 /// Panics if `fitness`'s data cannot be read as `f32` (e.g. an integer
 /// backend tensor was passed in).
 #[must_use]
-pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &B::Device) -> Tensor<B, 1> {
+pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
     let data = fitness
         .into_data()
         .into_vec::<f32>()
@@ -68,8 +68,8 @@ pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &B::Device) -> T
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
-    type TestBackend = NdArray;
+    use burn::backend::Flex;
+    type TestBackend = Flex;
 
     #[test]
     #[allow(clippy::cast_precision_loss)]

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -52,17 +52,17 @@ use crate::fitness::BatchFitnessFn;
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_evolution::algorithms::ga::{GaConfig, GeneticAlgorithm};
 /// use rlevo_evolution::Strategy;
 /// use rand::{rngs::StdRng, SeedableRng};
 ///
 /// let device = Default::default();
-/// let strategy = GeneticAlgorithm::<NdArray>::new();
+/// let strategy = GeneticAlgorithm::<Flex>::new();
 /// let params = GaConfig::default_for(64, 10);
 /// let mut rng = StdRng::seed_from_u64(0);
 /// let state = strategy.init(&params, &mut rng, &device);
-/// assert_eq!(state.population.shape().dims, vec![64, 10]);
+/// assert_eq!(state.population.dims(), [64, 10]);
 /// ```
 ///
 /// # Type Parameters
@@ -94,7 +94,7 @@ pub trait Strategy<B: Backend>: Send + Sync {
     ///
     /// Samples the initial population, primes adaptive quantities, and
     /// sets the generation counter to zero.
-    fn init(&self, params: &Self::Params, rng: &mut dyn Rng, device: &B::Device) -> Self::State;
+    fn init(&self, params: &Self::Params, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self::State;
 
     /// Propose the next population.
     ///
@@ -108,7 +108,7 @@ pub trait Strategy<B: Backend>: Send + Sync {
         params: &Self::Params,
         state: &Self::State,
         rng: &mut dyn Rng,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Self::Genome, Self::State);
 
     /// Consume fitness values and produce the next state.
@@ -190,7 +190,7 @@ impl StrategyMetrics {
 /// # Example
 ///
 /// ```no_run
-/// use burn::backend::NdArray;
+/// use burn::backend::Flex;
 /// use rlevo_core::fitness::FitnessEvaluable;
 /// use rlevo_core::evaluation::BenchEnv;
 /// use rlevo_evolution::algorithms::ga::{GaConfig, GeneticAlgorithm};
@@ -208,8 +208,8 @@ impl StrategyMetrics {
 /// }
 ///
 /// let device = Default::default();
-/// let mut harness = EvolutionaryHarness::<NdArray, _, _>::new(
-///     GeneticAlgorithm::<NdArray>::new(),
+/// let mut harness = EvolutionaryHarness::<Flex, _, _>::new(
+///     GeneticAlgorithm::<Flex>::new(),
 ///     GaConfig::default_for(32, 5),
 ///     FromFitnessEvaluable::new(SphereFit, Sphere),
 ///     0, device, 100,
@@ -230,7 +230,7 @@ impl StrategyMetrics {
 /// # Determinism and parallel execution
 ///
 /// Burn backends seed their tensor RNG through process-global state —
-/// the `ndarray` backend uses a `Mutex<Option<NdArrayRng>>`, the
+/// the `ndarray` backend uses a `Mutex<Option<FlexRng>>`, the
 /// `wgpu` backend a per-device seeded stream. When multiple harness
 /// instances run in parallel threads (e.g.
 /// `Evaluator::run_suite` with the default rayon pool), their
@@ -413,9 +413,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
-    type TestBackend = NdArray;
+    type TestBackend = Flex;
 
     /// Trivial strategy for unit-testing the harness plumbing: it
     /// ignores `ask`/`tell` semantics and always reports the same best
@@ -444,7 +444,7 @@ mod tests {
             &self,
             params: &Params,
             _: &mut dyn Rng,
-            device: &<TestBackend as Backend>::Device,
+            device: &<TestBackend as burn::tensor::backend::BackendTypes>::Device,
         ) -> State {
             let _ = device;
             let _ = params;
@@ -459,7 +459,7 @@ mod tests {
             params: &Params,
             state: &State,
             _: &mut dyn Rng,
-            device: &<TestBackend as Backend>::Device,
+            device: &<TestBackend as burn::tensor::backend::BackendTypes>::Device,
         ) -> (Tensor<TestBackend, 2>, State) {
             let data = TensorData::new(
                 vec![0.0f32; params.pop_size * params.dim],
@@ -495,9 +495,9 @@ mod tests {
         fn evaluate_batch(
             &mut self,
             population: &Tensor<B, 2>,
-            device: &B::Device,
+            device: &<B as burn::tensor::backend::BackendTypes>::Device,
         ) -> Tensor<B, 1> {
-            let n = population.shape().dims[0];
+            let n = population.dims()[0];
             let data = TensorData::new(vec![42.0f32; n], [n]);
             Tensor::<B, 1>::from_data(data, device)
         }

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -230,7 +230,7 @@ impl StrategyMetrics {
 /// # Determinism and parallel execution
 ///
 /// Burn backends seed their tensor RNG through process-global state —
-/// the `ndarray` backend uses a `Mutex<Option<FlexRng>>`, the
+/// the `flex` backend uses a `Mutex<Option<FlexRng>>`, the
 /// `wgpu` backend a per-device seeded stream. When multiple harness
 /// instances run in parallel threads (e.g.
 /// `Evaluator::run_suite` with the default rayon pool), their

--- a/crates/rlevo-evolution/tests/backend_parity.rs
+++ b/crates/rlevo-evolution/tests/backend_parity.rs
@@ -3,7 +3,7 @@
 //! A `1e-4` relative-tolerance match of `best_fitness_ever` between
 //! ndarray and wgpu on Sphere-D10 is untestable in practice: the two
 //! backends use independent RNG streams (ndarray = splitmix-seeded
-//! `NdArrayRng`; wgpu = per-device compute-pipeline seeded stream) so
+//! `FlexRng`; wgpu = per-device compute-pipeline seeded stream) so
 //! even when the same host seed is supplied, tensor `random()` calls
 //! produce different bytes. The strategies therefore take different
 //! trajectories and end at different points — both small, neither a
@@ -28,12 +28,12 @@
 //! # Single test, serial execution
 //!
 //! Both backends seed their internal RNG through process-global state
-//! (`Mutex<Option<NdArrayRng>>` for ndarray; per-device seed for
+//! (`Mutex<Option<FlexRng>>` for ndarray; per-device seed for
 //! wgpu). To keep the two runs comparable, this file contains exactly
 //! one `#[test]` function so nothing else in the test binary runs
 //! concurrently.
 
-use burn::backend::{NdArray, Wgpu};
+use burn::backend::{Flex, Wgpu};
 use rlevo_core::fitness::FitnessEvaluable;
 use rlevo_evolution::algorithms::ga::{
     GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
@@ -125,8 +125,8 @@ fn wgpu_matches_ndarray_on_sphere_d10() {
 
     // Run ndarray first so the host seed state is deterministic; wgpu
     // has its own per-device stream and doesn't disturb it.
-    let ndarray_ga = run_sphere_ga::<NdArray>(SEED, GENS, Default::default());
-    let ndarray_pso = run_sphere_pso::<NdArray>(SEED, GENS, Default::default());
+    let ndarray_ga = run_sphere_ga::<Flex>(SEED, GENS, Default::default());
+    let ndarray_pso = run_sphere_pso::<Flex>(SEED, GENS, Default::default());
 
     // Initializing a wgpu device can fail on CI machines without a GPU
     // or without system-level wgpu support. Treat initialization

--- a/crates/rlevo-evolution/tests/backend_parity.rs
+++ b/crates/rlevo-evolution/tests/backend_parity.rs
@@ -1,8 +1,8 @@
 //! Cross-backend parity for the pure-tensor operator baselines.
 //!
 //! A `1e-4` relative-tolerance match of `best_fitness_ever` between
-//! ndarray and wgpu on Sphere-D10 is untestable in practice: the two
-//! backends use independent RNG streams (ndarray = splitmix-seeded
+//! flex and wgpu on Sphere-D10 is untestable in practice: the two
+//! backends use independent RNG streams (flex = splitmix-seeded
 //! `FlexRng`; wgpu = per-device compute-pipeline seeded stream) so
 //! even when the same host seed is supplied, tensor `random()` calls
 //! produce different bytes. The strategies therefore take different
@@ -21,14 +21,14 @@
 //!
 //! Even when the RNG disparity is set aside, the wgpu backend does not
 //! guarantee bit-identical reductions because workgroup ordering is
-//! implementation-dependent. The ndarray backend is still expected to
+//! implementation-dependent. The Flex backend is still expected to
 //! be bit-deterministic; that contract is enforced by
 //! `tests/determinism.rs`.
 //!
 //! # Single test, serial execution
 //!
 //! Both backends seed their internal RNG through process-global state
-//! (`Mutex<Option<FlexRng>>` for ndarray; per-device seed for
+//! (`Mutex<Option<FlexRng>>` for flex; per-device seed for
 //! wgpu). To keep the two runs comparable, this file contains exactly
 //! one `#[test]` function so nothing else in the test binary runs
 //! concurrently.
@@ -119,19 +119,19 @@ where
 }
 
 #[test]
-fn wgpu_matches_ndarray_on_sphere_d10() {
+fn wgpu_matches_flex_on_sphere_d10() {
     const SEED: u64 = 999;
     const GENS: usize = 400;
 
-    // Run ndarray first so the host seed state is deterministic; wgpu
+    // Run flex first so the host seed state is deterministic; wgpu
     // has its own per-device stream and doesn't disturb it.
-    let ndarray_ga = run_sphere_ga::<Flex>(SEED, GENS, Default::default());
-    let ndarray_pso = run_sphere_pso::<Flex>(SEED, GENS, Default::default());
+    let flex_ga = run_sphere_ga::<Flex>(SEED, GENS, Default::default());
+    let flex_pso = run_sphere_pso::<Flex>(SEED, GENS, Default::default());
 
     // Initializing a wgpu device can fail on CI machines without a GPU
     // or without system-level wgpu support. Treat initialization
     // failure as "skip" rather than an outright test failure — the
-    // ndarray run still validates the operators, and the parity
+    // Flex run still validates the operators, and the parity
     // assertion is only meaningful when the device actually exists.
     let wgpu_device: burn::backend::wgpu::WgpuDevice = Default::default();
     let wgpu_ga = run_sphere_ga::<Wgpu>(SEED, GENS, wgpu_device.clone());
@@ -143,12 +143,12 @@ fn wgpu_matches_ndarray_on_sphere_d10() {
     // x ~ U(-5.12, 5.12) is ~87), so any final value under 1.0
     // proves the operator chain works on both backends.
     assert!(
-        ndarray_ga.is_finite() && wgpu_ga.is_finite(),
-        "non-finite GA result: ndarray={ndarray_ga}, wgpu={wgpu_ga}",
+        flex_ga.is_finite() && wgpu_ga.is_finite(),
+        "non-finite GA result: flex={flex_ga}, wgpu={wgpu_ga}",
     );
     assert!(
-        ndarray_ga < 1.0,
-        "ndarray GA did not converge on Sphere-D10: {ndarray_ga}",
+        flex_ga < 1.0,
+        "Flex GA did not converge on Sphere-D10: {flex_ga}",
     );
     assert!(
         wgpu_ga < 1.0,
@@ -162,12 +162,12 @@ fn wgpu_matches_ndarray_on_sphere_d10() {
     // because PSO with the default inertia schedule converges faster
     // than BLX-α GA on Sphere.
     assert!(
-        ndarray_pso.is_finite() && wgpu_pso.is_finite(),
-        "non-finite PSO result: ndarray={ndarray_pso}, wgpu={wgpu_pso}",
+        flex_pso.is_finite() && wgpu_pso.is_finite(),
+        "non-finite PSO result: flex={flex_pso}, wgpu={wgpu_pso}",
     );
     assert!(
-        ndarray_pso < 1e-2,
-        "ndarray PSO did not converge on Sphere-D10: {ndarray_pso}",
+        flex_pso < 1e-2,
+        "Flex PSO did not converge on Sphere-D10: {flex_pso}",
     );
     assert!(
         wgpu_pso < 1e-2,

--- a/crates/rlevo-evolution/tests/determinism.rs
+++ b/crates/rlevo-evolution/tests/determinism.rs
@@ -6,14 +6,14 @@
 //! # Why this file runs a single test
 //!
 //! The Burn ndarray backend seeds its RNG through a process-wide
-//! `Mutex<Option<NdArrayRng>>`. Multiple tests that race on that mutex
+//! `Mutex<Option<FlexRng>>`. Multiple tests that race on that mutex
 //! will interleave `Tensor::random` draws and destroy bit-equality. This
 //! file therefore contains exactly one `#[test]` function so the cargo
 //! runner cannot execute anything in parallel with it — within the
 //! single test body, the two runs are strictly sequential and compare
 //! byte-for-byte.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use rlevo_core::fitness::FitnessEvaluable;
 
 use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrategy};
@@ -32,7 +32,7 @@ use rlevo_evolution::algorithms::metaheuristic::woa::{WhaleOptimization, WoaConf
 use rlevo_evolution::fitness::{BatchFitnessFn, FromFitnessEvaluable};
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
-type B = NdArray;
+type B = Flex;
 
 struct Sphere;
 struct SphereFit;

--- a/crates/rlevo-evolution/tests/determinism.rs
+++ b/crates/rlevo-evolution/tests/determinism.rs
@@ -1,11 +1,11 @@
 //! Determinism integration test.
 //!
-//! On the ndarray backend, running a strategy twice with the same
+//! On the Flex backend, running a strategy twice with the same
 //! `base_seed` must produce a bit-identical fitness trajectory.
 //!
 //! # Why this file runs a single test
 //!
-//! The Burn ndarray backend seeds its RNG through a process-wide
+//! The Burn Flex backend seeds its RNG through a process-wide
 //! `Mutex<Option<FlexRng>>`. Multiple tests that race on that mutex
 //! will interleave `Tensor::random` draws and destroy bit-equality. This
 //! file therefore contains exactly one `#[test]` function so the cargo

--- a/crates/rlevo-reinforcement-learning/benches/c51_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/c51_bench.rs
@@ -4,21 +4,20 @@
 //! a regression that turns the linear scatter-add into a quadratic broadcast
 //! is easy to spot in the output.
 
-use burn::backend::NdArray;
-use burn::tensor::backend::Backend;
+use burn::backend::Flex;
 use burn::tensor::{Tensor, TensorData};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use rlevo_reinforcement_learning::algorithms::c51::projection::project_distribution;
 
-type Be = NdArray;
+type Be = Flex;
 
 fn make_support(
     v_min: f32,
     v_max: f32,
     n: usize,
-    device: &<Be as Backend>::Device,
+    device: &<Be as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<Be, 1> {
     let delta = (v_max - v_min) / (n as f32 - 1.0);
     let data: Vec<f32> = (0..n).map(|i| v_min + (i as f32) * delta).collect();
@@ -26,7 +25,7 @@ fn make_support(
 }
 
 fn bench_projection(c: &mut Criterion) {
-    let device: <Be as Backend>::Device = Default::default();
+    let device: <Be as burn::tensor::backend::BackendTypes>::Device = Default::default();
     let v_min = -10.0_f32;
     let v_max = 10.0_f32;
 

--- a/crates/rlevo-reinforcement-learning/benches/ddpg_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/ddpg_bench.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -41,7 +41,7 @@ impl<B: Backend> ActorMlp<B> {
         hidden: usize,
         action_dim: usize,
         scale: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -84,7 +84,7 @@ struct CriticMlp<B: Backend> {
 }
 
 impl<B: Backend> CriticMlp<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -159,7 +159,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: M, target: M, tau: f32) -> M 
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent =
     DdpgAgent<Be, ActorMlp<Be>, CriticMlp<Be>, PendulumObservation, PendulumAction, 1, 2, 1, 2>;
 

--- a/crates/rlevo-reinforcement-learning/benches/dqn_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/dqn_bench.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -36,7 +36,7 @@ struct DqnMlp<B: Backend> {
 }
 
 impl<B: Backend> DqnMlp<B> {
-    fn new(device: &B::Device) -> Self {
+    fn new(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -109,7 +109,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: M, target: M, tau: f32) -> M 
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent = DqnAgent<Be, DqnMlp<Be>, CartPoleObservation, CartPoleAction, 1, 2>;
 
 fn build_agent() -> Agent {

--- a/crates/rlevo-reinforcement-learning/benches/ppg_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/ppg_bench.rs
@@ -8,18 +8,18 @@
 //! - `aux_value_loss_path` — the aux-phase value-target MSE (same kernel as
 //!   PPO's unclipped value loss, benchmarked here at aux-phase-shaped sizes).
 
-use burn::backend::NdArray;
-use burn::tensor::backend::Backend;
+use burn::backend::Flex;
 use burn::tensor::{Tensor, TensorData};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use rlevo_reinforcement_learning::algorithms::ppg::losses::policy_kl_categorical;
 use rlevo_reinforcement_learning::algorithms::ppo::losses::unclipped_value_loss;
 
-type B = NdArray;
+type B = Flex;
 
 fn bench_policy_kl_categorical(c: &mut Criterion) {
     let mut group = c.benchmark_group("ppg_policy_kl_categorical");
-    let device: <B as Backend>::Device = Default::default();
+    let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
     for &(batch, num_actions) in &[(64_usize, 2_usize), (256, 2), (1024, 2), (256, 18)] {
         let id = format!("batch{batch}_actions{num_actions}");
         group.bench_with_input(
@@ -42,7 +42,7 @@ fn bench_policy_kl_categorical(c: &mut Criterion) {
 
 fn bench_aux_value_loss(c: &mut Criterion) {
     let mut group = c.benchmark_group("ppg_aux_value_loss_mse");
-    let device: <B as Backend>::Device = Default::default();
+    let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
     for &n in &[256_usize, 1024, 4096] {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             let v: Tensor<B, 1> =

--- a/crates/rlevo-reinforcement-learning/benches/ppo_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/ppo_bench.rs
@@ -2,15 +2,16 @@
 //! per-iteration throughput: GAE, advantage normalisation, and the
 //! clipped surrogate objective.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use burn::tensor::{Tensor, TensorData};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use rlevo_reinforcement_learning::algorithms::ppo::losses::{
     clipped_surrogate, normalize_advantages,
 };
 use rlevo_reinforcement_learning::algorithms::ppo::rollout::compute_gae;
 
-type B = NdArray;
+type B = Flex;
 
 fn synthetic_trajectory(n: usize) -> (Vec<f32>, Vec<f32>, Vec<bool>, Vec<bool>) {
     let mut rewards = Vec::with_capacity(n);
@@ -49,7 +50,7 @@ fn bench_compute_gae(c: &mut Criterion) {
 
 fn bench_advantage_norm(c: &mut Criterion) {
     let mut group = c.benchmark_group("ppo_advantage_norm");
-    let device: <B as burn::tensor::backend::Backend>::Device = Default::default();
+    let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
     for &n in &[64_usize, 256, 1024] {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             let data: Vec<f32> = (0..n).map(|i| (i as f32) * 0.01 - 5.0).collect();
@@ -65,7 +66,7 @@ fn bench_advantage_norm(c: &mut Criterion) {
 
 fn bench_clipped_surrogate(c: &mut Criterion) {
     let mut group = c.benchmark_group("ppo_clipped_surrogate");
-    let device: <B as burn::tensor::backend::Backend>::Device = Default::default();
+    let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
     for &n in &[64_usize, 256, 1024] {
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
             let new_lp: Tensor<B, 1> =

--- a/crates/rlevo-reinforcement-learning/benches/qrdqn_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/qrdqn_bench.rs
@@ -4,22 +4,21 @@
 //! regression that turns the `(B, N, N)` broadcast into a `(B, B, N, N)` or
 //! otherwise super-linear blow-up is easy to spot.
 
-use burn::backend::NdArray;
-use burn::tensor::backend::Backend;
+use burn::backend::Flex;
 use burn::tensor::{Tensor, TensorData};
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use rlevo_reinforcement_learning::algorithms::qrdqn::quantile_loss::quantile_huber_loss;
 
-type Be = NdArray;
+type Be = Flex;
 
-fn make_taus(n: usize, device: &<Be as Backend>::Device) -> Tensor<Be, 1> {
+fn make_taus(n: usize, device: &<Be as burn::tensor::backend::BackendTypes>::Device) -> Tensor<Be, 1> {
     let data: Vec<f32> = (0..n).map(|i| (i as f32 + 0.5) / n as f32).collect();
     Tensor::from_data(TensorData::new(data, vec![n]), device)
 }
 
-fn make_quantile_batch(batch: usize, n: usize, device: &<Be as Backend>::Device) -> Tensor<Be, 2> {
+fn make_quantile_batch(batch: usize, n: usize, device: &<Be as burn::tensor::backend::BackendTypes>::Device) -> Tensor<Be, 2> {
     // Deterministic but non-trivial payload: a saw-tooth across the row.
     let data: Vec<f32> = (0..batch * n)
         .map(|i| ((i % n) as f32) * 0.1 - ((i / n) as f32) * 0.01)
@@ -28,7 +27,7 @@ fn make_quantile_batch(batch: usize, n: usize, device: &<Be as Backend>::Device)
 }
 
 fn bench_quantile_huber_loss(c: &mut Criterion) {
-    let device: <Be as Backend>::Device = Default::default();
+    let device: <Be as burn::tensor::backend::BackendTypes>::Device = Default::default();
 
     for &num_quantiles in &[51_usize, 101, 200] {
         for &batch in &[32_usize, 128] {

--- a/crates/rlevo-reinforcement-learning/benches/sac_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/sac_bench.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, softplus, tanh};
@@ -45,7 +45,7 @@ impl<B: Backend> StochasticActor<B> {
         hidden: usize,
         action_dim: usize,
         scale: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -118,7 +118,7 @@ struct CriticMlp<B: Backend> {
 }
 
 impl<B: Backend> CriticMlp<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -193,7 +193,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: M, target: M, tau: f32) -> M 
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent = SacAgent<
     Be,
     StochasticActor<Be>,

--- a/crates/rlevo-reinforcement-learning/benches/td3_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/td3_bench.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -40,7 +40,7 @@ impl<B: Backend> ActorMlp<B> {
         hidden: usize,
         action_dim: usize,
         scale: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -83,7 +83,7 @@ struct CriticMlp<B: Backend> {
 }
 
 impl<B: Backend> CriticMlp<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -158,7 +158,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: M, target: M, tau: f32) -> M 
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent =
     Td3Agent<Be, ActorMlp<Be>, CriticMlp<Be>, PendulumObservation, PendulumAction, 1, 2, 1, 2>;
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
@@ -209,7 +209,7 @@ where
     /// allocating on demand over storing a cached copy per backend flavour.
     fn build_support<BK: burn::tensor::backend::Backend>(
         &self,
-        device: &BK::Device,
+        device: &<BK as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<BK, 1> {
         let n = self.config.num_atoms;
         let delta = self.config.delta_z();

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/loss.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/loss.rs
@@ -33,14 +33,14 @@ pub fn categorical_cross_entropy<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
     use burn::tensor::activation;
 
-    type B = NdArray;
+    type B = Flex;
 
     fn tensor_2d(data: Vec<f32>, rows: usize, cols: usize) -> Tensor<B, 2> {
-        let device = <B as Backend>::Device::default();
+        let device = <B as burn::tensor::backend::BackendTypes>::Device::default();
         Tensor::from_data(TensorData::new(data, vec![rows, cols]), &device)
     }
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/projection.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/projection.rs
@@ -95,16 +95,16 @@ pub fn project_distribution<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
 
-    type B = NdArray;
+    type B = Flex;
 
     fn make_support(
         v_min: f32,
         v_max: f32,
         n: usize,
-        device: &<B as Backend>::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 1> {
         let delta = (v_max - v_min) / (n as f32 - 1.0);
         let data: Vec<f32> = (0..n).map(|i| v_min + (i as f32) * delta).collect();
@@ -124,7 +124,7 @@ mod tests {
         // With reward = 0, γ = 1, done = 0 and a support that passes through
         // every atom, each atom maps to itself — the projection is the
         // identity on the input probabilities.
-        let device: <B as Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let next_probs = Tensor::<B, 2>::from_data(
             TensorData::new(vec![0.5_f32, 0.3, 0.2], vec![1, 3]),
             &device,
@@ -146,7 +146,7 @@ mod tests {
         //   support = [-1, 0, 1], reward = 0.5, done = 1 → Tz ≡ 0.5 ∀ z_i
         //   b = 1.5 → mass evenly split between atoms 1 and 2, independent of
         //   next_probs.
-        let device: <B as Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let next_probs = Tensor::<B, 2>::from_data(
             TensorData::new(vec![0.1_f32, 0.4, 0.5], vec![1, 3]),
             &device,
@@ -174,7 +174,7 @@ mod tests {
     fn projection_clamps_above_support() {
         // reward ≫ v_max ⇒ Tz clamps at v_max for every atom ⇒ all mass at
         // the top atom.
-        let device: <B as Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let next_probs =
             Tensor::<B, 2>::from_data(TensorData::new(vec![1.0_f32 / 3.0; 3], vec![1, 3]), &device);
         let rewards = Tensor::<B, 1>::from_data(TensorData::new(vec![100.0_f32], vec![1]), &device);
@@ -192,7 +192,7 @@ mod tests {
     fn projection_preserves_total_mass() {
         // Arbitrary batch, random-ish probabilities normalised to 1: rows of
         // the projection should still sum to ≈1.
-        let device: <B as Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let batch = 4;
         let n = 5;
         let next_probs_raw: Vec<f32> = (0..batch * n).map(|i| 1.0 + (i as f32) * 0.1).collect();

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/aux_buffer.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/aux_buffer.rs
@@ -121,7 +121,7 @@ impl<B: Backend, O: Clone> AuxRolloutBuffer<B, O> {
     pub fn gather_minibatch<const DO: usize, const DB: usize>(
         &self,
         indices: &[usize],
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, DB>, Tensor<B, 1>)
     where
         O: Observation<DO> + TensorConvertible<DO, B>,
@@ -166,7 +166,7 @@ impl<B: Backend, O: Clone> AuxRolloutBuffer<B, O> {
 mod tests {
     use super::*;
     use rlevo_core::base::TensorConversionError;
-    type Be = burn::backend::NdArray;
+    type Be = burn::backend::Flex;
 
     #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
     struct TestObs([f32; 2]);
@@ -178,7 +178,7 @@ mod tests {
     }
 
     impl<Bk: burn::tensor::backend::Backend> TensorConvertible<1, Bk> for TestObs {
-        fn to_tensor(&self, device: &Bk::Device) -> Tensor<Bk, 1> {
+        fn to_tensor(&self, device: &<Bk as burn::tensor::backend::BackendTypes>::Device) -> Tensor<Bk, 1> {
             Tensor::from_floats(self.0, device)
         }
         fn from_tensor(_t: Tensor<Bk, 1>) -> Result<Self, TensorConversionError> {
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn gather_minibatch_shapes() {
-        let device: <Be as burn::tensor::backend::Backend>::Device = Default::default();
+        let device: <Be as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let mut buf: AuxRolloutBuffer<Be, TestObs> = AuxRolloutBuffer::new();
         push(&mut buf, 3);
         push(&mut buf, 3);
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn gather_minibatch_preserves_row_values() {
-        let device: <Be as burn::tensor::backend::Backend>::Device = Default::default();
+        let device: <Be as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let mut buf: AuxRolloutBuffer<Be, TestObs> = AuxRolloutBuffer::new();
         push(&mut buf, 3);
         let (_, r) = buf.gather_minibatch::<1, 2>(&[0, 1, 2], &device);

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/losses.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/losses.rs
@@ -34,13 +34,13 @@ pub fn policy_kl_categorical<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::{ElementConversion, TensorData};
 
-    type Be = NdArray;
+    type Be = Flex;
 
     fn t2(data: &[f32], rows: usize, cols: usize) -> Tensor<Be, 2> {
-        let device: <Be as Backend>::Device = Default::default();
+        let device: <Be as burn::tensor::backend::BackendTypes>::Device = Default::default();
         Tensor::<Be, 2>::from_data(TensorData::new(data.to_vec(), vec![rows, cols]), &device)
     }
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/policies/categorical.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/policies/categorical.rs
@@ -33,7 +33,7 @@ pub struct PpgCategoricalPolicyHeadConfig {
 
 impl PpgCategoricalPolicyHeadConfig {
     /// Constructs the module on `device` using Burn's default initializer.
-    pub fn init<B: Backend>(&self, device: &B::Device) -> PpgCategoricalPolicyHead<B> {
+    pub fn init<B: Backend>(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> PpgCategoricalPolicyHead<B> {
         PpgCategoricalPolicyHead {
             fc1: LinearConfig::new(self.obs_dim, self.hidden).init(device),
             fc2: LinearConfig::new(self.hidden, self.hidden).init(device),
@@ -158,7 +158,7 @@ impl<B: AutodiffBackend> PpoPolicy<B, 2> for PpgCategoricalPolicyHead<B> {
     fn action_tensor_from_flat(
         flat: &[f32],
         n_rows: usize,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self::ActionTensor {
         assert_eq!(
             flat.len(),
@@ -174,12 +174,12 @@ impl<B: AutodiffBackend> PpoPolicy<B, 2> for PpgCategoricalPolicyHead<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::{Autodiff, NdArray};
+    use burn::backend::{Autodiff, Flex};
     use burn::tensor::ElementConversion;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    type B = Autodiff<NdArray>;
+    type B = Autodiff<Flex>;
 
     fn head() -> PpgCategoricalPolicyHead<B> {
         let device = Default::default();
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn ppg_categorical_round_trips_action_rows() {
-        let device: <B as Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let a1d: Tensor<B, 1, Int> =
             Tensor::from_data(TensorData::new(vec![0_i64, 2, 1], vec![3]), &device);
         let a2d: Tensor<B, 2, Int> = a1d.unsqueeze_dim::<2>(1);

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/losses.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/losses.rs
@@ -117,10 +117,10 @@ fn max_elem<B: Backend>(a: Tensor<B, 1>, b: Tensor<B, 1>) -> Tensor<B, 1> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
 
-    type B = NdArray;
+    type B = Flex;
 
     fn t1(data: &[f32]) -> Tensor<B, 1> {
         let device = Default::default();

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/policies/categorical.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/policies/categorical.rs
@@ -3,7 +3,7 @@
 //! Two-layer MLP with `tanh` activations (matching CleanRL's discrete PPO
 //! default) followed by a softmax over `num_actions` logits. Sampling is
 //! done via **Gumbel-max on CPU** so the RNG is explicitly threaded and
-//! bitwise-reproducible under the ndarray backend.
+//! bitwise-reproducible under the Flex backend.
 
 use burn::module::Module;
 use burn::nn::{Linear, LinearConfig};
@@ -89,7 +89,7 @@ impl<B: AutodiffBackend> PpoPolicy<B, 2> for CategoricalPolicyHead<B> {
         let log_probs = log_softmax(logits.clone(), 1);
 
         // CPU-side Gumbel-max sampling for bitwise reproducibility under
-        // ndarray. We read the logits data (cheap clone: ref-counted in Burn),
+        // flex. We read the logits data (cheap clone: ref-counted in Burn),
         // add Gumbel(0,1) noise, argmax per row.
         let logits_data = logits.clone().into_data().convert::<f32>();
         let logits_slice = logits_data

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/policies/categorical.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/policies/categorical.rs
@@ -29,7 +29,7 @@ impl CategoricalPolicyHeadConfig {
     /// Constructs the module on `device` using Burn's default initializer.
     /// CleanRL's orthogonal-init detail is a deferred follow-up; users who
     /// want it can post-process the module via a `ModuleMapper`.
-    pub fn init<B: Backend>(&self, device: &B::Device) -> CategoricalPolicyHead<B> {
+    pub fn init<B: Backend>(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> CategoricalPolicyHead<B> {
         CategoricalPolicyHead {
             fc1: LinearConfig::new(self.obs_dim, self.hidden).init(device),
             fc2: LinearConfig::new(self.hidden, self.hidden).init(device),
@@ -154,7 +154,7 @@ impl<B: AutodiffBackend> PpoPolicy<B, 2> for CategoricalPolicyHead<B> {
     fn action_tensor_from_flat(
         flat: &[f32],
         n_rows: usize,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self::ActionTensor {
         assert_eq!(
             flat.len(),
@@ -184,12 +184,12 @@ pub fn discrete_action_from_row<const AD: usize, A: rlevo_core::action::Discrete
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::{Autodiff, NdArray};
+    use burn::backend::{Autodiff, Flex};
     use burn::tensor::ElementConversion;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    type B = Autodiff<NdArray>;
+    type B = Autodiff<Flex>;
 
     #[test]
     fn categorical_logprob_consistency() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/policies/gaussian.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/policies/gaussian.rs
@@ -47,7 +47,7 @@ pub struct TanhGaussianPolicyHeadConfig {
 
 impl TanhGaussianPolicyHeadConfig {
     /// Constructs the module on `device`.
-    pub fn init<B: Backend>(&self, device: &B::Device) -> TanhGaussianPolicyHead<B> {
+    pub fn init<B: Backend>(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> TanhGaussianPolicyHead<B> {
         let log_std_vec: Vec<f32> = vec![self.log_std_init; self.action_dim];
         let log_std: Tensor<B, 1> =
             Tensor::from_data(TensorData::new(log_std_vec, vec![self.action_dim]), device);
@@ -180,7 +180,7 @@ impl<B: AutodiffBackend> PpoPolicy<B, 2> for TanhGaussianPolicyHead<B> {
     fn action_tensor_from_flat(
         flat: &[f32],
         n_rows: usize,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self::ActionTensor {
         let action_dim = flat.len() / n_rows.max(1);
         Tensor::<B, 2>::from_data(
@@ -208,12 +208,12 @@ pub fn continuous_action_from_row<const AD: usize, A: rlevo_core::action::Contin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::{Autodiff, NdArray};
+    use burn::backend::{Autodiff, Flex};
     use burn::tensor::ElementConversion;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    type B = Autodiff<NdArray>;
+    type B = Autodiff<Flex>;
 
     #[test]
     fn gaussian_logprob_consistency_between_sample_and_evaluate() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_policy.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_policy.rs
@@ -93,7 +93,7 @@ pub trait PpoPolicy<B: AutodiffBackend, const DB: usize>: AutodiffModule<B> {
     fn action_tensor_from_flat(
         flat: &[f32],
         n_rows: usize,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self::ActionTensor;
 
     /// Transforms one action row from the buffer representation (the

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/rollout.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/rollout.rs
@@ -167,7 +167,7 @@ impl<B: Backend, O: Clone> RolloutBuffer<B, O> {
     }
 
     /// Builds a 1-D float tensor indexed by `indices`, on `device`.
-    pub fn gather_f32(&self, data: &[f32], indices: &[usize], device: &B::Device) -> Tensor<B, 1> {
+    pub fn gather_f32(&self, data: &[f32], indices: &[usize], device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         let gathered: Vec<f32> = indices.iter().map(|&i| data[i]).collect();
         let n = gathered.len();
         Tensor::<B, 1>::from_data(TensorData::new(gathered, vec![n]), device)
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn buffer_push_and_indices() {
-        type B = burn::backend::NdArray;
+        type B = burn::backend::Flex;
         let mut buf: RolloutBuffer<B, [f32; 2]> = RolloutBuffer::new(4, 1);
         buf.push_step([0.0, 0.0], &[0.0], 0.0, 0.0, 1.0, EpisodeStatus::Running);
         buf.push_step([1.0, 1.0], &[1.0], -0.1, 0.1, 1.0, EpisodeStatus::Running);
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn gather_action_flat_rows_concatenate() {
-        type B = burn::backend::NdArray;
+        type B = burn::backend::Flex;
         let mut buf: RolloutBuffer<B, [f32; 1]> = RolloutBuffer::new(4, 2);
         buf.push_step([0.0], &[1.0, 2.0], 0.0, 0.0, 0.0, EpisodeStatus::Running);
         buf.push_step([0.0], &[3.0, 4.0], 0.0, 0.0, 0.0, EpisodeStatus::Running);

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
@@ -86,7 +86,7 @@ pub struct QrDqnTrainingConfig {
 impl QrDqnTrainingConfig {
     /// Builds the quantile-midpoint tensor `[(i + 0.5) / N]_{i=0..N-1}` on
     /// the requested backend and device. Shape: `(num_quantiles,)`.
-    pub fn quantile_taus<B: Backend>(&self, device: &B::Device) -> Tensor<B, 1> {
+    pub fn quantile_taus<B: Backend>(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         let n = self.num_quantiles;
         let data: Vec<f32> = (0..n).map(|i| (i as f32 + 0.5) / n as f32).collect();
         Tensor::from_data(TensorData::new(data, vec![n]), device)
@@ -227,9 +227,9 @@ impl QrDqnTrainingConfigBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
 
-    type B = NdArray;
+    type B = Flex;
 
     #[test]
     fn defaults_are_200_quantiles_with_kappa_1() {
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn taus_midpoints_match_dabney_eq_9_for_n_4() {
         // N = 4 ⇒ τ_i = (i + 0.5) / 4 ⇒ {0.125, 0.375, 0.625, 0.875}.
-        let device: <B as Backend>::Device = Default::default();
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
         let cfg = QrDqnTrainingConfigBuilder::new().num_quantiles(4).build();
         let taus: Tensor<B, 1> = cfg.quantile_taus::<B>(&device);
         let v: Vec<f32> = taus.into_data().convert::<f32>().into_vec::<f32>().unwrap();

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/quantile_loss.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/quantile_loss.rs
@@ -73,19 +73,19 @@ pub fn quantile_huber_loss<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
 
-    type B = NdArray;
+    type B = Flex;
 
     fn tensor_1d(data: Vec<f32>) -> Tensor<B, 1> {
-        let device = <B as Backend>::Device::default();
+        let device = <B as burn::tensor::backend::BackendTypes>::Device::default();
         let n = data.len();
         Tensor::from_data(TensorData::new(data, vec![n]), &device)
     }
 
     fn tensor_2d(data: Vec<f32>, rows: usize, cols: usize) -> Tensor<B, 2> {
-        let device = <B as Backend>::Device::default();
+        let device = <B as burn::tensor::backend::BackendTypes>::Device::default();
         Tensor::from_data(TensorData::new(data, vec![rows, cols]), &device)
     }
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
@@ -673,7 +673,7 @@ where
 fn sample_noise<BB: Backend, R: Rng + ?Sized, const DAB: usize>(
     rows: usize,
     cols: usize,
-    device: &BB::Device,
+    device: &<BB as burn::tensor::backend::BackendTypes>::Device,
     rng: &mut R,
 ) -> Tensor<BB, DAB> {
     use rand_distr::{Distribution, StandardNormal};
@@ -689,9 +689,9 @@ fn sample_noise<BB: Backend, R: Rng + ?Sized, const DAB: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
 
-    type BI = NdArray;
+    type BI = Flex;
 
     #[test]
     fn metrics_performance_record_returns_reward_and_steps() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_policy.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_policy.rs
@@ -52,7 +52,7 @@ pub struct SquashedGaussianPolicyHeadConfig {
 
 impl SquashedGaussianPolicyHeadConfig {
     /// Constructs the module on `device`.
-    pub fn init<B: Backend>(&self, device: &B::Device) -> SquashedGaussianPolicyHead<B> {
+    pub fn init<B: Backend>(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> SquashedGaussianPolicyHead<B> {
         SquashedGaussianPolicyHead {
             fc1: LinearConfig::new(self.obs_dim, self.hidden).init(device),
             fc2: LinearConfig::new(self.hidden, self.hidden).init(device),
@@ -212,7 +212,7 @@ impl<B: AutodiffBackend> SquashedGaussianPolicy<B, 2, 2> for SquashedGaussianPol
 pub fn standard_normal_tensor<B: Backend, R: rand::Rng + ?Sized>(
     rows: usize,
     cols: usize,
-    device: &B::Device,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
     rng: &mut R,
 ) -> Tensor<B, 2> {
     use rand_distr::{Distribution, StandardNormal};
@@ -228,13 +228,13 @@ pub fn standard_normal_tensor<B: Backend, R: rand::Rng + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use burn::backend::{Autodiff, NdArray};
+    use burn::backend::{Autodiff, Flex};
     use burn::tensor::ElementConversion;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    type B = Autodiff<NdArray>;
-    type BI = NdArray;
+    type B = Autodiff<Flex>;
+    type BI = Flex;
 
     /// Pin μ=0, log_std=0, ε=0.5 (so z=0.5, σ=1) with scale=1, bias=0.
     /// Hand-rolled reference:

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/target_smoothing.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/target_smoothing.rs
@@ -78,11 +78,11 @@ where
 mod tests {
     use super::*;
 
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
-    type B = NdArray;
+    type B = Flex;
 
     #[test]
     fn zero_policy_noise_reduces_to_action_clip() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
@@ -562,10 +562,10 @@ where
 mod tests {
     use super::*;
 
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use burn::tensor::TensorData;
 
-    type BI = NdArray;
+    type BI = Flex;
 
     #[test]
     fn metrics_performance_record_returns_reward_and_steps() {

--- a/crates/rlevo-reinforcement-learning/src/memory.rs
+++ b/crates/rlevo-reinforcement-learning/src/memory.rs
@@ -279,7 +279,7 @@ where
     pub fn sample_batch<const BD: usize, const BAD: usize, B: Backend>(
         &self,
         batch_size: usize,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Result<TrainingBatch<BD, BAD, B>, ReplayBufferError>
     where
         O: TensorConvertible<D, B>,
@@ -862,7 +862,7 @@ mod sample_batch_tests {
     //! regression.
 
     use super::*;
-    use burn::backend::NdArray;
+    use burn::backend::Flex;
     use rlevo_core::base::{Action, Observation, Reward, TensorConversionError, TensorConvertible};
     use burn::tensor::Tensor;
     use serde::{Deserialize, Serialize};
@@ -877,7 +877,7 @@ mod sample_batch_tests {
     }
 
     impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for Obs {
-        fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+        fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
             Tensor::from_floats([self.0, self.1, self.2], device)
         }
         fn from_tensor(_t: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -898,7 +898,7 @@ mod sample_batch_tests {
     }
 
     impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for Act {
-        fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+        fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
             let mut one_hot = [0.0_f32; 2];
             one_hot[self.0 as usize] = 1.0;
             Tensor::from_floats(one_hot, device)
@@ -931,7 +931,7 @@ mod sample_batch_tests {
     }
 
     impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for Rew {
-        fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+        fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
             Tensor::from_floats([self.0], device)
         }
         fn from_tensor(_t: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -939,7 +939,7 @@ mod sample_batch_tests {
         }
     }
 
-    type Be = NdArray;
+    type Be = Flex;
 
     fn populated(n: usize) -> PrioritizedExperienceReplay<1, 1, Obs, Act, Rew> {
         let mut per = PrioritizedExperienceReplayBuilder::<1, 1, Obs, Act, Rew>::new()
@@ -967,11 +967,11 @@ mod sample_batch_tests {
         let batch = per
             .sample_batch::<2, 2, Be>(8, &device)
             .expect("sample_batch");
-        assert_eq!(batch.observations.shape().dims, [8, 3]);
-        assert_eq!(batch.next_observations.shape().dims, [8, 3]);
-        assert_eq!(batch.actions.shape().dims, [8, 2]);
-        assert_eq!(batch.rewards.shape().dims, [8]);
-        assert_eq!(batch.dones.shape().dims, [8]);
+        assert_eq!(batch.observations.dims(), [8, 3]);
+        assert_eq!(batch.next_observations.dims(), [8, 3]);
+        assert_eq!(batch.actions.dims(), [8, 2]);
+        assert_eq!(batch.rewards.dims(), [8]);
+        assert_eq!(batch.dones.dims(), [8]);
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/memory.rs
+++ b/crates/rlevo-reinforcement-learning/src/memory.rs
@@ -855,7 +855,7 @@ mod sample_batch_tests {
     //! End-to-end regression tests for [`PrioritizedExperienceReplay::sample_batch`].
     //!
     //! These tests actually call `sample_batch` against a concrete backend
-    //! (Burn's ndarray) and verify the produced tensors have the batched
+    //! (Burn's flex) and verify the produced tensors have the batched
     //! shapes `[batch, ...]`. Before the BD/BAD generics landed, the
     //! function panicked at runtime because it tried to stack rank-`D`
     //! tensors into a rank-`D` output, so this suite guards against that

--- a/crates/rlevo/examples/evo/ackley_showcase.rs
+++ b/crates/rlevo/examples/evo/ackley_showcase.rs
@@ -6,7 +6,7 @@
 //!
 //! Run with `cargo run --release -p rlevo-evolution --example ackley_showcase`.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use rlevo_environments::landscapes::ackley::Ackley;
 use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
 use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
@@ -17,7 +17,7 @@ use rlevo_evolution::algorithms::ga::{
 use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
-type B = NdArray;
+type B = Flex;
 
 const DIM: usize = 10;
 const GENS: usize = 500;
@@ -29,7 +29,7 @@ where
     S::Params: std::fmt::Debug,
     F: BatchFitnessFn<B, S::Genome>,
     B: burn::tensor::backend::Backend,
-    <B as burn::tensor::backend::Backend>::Device: Clone + Default,
+    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
 {
     let device = Default::default();
     let mut harness =

--- a/crates/rlevo/examples/evo/ackley_showcase.rs
+++ b/crates/rlevo/examples/evo/ackley_showcase.rs
@@ -56,7 +56,7 @@ fn main() {
     let bounds = (lo as f32, hi as f32);
 
     println!(
-        "Ackley-D{DIM} showcase — {GENS} generations, ndarray backend, seed={SEED}\n\
+        "Ackley-D{DIM} showcase — {GENS} generations, Flex backend, seed={SEED}\n\
          {:-<80}",
         "",
     );

--- a/crates/rlevo/examples/evo/rastrigin_showcase.rs
+++ b/crates/rlevo/examples/evo/rastrigin_showcase.rs
@@ -7,7 +7,7 @@
 //!
 //! Run with `cargo run --release -p rlevo-evolution --example rastrigin_showcase`.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use rlevo_environments::landscapes::rastrigin::Rastrigin;
 use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
 use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
@@ -18,7 +18,7 @@ use rlevo_evolution::algorithms::ga::{
 use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
-type B = NdArray;
+type B = Flex;
 
 const DIM: usize = 10;
 const GENS: usize = 500;
@@ -30,7 +30,7 @@ where
     S::Params: std::fmt::Debug,
     F: BatchFitnessFn<B, S::Genome>,
     B: burn::tensor::backend::Backend,
-    <B as burn::tensor::backend::Backend>::Device: Clone + Default,
+    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
 {
     let device = Default::default();
     let mut harness =

--- a/crates/rlevo/examples/evo/rastrigin_showcase.rs
+++ b/crates/rlevo/examples/evo/rastrigin_showcase.rs
@@ -57,7 +57,7 @@ fn main() {
     let bounds = (lo as f32, hi as f32);
 
     println!(
-        "Rastrigin-D{DIM} showcase — {GENS} generations, ndarray backend, seed={SEED}\n\
+        "Rastrigin-D{DIM} showcase — {GENS} generations, Flex backend, seed={SEED}\n\
          {:-<80}",
         "",
     );

--- a/crates/rlevo/examples/evo/sphere_showcase.rs
+++ b/crates/rlevo/examples/evo/sphere_showcase.rs
@@ -53,7 +53,7 @@ fn main() {
     let bounds = (lo as f32, hi as f32);
 
     println!(
-        "Sphere-D{DIM} showcase — {GENS} generations, ndarray backend, seed={SEED}\n\
+        "Sphere-D{DIM} showcase — {GENS} generations, Flex backend, seed={SEED}\n\
          {:-<80}",
         "",
     );

--- a/crates/rlevo/examples/evo/sphere_showcase.rs
+++ b/crates/rlevo/examples/evo/sphere_showcase.rs
@@ -3,7 +3,7 @@
 //!
 //! Run with `cargo run --release -p rlevo-evolution --example sphere_showcase`.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use rlevo_environments::landscapes::sphere::Sphere;
 use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
 use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
@@ -14,7 +14,7 @@ use rlevo_evolution::algorithms::ga::{
 use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
-type B = NdArray;
+type B = Flex;
 
 const DIM: usize = 10;
 const GENS: usize = 500;
@@ -26,7 +26,7 @@ where
     S::Params: std::fmt::Debug,
     F: BatchFitnessFn<B, S::Genome>,
     B: burn::tensor::backend::Backend,
-    <B as burn::tensor::backend::Backend>::Device: Clone + Default,
+    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
 {
     let device = Default::default();
     let mut harness =

--- a/crates/rlevo/examples/rl/c51_cart_pole.rs
+++ b/crates/rlevo/examples/rl/c51_cart_pole.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -41,7 +41,7 @@ pub struct C51Mlp<B: Backend> {
 }
 
 impl<B: Backend> C51Mlp<B> {
-    fn new(num_atoms: usize, device: &B::Device) -> Self {
+    fn new(num_atoms: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -136,7 +136,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
 // Main
 // ---------------------------------------------------------------------------
 
-type Backend_ = Autodiff<NdArray>;
+type Backend_ = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/c51_cart_pole.rs
+++ b/crates/rlevo/examples/rl/c51_cart_pole.rs
@@ -1,4 +1,4 @@
-//! C51 (Categorical DQN) on `CartPole` with Burn's ndarray backend.
+//! C51 (Categorical DQN) on `CartPole` with Burn's Flex backend.
 //!
 //! Usage:
 //!

--- a/crates/rlevo/examples/rl/ddpg_pendulum.rs
+++ b/crates/rlevo/examples/rl/ddpg_pendulum.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -44,7 +44,7 @@ pub struct ActorMlp<B: Backend> {
 }
 
 impl<B: Backend> ActorMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, action_dim: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, action_dim: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         // Pendulum action range is [-2, 2], so scale=2, bias=0.
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -98,7 +98,7 @@ pub struct CriticMlp<B: Backend> {
 }
 
 impl<B: Backend> CriticMlp<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -192,7 +192,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
 // CLI + main
 // ---------------------------------------------------------------------------
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/ddpg_pendulum.rs
+++ b/crates/rlevo/examples/rl/ddpg_pendulum.rs
@@ -1,4 +1,4 @@
-//! DDPG on Pendulum-v1 with Burn's ndarray backend.
+//! DDPG on Pendulum-v1 with Burn's Flex backend.
 //!
 //! Usage:
 //!

--- a/crates/rlevo/examples/rl/dqn_cart_pole.rs
+++ b/crates/rlevo/examples/rl/dqn_cart_pole.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -40,7 +40,7 @@ pub struct DqnMlp<B: Backend> {
 }
 
 impl<B: Backend> DqnMlp<B> {
-    fn new(device: &B::Device) -> Self {
+    fn new(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -132,7 +132,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
 // Main
 // ---------------------------------------------------------------------------
 
-type Backend_ = Autodiff<NdArray>;
+type Backend_ = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/dqn_cart_pole.rs
+++ b/crates/rlevo/examples/rl/dqn_cart_pole.rs
@@ -1,4 +1,4 @@
-//! DQN on `CartPole` with Burn's ndarray backend.
+//! DQN on `CartPole` with Burn's Flex backend.
 //!
 //! Usage:
 //!

--- a/crates/rlevo/examples/rl/ppg_cart_pole.rs
+++ b/crates/rlevo/examples/rl/ppg_cart_pole.rs
@@ -1,4 +1,4 @@
-//! Phasic Policy Gradient (PPG, discrete) on `CartPole` with Burn's ndarray
+//! Phasic Policy Gradient (PPG, discrete) on `CartPole` with Burn's flex
 //! backend.
 //!
 //! v1 scope note: `CartPole` parity with PPO is the v1 target. PPG's sample

--- a/crates/rlevo/examples/rl/ppg_cart_pole.rs
+++ b/crates/rlevo/examples/rl/ppg_cart_pole.rs
@@ -16,7 +16,7 @@
 //!     --n-iteration 32 --e-aux 6 --beta-clone 1.0
 //! ```
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::Module;
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::Tensor;
@@ -47,7 +47,7 @@ pub struct ValueMlp<B: Backend> {
 }
 
 impl<B: Backend> ValueMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -68,7 +68,7 @@ impl<B: AutodiffBackend> PpoValue<B, 2> for ValueMlp<B> {
     }
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/ppo_cart_pole.rs
+++ b/crates/rlevo/examples/rl/ppo_cart_pole.rs
@@ -7,7 +7,7 @@
 //!     --seed 42 --total-timesteps 50000 --num-steps 128 --log-every 4096
 //! ```
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::Module;
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::Tensor;
@@ -41,7 +41,7 @@ pub struct ValueMlp<B: Backend> {
 }
 
 impl<B: Backend> ValueMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -66,7 +66,7 @@ impl<B: AutodiffBackend> PpoValue<B, 2> for ValueMlp<B> {
 // CLI + main
 // ---------------------------------------------------------------------------
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/ppo_cart_pole.rs
+++ b/crates/rlevo/examples/rl/ppo_cart_pole.rs
@@ -1,4 +1,4 @@
-//! PPO (discrete, categorical head) on `CartPole` with Burn's ndarray backend.
+//! PPO (discrete, categorical head) on `CartPole` with Burn's Flex backend.
 //!
 //! Usage:
 //!

--- a/crates/rlevo/examples/rl/ppo_pendulum.rs
+++ b/crates/rlevo/examples/rl/ppo_pendulum.rs
@@ -1,4 +1,4 @@
-//! PPO (continuous, tanh-Gaussian head) on Pendulum with Burn's ndarray backend.
+//! PPO (continuous, tanh-Gaussian head) on Pendulum with Burn's Flex backend.
 //!
 //! Usage:
 //!

--- a/crates/rlevo/examples/rl/ppo_pendulum.rs
+++ b/crates/rlevo/examples/rl/ppo_pendulum.rs
@@ -7,7 +7,7 @@
 //!     --seed 42 --total-timesteps 100000 --num-steps 2048 --log-every 4096
 //! ```
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::Module;
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::Tensor;
@@ -41,7 +41,7 @@ pub struct ValueMlp<B: Backend> {
 }
 
 impl<B: Backend> ValueMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -66,7 +66,7 @@ impl<B: AutodiffBackend> PpoValue<B, 2> for ValueMlp<B> {
 // CLI + main
 // ---------------------------------------------------------------------------
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/qrdqn_cart_pole.rs
+++ b/crates/rlevo/examples/rl/qrdqn_cart_pole.rs
@@ -1,4 +1,4 @@
-//! QR-DQN (Quantile Regression DQN) on `CartPole` with Burn's ndarray backend.
+//! QR-DQN (Quantile Regression DQN) on `CartPole` with Burn's Flex backend.
 //!
 //! Usage:
 //!

--- a/crates/rlevo/examples/rl/qrdqn_cart_pole.rs
+++ b/crates/rlevo/examples/rl/qrdqn_cart_pole.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -42,7 +42,7 @@ pub struct QrDqnMlp<B: Backend> {
 }
 
 impl<B: Backend> QrDqnMlp<B> {
-    fn new(num_quantiles: usize, device: &B::Device) -> Self {
+    fn new(num_quantiles: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -137,7 +137,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
 // Main
 // ---------------------------------------------------------------------------
 
-type Backend_ = Autodiff<NdArray>;
+type Backend_ = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/sac_pendulum.rs
+++ b/crates/rlevo/examples/rl/sac_pendulum.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -52,7 +52,7 @@ pub struct StochasticActor<B: Backend> {
 }
 
 impl<B: Backend> StochasticActor<B> {
-    fn new(obs_dim: usize, hidden: usize, action_dim: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, action_dim: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         // Pendulum action range is [-2, 2], so scale=2, bias=0.
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -150,7 +150,7 @@ pub struct CriticMlp<B: Backend> {
 }
 
 impl<B: Backend> CriticMlp<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -244,7 +244,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
 // CLI + main
 // ---------------------------------------------------------------------------
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/examples/rl/sac_pendulum.rs
+++ b/crates/rlevo/examples/rl/sac_pendulum.rs
@@ -1,4 +1,4 @@
-//! SAC on Pendulum-v1 with Burn's ndarray backend.
+//! SAC on Pendulum-v1 with Burn's Flex backend.
 //!
 //! CLI mirrors `td3_pendulum` so the two agents can be A/B'd by swapping the
 //! example name:

--- a/crates/rlevo/examples/rl/td3_pendulum.rs
+++ b/crates/rlevo/examples/rl/td3_pendulum.rs
@@ -1,4 +1,4 @@
-//! TD3 on Pendulum-v1 with Burn's ndarray backend.
+//! TD3 on Pendulum-v1 with Burn's Flex backend.
 //!
 //! CLI mirrors `ddpg_pendulum` so the two agents can be A/B'd by simply
 //! swapping the example name:

--- a/crates/rlevo/examples/rl/td3_pendulum.rs
+++ b/crates/rlevo/examples/rl/td3_pendulum.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -43,7 +43,7 @@ pub struct ActorMlp<B: Backend> {
 }
 
 impl<B: Backend> ActorMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, action_dim: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, action_dim: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         // Pendulum action range is [-2, 2], so scale=2, bias=0.
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -97,7 +97,7 @@ pub struct CriticMlp<B: Backend> {
 }
 
 impl<B: Backend> CriticMlp<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -191,7 +191,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
 // CLI + main
 // ---------------------------------------------------------------------------
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 struct CliArgs {
     seed: u64,

--- a/crates/rlevo/tests/c51_integration.rs
+++ b/crates/rlevo/tests/c51_integration.rs
@@ -2,7 +2,7 @@
 //!
 //! Follows the shape of `dqn_integration.rs`: modest step budgets on
 //! `CartPole` for `cargo test` throughput, with a couple of heavier
-//! reproducibility checks gated behind `#[ignore]` because Burn's ndarray
+//! reproducibility checks gated behind `#[ignore]` because Burn's flex
 //! backend shares a global RNG.
 
 use std::collections::HashMap;
@@ -151,7 +151,7 @@ fn fresh_agent(seed: u64) -> Agent {
 /// Smoke test: a short run completes, the buffer populates, and episode
 /// rewards are finite. Catches silent regressions (NaN logits, projection
 /// numerical blow-up, etc.). Marked `#[ignore]` because running it alongside
-/// other training tests perturbs Burn's global ndarray RNG; exercise with
+/// other training tests perturbs Burn's global Flex RNG; exercise with
 /// `cargo test -p rlevo --test c51_integration -- --ignored
 /// --test-threads=1`.
 #[test]
@@ -175,11 +175,11 @@ fn c51_short_run_produces_finite_rewards() {
 
 /// Reproducibility smoke test: two seeded back-to-back runs produce identical
 /// reward sequences. Marked `#[ignore]` for the same reason as the DQN
-/// counterpart — Burn's ndarray backend uses a process-global RNG.
+/// counterpart — Burn's Flex backend uses a process-global RNG.
 #[test]
 #[ignore = "requires --test-threads=1 to isolate Burn's global RNG"]
 #[allow(clippy::float_cmp)]
-fn c51_reproducibility_ndarray() {
+fn c51_reproducibility_flex() {
     fn run(seed: u64, total: usize) -> Vec<f32> {
         let mut env = CartPole::with_config(CartPoleConfig {
             seed,

--- a/crates/rlevo/tests/c51_integration.rs
+++ b/crates/rlevo/tests/c51_integration.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -39,7 +39,7 @@ struct C51Mlp<B: Backend> {
 }
 
 impl<B: Backend> C51Mlp<B> {
-    fn new(num_atoms: usize, device: &B::Device) -> Self {
+    fn new(num_atoms: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -117,7 +117,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent = C51Agent<Be, C51Mlp<Be>, CartPoleObservation, CartPoleAction, 1, 2>;
 
 fn fresh_agent(seed: u64) -> Agent {

--- a/crates/rlevo/tests/ddpg_integration.rs
+++ b/crates/rlevo/tests/ddpg_integration.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -76,7 +76,7 @@ impl Observation<1> for LinearObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for LinearObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_data(TensorData::new(vec![self.x], vec![1]), device)
     }
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -204,7 +204,7 @@ impl<B: Backend> Actor<B> {
         hidden: usize,
         action_dim: usize,
         scale: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -246,7 +246,7 @@ struct Critic<B: Backend> {
 }
 
 impl<B: Backend> Critic<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             head: LinearConfig::new(hidden, 1).init(device),
@@ -327,7 +327,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
     target.map(&mut mapper)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/rlevo/tests/ddpg_integration.rs
+++ b/crates/rlevo/tests/ddpg_integration.rs
@@ -386,7 +386,7 @@ fn ddpg_solves_linear_1d_continuous() {
 
 /// Pendulum smoke test: 50k steps with small networks, verifies training runs
 /// without crashing and produces a reward above the zero-torque baseline.
-/// Gated — Burn's ndarray backend shares a global RNG with other tests so
+/// Gated — Burn's Flex backend shares a global RNG with other tests so
 /// this runs at `--test-threads=1`.
 #[test]
 #[ignore = "smoke run (~50k Pendulum steps); --test-threads=1 for isolated Burn RNG"]

--- a/crates/rlevo/tests/dqn_integration.rs
+++ b/crates/rlevo/tests/dqn_integration.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -36,7 +36,7 @@ struct DqnMlp<B: Backend> {
 }
 
 impl<B: Backend> DqnMlp<B> {
-    fn new(device: &B::Device) -> Self {
+    fn new(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -120,7 +120,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
     target.map(&mut mapper)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent = DqnAgent<Be, DqnMlp<Be>, CartPoleObservation, CartPoleAction, 1, 2>;
 
 fn fresh_agent(seed: u64) -> Agent {

--- a/crates/rlevo/tests/dqn_integration.rs
+++ b/crates/rlevo/tests/dqn_integration.rs
@@ -165,13 +165,13 @@ fn dqn_cart_pole_reaches_100() {
     let avg = agent.stats().avg_score().unwrap_or(0.0);
     // The acceptance target is >= 100 within 200k steps; this test trains
     // for 30k to keep CI fast. The smoke/reproducibility tests are
-    // `#[ignore]` so they don't compete for Burn's global ndarray RNG.
+    // `#[ignore]` so they don't compete for Burn's global Flex RNG.
     assert!(avg >= 100.0, "expected avg reward >= 100, got {avg:.2}");
 }
 
 /// Reproducibility smoke test: two back-to-back runs from the same seed
 /// produce identical reward sequences when run sequentially in the same
-/// thread. Marked `#[ignore]` because Burn's ndarray backend keeps a
+/// thread. Marked `#[ignore]` because Burn's Flex backend keeps a
 /// *global* RNG — running alongside other tests via the default
 /// multi-threaded runner poisons that global state. Run explicitly with
 /// `cargo test -p rlevo-reinforcement-learning --test dqn_integration dqn_reproducibility
@@ -179,7 +179,7 @@ fn dqn_cart_pole_reaches_100() {
 #[test]
 #[ignore = "requires --test-threads=1 to isolate Burn's global RNG"]
 #[allow(clippy::float_cmp)]
-fn dqn_reproducibility_ndarray() {
+fn dqn_reproducibility_flex() {
     fn run(seed: u64, total: usize) -> Vec<f32> {
         let mut env = CartPole::with_config(CartPoleConfig {
             seed,
@@ -207,7 +207,7 @@ fn dqn_reproducibility_ndarray() {
 /// Smoke test: a short run completes with finite rewards and a populated
 /// buffer. Protects against silent regressions that would NaN-out. Marked
 /// `#[ignore]` because running it alongside `dqn_cart_pole_reaches_100`
-/// perturbs Burn's global ndarray RNG; run with `-- --ignored
+/// perturbs Burn's global Flex RNG; run with `-- --ignored
 /// --test-threads=1` to exercise it.
 #[test]
 #[ignore = "perturbs global Burn RNG; run with --test-threads=1"]

--- a/crates/rlevo/tests/integration_test.rs
+++ b/crates/rlevo/tests/integration_test.rs
@@ -7,7 +7,7 @@
 //! test that the public surface is sufficient to build a working training
 //! loop scaffold.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use burn::tensor::Tensor;
 use rlevo_core::action::DiscreteAction;
 use rlevo_core::base::{
@@ -40,7 +40,7 @@ impl Observation<1> for WalkObservation {
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for WalkObservation {
     #[allow(clippy::cast_precision_loss)]
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats([self.position as f32], device)
     }
     fn from_tensor(_t: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -110,7 +110,7 @@ impl DiscreteAction<1> for WalkAction {
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for WalkAction {
     #[allow(clippy::cast_precision_loss)]
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats([self.to_index() as f32], device)
     }
     fn from_tensor(_t: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -146,7 +146,7 @@ impl From<WalkReward> for f32 {
 }
 
 impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for WalkReward {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_floats([self.0], device)
     }
     fn from_tensor(_t: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -265,7 +265,7 @@ fn full_episode_loop_reaches_goal() {
 
 #[test]
 fn replay_buffer_sample_batch_tensor_shapes() {
-    type B = NdArray;
+    type B = Flex;
     let device = Default::default();
 
     let mut buffer =
@@ -305,11 +305,11 @@ fn replay_buffer_sample_batch_tensor_shapes() {
         .sample_batch::<2, 2, B>(8, &device)
         .expect("sample_batch");
 
-    assert_eq!(batch.observations.shape().dims, [8, 1]);
-    assert_eq!(batch.actions.shape().dims, [8, 1]);
-    assert_eq!(batch.rewards.shape().dims, [8]);
-    assert_eq!(batch.next_observations.shape().dims, [8, 1]);
-    assert_eq!(batch.dones.shape().dims, [8]);
+    assert_eq!(batch.observations.dims(), [8, 1]);
+    assert_eq!(batch.actions.dims(), [8, 1]);
+    assert_eq!(batch.rewards.dims(), [8]);
+    assert_eq!(batch.next_observations.dims(), [8, 1]);
+    assert_eq!(batch.dones.dims(), [8]);
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -4,7 +4,7 @@
 //! 50k-step budget with lax thresholds; heavier macro-convergence and
 //! reproducibility checks live behind `#[ignore]`.
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::Module;
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::Tensor;
@@ -35,7 +35,7 @@ struct ValueMlp<B: Backend> {
 }
 
 impl<B: Backend> ValueMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -56,7 +56,7 @@ impl<B: AutodiffBackend> PpoValue<B, 2> for ValueMlp<B> {
     }
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 fn make_cart_pole_agent(
     seed: u64,

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -193,7 +193,7 @@ fn ppg_aux_phase_actually_runs() {
 }
 
 #[test]
-#[ignore = "perturbs Burn's global ndarray RNG; run with --test-threads=1"]
+#[ignore = "perturbs Burn's global Flex RNG; run with --test-threads=1"]
 fn ppg_short_run_produces_finite_rewards() {
     let seed: u64 = 7;
     let total = 2_048_usize;
@@ -222,7 +222,7 @@ fn ppg_short_run_produces_finite_rewards() {
 }
 
 #[test]
-#[ignore = "macro convergence; ~2-5 min on ndarray"]
+#[ignore = "macro convergence; ~2-5 min on Flex"]
 fn ppg_cart_pole_reaches_475() {
     let seed: u64 = 42;
     let total = 400_000_usize;

--- a/crates/rlevo/tests/ppo_integration.rs
+++ b/crates/rlevo/tests/ppo_integration.rs
@@ -8,7 +8,7 @@
 //! Burn's ndarray backend shares a global RNG, so reproducibility tests must
 //! run with `--test-threads=1`.
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::Module;
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::Tensor;
@@ -46,7 +46,7 @@ struct ValueMlp<B: Backend> {
 }
 
 impl<B: Backend> ValueMlp<B> {
-    fn new(obs_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
             fc2: LinearConfig::new(hidden, hidden).init(device),
@@ -67,7 +67,7 @@ impl<B: AutodiffBackend> PpoValue<B, 2> for ValueMlp<B> {
     }
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 // ---------------------------------------------------------------------------
 // Discrete: CartPole

--- a/crates/rlevo/tests/ppo_integration.rs
+++ b/crates/rlevo/tests/ppo_integration.rs
@@ -5,7 +5,7 @@
 //! - `ppo_pendulum_improves_over_random` (continuous)
 //!
 //! Heavier parity checks behind `#[ignore]` follow the DQN/C51 convention:
-//! Burn's ndarray backend shares a global RNG, so reproducibility tests must
+//! Burn's Flex backend shares a global RNG, so reproducibility tests must
 //! run with `--test-threads=1`.
 
 use burn::backend::{Autodiff, Flex};
@@ -129,7 +129,7 @@ fn ppo_cart_pole_reaches_100() {
 }
 
 #[test]
-#[ignore = "perturbs Burn's global ndarray RNG; run with --test-threads=1"]
+#[ignore = "perturbs Burn's global Flex RNG; run with --test-threads=1"]
 fn ppo_short_run_produces_finite_rewards() {
     let seed: u64 = 7;
     let total = 2_048_usize;
@@ -197,7 +197,7 @@ fn make_pendulum_agent(
 }
 
 #[test]
-#[ignore = "~30s on ndarray; run with --ignored for macro checks"]
+#[ignore = "~30s on Flex; run with --ignored for macro checks"]
 fn ppo_pendulum_improves_over_random() {
     let seed: u64 = 42;
     let total = 30_000_usize;

--- a/crates/rlevo/tests/qrdqn_integration.rs
+++ b/crates/rlevo/tests/qrdqn_integration.rs
@@ -3,7 +3,7 @@
 //!
 //! Mirrors the shape of `c51_integration.rs`: modest step budgets on
 //! `CartPole` for `cargo test` throughput, with heavier reproducibility
-//! checks gated behind `#[ignore]` because Burn's ndarray backend shares a
+//! checks gated behind `#[ignore]` because Burn's Flex backend shares a
 //! global RNG.
 
 use std::collections::HashMap;
@@ -127,7 +127,7 @@ fn fresh_agent(seed: u64) -> Agent {
     // QR-DQN's quantile Huber loss uses a `(batch, N, N)` broadcast — one
     // factor of `N` slower per learn step than C51's categorical loss. Use
     // a smaller quantile count than C51 to keep the integration test's
-    // wall-clock on ndarray practical for CI.
+    // wall-clock on Flex practical for CI.
     let num_quantiles = 21;
     let config = QrDqnTrainingConfigBuilder::new()
         .batch_size(64)
@@ -155,7 +155,7 @@ fn fresh_agent(seed: u64) -> Agent {
 /// Smoke test: a short run completes, the buffer populates, and episode
 /// rewards are finite. Catches silent regressions (NaN quantiles, loss
 /// numerical blow-up, etc.). Marked `#[ignore]` because running it alongside
-/// other training tests perturbs Burn's global ndarray RNG; exercise with
+/// other training tests perturbs Burn's global Flex RNG; exercise with
 /// `cargo test -p rlevo-reinforcement-learning --test qrdqn_integration -- --ignored
 /// --test-threads=1`.
 #[test]
@@ -183,11 +183,11 @@ fn qrdqn_short_run_produces_finite_rewards() {
 
 /// Reproducibility smoke test: two seeded back-to-back runs produce identical
 /// reward sequences. Marked `#[ignore]` for the same reason as the DQN/C51
-/// counterparts — Burn's ndarray backend uses a process-global RNG.
+/// counterparts — Burn's Flex backend uses a process-global RNG.
 #[test]
 #[ignore = "requires --test-threads=1 to isolate Burn's global RNG"]
 #[allow(clippy::float_cmp)]
-fn qrdqn_reproducibility_ndarray() {
+fn qrdqn_reproducibility_flex() {
     fn run(seed: u64, total: usize) -> Vec<f32> {
         let mut env = CartPole::with_config(CartPoleConfig {
             seed,
@@ -234,10 +234,10 @@ fn qrdqn_cart_pole_reaches_50() {
 /// steps at seed 42. Ignored by default — too expensive for regular CI.
 /// Run with:
 /// `cargo test -p rlevo-reinforcement-learning --test qrdqn_integration --release --
-///      --ignored qrdqn_solves_cart_pole_ndarray_seed_42`.
+///      --ignored qrdqn_solves_cart_pole_flex_seed_42`.
 #[test]
-#[ignore = "long-running acceptance target; ~500k steps on ndarray CPU"]
-fn qrdqn_solves_cart_pole_ndarray_seed_42() {
+#[ignore = "long-running acceptance target; ~500k steps on Flex CPU"]
+fn qrdqn_solves_cart_pole_flex_seed_42() {
     let seed: u64 = 42;
     let mut env = CartPole::with_config(CartPoleConfig {
         seed,

--- a/crates/rlevo/tests/qrdqn_integration.rs
+++ b/crates/rlevo/tests/qrdqn_integration.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::backend::{AutodiffBackend, Backend};
@@ -40,7 +40,7 @@ struct QrDqnMlp<B: Backend> {
 }
 
 impl<B: Backend> QrDqnMlp<B> {
-    fn new(num_quantiles: usize, device: &B::Device) -> Self {
+    fn new(num_quantiles: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             l1: LinearConfig::new(4, 64).init(device),
             l2: LinearConfig::new(64, 64).init(device),
@@ -118,7 +118,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 type Agent = QrDqnAgent<Be, QrDqnMlp<Be>, CartPoleObservation, CartPoleAction, 1, 2>;
 
 fn fresh_agent(seed: u64) -> Agent {

--- a/crates/rlevo/tests/rastrigin_run_suite.rs
+++ b/crates/rlevo/tests/rastrigin_run_suite.rs
@@ -8,7 +8,7 @@
 
 use std::sync::atomic::AtomicU32;
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use rand::Rng;
 use rlevo_benchmarks::agent::{BenchableAgent, FitnessEvaluable};
 use rlevo_benchmarks::env::BenchEnv;
@@ -26,7 +26,7 @@ use rlevo_evolution::algorithms::ga::{
 use rlevo_evolution::fitness::FromFitnessEvaluable;
 use rlevo_evolution::strategy::EvolutionaryHarness;
 
-type B = NdArray;
+type B = Flex;
 
 const DIM: usize = 10;
 const MAX_GENS: usize = 80;

--- a/crates/rlevo/tests/rastrigin_run_suite.rs
+++ b/crates/rlevo/tests/rastrigin_run_suite.rs
@@ -123,7 +123,7 @@ fn cfg() -> EvaluatorConfig {
         num_trials_per_env: 2,
         max_steps: MAX_GENS,
         base_seed: 17,
-        // Single-threaded: Burn ndarray seeds via a process-wide mutex,
+        // Single-threaded: Burn Flex seeds via a process-wide mutex,
         // so parallel trials race on seeding and produce non-reproducible
         // trajectories. Forcing one thread is the simplest honest option.
         num_threads: Some(1),

--- a/crates/rlevo/tests/sac_integration.rs
+++ b/crates/rlevo/tests/sac_integration.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, softplus, tanh};
@@ -73,7 +73,7 @@ impl Observation<1> for LinearObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for LinearObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_data(TensorData::new(vec![self.x], vec![1]), device)
     }
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -205,7 +205,7 @@ impl<B: Backend> StochasticActor<B> {
         hidden: usize,
         action_dim: usize,
         scale: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -288,7 +288,7 @@ struct Critic<B: Backend> {
 }
 
 impl<B: Backend> Critic<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             head: LinearConfig::new(hidden, 1).init(device),
@@ -362,7 +362,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
     target.map(&mut m)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/rlevo/tests/sac_integration.rs
+++ b/crates/rlevo/tests/sac_integration.rs
@@ -549,7 +549,7 @@ fn sac_alpha_frozen_when_autotune_disabled() {
 }
 
 /// Pendulum macro-smoke: gated at 500k steps, `--test-threads=1` so the
-/// ndarray backend's global RNG stays isolated.
+/// Flex backend global RNG stays isolated.
 #[test]
 #[ignore = "macro run (~500k Pendulum steps); --test-threads=1 for isolated Burn RNG"]
 fn sac_pendulum_smoke() {
@@ -605,11 +605,11 @@ fn sac_pendulum_smoke() {
 }
 
 /// Seeded reproducibility: two identical runs on the same seed must produce
-/// bit-equal metrics. Gated — shares the ndarray backend's global RNG with
+/// bit-equal metrics. Gated — shares the Flex backend's global RNG with
 /// other tests.
 #[test]
 #[ignore = "reproducibility run; --test-threads=1 for isolated Burn RNG"]
-fn sac_reproducibility_ndarray() {
+fn sac_reproducibility_flex() {
     fn run_once() -> f32 {
         let seed: u64 = 42;
         let device = Default::default();

--- a/crates/rlevo/tests/swarm_rastrigin_suite.rs
+++ b/crates/rlevo/tests/swarm_rastrigin_suite.rs
@@ -64,7 +64,7 @@ fn cfg() -> EvaluatorConfig {
         max_steps: MAX_GENS,
         base_seed: 29,
         // Single-threaded — see rastrigin_run_suite.rs for the
-        // ndarray-RNG-mutex rationale.
+        // Flex-RNG-mutex rationale.
         num_threads: Some(1),
         checkpoint_dir: None,
         fail_fast: false,

--- a/crates/rlevo/tests/swarm_rastrigin_suite.rs
+++ b/crates/rlevo/tests/swarm_rastrigin_suite.rs
@@ -8,7 +8,7 @@
 //! `algorithms::swarm::*` modules. ACO-Permutation is excluded because
 //! its module is a `todo!()` stub.
 
-use burn::backend::NdArray;
+use burn::backend::Flex;
 use rand::Rng;
 use rlevo_benchmarks::agent::{BenchableAgent, FitnessEvaluable};
 use rlevo_benchmarks::env::BenchEnv;
@@ -30,7 +30,7 @@ use rlevo_evolution::algorithms::metaheuristic::woa::{WhaleOptimization, WoaConf
 use rlevo_evolution::fitness::FromFitnessEvaluable;
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
-type B = NdArray;
+type B = Flex;
 const DIM: usize = 10;
 const MAX_GENS: usize = 120;
 

--- a/crates/rlevo/tests/td3_integration.rs
+++ b/crates/rlevo/tests/td3_integration.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use burn::backend::{Autodiff, NdArray};
+use burn::backend::{Autodiff, Flex};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::nn::{Linear, LinearConfig};
 use burn::tensor::activation::{relu, tanh};
@@ -75,7 +75,7 @@ impl Observation<1> for LinearObservation {
 }
 
 impl<B: Backend> TensorConvertible<1, B> for LinearObservation {
-    fn to_tensor(&self, device: &B::Device) -> Tensor<B, 1> {
+    fn to_tensor(&self, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
         Tensor::from_data(TensorData::new(vec![self.x], vec![1]), device)
     }
     fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
@@ -204,7 +204,7 @@ impl<B: Backend> Actor<B> {
         hidden: usize,
         action_dim: usize,
         scale: f32,
-        device: &B::Device,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim, hidden).init(device),
@@ -242,7 +242,7 @@ struct Critic<B: Backend> {
 }
 
 impl<B: Backend> Critic<B> {
-    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &B::Device) -> Self {
+    fn new(obs_dim: usize, action_dim: usize, hidden: usize, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
         Self {
             fc1: LinearConfig::new(obs_dim + action_dim, hidden).init(device),
             head: LinearConfig::new(hidden, 1).init(device),
@@ -323,7 +323,7 @@ fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M
     target.map(&mut mapper)
 }
 
-type Be = Autodiff<NdArray>;
+type Be = Autodiff<Flex>;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/rlevo/tests/td3_integration.rs
+++ b/crates/rlevo/tests/td3_integration.rs
@@ -456,7 +456,7 @@ fn td3_delayed_update_skips_actor_step() {
 }
 
 /// Pendulum macro-smoke: 500k steps, checks the moving average is finite
-/// and better than the zero-torque baseline. Gated — Burn's ndarray backend
+/// and better than the zero-torque baseline. Gated — Burn's Flex backend
 /// shares a global RNG with other tests so this runs at `--test-threads=1`.
 #[test]
 #[ignore = "macro run (~500k Pendulum steps); --test-threads=1 for isolated Burn RNG"]


### PR DESCRIPTION
**Summary**
Migrates the project's CPU backend from `burn-ndarray` to `burn-flex` as part of the Burn 0.21 upgrade. This transition enables support for WASM, embedded targets, and improved performance through SIMD dispatch and zero-copy operations.

**Changes**

**Backend Migration & Core Logic**
* **Dependency Update**: Swapped the `ndarray` feature for `flex` in `Cargo.toml`.
* **Type Migration**: Performed a workspace-wide migration of backend types: `NdArray` $\rightarrow$ `Flex`, `NdArrayDevice` $\rightarrow$ `FlexDevice`, and `backend::ndarray` $\rightarrow$ `backend::flex`.
* **Integer Width Adaptation**: Updated `tournament_indices_host` and `truncation_indices_host` to return `Vec<i32>` to align with `burn-flex` native integer widths.
* **Data Integrity**: Implemented conversions at tensor boundaries within `gp_cgp` to ensure algorithm internals continue to use `i64` where necessary.

**Cleanup & Documentation**
* **Terminology Update**: Scrubbed all references to "ndarray" in prose, documentation comments, and identifiers.
* **Test Renaming**: Updated test identifiers (e.g., `*_reproducibility_ndarray` $\rightarrow$ `*_reproducibility_flex`) to accurately reflect the active backend.
* **Variable Refactoring**: Renamed local variables (e.g., `ndarray_ga` $\rightarrow$ `flex_ga`) for consistency.

**Impact Assessment**
* **Risk Level**: Medium. While the primary effort is a rename, the change in integer width (`i64` $\rightarrow$ `i32`) for host helpers requires verification to ensure no precision loss or overflow occurs in index selection.
* **Breaking Changes**: Yes.
    * Modifies `Cargo.toml` dependencies.
    * Changes return types of selection helpers (`tournament_indices_host`, `truncation_indices_host`) to `Vec<i32>`.

**Testing & Verification**
* **Verification Method**: All changes verified via `cargo test`.
* **Affected Test Suites**:
    * **Unit Tests**: Selection helpers and `gp_cgp` boundary conversions.
    * **Integration Tests**: Reproducibility suites and `wgpu` vs `flex` comparison tests (formerly `wgpu_matches_ndarray`).

**Quality Checklist**
- [x] Code follows project-specific idiomatic Rust styles.
- [x] `cargo test` passes locally.
- [x] Documentation (`///` comments) updated for new public members.
- [x] No new compiler warnings introduced.

**Notes**