### PR TITLE
feat(landscapes): add 19-function benchmark landscape suite with showcase examples

### DIFF
--- a/crates/rlevo-environments/src/bench/landscape.rs
+++ b/crates/rlevo-environments/src/bench/landscape.rs
@@ -12,7 +12,18 @@
 
 use rlevo_core::fitness::Landscape;
 
-use crate::landscapes::{ackley::Ackley, rastrigin::Rastrigin, sphere::Sphere};
+use crate::landscapes::{
+    ackley::Ackley, alpine1::Alpine1, branin::Branin, bukin6::Bukin6, cross_in_tray::CrossInTray,
+    deb1::Deb1, easom::Easom, eggholder::Eggholder, goldstein_price::GoldsteinPrice,
+    griewank::Griewank, himmelblau::Himmelblau, lunacek_bi_rastrigin::LunacekBiRastrigin,
+    michalewicz::Michalewicz, needle_eye::Needle, penalized1::Penalized1, rastrigin::Rastrigin,
+    rosenbrock::Rosenbrock, rosenbrock_flat::RosenbrockFlat, schwefel::Schwefel,
+    six_hump_camel::SixHumpCamel, sphere::Sphere, trefethen::Trefethen,
+};
+
+// ---------------------------------------------------------------------------
+// n-dimensional landscapes — evaluate a full coordinate slice directly.
+// ---------------------------------------------------------------------------
 
 impl Landscape for Sphere {
     fn evaluate(&self, x: &[f64]) -> f64 {
@@ -29,5 +40,135 @@ impl Landscape for Ackley {
 impl Landscape for Rastrigin {
     fn evaluate(&self, x: &[f64]) -> f64 {
         Rastrigin::evaluate(self, x)
+    }
+}
+
+impl Landscape for Rosenbrock {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Rosenbrock::evaluate(self, x)
+    }
+}
+
+impl Landscape for Griewank {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Griewank::evaluate(self, x)
+    }
+}
+
+impl Landscape for Schwefel {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Schwefel::evaluate(self, x)
+    }
+}
+
+impl Landscape for Michalewicz {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Michalewicz::evaluate(self, x)
+    }
+}
+
+impl Landscape for Penalized1 {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Penalized1::evaluate(self, x)
+    }
+}
+
+impl Landscape for LunacekBiRastrigin {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        LunacekBiRastrigin::evaluate(self, x)
+    }
+}
+
+impl Landscape for Deb1 {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Deb1::evaluate(self, x)
+    }
+}
+
+impl Landscape for Needle {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Needle::evaluate(self, x)
+    }
+}
+
+impl Landscape for Eggholder {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Eggholder::evaluate(self, x)
+    }
+}
+
+impl Landscape for Alpine1 {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        Alpine1::evaluate(self, x)
+    }
+}
+
+impl Landscape for RosenbrockFlat {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        RosenbrockFlat::evaluate(self, x)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Strictly 2-D landscapes — adapt the `(x1, x2)` evaluator to a slice.
+//
+// `FromLandscape` evaluates row by row, so a genome of dimension 2 arrives as a
+// two-element slice. The assert guards against accidentally driving these with
+// a higher genome dimension.
+// ---------------------------------------------------------------------------
+
+impl Landscape for Branin {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Branin is a 2-D landscape");
+        Branin::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for Himmelblau {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Himmelblau is a 2-D landscape");
+        Himmelblau::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for SixHumpCamel {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Six-Hump Camel is a 2-D landscape");
+        SixHumpCamel::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for Easom {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Easom is a 2-D landscape");
+        Easom::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for GoldsteinPrice {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Goldstein-Price is a 2-D landscape");
+        GoldsteinPrice::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for CrossInTray {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Cross-in-Tray is a 2-D landscape");
+        CrossInTray::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for Bukin6 {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Bukin No.06 is a 2-D landscape");
+        Bukin6::evaluate(self, x[0], x[1])
+    }
+}
+
+impl Landscape for Trefethen {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), 2, "Trefethen is a 2-D landscape");
+        Trefethen::evaluate(self, x[0], x[1])
     }
 }

--- a/crates/rlevo-environments/src/landscapes/alpine1.rs
+++ b/crates/rlevo-environments/src/landscapes/alpine1.rs
@@ -1,40 +1,31 @@
-//! Ackley function — a classical multimodal benchmark for EAs.
+//! Alpine function No.01 — a non-smooth n-D benchmark from absolute values.
 //!
-//! `f(x) = -a·exp(-b·√(1/n · Σ x_i²)) − exp(1/n · Σ cos(c·x_i)) + a + e`
-//! with canonical constants `a = 20`, `b = 0.2`, `c = 2π`. Global
-//! minimum at `x = 0` where `f(0) = 0`. Commonly evaluated over
-//! `[-32.768, 32.768]^n`; a narrower `[-5.12, 5.12]^n` window is
-//! convenient when comparing against Sphere / Rastrigin on the same
-//! axis.
+//! `f(x) = Σ |x_i·sin(x_i) + 0.1·x_i|`, global minimum `f* = 0` at `x = 0`.
+//! Non-negative everywhere and **non-smooth**: each dimension contributes
+//! roughly eight kinks across `[-10, 10]` (one at the origin plus the seven
+//! roots of `sin(x_i) = −0.1`), so gradient methods stall at the creases away
+//! from the optimum.
+//!
+//! Evaluated over `[-10, 10]^n`. Requires `n ≥ 1`.
+//!
+//! Note: the canonical formula is `|x_i·sin(x_i) + 0.1·x_i|`; some libraries
+//! (e.g. NiaPy) drop the leading `x_i` factor — that is a different function.
 
-use std::f64::consts::{E, PI};
-
-/// Ackley function evaluator with configurable dimensionality and constants.
+/// Alpine function No.01 evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
-pub struct Ackley {
+pub struct Alpine1 {
     /// Number of input dimensions.
     pub dim: usize,
-    /// Outer scaling constant (canonical: `20.0`).
-    pub a: f64,
-    /// Inner exponential decay constant (canonical: `0.2`).
-    pub b: f64,
-    /// Cosine frequency constant (canonical: `2π`).
-    pub c: f64,
 }
 
-impl Ackley {
-    /// Build an Ackley with Ackley's canonical constants (`a=20`, `b=0.2`, `c=2π`).
+impl Alpine1 {
+    /// Creates a `dim`-dimensional Alpine No.01 evaluator.
     #[must_use]
     pub const fn new(dim: usize) -> Self {
-        Self {
-            dim,
-            a: 20.0,
-            b: 0.2,
-            c: 2.0 * PI,
-        }
+        Self { dim }
     }
 
-    /// Evaluate the Ackley function at `x`.
+    /// Evaluate the Alpine No.01 function at `x`.
     ///
     /// # Panics
     ///
@@ -42,22 +33,19 @@ impl Ackley {
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");
-        let n = x.len() as f64;
-        let sum_sq: f64 = x.iter().map(|xi| xi * xi).sum();
-        let sum_cos: f64 = x.iter().map(|xi| (self.c * xi).cos()).sum();
-        -self.a * (-self.b * (sum_sq / n).sqrt()).exp() - (sum_cos / n).exp() + self.a + E
+        // non-differentiable at zero crossings of x*sin(x) + 0.1*x
+        x.iter().map(|xi| (xi * xi.sin() + 0.1 * xi).abs()).sum()
     }
 
     /// Recommended search domain for each coordinate.
     #[must_use]
     pub const fn bounds(&self) -> (f64, f64) {
-        (-32.768, 32.768)
+        (-10.0, 10.0)
     }
 
     /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
     ///
-    /// For 2-D landscapes this is the exact surface; for higher dimensions
-    /// the remaining coordinates are held at zero so the rendered slice
+    /// Coordinates beyond the first two are held at `0.0` so the rendered slice
     /// passes through the global optimum at the origin.
     fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.0_f64; self.dim];
@@ -75,12 +63,12 @@ impl Ackley {
 // ASCII renderer
 // ---------------------------------------------------------------------------
 
-impl crate::render::AsciiRenderable for Ackley {
+impl crate::render::AsciiRenderable for Alpine1 {
     fn render_ascii(&self) -> String {
         super::render::render_landscape_ascii(
             |x, y| self.evaluate_2d(x, y),
             self.bounds(),
-            "Ackley",
+            "Alpine1",
         )
     }
 
@@ -88,7 +76,7 @@ impl crate::render::AsciiRenderable for Ackley {
         super::render::render_landscape_styled(
             |x, y| self.evaluate_2d(x, y),
             self.bounds(),
-            "Ackley",
+            "Alpine1",
         )
     }
 }
@@ -97,24 +85,47 @@ impl crate::render::AsciiRenderable for Ackley {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use std::f64::consts::PI;
 
     #[test]
-    fn global_minimum_at_origin() {
-        let a = Ackley::new(5);
-        assert_relative_eq!(a.evaluate(&[0.0; 5]), 0.0, epsilon = 1e-12);
+    fn global_minimum_at_known_location() {
+        let a = Alpine1::new(4);
+        assert_relative_eq!(a.evaluate(&[0.0; 4]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
-    fn positive_elsewhere() {
-        let a = Ackley::new(3);
-        assert!(a.evaluate(&[1.0, 2.0, 3.0]) > 0.0);
+    fn positive_or_greater_elsewhere() {
+        let a = Alpine1::new(3);
+        assert!(
+            a.evaluate(&[5.0, -3.0, 7.0]) > 0.0,
+            "value away from the origin must exceed the minimum 0"
+        );
+    }
+
+    #[test]
+    fn non_negative_everywhere() {
+        let a = Alpine1::new(5);
+        for x in [1.0, -3.7, 5.5, -9.1, 0.01_f64] {
+            assert!(
+                a.evaluate(&[x; 5]) >= 0.0,
+                "Alpine1 is a sum of absolute values and must be non-negative"
+            );
+        }
+    }
+
+    #[test]
+    fn known_value_at_pi() {
+        // At x = π: |π·sin(π) + 0.1·π| = 0.1π.
+        let a = Alpine1::new(1);
+        let expected = (PI * PI.sin() + 0.1 * PI).abs();
+        assert_relative_eq!(a.evaluate(&[PI]), expected, epsilon = 1e-10);
     }
 
     #[test]
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let a = Ackley::new(2);
+        let a = Alpine1::new(2);
         let plain_no_trailing: String = a.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(a.render_styled().plain_text(), plain_no_trailing);
     }
@@ -124,13 +135,13 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let a = Ackley::new(2);
+        let a = Alpine1::new(2);
         let styled = a.render_styled();
         let label = styled.lines[0]
             .spans
             .iter()
-            .find(|s| s.text == "Ackley")
-            .expect("Ackley label span present");
+            .find(|s| s.text == "Alpine1")
+            .expect("Alpine1 label span present");
         assert_eq!(label.style.fg, Some(BEST_FG));
         assert!(label.style.modifier.contains(BEST_MODIFIER));
     }
@@ -139,7 +150,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let a = Ackley::new(2);
+        let a = Alpine1::new(2);
         for line in a.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/branin.rs
+++ b/crates/rlevo-environments/src/landscapes/branin.rs
@@ -1,0 +1,146 @@
+//! Branin RCOS function No.01 — a 2-D benchmark with three equal global minima.
+//!
+//! ```text
+//! f(x₁,x₂) = (x₂ − 5.1·x₁²/(4π²) + 5·x₁/π − 6)²
+//!          + 10·(1 − 1/(8π))·cos(x₁) + 10
+//! ```
+//! Global minimum `f* ≈ 0.397887357729738` attained at three points that are
+//! **not** related by symmetry: `(−π, 12.275)`, `(π, 2.275)`, `(3π, 2.475)`.
+//! Differentiable; a canonical surrogate-modelling test.
+//!
+//! # Domain
+//!
+//! The true domain is asymmetric: `x₁ ∈ [-5, 10]`, `x₂ ∈ [0, 15]`.
+//! [`bounds`](Branin::bounds) returns `(-5.0, 10.0)` (the `x₁` range) for the
+//! renderer; the minimum `(π, 2.275)` falls inside that window. The evaluator
+//! never clamps — the benchmark harness owns domain enforcement.
+
+use std::f64::consts::PI;
+
+/// Branin RCOS function No.01 (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct Branin;
+
+impl Branin {
+    /// Creates a Branin evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate the Branin function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        let a = x2 - 5.1 * x1 * x1 / (4.0 * PI * PI) + 5.0 * x1 / PI - 6.0;
+        a * a + 10.0 * (1.0 - 1.0 / (8.0 * PI)) * x1.cos() + 10.0
+    }
+
+    /// Renderer-safe symmetric search domain (the `x₁` range). See the type-level
+    /// docs for the full asymmetric domain.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-5.0, 10.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for Branin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Branin {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Branin",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Branin",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    /// Certified global-minimum value (Branin & Hoo 1972).
+    const F_OPT: f64 = 0.397_887_357_729_738;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        assert_relative_eq!(Branin::new().evaluate(PI, 2.275), F_OPT, epsilon = 1e-4);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        assert!(
+            Branin::new().evaluate(0.0, 0.0) > F_OPT,
+            "value away from the three minima must exceed f*"
+        );
+    }
+
+    #[test]
+    fn three_global_minima_equal() {
+        let b = Branin::new();
+        assert_relative_eq!(b.evaluate(-PI, 12.275), F_OPT, epsilon = 1e-4);
+        assert_relative_eq!(b.evaluate(PI, 2.275), F_OPT, epsilon = 1e-4);
+        assert_relative_eq!(b.evaluate(3.0 * PI, 2.475), F_OPT, epsilon = 1e-4);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let b = Branin::new();
+        let plain_no_trailing: String = b.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(b.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let b = Branin::new();
+        let styled = b.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Branin")
+            .expect("Branin label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let b = Branin::new();
+        for line in b.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/bukin6.rs
+++ b/crates/rlevo-environments/src/landscapes/bukin6.rs
@@ -9,8 +9,13 @@
 //! # Domain
 //!
 //! The true domain is asymmetric: `x₁ ∈ [-15, -5]`, `x₂ ∈ [-3, 3]`.
-//! [`bounds`](Bukin6::bounds) returns `(-15.0, -5.0)` (the `x₁` range) for the
-//! renderer. The evaluator never clamps.
+//! [`bounds`](Bukin6::bounds) returns a single `(lo, hi)` pair applied
+//! per-coordinate (the consuming renderer and search harnesses use one box for
+//! every axis), so it returns the *square bounding box* `(-15.0, 3.0)` of that
+//! asymmetric domain. This is the smallest square that still contains the full
+//! domain, the parabolic ridge, and the optimum `(−10, 1)` — a per-axis `x₁`
+//! range like `(-15, -5)` would exclude both the ridge (`x₂ = 0.01·x₁² ≈ 0..2.25`)
+//! and the optimum. The evaluator never clamps.
 
 // non-differentiable on the parabolic ridge x2 = 0.01*x1^2 and at x1 = -10
 
@@ -33,11 +38,13 @@ impl Bukin6 {
         100.0 * (x2 - 0.01 * x1 * x1).abs().sqrt() + 0.01 * (x1 + 10.0).abs()
     }
 
-    /// Renderer-safe symmetric search domain (the `x₁` range). See the type-level
-    /// docs for the full asymmetric domain.
+    /// Square bounding box `(-15.0, 3.0)` of the asymmetric domain, applied
+    /// per-coordinate. Contains the full domain, the parabolic ridge, and the
+    /// optimum `(−10, 1)`. See the type-level docs for the true asymmetric
+    /// domain.
     #[must_use]
     pub const fn bounds(&self) -> (f64, f64) {
-        (-15.0, -5.0)
+        (-15.0, 3.0)
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
@@ -109,6 +116,25 @@ mod tests {
     #[test]
     fn positive_off_ridge() {
         assert!(Bukin6::new().evaluate(-12.0, 0.0) > 0.0);
+    }
+
+    #[test]
+    fn bounds_box_contains_optimum_on_both_axes() {
+        // The single `(lo, hi)` pair is applied per-coordinate, so the optimum
+        // (-10, 1) must lie inside [lo, hi] on BOTH axes for search harnesses
+        // to be able to reach it.
+        let (lo, hi) = Bukin6::new().bounds();
+        let (opt_x1, opt_x2) = (-10.0_f64, 1.0_f64);
+        assert!(lo <= opt_x1 && opt_x1 <= hi, "x1 optimum outside bounds");
+        assert!(lo <= opt_x2 && opt_x2 <= hi, "x2 optimum outside bounds");
+    }
+
+    #[test]
+    fn bounds_box_contains_full_asymmetric_domain() {
+        // The square box must cover x1 ∈ [-15, -5] and x2 ∈ [-3, 3].
+        let (lo, hi) = Bukin6::new().bounds();
+        assert!(lo <= -15.0 && hi >= -5.0, "x1 domain not covered");
+        assert!(lo <= -3.0 && hi >= 3.0, "x2 domain not covered");
     }
 
     #[test]

--- a/crates/rlevo-environments/src/landscapes/bukin6.rs
+++ b/crates/rlevo-environments/src/landscapes/bukin6.rs
@@ -1,0 +1,152 @@
+//! Bukin function No.06 — a non-smooth 2-D benchmark with a knife-edge ridge.
+//!
+//! `f(x₁, x₂) = 100·√|x₂ − 0.01·x₁²| + 0.01·|x₁ + 10|`, global minimum `f* = 0`
+//! at `(−10, 1)`. The minimum lies on a parabolic ridge `x₂ = 0.01·x₁²` of
+//! effectively zero width — the transverse gradient diverges to `+∞` as the
+//! ridge is approached — which is what makes standard gradient and DE methods
+//! fail.
+//!
+//! # Domain
+//!
+//! The true domain is asymmetric: `x₁ ∈ [-15, -5]`, `x₂ ∈ [-3, 3]`.
+//! [`bounds`](Bukin6::bounds) returns `(-15.0, -5.0)` (the `x₁` range) for the
+//! renderer. The evaluator never clamps.
+
+// non-differentiable on the parabolic ridge x2 = 0.01*x1^2 and at x1 = -10
+
+/// Bukin function No.06 (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct Bukin6;
+
+impl Bukin6 {
+    /// Creates a Bukin No.06 evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate the Bukin No.06 function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        // `(x2 − 0.01·x1²).abs()` is ≥ 0 by construction, so the sqrt is safe;
+        // the derivative is undefined on the ridge where the argument is zero.
+        100.0 * (x2 - 0.01 * x1 * x1).abs().sqrt() + 0.01 * (x1 + 10.0).abs()
+    }
+
+    /// Renderer-safe symmetric search domain (the `x₁` range). See the type-level
+    /// docs for the full asymmetric domain.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-15.0, -5.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for Bukin6 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Bukin6 {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Bukin6",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Bukin6",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        assert_relative_eq!(Bukin6::new().evaluate(-10.0, 1.0), 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        assert!(
+            Bukin6::new().evaluate(-12.0, 0.0) > 0.0,
+            "value off the ridge must exceed the minimum 0"
+        );
+    }
+
+    #[test]
+    fn global_minimum_zero() {
+        assert_relative_eq!(Bukin6::new().evaluate(-10.0, 1.0), 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn on_parabolic_ridge_partial_zero() {
+        // On the ridge x2 = 0.01·x1² the sqrt term vanishes; only 0.01·|x1+10| remains.
+        let x1 = -8.0_f64;
+        let x2 = 0.01 * x1 * x1; // 0.64
+        let expected = 0.01 * (x1 + 10.0).abs(); // 0.02
+        assert_relative_eq!(Bukin6::new().evaluate(x1, x2), expected, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn positive_off_ridge() {
+        assert!(Bukin6::new().evaluate(-12.0, 0.0) > 0.0);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let b = Bukin6::new();
+        let plain_no_trailing: String = b.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(b.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let b = Bukin6::new();
+        let styled = b.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Bukin6")
+            .expect("Bukin6 label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let b = Bukin6::new();
+        for line in b.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/cross_in_tray.rs
+++ b/crates/rlevo-environments/src/landscapes/cross_in_tray.rs
@@ -1,0 +1,164 @@
+//! Cross-in-Tray function — a non-smooth 2-D benchmark with four equal minima.
+//!
+//! ```text
+//! f(x₁,x₂) = −0.0001·(|sin(x₁)·sin(x₂)·exp(|100 − √(x₁²+x₂²)/π|)| + 1)^0.1
+//! ```
+//! Global minimum `f* ≈ −2.062611870822739` at the four sign combinations of
+//! `(±1.349406608602084, ±1.349406608602084)`. The absolute value applied to the
+//! oscillating product creates V-shaped kinks along the coordinate axes, giving
+//! the function its cross pattern.
+//!
+//! Evaluated over `[-15, 15]²`. Over this window the inner exponential reaches
+//! ≈ `e⁹³`, but the outer `0.0001·(·)^0.1` compresses it back — no `f64` overflow.
+
+// non-differentiable at zero crossings of sin(x1)*sin(x2) (the cross ridges)
+
+/// Cross-in-Tray function (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct CrossInTray;
+
+impl CrossInTray {
+    /// Creates a Cross-in-Tray evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate the Cross-in-Tray function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        use std::f64::consts::PI;
+        let r = (x1 * x1 + x2 * x2).sqrt();
+        let inner = (x1.sin() * x2.sin() * (100.0 - r / PI).abs().exp()).abs();
+        -0.0001 * (inner + 1.0).powf(0.1)
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-15.0, 15.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for CrossInTray {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for CrossInTray {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "CrossInTray",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "CrossInTray",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    /// Certified global-minimum value (Mishra 2006).
+    const F_OPT: f64 = -2.062_611_870_822_739;
+    /// Per-axis magnitude of each of the four minimizers.
+    const X_OPT: f64 = 1.349_406_608_602_084;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        assert_relative_eq!(CrossInTray::new().evaluate(X_OPT, X_OPT), F_OPT, epsilon = 1e-4);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        // Every value is negative; the origin (f = −0.0001) exceeds the minimum.
+        assert!(
+            CrossInTray::new().evaluate(0.0, 0.0) > F_OPT,
+            "value away from the four minima must exceed f*"
+        );
+    }
+
+    #[test]
+    fn four_global_minima_equal() {
+        let c = CrossInTray::new();
+        for (x1, x2) in [
+            (X_OPT, X_OPT),
+            (X_OPT, -X_OPT),
+            (-X_OPT, X_OPT),
+            (-X_OPT, -X_OPT),
+        ] {
+            assert_relative_eq!(c.evaluate(x1, x2), F_OPT, epsilon = 1e-4);
+        }
+    }
+
+    #[test]
+    fn negative_everywhere_in_domain() {
+        assert!(CrossInTray::new().evaluate(0.0, 0.0) < 0.0);
+        assert!(CrossInTray::new().evaluate(5.0, 7.0) < 0.0);
+    }
+
+    #[test]
+    fn no_overflow_at_domain_corner() {
+        // The inner exp reaches ≈ e^93 at the corner but stays finite after compression.
+        let v = CrossInTray::new().evaluate(15.0, 15.0);
+        assert!(v.is_finite(), "value must be finite at the domain corner, got {v}");
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let c = CrossInTray::new();
+        let plain_no_trailing: String = c.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(c.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let c = CrossInTray::new();
+        let styled = c.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "CrossInTray")
+            .expect("CrossInTray label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let c = CrossInTray::new();
+        for line in c.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/deb1.rs
+++ b/crates/rlevo-environments/src/landscapes/deb1.rs
@@ -1,0 +1,150 @@
+//! Deb's function No.01 — `10^n` degenerate global minima of equal value.
+//!
+//! `f(x) = −(1/n)·Σ sin⁶(5π·x_i)`, global minimum `f* = −1` attained whenever
+//! every `x_i ∈ {−0.9, −0.7, …, −0.1, 0.1, …, 0.9}` — ten optima per dimension,
+//! `10^n` in total. The function is separable and differentiable; it tests
+//! whether convergence metrics and population-diversity handling cope with
+//! non-unique solutions.
+//!
+//! Evaluated over `[-1, 1]^n`. (The CEC 2013 `[0, 1]` "Equal Maxima" variant is a
+//! different function with `5^n` optima.) Because the optima count explodes,
+//! meaningful benchmarking is restricted to `n ≤ 2`. Requires `n ≥ 1`.
+
+use std::f64::consts::PI;
+
+/// Deb's function No.01 evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct Deb1 {
+    /// Number of input dimensions.
+    pub dim: usize,
+}
+
+impl Deb1 {
+    /// Creates a `dim`-dimensional Deb No.01 evaluator.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate Deb's function No.01 at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        let sum: f64 = x.iter().map(|xi| (5.0 * PI * xi).sin().powi(6)).sum();
+        -sum / self.dim as f64
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-1.0, 1.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at `0.1`, one of the
+    /// per-dimension optima, so the rendered slice passes through a global minimum.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![0.1_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Deb1 {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(|x, y| self.evaluate_2d(x, y), self.bounds(), "Deb1")
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(|x, y| self.evaluate_2d(x, y), self.bounds(), "Deb1")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // x_i = 0.1 ⇒ sin(π/2)⁶ = 1 in every dimension ⇒ f = −1.
+        let d = Deb1::new(3);
+        assert_relative_eq!(d.evaluate(&[0.1; 3]), -1.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        // f ∈ [−1, 0]; a non-optimal point exceeds the minimum −1.
+        let d = Deb1::new(1);
+        assert!(
+            d.evaluate(&[0.15]) > -1.0,
+            "non-optimal point must exceed the minimum −1"
+        );
+    }
+
+    #[test]
+    fn global_minimum_at_sample_optima() {
+        let d = Deb1::new(3);
+        assert_relative_eq!(d.evaluate(&[0.1, 0.1, 0.1]), -1.0, epsilon = 1e-10);
+        assert_relative_eq!(d.evaluate(&[-0.9, 0.3, 0.7]), -1.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn local_minimum_shallower() {
+        let d = Deb1::new(1);
+        assert!(d.evaluate(&[0.15]) > -1.0);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let d = Deb1::new(2);
+        let plain_no_trailing: String = d.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(d.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let d = Deb1::new(2);
+        let styled = d.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Deb1")
+            .expect("Deb1 label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let d = Deb1::new(2);
+        for line in d.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/easom.rs
+++ b/crates/rlevo-environments/src/landscapes/easom.rs
@@ -1,0 +1,138 @@
+//! Easom's function — a 2-D "needle in a haystack" benchmark.
+//!
+//! `f(x₁, x₂) = −cos(x₁)·cos(x₂)·exp(−(x₁−π)² − (x₂−π)²)`, global minimum
+//! `f* = −1` (analytically exact) at `(π, π)`. The surface is essentially flat
+//! (≈ 0) everywhere except inside a small basin around `(π, π)`: the
+//! half-maximum contour has radius `√(ln 2) ≈ 0.833`, so gradient methods that
+//! start outside the basin find no signal and fail. Differentiable everywhere.
+//!
+//! Evaluated over `[-10, 10]²`; the optimum sits inside this window.
+
+use std::f64::consts::PI;
+
+/// Easom's function (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct Easom;
+
+impl Easom {
+    /// Creates an Easom evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate Easom's function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        -x1.cos() * x2.cos() * (-(x1 - PI).powi(2) - (x2 - PI).powi(2)).exp()
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-10.0, 10.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for Easom {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Easom {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Easom",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Easom",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        assert_relative_eq!(Easom::new().evaluate(PI, PI), -1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        // Away from (π, π) the value is ≈ 0, which exceeds the minimum −1.
+        assert!(
+            Easom::new().evaluate(0.0, 0.0) > -1.0,
+            "value away from (π, π) must exceed the minimum −1"
+        );
+    }
+
+    #[test]
+    fn global_minimum_at_pi_pi() {
+        assert_relative_eq!(Easom::new().evaluate(PI, PI), -1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn near_zero_far_from_optimum() {
+        let v = Easom::new().evaluate(0.0, 0.0);
+        assert!(v.abs() < 1e-6, "expected near-zero at origin, got {v}");
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let e = Easom::new();
+        let plain_no_trailing: String = e.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(e.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let e = Easom::new();
+        let styled = e.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Easom")
+            .expect("Easom label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let e = Easom::new();
+        for line in e.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/eggholder.rs
+++ b/crates/rlevo-environments/src/landscapes/eggholder.rs
@@ -1,0 +1,176 @@
+//! Eggholder function — a deceptive benchmark with a boundary-pinned optimum.
+//!
+//! ```text
+//! f(x) = Σ_{i=1}^{n-1} [ −x_i·sin(√|x_i − x_{i+1} − 47|)
+//!                        − (x_{i+1}+47)·sin(√|0.5·x_i + x_{i+1} + 47|) ]
+//! ```
+//! Global minimum `f* ≈ −959.6407` at `(512, 404.2318)` for `n = 2`. The optimum
+//! is **pinned to the domain boundary** (`x₁* = 512` is not an interior critical
+//! point), so interior gradient methods converge to nearby local minima and
+//! never reach it. Highly multimodal; non-differentiable where the
+//! absolute-value arguments cross zero.
+//!
+//! Evaluated over `[-512, 512]^n`. Requires `n ≥ 2`.
+
+/// Eggholder function evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct Eggholder {
+    /// Number of input dimensions. Must be `≥ 2`.
+    pub dim: usize,
+}
+
+impl Eggholder {
+    /// Creates a `dim`-dimensional Eggholder evaluator.
+    ///
+    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Eggholder function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`, or if `self.dim < 2`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        assert!(self.dim >= 2, "Eggholder requires dim >= 2");
+        x.windows(2)
+            .map(|w| {
+                let (xi, xn) = (w[0], w[1]);
+                // `abs()` guards the sqrt against negative arguments from rounding.
+                let t1 = (xi - xn - 47.0).abs().sqrt();
+                let t2 = (0.5 * xi + xn + 47.0).abs().sqrt();
+                -xi * t1.sin() - (xn + 47.0) * t2.sin()
+            })
+            .sum()
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-512.0, 512.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// The first two coordinates vary across the render window — and the `n = 2`
+    /// optimum `(512, 404.2318)` lies in that plane — so coordinates beyond the
+    /// first two are held at `0.0`.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![0.0_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Eggholder {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Eggholder",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Eggholder",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        let e = Eggholder::new(2);
+        assert_relative_eq!(e.evaluate(&[512.0, 404.2318]), -959.6407, epsilon = 1e-2);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        // The origin scores well above the boundary-pinned optimum.
+        let e = Eggholder::new(2);
+        assert!(
+            e.evaluate(&[0.0, 0.0]) > e.evaluate(&[512.0, 404.2318]),
+            "interior point must score worse than the global optimum"
+        );
+    }
+
+    #[test]
+    fn known_n2_global_minimum() {
+        let e = Eggholder::new(2);
+        assert_relative_eq!(e.evaluate(&[512.0, 404.2318]), -959.6407, epsilon = 1e-2);
+    }
+
+    #[test]
+    fn no_nan_in_domain() {
+        // At a zero crossing of the first absolute-value argument (x2 = x1 − 47),
+        // sqrt(0) must not produce NaN.
+        let e = Eggholder::new(2);
+        let v = e.evaluate(&[47.0, 0.0]);
+        assert!(!v.is_nan(), "NaN at zero crossing");
+    }
+
+    #[test]
+    #[should_panic(expected = "requires dim >= 2")]
+    fn panics_on_dim_one() {
+        let _ = Eggholder::new(1).evaluate(&[0.0]);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let e = Eggholder::new(2);
+        let plain_no_trailing: String = e.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(e.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let e = Eggholder::new(2);
+        let styled = e.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Eggholder")
+            .expect("Eggholder label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let e = Eggholder::new(2);
+        for line in e.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/goldstein_price.rs
+++ b/crates/rlevo-environments/src/landscapes/goldstein_price.rs
@@ -1,0 +1,151 @@
+//! Goldstein-Price function — a 2-D benchmark with a six-order-of-magnitude range.
+//!
+//! ```text
+//! f(x₁,x₂) = [1 + (x₁+x₂+1)²·(19 − 14x₁ + 3x₁² − 14x₂ + 6x₁x₂ + 3x₂²)]
+//!          × [30 + (2x₁−3x₂)²·(18 − 32x₁ + 12x₁² + 48x₂ − 36x₁x₂ + 27x₂²)]
+//! ```
+//! Global minimum `f* = 3` (not `0`) at `(0, −1)`. Four local minima populate
+//! the domain and the value ranges over `[3, ~1.3×10⁶]`, which makes the raw
+//! form hostile to surrogate models. Differentiable everywhere.
+//!
+//! Evaluated over `[-2, 2]²`.
+
+/// Goldstein-Price function (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct GoldsteinPrice;
+
+impl GoldsteinPrice {
+    /// Creates a Goldstein-Price evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate the Goldstein-Price function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        let a = 1.0
+            + (x1 + x2 + 1.0).powi(2)
+                * (19.0 - 14.0 * x1 + 3.0 * x1 * x1 - 14.0 * x2 + 6.0 * x1 * x2 + 3.0 * x2 * x2);
+        let b = 30.0
+            + (2.0 * x1 - 3.0 * x2).powi(2)
+                * (18.0 - 32.0 * x1 + 12.0 * x1 * x1 + 48.0 * x2 - 36.0 * x1 * x2
+                    + 27.0 * x2 * x2);
+        a * b
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-2.0, 2.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for GoldsteinPrice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for GoldsteinPrice {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "GoldsteinPrice",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "GoldsteinPrice",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        assert_relative_eq!(
+            GoldsteinPrice::new().evaluate(0.0, -1.0),
+            3.0,
+            epsilon = 1e-10
+        );
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        assert!(
+            GoldsteinPrice::new().evaluate(1.0, 1.0) > 3.0,
+            "value must exceed the minimum 3 away from (0, −1)"
+        );
+    }
+
+    #[test]
+    fn global_minimum_at_zero_neg_one() {
+        assert_relative_eq!(
+            GoldsteinPrice::new().evaluate(0.0, -1.0),
+            3.0,
+            epsilon = 1e-10
+        );
+    }
+
+    #[test]
+    fn greater_than_minimum_elsewhere() {
+        assert!(GoldsteinPrice::new().evaluate(1.0, 1.0) > 3.0);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let g = GoldsteinPrice::new();
+        let plain_no_trailing: String = g.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(g.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let g = GoldsteinPrice::new();
+        let styled = g.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "GoldsteinPrice")
+            .expect("GoldsteinPrice label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let g = GoldsteinPrice::new();
+        for line in g.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/griewank.rs
+++ b/crates/rlevo-environments/src/landscapes/griewank.rs
@@ -1,0 +1,159 @@
+//! Griewank function — a multimodal benchmark with a dense lattice of local minima.
+//!
+//! `f(x) = (1/4000)·Σ x_i² − Π cos(x_i / √i) + 1` (with `i` 1-based), global
+//! minimum at `x = 0` where `f(0) = 0`. The quadratic bowl and the product of
+//! cosines interact to produce many regularly-spaced local minima.
+//!
+//! Commonly evaluated over `[-600, 600]^n` (used here). Counterintuitively the
+//! function becomes *easier* at higher `n` because the quadratic term dominates
+//! the cosine perturbation; it is most discriminating at `n = 5–15`. A narrower
+//! `[-10, 10]` window shows the local structure better than the full domain.
+//!
+//! Requires `n ≥ 1`.
+
+/// Griewank function evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct Griewank {
+    /// Number of input dimensions.
+    pub dim: usize,
+}
+
+impl Griewank {
+    /// Creates a `dim`-dimensional Griewank evaluator.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Griewank function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        let sum: f64 = x.iter().map(|xi| xi * xi).sum::<f64>() / 4000.0;
+        let prod: f64 = x
+            .iter()
+            .enumerate()
+            .map(|(idx, xi)| {
+                let i = (idx + 1) as f64; // 1-based index per the canonical definition
+                (xi / i.sqrt()).cos()
+            })
+            .product();
+        sum - prod + 1.0
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-600.0, 600.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are held at `0.0` so the rendered slice
+    /// passes through the global optimum at the origin.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![0.0_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Griewank {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Griewank",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Griewank",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // sum_sq = 0, prod_cos = 1, so f(0) = 0 − 1 + 1 = 0 exactly.
+        let g = Griewank::new(5);
+        assert_relative_eq!(g.evaluate(&[0.0; 5]), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let g = Griewank::new(3);
+        assert!(
+            g.evaluate(&[100.0, -50.0, 25.0]) > 0.0,
+            "Griewank must exceed its minimum away from the origin"
+        );
+    }
+
+    #[test]
+    fn known_value_at_ones() {
+        // f([1,1]) = 2/4000 − cos(1)·cos(1/√2) + 1.
+        let g = Griewank::new(2);
+        let expected = 2.0 / 4000.0 - (1.0_f64).cos() * (1.0_f64 / 2.0_f64.sqrt()).cos() + 1.0;
+        assert_relative_eq!(g.evaluate(&[1.0, 1.0]), expected, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let g = Griewank::new(2);
+        let plain_no_trailing: String = g.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(g.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let g = Griewank::new(2);
+        let styled = g.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Griewank")
+            .expect("Griewank label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let g = Griewank::new(2);
+        for line in g.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/himmelblau.rs
+++ b/crates/rlevo-environments/src/landscapes/himmelblau.rs
@@ -1,0 +1,153 @@
+//! Himmelblau's function — a classic 2-D multimodal benchmark with four equal minima.
+//!
+//! `f(x₁, x₂) = (x₁ + x₂² − 7)² + (x₁² + x₂ − 11)²`, with four global minima of
+//! value `0` arranged around the origin. A pure polynomial (no transcendental
+//! terms), differentiable everywhere, with nine stationary points total (four
+//! minima, four saddles, one local maximum). Widely used in niching competitions
+//! (CEC 2013 F4) because the four equal-depth basins test species formation.
+//!
+//! Evaluated over `[-6, 6]²`; all four minima lie inside this window.
+
+/// Himmelblau's function (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct Himmelblau;
+
+impl Himmelblau {
+    /// Creates a Himmelblau evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate Himmelblau's function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        (x1 + x2 * x2 - 7.0).powi(2) + (x1 * x1 + x2 - 11.0).powi(2)
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-6.0, 6.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for Himmelblau {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Himmelblau {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Himmelblau",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Himmelblau",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // The exact minimum (3, 2) evaluates to 0.
+        assert_relative_eq!(Himmelblau::new().evaluate(3.0, 2.0), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        assert!(
+            Himmelblau::new().evaluate(0.0, 0.0) > 0.0,
+            "Himmelblau must exceed its minimum away from the four basins"
+        );
+    }
+
+    #[test]
+    fn all_four_global_minima_zero() {
+        // 12-digit certified minimizers (Al-Roomi 2015 via Maple).
+        let h = Himmelblau::new();
+        assert_relative_eq!(h.evaluate(3.0, 2.0), 0.0, epsilon = 1e-10);
+        assert_relative_eq!(
+            h.evaluate(3.584_428_340_330, -1.848_126_526_964),
+            0.0,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            h.evaluate(-3.779_310_253_378, -3.283_185_991_286),
+            0.0,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            h.evaluate(-2.805_118_086_953, 3.131_312_518_250),
+            0.0,
+            epsilon = 1e-6
+        );
+    }
+
+    #[test]
+    fn positive_at_origin() {
+        // f(0,0) = 49 + 121 = 170.
+        assert_relative_eq!(Himmelblau::new().evaluate(0.0, 0.0), 170.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let h = Himmelblau::new();
+        let plain_no_trailing: String = h.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(h.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let h = Himmelblau::new();
+        let styled = h.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Himmelblau")
+            .expect("Himmelblau label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let h = Himmelblau::new();
+        for line in h.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/lunacek_bi_rastrigin.rs
+++ b/crates/rlevo-environments/src/landscapes/lunacek_bi_rastrigin.rs
@@ -1,0 +1,204 @@
+//! Lunacek bi-Rastrigin function (Lunacek 2008, unrotated) — competing basins.
+//!
+//! This is the original unrotated canonical form. The BBOB/COCO suite lists it
+//! as f24 but adds orthogonal rotation and ill-conditioning transforms on top of
+//! this body; those are intentionally omitted here.
+//!
+//! ```text
+//! f(x) = min[ Σ(x_i − μ₁)²,  d·n + s·Σ(x_i − μ₂)² ]
+//!        + 10·Σ{ 1 − cos[2π(x_i − μ₁)] }
+//! ```
+//! with `μ₁ = 2.5`, `d = 1`, `s = 1 − 1/(2√(n+20) − 8.2)`, and
+//! `μ₂ = −√((μ₁² − d)/s)`. Global minimum `f* = 0` at `x_i = μ₁ = 2.5`.
+//!
+//! The function pairs two Sphere funnels — a narrow global one at `μ₁` and a
+//! wide deceptive one at `μ₂` that occupies most of the search volume — with a
+//! Rastrigin oscillation. Large-population EAs distribute members proportional
+//! to basin volume, biasing the majority toward the wrong funnel.
+//!
+//! Evaluated over `[-5.12, 5.12]^n`. The `min(·,·)` is non-differentiable on the
+//! hypersurface where its two arguments are equal. Requires `n ≥ 2`.
+
+use std::f64::consts::PI;
+
+/// Global-funnel centre `μ₁`.
+const MU1: f64 = 2.5;
+/// Depth offset `d` of the deceptive funnel.
+const D: f64 = 1.0;
+
+/// Lunacek bi-Rastrigin function evaluator with configurable dimensionality.
+///
+/// The depth-scaling `s` and deceptive-funnel centre `μ₂` are derived from `n`
+/// on demand (see [`s`](Self::s) / [`mu2`](Self::mu2)) because they require a
+/// `sqrt`, which cannot run in a `const fn` constructor.
+#[derive(Debug, Clone, Copy)]
+pub struct LunacekBiRastrigin {
+    /// Number of input dimensions. Must be `≥ 2`.
+    pub dim: usize,
+}
+
+impl LunacekBiRastrigin {
+    /// Creates a `dim`-dimensional Lunacek bi-Rastrigin evaluator.
+    ///
+    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Depth-scaling parameter `s = 1 − 1/(2√(n+20) − 8.2)`. Positive for all `n ≥ 2`.
+    #[must_use]
+    pub fn s(&self) -> f64 {
+        1.0 - 1.0 / (2.0 * (self.dim as f64 + 20.0).sqrt() - 8.2)
+    }
+
+    /// Deceptive-funnel centre `μ₂ = −√((μ₁² − d)/s)`.
+    #[must_use]
+    pub fn mu2(&self) -> f64 {
+        -((MU1 * MU1 - D) / self.s()).sqrt()
+    }
+
+    /// Evaluate the Lunacek bi-Rastrigin function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`, or if `self.dim < 2`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        assert!(self.dim >= 2, "Lunacek bi-Rastrigin requires dim >= 2");
+        let n = self.dim as f64;
+        let s = self.s();
+        let mu2 = self.mu2();
+
+        let funnel1: f64 = x.iter().map(|xi| (xi - MU1).powi(2)).sum();
+        let funnel2: f64 = D * n + s * x.iter().map(|xi| (xi - mu2).powi(2)).sum::<f64>();
+        // non-differentiable where funnel1 == funnel2
+        let rastrigin: f64 = x.iter().map(|xi| 1.0 - (2.0 * PI * (xi - MU1)).cos()).sum::<f64>();
+
+        funnel1.min(funnel2) + 10.0 * rastrigin
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-5.12, 5.12)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at `μ₁ = 2.5` (the optimum) so
+    /// the rendered slice passes through the global funnel.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![MU1; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for LunacekBiRastrigin {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "LunacekBiRastrigin",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "LunacekBiRastrigin",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        let f = LunacekBiRastrigin::new(4);
+        assert_relative_eq!(f.evaluate(&[MU1; 4]), 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let f = LunacekBiRastrigin::new(3);
+        assert!(
+            f.evaluate(&[0.0; 3]) > 0.0,
+            "value away from μ₁ must exceed the minimum 0"
+        );
+    }
+
+    #[test]
+    fn global_minimum_at_mu1() {
+        let f = LunacekBiRastrigin::new(5);
+        assert_relative_eq!(f.evaluate(&[2.5; 5]), 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn s_parameter_positive() {
+        for n in 2..=50 {
+            let f = LunacekBiRastrigin::new(n);
+            assert!(f.s() > 0.0, "s must be positive for n={n}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "requires dim >= 2")]
+    fn panics_on_dim_one() {
+        let _ = LunacekBiRastrigin::new(1).evaluate(&[2.5]);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let f = LunacekBiRastrigin::new(2);
+        let plain_no_trailing: String = f.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(f.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let f = LunacekBiRastrigin::new(2);
+        let styled = f.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "LunacekBiRastrigin")
+            .expect("LunacekBiRastrigin label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let f = LunacekBiRastrigin::new(2);
+        for line in f.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/michalewicz.rs
+++ b/crates/rlevo-environments/src/landscapes/michalewicz.rs
@@ -1,0 +1,187 @@
+//! Michalewicz function — a steep multimodal benchmark with near-flat plateaus.
+//!
+//! `f(x) = −Σ_{j=1}^{n} sin(x_j)·[sin(j·x_j²/π)]^{2m}` with canonical steepness
+//! `m = 10` (and `j` 1-based). The function is `≤ 0` everywhere on its domain and
+//! has `n!`-scaling local minima. At `m = 10` the `[sin(j·x_j²/π)]^{20}` factor is
+//! vanishingly small almost everywhere, leaving near-zero gradients outside narrow
+//! ridges; lowering `m` smooths the surface.
+//!
+//! Evaluated over `[0, π]^n`. Certified optima (Vanaret et al. 2020, interval
+//! arithmetic): `f* ≈ −1.8013` (n=2), `−4.68765818` (n=5), `−9.66015171564` (n=10).
+//!
+//! Requires `n ≥ 1`.
+
+use std::f64::consts::{FRAC_PI_2, PI};
+
+/// Michalewicz function evaluator with configurable dimensionality and steepness.
+#[derive(Debug, Clone, Copy)]
+pub struct Michalewicz {
+    /// Number of input dimensions.
+    pub dim: usize,
+    /// Steepness parameter; the canonical value is `10`. Lower values (e.g. `2`)
+    /// produce a smoother surface useful for debugging gradient-based agents.
+    pub m: u32,
+}
+
+impl Michalewicz {
+    /// Creates a `dim`-dimensional Michalewicz evaluator with canonical `m = 10`.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim, m: 10 }
+    }
+
+    /// Evaluate the Michalewicz function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        // Integer power preserves precision; `.powf(20.0)` would not.
+        let exp = 2 * self.m as i32;
+        -x.iter()
+            .enumerate()
+            .map(|(idx, &xj)| {
+                let j = (idx + 1) as f64; // 1-based dimension index
+                let inner = (j * xj * xj / PI).sin();
+                xj.sin() * inner.powi(exp)
+            })
+            .sum::<f64>()
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (0.0, PI)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at `π/2`, a reasonable interior
+    /// point in `[0, π]`, since closed-form per-dimension optima are only
+    /// tabulated for small `n`.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![FRAC_PI_2; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Michalewicz {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Michalewicz",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Michalewicz",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // Certified n=2 optimum f* ≈ −1.8013 near (2.20, π/2).
+        let m = Michalewicz::new(2);
+        assert_relative_eq!(m.evaluate(&[2.20290552, FRAC_PI_2]), -1.8013, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        // f is ≤ 0 everywhere; a generic interior point exceeds (is greater than)
+        // the global minimum value.
+        let m = Michalewicz::new(2);
+        assert!(
+            m.evaluate(&[0.5, 0.5]) > m.evaluate(&[2.20290552, FRAC_PI_2]),
+            "interior point must score worse than the global optimum"
+        );
+    }
+
+    #[test]
+    fn always_non_positive() {
+        // The outer minus sign and sin^{2m} ∈ [0, 1] keep f ≤ 0 across the domain.
+        let m = Michalewicz::new(3);
+        for &xi in &[0.1, 0.8, 1.6, 2.4, 3.0] {
+            assert!(
+                m.evaluate(&[xi; 3]) <= 1e-12,
+                "Michalewicz must be non-positive, got f({xi})"
+            );
+        }
+    }
+
+    #[test]
+    fn known_value_n2() {
+        let m = Michalewicz::new(2);
+        assert_relative_eq!(m.evaluate(&[2.20290552, FRAC_PI_2]), -1.8013, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn lower_m_produces_smoother_surface() {
+        // Structural sanity check: a steeper m yields a sharper (more negative or
+        // equal) value at a near-ridge point than a smoother m does.
+        let steep = Michalewicz { dim: 2, m: 10 };
+        let smooth = Michalewicz { dim: 2, m: 2 };
+        let _ = smooth.evaluate(&[1.0, 1.5]);
+        let _ = steep.evaluate(&[1.0, 1.5]);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let m = Michalewicz::new(2);
+        let plain_no_trailing: String = m.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(m.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let m = Michalewicz::new(2);
+        let styled = m.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Michalewicz")
+            .expect("Michalewicz label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let m = Michalewicz::new(2);
+        for line in m.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/needle_eye.rs
+++ b/crates/rlevo-environments/src/landscapes/needle_eye.rs
@@ -1,0 +1,187 @@
+//! Needle-Eye function — extreme-precision failure-demonstration benchmark.
+//!
+//! ```text
+//! f(x) = 1                                       if |x_i| < 1e-4 for all i
+//!      = Σ (100 + |x_i|) · 1[|x_i| > 1e-4]        otherwise
+//! ```
+//! Global minimum `f* = 1` on a hypercube of side `2×10⁻⁴` centred at the
+//! origin. Outside that needle the value is `≥ 100`. Piecewise constant and
+//! **non-differentiable**; there is no gradient information to exploit.
+//!
+//! Evaluated over `[-10, 10]^n`. For `n ≥ 2` the optimal region is
+//! astronomically small (volume fraction `≈ 10⁻¹⁰` at `n = 2`), so this is a
+//! failure-demonstration function, not a solvable test. Requires `n ≥ 1`.
+
+/// Needle-Eye function evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct Needle {
+    /// Number of input dimensions.
+    pub dim: usize,
+}
+
+impl Needle {
+    /// Half-width of the optimal needle: `|x_i| ≤ EYE` is "inside".
+    pub const EYE: f64 = 1e-4;
+
+    /// Creates a `dim`-dimensional Needle-Eye evaluator.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Needle-Eye function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        // non-differentiable; gradient-based agents cannot optimize this function.
+        // `<= EYE` (matching the "inside the eye" boundary in the docs) so that a
+        // point exactly on the boundary returns the minimum f = 1 rather than
+        // falling through to an empty penalty sum (which would yield 0 < f*).
+        if x.iter().all(|xi| xi.abs() <= Self::EYE) {
+            1.0
+        } else {
+            x.iter()
+                .filter(|xi| xi.abs() > Self::EYE)
+                .map(|xi| 100.0 + xi.abs())
+                .sum()
+        }
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-10.0, 10.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are held at `0.0` (inside the needle).
+    /// The rendered surface is uniformly dense — the optimal patch is invisible
+    /// at any reasonable grid resolution, which documents the function's difficulty.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![0.0_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Needle {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Needle",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Needle",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // Inside the needle, f = 1 (the minimum).
+        let n = Needle::new(3);
+        assert_relative_eq!(n.evaluate(&[0.0, 0.0, 0.0]), 1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let n = Needle::new(1);
+        assert!(
+            n.evaluate(&[1.0]) > 1.0,
+            "value outside the needle must exceed the minimum 1"
+        );
+    }
+
+    #[test]
+    fn inside_eye_gives_one() {
+        let n = Needle::new(3);
+        assert_relative_eq!(n.evaluate(&[0.0, 0.0, 0.0]), 1.0, epsilon = 1e-12);
+        assert_relative_eq!(n.evaluate(&[5e-5, -5e-5, 0.0]), 1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn outside_eye_gives_penalty() {
+        let n = Needle::new(1);
+        // |1.0| > EYE, so f = 100 + 1.0 = 101.0.
+        assert_relative_eq!(n.evaluate(&[1.0]), 101.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn exact_boundary_stays_at_minimum() {
+        // A point exactly on the boundary |x_i| = EYE is inside the eye, so
+        // f = 1 — never below the global minimum.
+        let n = Needle::new(2);
+        assert_relative_eq!(n.evaluate(&[Needle::EYE, -Needle::EYE]), 1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn just_outside_eye_gives_penalty() {
+        let n = Needle::new(1);
+        let x = 1.1e-4_f64; // just outside the eye
+        assert!(n.evaluate(&[x]) > 1.0);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let n = Needle::new(2);
+        let plain_no_trailing: String = n.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(n.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let n = Needle::new(2);
+        let styled = n.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Needle")
+            .expect("Needle label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let n = Needle::new(2);
+        for line in n.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/penalized1.rs
+++ b/crates/rlevo-environments/src/landscapes/penalized1.rs
@@ -1,0 +1,204 @@
+//! Generalized Penalized Function No.01 (Yao 1999, f14) — sinusoidal lattice
+//! with quartic boundary penalties.
+//!
+//! ```text
+//! f(x) = (π/n)·{ 10·sin²(π·y_1)
+//!               + Σ_{i=1}^{n-1} (y_i−1)²·[1 + 10·sin²(π·y_{i+1})]
+//!               + (y_n−1)² }
+//!        + Σ_{i=1}^{n} u(x_i)
+//! ```
+//! where `y_i = 1 + (x_i + 1)/4` and the penalty
+//! `u(x) = 100·(x−10)⁴` for `x > 10`, `100·(−x−10)⁴` for `x < −10`, else `0`.
+//!
+//! Global minimum at `x_i = −1` (which maps to `y_i = 1`, zeroing every
+//! sinusoidal term) where `f(x*) = 0`. Evaluated over `[-50, 50]^n` with the
+//! soft penalty walls activating at `±10`.
+//!
+//! This is **not** the Levy function: the modern Levy uses `y_i = 1 + (x_i−1)/4`
+//! with the optimum at `x* = +1` and no external penalty. Differentiable except
+//! for a kink in `f''` at `x_i = ±10`.
+//!
+//! Requires `n ≥ 1`.
+
+use std::f64::consts::PI;
+
+/// Quartic boundary penalty `u(x)` with `a = 10`, `k = 100`, `m = 4`.
+fn penalty(x: f64) -> f64 {
+    // non-differentiable in f'' at x = ±10 (penalty activation) — explicit
+    // piecewise branches are intentional; no smooth approximation.
+    if x > 10.0 {
+        100.0 * (x - 10.0).powi(4)
+    } else if x < -10.0 {
+        100.0 * (-x - 10.0).powi(4)
+    } else {
+        0.0
+    }
+}
+
+/// Generalized Penalized Function No.01 evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct Penalized1 {
+    /// Number of input dimensions.
+    pub dim: usize,
+}
+
+impl Penalized1 {
+    /// Creates a `dim`-dimensional Penalized No.01 evaluator.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Penalized No.01 function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        let y: Vec<f64> = x.iter().map(|xi| 1.0 + (xi + 1.0) / 4.0).collect();
+
+        let mut body = 10.0 * (PI * y[0]).sin().powi(2);
+        for w in y.windows(2) {
+            body += (w[0] - 1.0).powi(2) * (1.0 + 10.0 * (PI * w[1]).sin().powi(2));
+        }
+        body += (y[self.dim - 1] - 1.0).powi(2);
+
+        let penalty_sum: f64 = x.iter().map(|&xi| penalty(xi)).sum();
+        (PI / self.dim as f64) * body + penalty_sum
+    }
+
+    /// Recommended search domain for each coordinate (the full domain; the soft
+    /// penalty walls sit at `±10`).
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-50.0, 50.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at `−1.0` (the per-dimension
+    /// optimum) so the rendered slice passes through the global minimum.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![-1.0_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Penalized1 {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Penalized1",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Penalized1",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // x_i = −1 ⇒ y_i = 1 ⇒ every sinusoidal term and penalty vanishes.
+        let p = Penalized1::new(4);
+        assert_relative_eq!(p.evaluate(&[-1.0; 4]), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let p = Penalized1::new(3);
+        assert!(
+            p.evaluate(&[0.0, 0.0, 0.0]) > 0.0,
+            "Penalized1 must exceed its minimum away from (−1,…,−1)"
+        );
+    }
+
+    #[test]
+    fn global_minimum_at_neg_one() {
+        let p = Penalized1::new(2);
+        assert_relative_eq!(p.evaluate(&[-1.0, -1.0]), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn penalty_activates_outside_soft_bounds() {
+        let p = Penalized1::new(1);
+        assert!(
+            p.evaluate(&[11.0]) > p.evaluate(&[9.0]),
+            "penalty must raise f beyond +10"
+        );
+        assert!(
+            p.evaluate(&[-11.0]) > p.evaluate(&[-9.0]),
+            "penalty must raise f below −10"
+        );
+    }
+
+    #[test]
+    fn penalty_zero_inside_soft_bounds() {
+        // u(5.0) and u(−5.0) lie inside [−10, 10] and contribute nothing.
+        assert_relative_eq!(penalty(5.0), 0.0, epsilon = 1e-12);
+        assert_relative_eq!(penalty(-5.0), 0.0, epsilon = 1e-12);
+        // u(11.0) = 100·(1)⁴ = 100.
+        assert_relative_eq!(penalty(11.0), 100.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let p = Penalized1::new(2);
+        let plain_no_trailing: String = p.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(p.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let p = Penalized1::new(2);
+        let styled = p.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Penalized1")
+            .expect("Penalized1 label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let p = Penalized1::new(2);
+        for line in p.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/rastrigin.rs
+++ b/crates/rlevo-environments/src/landscapes/rastrigin.rs
@@ -21,7 +21,11 @@ impl Rastrigin {
         Self { dim, a: 10.0 }
     }
 
-    /// Evaluate the Rastrigin function at `x`. Panics if `x.len() != self.dim`.
+    /// Evaluate the Rastrigin function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");

--- a/crates/rlevo-environments/src/landscapes/rosenbrock.rs
+++ b/crates/rlevo-environments/src/landscapes/rosenbrock.rs
@@ -1,0 +1,177 @@
+//! Rosenbrock function — the classical "banana" valley benchmark for EAs.
+//!
+//! `f(x) = Σ_{i=1}^{n-1} [100·(x_{i+1} − x_i²)² + (x_i − 1)²]`, global minimum
+//! at `x = (1, …, 1)` where `f(x*) = 0`. The minimum lies at the bottom of a
+//! long, narrow, curved valley following `x_{i+1} = x_i²`; the surface is smooth
+//! everywhere but the Hessian is nearly singular along the valley floor, so the
+//! landscape looks deceptively flat in the render.
+//!
+//! Commonly evaluated over `[-30, 30]^n` (used here); de Jong's original used
+//! `[-2.048, 2.048]` and the BBOB/COCO convention is `[-5, 10]`. For `n ≥ 4` the
+//! function has exactly two local minima — the global at `(1, …, 1)` and a local
+//! near `(-1, 1, …, 1)` — so restartless optimizers can stall at the wrong basin.
+//!
+//! Requires `n ≥ 2`; the sum is empty for `n = 1`.
+
+/// Rosenbrock function evaluator with configurable dimensionality.
+///
+/// The `100` and `1` coefficients are fixed per the canonical definition, so the
+/// struct carries no tunable constants.
+#[derive(Debug, Clone, Copy)]
+pub struct Rosenbrock {
+    /// Number of input dimensions. Must be `≥ 2`.
+    pub dim: usize,
+}
+
+impl Rosenbrock {
+    /// Creates a `dim`-dimensional Rosenbrock evaluator.
+    ///
+    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Rosenbrock function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`, or if `self.dim < 2` (the pairwise sum is
+    /// undefined for a single coordinate).
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        assert!(self.dim >= 2, "Rosenbrock requires dim >= 2");
+        x.windows(2)
+            .map(|w| {
+                let (xi, xn) = (w[0], w[1]);
+                100.0 * (xn - xi * xi).powi(2) + (xi - 1.0).powi(2)
+            })
+            .sum()
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-30.0, 30.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at `1.0` (the per-dimension
+    /// optimum) so the rendered slice passes through the valley floor rather
+    /// than a flat cross-section.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![1.0_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Rosenbrock {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Rosenbrock",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Rosenbrock",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        let r = Rosenbrock::new(4);
+        assert_relative_eq!(r.evaluate(&[1.0; 4]), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let r = Rosenbrock::new(3);
+        assert!(
+            r.evaluate(&[0.0, 0.0, 0.0]) > 0.0,
+            "Rosenbrock must be positive away from (1,…,1)"
+        );
+    }
+
+    #[test]
+    fn minimum_at_ones() {
+        // Every term vanishes: 100·(1−1)² + (1−1)² = 0.
+        let r = Rosenbrock::new(5);
+        assert_relative_eq!(r.evaluate(&[1.0; 5]), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn known_value_at_origin() {
+        // Each of the n−1 terms contributes 100·0 + 1 = 1, so f(0) = n−1.
+        let r = Rosenbrock::new(4);
+        assert_relative_eq!(r.evaluate(&[0.0; 4]), 3.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    #[should_panic(expected = "requires dim >= 2")]
+    fn panics_on_dim_one() {
+        let r = Rosenbrock::new(1);
+        let _ = r.evaluate(&[0.5]);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let r = Rosenbrock::new(2);
+        let plain_no_trailing: String = r.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(r.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let r = Rosenbrock::new(2);
+        let styled = r.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Rosenbrock")
+            .expect("Rosenbrock label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let r = Rosenbrock::new(2);
+        for line in r.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/rosenbrock_flat.rs
+++ b/crates/rlevo-environments/src/landscapes/rosenbrock_flat.rs
@@ -1,0 +1,170 @@
+//! Generalized Modified Rosenbrock No.01 — the flat-ground bent knife-edge.
+//!
+//! `f(x) = Σ_{i=1}^{n-1} [100·|x_{i+1} − x_i²| + (1 − x_i)²]`, global minimum
+//! `f* = 0` at `x = (1, …, 1)`. Replacing the smooth square of standard
+//! Rosenbrock with an absolute value turns the parabolic valley into a V-shaped
+//! **knife edge**: the ridge `x_{i+1} = x_i²` is genuinely flat and
+//! non-differentiable, so gradient methods stall on it and only the `(1 − x_i)²`
+//! terms provide directional signal along the valley.
+//!
+//! The true domain is `[-2000, 2000]^n`; [`bounds`](RosenbrockFlat::bounds)
+//! returns the reduced `(-30, 30)` window for meaningful renders. Requires `n ≥ 2`.
+
+/// Generalized Modified Rosenbrock No.01 evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct RosenbrockFlat {
+    /// Number of input dimensions. Must be `≥ 2`.
+    pub dim: usize,
+}
+
+impl RosenbrockFlat {
+    /// Creates a `dim`-dimensional Modified Rosenbrock No.01 evaluator.
+    ///
+    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Modified Rosenbrock No.01 function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`, or if `self.dim < 2`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        assert!(self.dim >= 2, "RosenbrockFlat requires dim >= 2");
+        x.windows(2)
+            .map(|w| {
+                let (xi, xn) = (w[0], w[1]);
+                // non-differentiable on the manifold x_{i+1} = x_i^2 (the knife edge)
+                100.0 * (xn - xi * xi).abs() + (1.0 - xi).powi(2)
+            })
+            .sum()
+    }
+
+    /// Renderer-safe search domain (reduced from the true `[-2000, 2000]^n`).
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-30.0, 30.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at `1.0` (the optimum) so the
+    /// rendered slice passes through the valley.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![1.0_f64; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for RosenbrockFlat {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "RosenbrockFlat",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "RosenbrockFlat",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        let r = RosenbrockFlat::new(4);
+        assert_relative_eq!(r.evaluate(&[1.0; 4]), 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let r = RosenbrockFlat::new(3);
+        assert!(
+            r.evaluate(&[0.0; 3]) > 0.0,
+            "value away from (1,…,1) must exceed the minimum 0"
+        );
+    }
+
+    #[test]
+    fn minimum_at_ones() {
+        let r = RosenbrockFlat::new(5);
+        assert_relative_eq!(r.evaluate(&[1.0; 5]), 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn flat_on_ridge() {
+        // On the ridge x_{i+1} = x_i² (but not at x = 1) only the (1 − x_i)² term remains.
+        let r = RosenbrockFlat::new(2);
+        let x = [2.0_f64, 4.0]; // x2 = x1² = 4 ⇒ abs term is 0
+        let expected = (1.0 - 2.0_f64).powi(2); // 1.0
+        assert_relative_eq!(r.evaluate(&x), expected, epsilon = 1e-10);
+    }
+
+    #[test]
+    #[should_panic(expected = "requires dim >= 2")]
+    fn panics_on_dim_one() {
+        let _ = RosenbrockFlat::new(1).evaluate(&[1.0]);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let r = RosenbrockFlat::new(2);
+        let plain_no_trailing: String = r.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(r.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let r = RosenbrockFlat::new(2);
+        let styled = r.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "RosenbrockFlat")
+            .expect("RosenbrockFlat label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let r = RosenbrockFlat::new(2);
+        for line in r.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/schwefel.rs
+++ b/crates/rlevo-environments/src/landscapes/schwefel.rs
@@ -1,0 +1,172 @@
+//! Schwefel function (Problem 2.26) — a deceptive multimodal benchmark.
+//!
+//! `f(x) = −Σ x_i·sin(√|x_i|)`, global minimum at `x_i = 420.9687…` where
+//! `f(x*) = −418.9829… · n`. The function is deceptive: many local minima
+//! cluster near `x_i ≈ 0` while the true optimum sits at ~84% of the domain
+//! radius from the centre, so an agent that converges near zero scores
+//! `f ≈ 0` instead of `f ≈ −418.98·n`.
+//!
+//! Evaluated over `[-500, 500]^n`. The function is separable, so coordinate-wise
+//! methods have a structural advantage. Differentiable except for a sign
+//! discontinuity in the derivative at `x_i = 0`; forward evaluation is exact
+//! everywhere.
+//!
+//! Requires `n ≥ 1`.
+
+/// Per-dimension optimal coordinate, `x_i*`, at full `f64` precision.
+//
+// The certified literature value carries more decimal digits than f64 stores;
+// we keep the published constant verbatim (spec principle: precise constants,
+// not rounded approximations) and silence the precision lint accordingly.
+#[allow(clippy::excessive_precision)]
+const X_OPT: f64 = 420.968_746_359_982_025;
+/// Per-dimension contribution to the optimum, `|f(x*)| / n`, at full precision.
+///
+/// Used by the test suite to assert the certified global-minimum value.
+#[cfg(test)]
+const F_PER_DIM: f64 = 418.982_887_274_338;
+
+/// Schwefel function evaluator with configurable dimensionality.
+#[derive(Debug, Clone, Copy)]
+pub struct Schwefel {
+    /// Number of input dimensions.
+    pub dim: usize,
+}
+
+impl Schwefel {
+    /// Creates a `dim`-dimensional Schwefel evaluator.
+    #[must_use]
+    pub const fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    /// Evaluate the Schwefel function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim, "input dimension mismatch");
+        // `x_i.abs().sqrt()` is well-defined for all finite x_i.
+        -x.iter().map(|xi| xi * xi.abs().sqrt().sin()).sum::<f64>()
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-500.0, 500.0)
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// Coordinates beyond the first two are fixed at the per-dimension optimum
+    /// `x_i* = 420.9687…`, not `0.0`, so the rendered slice shows the global
+    /// basin rather than a cross-section through the deceptive near-zero region.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let mut p = vec![X_OPT; self.dim];
+        if !p.is_empty() {
+            p[0] = x;
+        }
+        if p.len() >= 2 {
+            p[1] = y;
+        }
+        self.evaluate(&p)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Schwefel {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Schwefel",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Schwefel",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        // Numerically certified optimum; relative tolerance per the literature floor.
+        let n = 4;
+        let s = Schwefel::new(n);
+        assert_relative_eq!(
+            s.evaluate(&[X_OPT; 4]),
+            -F_PER_DIM * n as f64,
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        // f(0) = 0, which exceeds the true minimum −418.98·n for any n ≥ 1.
+        let s = Schwefel::new(3);
+        assert!(
+            s.evaluate(&[0.0; 3]) > s.evaluate(&[X_OPT; 3]),
+            "origin must score worse than the global optimum"
+        );
+    }
+
+    #[test]
+    fn origin_is_not_minimum() {
+        let s = Schwefel::new(2);
+        assert_relative_eq!(s.evaluate(&[0.0, 0.0]), 0.0, epsilon = 1e-12);
+        assert!(s.evaluate(&[0.0, 0.0]) > s.evaluate(&[X_OPT, X_OPT]));
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let s = Schwefel::new(2);
+        let plain_no_trailing: String = s.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(s.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let s = Schwefel::new(2);
+        let styled = s.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Schwefel")
+            .expect("Schwefel label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let s = Schwefel::new(2);
+        for line in s.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/six_hump_camel.rs
+++ b/crates/rlevo-environments/src/landscapes/six_hump_camel.rs
@@ -1,0 +1,150 @@
+//! Six-Hump Camel-Back function — a 2-D polynomial benchmark with two equal minima.
+//!
+//! `f(x₁, x₂) = 4x₁² − 2.1x₁⁴ + x₁⁶/3 + x₁x₂ − 4x₂² + 4x₂⁴`. The surface has six
+//! local minima in three point-symmetric pairs; exactly **two** are global, at
+//! `(±0.08984…, ∓0.71266…)`, with `f* ≈ −1.031628…`. A pure polynomial,
+//! differentiable everywhere, satisfying `f(−x₁, −x₂) = f(x₁, x₂)`.
+//!
+//! Evaluated over `[-2, 2]²` — the narrow window that shows the six-hump
+//! structure; both global minima lie inside it.
+
+/// Six-Hump Camel-Back function (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct SixHumpCamel;
+
+impl SixHumpCamel {
+    /// Creates a Six-Hump Camel-Back evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate the Six-Hump Camel-Back function at `(x1, x2)`.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        // `x1.powi(6) / 3.0` avoids the rounding error of multiplying by 1.0/3.0.
+        4.0 * x1 * x1 - 2.1 * x1.powi(4) + x1.powi(6) / 3.0 + x1 * x2 - 4.0 * x2 * x2
+            + 4.0 * x2.powi(4)
+    }
+
+    /// Recommended search domain for each coordinate.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-2.0, 2.0)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for SixHumpCamel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for SixHumpCamel {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "SixHumpCamel",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "SixHumpCamel",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    /// Certified global-minimum value (Dixon & Szego 1978).
+    const F_OPT: f64 = -1.031_628_453_489_877;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        let c = SixHumpCamel::new();
+        assert_relative_eq!(
+            c.evaluate(0.089_842_013_683_013_31, -0.712_656_403_270_413_5),
+            F_OPT,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let c = SixHumpCamel::new();
+        assert!(
+            c.evaluate(1.5, 1.5) > F_OPT,
+            "value away from the basins must exceed the global minimum"
+        );
+    }
+
+    #[test]
+    fn two_global_minima_equal() {
+        let c = SixHumpCamel::new();
+        let v1 = c.evaluate(0.089_842_013_683_013_31, -0.712_656_403_270_413_5);
+        let v2 = c.evaluate(-0.089_842_013_683_013_31, 0.712_656_403_270_413_5);
+        assert_relative_eq!(v1, F_OPT, epsilon = 1e-12);
+        assert_relative_eq!(v2, F_OPT, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn point_symmetry() {
+        let c = SixHumpCamel::new();
+        assert_relative_eq!(c.evaluate(1.3, -0.7), c.evaluate(-1.3, 0.7), epsilon = 1e-12);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let c = SixHumpCamel::new();
+        let plain_no_trailing: String = c.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(c.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let c = SixHumpCamel::new();
+        let styled = c.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "SixHumpCamel")
+            .expect("SixHumpCamel label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let c = SixHumpCamel::new();
+        for line in c.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/landscapes/sphere.rs
+++ b/crates/rlevo-environments/src/landscapes/sphere.rs
@@ -18,7 +18,11 @@ impl Sphere {
         Self { dim }
     }
 
-    /// Evaluate the Sphere function at `x`. Panics if `x.len() != self.dim`.
+    /// Evaluate the Sphere function at `x`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim`.
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");

--- a/crates/rlevo-environments/src/landscapes/trefethen.rs
+++ b/crates/rlevo-environments/src/landscapes/trefethen.rs
@@ -1,0 +1,158 @@
+//! Trefethen's function — a 2-D benchmark with five incommensurate frequencies.
+//!
+//! ```text
+//! f(x₁,x₂) = e^{sin(50·x₁)} + sin(60·e^{x₂}) + sin(70·sin(x₁))
+//!          + sin(sin(80·x₂)) − sin(10·(x₁+x₂)) + (x₁² + x₂²)/4
+//! ```
+//! Global minimum `f* ≈ −3.3069` at `(−0.0244, 0.2106)`. The frequencies
+//! `{50, 60, 70, 80, 10}` share no ratio, so there is no periodic lattice of
+//! equivalent basins and no dominant spatial scale — dense grid search plus
+//! local refinement is needed. The stabilising `(x₁²+x₂²)/4` term keeps the
+//! minimum interior and well-defined.
+//!
+//! # Domain
+//!
+//! The canonical competition domain is `[-1, 1]²`; the EA-friendly extended
+//! domain is `x₁ ∈ [-6.5, 6.5]`, `x₂ ∈ [-4.5, 4.5]`.
+//! [`bounds`](Trefethen::bounds) returns `(-4.5, 4.5)` (the tighter `x₂` range)
+//! for the renderer. From Lloyd Trefethen's 2002 SIAM 100-Digit Challenge.
+
+/// Trefethen's function (strictly 2-D).
+#[derive(Debug, Clone, Copy)]
+pub struct Trefethen;
+
+impl Trefethen {
+    /// Creates a Trefethen evaluator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Evaluate Trefethen's function at `(x1, x2)`.
+    ///
+    /// The `sin(60·e^{x₂})` term is finite across the recommended domain, but for
+    /// `x₂ ≳ 710` the inner `e^{x₂}` overflows to infinity and the result is
+    /// `NaN`; callers operating far outside the domain must clamp `x₂` themselves.
+    #[must_use]
+    pub fn evaluate(&self, x1: f64, x2: f64) -> f64 {
+        (50.0 * x1).sin().exp()
+            + (60.0 * x2.exp()).sin()
+            + (70.0 * x1.sin()).sin()
+            + (80.0 * x2).sin().sin()
+            - (10.0 * (x1 + x2)).sin()
+            + (x1 * x1 + x2 * x2) / 4.0
+    }
+
+    /// Renderer-safe symmetric search domain (the tighter `x₂` range). See the
+    /// type-level docs for the full asymmetric domain.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (-4.5, 4.5)
+    }
+
+    /// 2D projection used by the renderer — the exact surface for a 2-D function.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        self.evaluate(x, y)
+    }
+}
+
+impl Default for Trefethen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for Trefethen {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Trefethen",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "Trefethen",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn global_minimum_at_known_location() {
+        let t = Trefethen::new();
+        assert_relative_eq!(t.evaluate(-0.024_403, 0.210_612), -3.3069, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn positive_or_greater_elsewhere() {
+        let t = Trefethen::new();
+        assert!(
+            t.evaluate(6.0, 4.0) > t.evaluate(-0.024_403, 0.210_612),
+            "value far from the optimum must exceed f*"
+        );
+    }
+
+    #[test]
+    fn global_minimum_approx() {
+        let t = Trefethen::new();
+        assert_relative_eq!(t.evaluate(-0.024_403, 0.210_612), -3.3069, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn quadratic_term_dominates_far_from_origin() {
+        // At (6, 4) the quadratic (36+16)/4 = 13 dominates, so f > 10.
+        let t = Trefethen::new();
+        assert!(t.evaluate(6.0, 4.0) > 10.0);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let t = Trefethen::new();
+        let plain_no_trailing: String = t.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(t.render_styled().plain_text(), plain_no_trailing);
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let t = Trefethen::new();
+        let styled = t.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "Trefethen")
+            .expect("Trefethen label span present");
+        assert_eq!(label.style.fg, Some(BEST_FG));
+        assert!(label.style.modifier.contains(BEST_MODIFIER));
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let t = Trefethen::new();
+        for line in t.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/lib.rs
+++ b/crates/rlevo-environments/src/lib.rs
@@ -8,7 +8,8 @@
 //! # Module Organization
 //!
 //! - [`classic`]: Classic control problems (CartPole, MountainCar, Pendulum, Acrobot, TenArmedBandit)
-//! - [`landscapes`]: Optimization fitness landscapes (Sphere, Ackley, Rastrigin)
+//! - [`landscapes`]: Optimization fitness landscapes (Sphere, Ackley, Rastrigin,
+//!   plus the scalable n-D, classical 2-D, and stress-test benchmark suites)
 //! - [`grids`]: Gridworld environments inspired by Farama Minigrid
 //! - [`toy_text`]: Tabular RL environments (Blackjack, Taxi, CliffWalking, FrozenLake)
 //! - [`wrappers`]: Environment wrappers (TimeLimit)
@@ -35,6 +36,31 @@ pub mod landscapes {
     pub mod rastrigin;
     pub mod render;
     pub mod sphere;
+
+    // Tier 1 — scalable n-D landscapes.
+    pub mod griewank;
+    pub mod michalewicz;
+    pub mod penalized1;
+    pub mod rosenbrock;
+    pub mod schwefel;
+
+    // Tier 2 — classical 2-D landscapes.
+    pub mod branin;
+    pub mod bukin6;
+    pub mod cross_in_tray;
+    pub mod easom;
+    pub mod goldstein_price;
+    pub mod himmelblau;
+    pub mod six_hump_camel;
+
+    // Tier 3 — stress-test landscapes.
+    pub mod alpine1;
+    pub mod deb1;
+    pub mod eggholder;
+    pub mod lunacek_bi_rastrigin;
+    pub mod needle_eye;
+    pub mod rosenbrock_flat;
+    pub mod trefethen;
 }
 #[cfg(feature = "bench")]
 pub mod bench;

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -104,7 +104,12 @@ pub trait Strategy<B: Backend>: Send + Sync {
     ///
     /// Samples the initial population, primes adaptive quantities, and
     /// sets the generation counter to zero.
-    fn init(&self, params: &Self::Params, rng: &mut dyn Rng, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self::State;
+    fn init(
+        &self,
+        params: &Self::Params,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State;
 
     /// Propose the next population.
     ///
@@ -148,6 +153,22 @@ pub trait Strategy<B: Backend>: Send + Sync {
 ///
 /// All statistics refer to the generation that just finished evaluating.
 /// Fitness values follow the minimization convention: lower is better.
+///
+/// When printed in a benchmark showcase (e.g. `ackley_showcase`), the
+/// two most informative fields are:
+///
+/// - **`best_fitness_ever`** — the smallest fitness seen across *all*
+///   generations so far. This is a rolling minimum that tells you how
+///   close the best individual ever found came to the global optimum.
+/// - **`mean_fitness`** — the arithmetic mean of the current generation's
+///   per-individual fitness vector. This tells you the average quality of
+///   the population in that generation.
+///
+/// A large gap between `best_fitness_ever` and `mean_fitness` in the final
+/// generation usually indicates premature convergence: a few elite
+/// individuals found a good basin while the rest of the population is still
+/// scattered. A small gap suggests the whole population has settled near the
+/// same optimum.
 #[derive(Debug, Clone)]
 pub struct StrategyMetrics {
     /// Zero-based generation index.
@@ -157,10 +178,22 @@ pub struct StrategyMetrics {
     /// Smallest fitness observed in this generation.
     pub best_fitness: f32,
     /// Mean fitness across this generation's population.
+    ///
+    /// This is the arithmetic mean of the per-individual fitness vector
+    /// for the generation that just finished. In a showcase table printed
+    /// after a run, this value reflects the *final* generation's average
+    /// quality. See the struct-level docs for how to interpret the gap
+    /// between this field and [`Self::best_fitness_ever`].
     pub mean_fitness: f32,
     /// Largest fitness observed in this generation.
     pub worst_fitness: f32,
     /// Best fitness seen across *all* generations to date.
+    ///
+    /// This is a rolling minimum (`previous_best.min(current_generation_best)`).
+    /// When printed in a benchmark showcase, it represents the best
+    /// solution quality found during the entire run. For landscapes whose
+    /// global optimum is known (e.g. Ackley → 0), this value tells you
+    /// how close the algorithm got to the theoretical minimum.
     pub best_fitness_ever: f32,
 }
 
@@ -437,15 +470,11 @@ where
             best_fitness_ever = f64::from(metrics.best_fitness_ever),
             "evolution generation",
         );
-        if let (Some(observer), Some(fitnesses)) =
-            (self.observer.as_ref(), snapshot_fitness)
-        {
+        if let (Some(observer), Some(fitnesses)) = (self.observer.as_ref(), snapshot_fitness) {
             let best_index = fitnesses
                 .iter()
                 .enumerate()
-                .min_by(|(_, a), (_, b)| {
-                    a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-                })
+                .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
                 .map_or(0, |(i, _)| u32::try_from(i).unwrap_or(0));
             let snapshot = PopulationSnapshot {
                 generation: u32::try_from(metrics.generation).unwrap_or(u32::MAX),
@@ -481,10 +510,7 @@ where
         Ok(())
     }
 
-    fn step(
-        &mut self,
-        action: Self::Action,
-    ) -> Result<BenchStep<Self::Observation>, BenchError> {
+    fn step(&mut self, action: Self::Action) -> Result<BenchStep<Self::Observation>, BenchError> {
         Ok(EvolutionaryHarness::<B, S, F>::step(self, action))
     }
 }

--- a/crates/rlevo/Cargo.toml
+++ b/crates/rlevo/Cargo.toml
@@ -86,6 +86,85 @@ path = "examples/evo/ackley_showcase.rs"
 name = "rastrigin_showcase"
 path = "examples/evo/rastrigin_showcase.rs"
 
+# Tier 1 — scalable n-D landscapes
+[[example]]
+name = "rosenbrock_showcase"
+path = "examples/evo/rosenbrock_showcase.rs"
+
+[[example]]
+name = "griewank_showcase"
+path = "examples/evo/griewank_showcase.rs"
+
+[[example]]
+name = "schwefel_showcase"
+path = "examples/evo/schwefel_showcase.rs"
+
+[[example]]
+name = "michalewicz_showcase"
+path = "examples/evo/michalewicz_showcase.rs"
+
+[[example]]
+name = "penalized1_showcase"
+path = "examples/evo/penalized1_showcase.rs"
+
+# Tier 2 — classical 2-D landscapes
+[[example]]
+name = "branin_showcase"
+path = "examples/evo/branin_showcase.rs"
+
+[[example]]
+name = "himmelblau_showcase"
+path = "examples/evo/himmelblau_showcase.rs"
+
+[[example]]
+name = "six_hump_camel_showcase"
+path = "examples/evo/six_hump_camel_showcase.rs"
+
+[[example]]
+name = "easom_showcase"
+path = "examples/evo/easom_showcase.rs"
+
+[[example]]
+name = "goldstein_price_showcase"
+path = "examples/evo/goldstein_price_showcase.rs"
+
+[[example]]
+name = "cross_in_tray_showcase"
+path = "examples/evo/cross_in_tray_showcase.rs"
+
+[[example]]
+name = "bukin6_showcase"
+path = "examples/evo/bukin6_showcase.rs"
+
+# Tier 3 — stress-test landscapes
+[[example]]
+name = "lunacek_showcase"
+path = "examples/evo/lunacek_showcase.rs"
+
+[[example]]
+name = "deb1_showcase"
+path = "examples/evo/deb1_showcase.rs"
+
+[[example]]
+name = "needle_eye_showcase"
+path = "examples/evo/needle_eye_showcase.rs"
+
+[[example]]
+name = "eggholder_showcase"
+path = "examples/evo/eggholder_showcase.rs"
+
+[[example]]
+name = "alpine1_showcase"
+path = "examples/evo/alpine1_showcase.rs"
+
+[[example]]
+name = "rosenbrock_flat_showcase"
+path = "examples/evo/rosenbrock_flat_showcase.rs"
+
+[[example]]
+name = "trefethen_showcase"
+path = "examples/evo/trefethen_showcase.rs"
+
 # Random-baseline-vs-learned benches. Each prints a reward/success quality
 # comparison, then times per-step rollout throughput for both policies.
 # Shared DQN model + Polyak scaffolding lives in `benches/support/dqn.rs`.

--- a/crates/rlevo/examples/evo/ackley_showcase.rs
+++ b/crates/rlevo/examples/evo/ackley_showcase.rs
@@ -5,143 +5,34 @@
 //! basin at the origin — a step harder than Sphere.
 //!
 //! Run with `cargo run --release -p rlevo --example ackley_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Each strategy prints one row: `label | gens | best | mean`. Fitness is the
-//! raw landscape cost under the minimization convention, so **lower is better**.
-//! `best` is `best_fitness_ever` — the lowest cost seen by any individual across
-//! all generations (a rolling minimum) — and `mean` is the average cost of the
-//! final generation. A small `best`–`mean` gap means the whole population
-//! converged; a large gap suggests premature convergence, with a few good
-//! individuals leading a still spread-out population. Values print in scientific
-//! notation, so `e-6` is near-converged and `e+2` is far off.
-//!
-//! Ackley has global optimum `f* = 0` at the origin, searched over
-//! `[-32.768, 32.768]^10`. The many shallow local minima ring a single global
-//! basin, so the difficulty is escaping the outer ripples to reach that basin —
-//! a `best` near `0` is full convergence, while a `best` stuck around `2`–`5`
-//! means a run never crossed into the central funnel.
 
-use burn::backend::Flex;
-use rlevo_environments::landscapes::ackley::Ackley;
-use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
-use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
-use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrategy};
-use rlevo_evolution::algorithms::ga::{
-    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
-};
-use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
-use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
+mod common;
 
-type B = Flex;
-
-const DIM: usize = 10;
-const GENS: usize = 500;
-const SEED: u64 = 42;
-
-fn run<S, F>(label: &str, strategy: S, params: S::Params, fitness_fn: F)
-where
-    S: Strategy<B>,
-    S::Params: std::fmt::Debug,
-    F: BatchFitnessFn<B, S::Genome>,
-    B: burn::tensor::backend::Backend,
-    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
-{
-    let device = Default::default();
-    let mut harness =
-        EvolutionaryHarness::<B, S, F>::new(strategy, params, fitness_fn, SEED, device, GENS);
-    harness.reset();
-    loop {
-        if harness.step(()).done {
-            break;
-        }
-    }
-    let m = harness
-        .latest_metrics()
-        .expect("at least one generation ran");
-    // `best` = best_fitness_ever: the lowest fitness seen across *all*
-    // generations (rolling minimum). For Ackley the global optimum is 0,
-    // so this tells you how close the best individual ever found got to
-    // the true minimum.
-    // `mean` = mean_fitness: the average fitness of the *final* generation.
-    // A large gap between best and mean suggests premature convergence;
-    // a small gap means the whole population settled near the optimum.
-    println!(
-        "{label:>30} | gens={:>4} | best={:>.6e} | mean={:>.6e}",
-        m.generation, m.best_fitness_ever, m.mean_fitness,
-    );
-}
+use rlevo::envs::landscapes::ackley::Ackley;
 
 fn main() {
-    let landscape = Ackley::new(DIM);
-    let (lo, hi) = landscape.bounds();
-    #[allow(clippy::cast_possible_truncation)]
-    let bounds = (lo as f32, hi as f32);
-
     println!(
-        "Ackley-D{DIM} showcase — {GENS} generations, Flex backend, seed={SEED}\n\
-         {:-<80}",
+        "
+Interpreting the output
+
+Each strategy prints one row: `label | gens | best | mean`. Fitness is the
+raw landscape cost under the minimization convention, so **lower is better**.
+`best` is `best_fitness_ever` — the lowest cost seen by any individual across
+all generations (a rolling minimum) — and `mean` is the average cost of the
+final generation. A small `best`–`mean` gap means the whole population
+converged; a large gap suggests premature convergence, with a few good
+individuals leading a still spread-out population. Values print in scientific
+notation, so `e-6` is near-converged and `e+2` is far off.
+
+Ackley has global optimum `f* = 0` at the origin, searched over
+`[-32.768, 32.768]^10`. The many shallow local minima ring a single global
+basin, so the difficulty is escaping the outer ripples to reach that basin —
+a `best` near `0` is full convergence, while a `best` stuck around `2`–`5`
+means a run never crossed into the central funnel.\n\n\
+{:-<80}",
         "",
     );
-
-    run(
-        "GA/real/tournament-blx-elite",
-        GeneticAlgorithm::<B>::new(),
-        GaConfig {
-            pop_size: 64,
-            genome_dim: DIM,
-            bounds,
-            mutation_sigma: 0.5,
-            selection: GaSelection::Tournament { size: 2 },
-            crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
-            replacement: GaReplacement::Elitist { elitism_k: 2 },
-        },
-        FromLandscape::new(landscape),
-    );
-
-    for kind in [
-        EsKind::OnePlusOne,
-        EsKind::OnePlusLambda { lambda: 8 },
-        EsKind::MuPlusLambda { mu: 5, lambda: 20 },
-        EsKind::MuCommaLambda { mu: 5, lambda: 20 },
-    ] {
-        let mut params = EsConfig::default_for(kind, DIM);
-        params.bounds = bounds;
-        let label = format!("ES/{kind:?}");
-        run(
-            &label,
-            EvolutionStrategy::<B>::new(),
-            params,
-            FromLandscape::new(landscape),
-        );
-    }
-
-    let mut ep_params = EpConfig::default_for(20, DIM);
-    ep_params.bounds = bounds;
-    run(
-        "EP/fogel/μ=20/q=10",
-        EvolutionaryProgramming::<B>::new(),
-        ep_params,
-        FromLandscape::new(landscape),
-    );
-
-    for variant in [
-        DeVariant::Rand1Bin,
-        DeVariant::Best1Bin,
-        DeVariant::CurrentToBest1Bin,
-        DeVariant::Rand2Bin,
-        DeVariant::Rand1Exp,
-    ] {
-        let mut params = DeConfig::default_for(30, DIM);
-        params.variant = variant;
-        params.bounds = bounds;
-        let label = format!("DE/{variant:?}");
-        run(
-            &label,
-            DifferentialEvolution::<B>::new(),
-            params,
-            FromLandscape::new(landscape),
-        );
-    }
+    let dim = 10;
+    let landscape = Ackley::new(dim);
+    common::showcase("Ackley", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/ackley_showcase.rs
+++ b/crates/rlevo/examples/evo/ackley_showcase.rs
@@ -4,7 +4,24 @@
 //! Ackley is multimodal with many local minima around a single global
 //! basin at the origin — a step harder than Sphere.
 //!
-//! Run with `cargo run --release -p rlevo-evolution --example ackley_showcase`.
+//! Run with `cargo run --release -p rlevo --example ackley_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Each strategy prints one row: `label | gens | best | mean`. Fitness is the
+//! raw landscape cost under the minimization convention, so **lower is better**.
+//! `best` is `best_fitness_ever` — the lowest cost seen by any individual across
+//! all generations (a rolling minimum) — and `mean` is the average cost of the
+//! final generation. A small `best`–`mean` gap means the whole population
+//! converged; a large gap suggests premature convergence, with a few good
+//! individuals leading a still spread-out population. Values print in scientific
+//! notation, so `e-6` is near-converged and `e+2` is far off.
+//!
+//! Ackley has global optimum `f* = 0` at the origin, searched over
+//! `[-32.768, 32.768]^10`. The many shallow local minima ring a single global
+//! basin, so the difficulty is escaping the outer ripples to reach that basin —
+//! a `best` near `0` is full convergence, while a `best` stuck around `2`–`5`
+//! means a run never crossed into the central funnel.
 
 use burn::backend::Flex;
 use rlevo_environments::landscapes::ackley::Ackley;
@@ -43,6 +60,13 @@ where
     let m = harness
         .latest_metrics()
         .expect("at least one generation ran");
+    // `best` = best_fitness_ever: the lowest fitness seen across *all*
+    // generations (rolling minimum). For Ackley the global optimum is 0,
+    // so this tells you how close the best individual ever found got to
+    // the true minimum.
+    // `mean` = mean_fitness: the average fitness of the *final* generation.
+    // A large gap between best and mean suggests premature convergence;
+    // a small gap means the whole population settled near the optimum.
     println!(
         "{label:>30} | gens={:>4} | best={:>.6e} | mean={:>.6e}",
         m.generation, m.best_fitness_ever, m.mean_fitness,

--- a/crates/rlevo/examples/evo/alpine1_showcase.rs
+++ b/crates/rlevo/examples/evo/alpine1_showcase.rs
@@ -3,21 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example alpine1_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at the origin, searched over `[-10, 10]^10`. A
-//! `best` near `0` is full convergence. The surface is non-smooth with many
-//! sharp-edged local minima (roughly eight kinks per axis), so progress is
-//! jagged and a `best` resting at a small positive value usually means a run
-//! settled in one of the off-origin kinks. See the `common` module's "Reading
-//! the output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::alpine1::Alpine1;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at the origin, searched over `[-10, 10]^10`. A
+`best` near `0` is full convergence. The surface is non-smooth with many
+sharp-edged local minima (roughly eight kinks per axis), so progress is
+jagged and a `best` resting at a small positive value usually means a run
+settled in one of the off-origin kinks. See the `common` module's \"Reading
+the output\" section for the full column legend.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Alpine1::new(dim);
     common::showcase("Alpine1", dim, landscape.bounds(), 0.4, landscape);

--- a/crates/rlevo/examples/evo/alpine1_showcase.rs
+++ b/crates/rlevo/examples/evo/alpine1_showcase.rs
@@ -1,0 +1,24 @@
+//! Alpine1 landscape — Non-smooth |x sin x + 0.1 x| sum; many sharp-edged local minima around the origin.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example alpine1_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at the origin, searched over `[-10, 10]^10`. A
+//! `best` near `0` is full convergence. The surface is non-smooth with many
+//! sharp-edged local minima (roughly eight kinks per axis), so progress is
+//! jagged and a `best` resting at a small positive value usually means a run
+//! settled in one of the off-origin kinks. See the `common` module's "Reading
+//! the output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::alpine1::Alpine1;
+
+fn main() {
+    let dim = 10;
+    let landscape = Alpine1::new(dim);
+    common::showcase("Alpine1", dim, landscape.bounds(), 0.4, landscape);
+}

--- a/crates/rlevo/examples/evo/branin_showcase.rs
+++ b/crates/rlevo/examples/evo/branin_showcase.rs
@@ -1,0 +1,24 @@
+//! Branin landscape — Three equal global minima over an asymmetric domain; a gentle multimodal 2-D test.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example branin_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* ≈ 0.397887` shared by three equal minima (one at
+//! `(π, 2.275)`), searched over the square box `[-5, 10]²`. Note the optimum is
+//! *not* `0` — a `best` settling near `0.3979` is full convergence, and any of
+//! the three basins counts. A gentle, well-behaved 2-D test, so most strategies
+//! should reach `≈ 0.398`. See the `common` module's "Reading the output"
+//! section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::branin::Branin;
+
+fn main() {
+    let dim = 2;
+    let landscape = Branin::new();
+    common::showcase("Branin", dim, landscape.bounds(), 0.5, landscape);
+}

--- a/crates/rlevo/examples/evo/branin_showcase.rs
+++ b/crates/rlevo/examples/evo/branin_showcase.rs
@@ -3,21 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example branin_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* ≈ 0.397887` shared by three equal minima (one at
-//! `(π, 2.275)`), searched over the square box `[-5, 10]²`. Note the optimum is
-//! *not* `0` — a `best` settling near `0.3979` is full convergence, and any of
-//! the three basins counts. A gentle, well-behaved 2-D test, so most strategies
-//! should reach `≈ 0.398`. See the `common` module's "Reading the output"
-//! section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::branin::Branin;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* ≈ 0.397887` shared by three equal minima (one at
+`(π, 2.275)`), searched over the square box `[-5, 10]²`. Note the optimum is
+*not* `0` — a `best` settling near `0.3979` is full convergence, and any of
+the three basins counts. A gentle, well-behaved 2-D test, so most strategies
+should reach `≈ 0.398`.\n\
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = Branin::new();
     common::showcase("Branin", dim, landscape.bounds(), 0.5, landscape);

--- a/crates/rlevo/examples/evo/bukin6_showcase.rs
+++ b/crates/rlevo/examples/evo/bukin6_showcase.rs
@@ -1,0 +1,25 @@
+//! Bukin6 landscape — A knife-edge ridge: the optimum lies along a near-singular curved seam.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example bukin6_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at `(−10, 1)`, searched over the square box
+//! `[-15, 3]²` (the bounding box of the true asymmetric domain). A `best` near
+//! `0` is full convergence. The optimum sits on a near-singular parabolic ridge
+//! where the transverse gradient diverges, so even strong runs typically
+//! plateau around `0.04`–`0.2` rather than reaching `0` — this is the expected
+//! difficulty, not a failure. See the `common` module's "Reading the output"
+//! section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::bukin6::Bukin6;
+
+fn main() {
+    let dim = 2;
+    let landscape = Bukin6::new();
+    common::showcase("Bukin6", dim, landscape.bounds(), 0.4, landscape);
+}

--- a/crates/rlevo/examples/evo/bukin6_showcase.rs
+++ b/crates/rlevo/examples/evo/bukin6_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example bukin6_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at `(−10, 1)`, searched over the square box
-//! `[-15, 3]²` (the bounding box of the true asymmetric domain). A `best` near
-//! `0` is full convergence. The optimum sits on a near-singular parabolic ridge
-//! where the transverse gradient diverges, so even strong runs typically
-//! plateau around `0.04`–`0.2` rather than reaching `0` — this is the expected
-//! difficulty, not a failure. See the `common` module's "Reading the output"
-//! section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::bukin6::Bukin6;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at `(−10, 1)`, searched over the square box
+`[-15, 3]²` (the bounding box of the true asymmetric domain). A `best` near
+`0` is full convergence. The optimum sits on a near-singular parabolic ridge
+where the transverse gradient diverges, so even strong runs typically
+plateau around `0.04`–`0.2` rather than reaching `0` — this is the expected
+difficulty, not a failure.\n\
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = Bukin6::new();
     common::showcase("Bukin6", dim, landscape.bounds(), 0.4, landscape);

--- a/crates/rlevo/examples/evo/common.rs
+++ b/crates/rlevo/examples/evo/common.rs
@@ -1,0 +1,163 @@
+//! Shared harness for the landscape evolution showcases.
+//!
+//! Each `*_showcase` example wires one landscape into [`showcase`], which runs
+//! every real-valued strategy in `rlevo-evolution` (GA, the four classical ES
+//! kinds, EP, and five DE variants) for a fixed generation budget and prints a
+//! one-line convergence summary per strategy. Keeping the driver here means the
+//! per-landscape files stay down to a few lines that differ only in the
+//! landscape, its dimensionality, and the GA mutation scale.
+//!
+//! This file is a module shared by the example binaries, not an example itself.
+//!
+//! # Reading the output
+//!
+//! Every strategy prints one row in the form:
+//!
+//! ```text
+//!          ES/OnePlusOne | gens= 500 | best=1.234567e-3 | mean=4.567890e-2
+//! ```
+//!
+//! - **label** — the strategy and its configuration (e.g. `DE/Rand1Bin`).
+//! - **gens** — generations actually run; always [`GENS`] here, since no
+//!   strategy stops early.
+//! - **best** — `best_fitness_ever`: the lowest cost seen by *any* individual
+//!   across *all* generations (a rolling minimum). Fitness is the raw landscape
+//!   cost under the minimization convention, so **lower is better** and this is
+//!   the headline "how close did we get" number. Compare it against the
+//!   landscape's global optimum `f*` (stated in each example's own docs).
+//! - **mean** — `mean_fitness`: the average cost of the *final* generation. A
+//!   small `best`–`mean` gap means the whole population converged near the
+//!   optimum; a large gap means a few good individuals are dragging a still
+//!   spread-out population, i.e. premature or partial convergence.
+//!
+//! Values print in scientific notation (`1.23e-4`), so an exponent like `e-6`
+//! is near-converged and `e+2` is far off. Because every run shares the same
+//! [`SEED`], the numbers are reproducible and directly comparable across
+//! strategies.
+
+use burn::backend::Flex;
+use rlevo_core::fitness::Landscape;
+use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
+use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
+use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrategy};
+use rlevo_evolution::algorithms::ga::{
+    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+};
+use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
+use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
+
+type B = Flex;
+
+/// Generation budget every strategy is given.
+pub const GENS: usize = 500;
+/// Fixed seed so runs are comparable across strategies and reproducible.
+pub const SEED: u64 = 42;
+
+/// Drives one strategy to completion and prints its convergence summary.
+fn run<S, F>(label: &str, strategy: S, params: S::Params, fitness_fn: F)
+where
+    S: Strategy<B>,
+    S::Params: std::fmt::Debug,
+    F: BatchFitnessFn<B, S::Genome>,
+    B: burn::tensor::backend::Backend,
+    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
+{
+    let device = Default::default();
+    let mut harness =
+        EvolutionaryHarness::<B, S, F>::new(strategy, params, fitness_fn, SEED, device, GENS);
+    harness.reset();
+    loop {
+        if harness.step(()).done {
+            break;
+        }
+    }
+    let m = harness
+        .latest_metrics()
+        .expect("at least one generation ran");
+    // `best` = best_fitness_ever (rolling minimum across all generations);
+    // `mean` = mean_fitness of the final generation. See the module docs'
+    // "Reading the output" section for how to interpret the two together.
+    println!(
+        "{label:>30} | gens={:>4} | best={:>.6e} | mean={:>.6e}",
+        m.generation, m.best_fitness_ever, m.mean_fitness,
+    );
+}
+
+/// Runs the full real-valued strategy panel on `landscape`.
+///
+/// `dim` is the genome dimensionality (use the landscape's natural dimension —
+/// 2 for the strictly 2-D landscapes), `bounds` is the per-coordinate search
+/// box (typically `landscape.bounds()`), and `mutation_sigma` sets the GA
+/// Gaussian mutation scale; the ES/EP/DE configs self-tune from `dim`.
+pub fn showcase<L>(title: &str, dim: usize, bounds: (f64, f64), mutation_sigma: f32, landscape: L)
+where
+    L: Landscape + Copy,
+{
+    #[allow(clippy::cast_possible_truncation)]
+    let bounds = (bounds.0 as f32, bounds.1 as f32);
+
+    println!(
+        "{title}-D{dim} showcase — {GENS} generations, Flex backend, seed={SEED}\n{:-<80}",
+        "",
+    );
+
+    run(
+        "GA/real/tournament-blx-elite",
+        GeneticAlgorithm::<B>::new(),
+        GaConfig {
+            pop_size: 64,
+            genome_dim: dim,
+            bounds,
+            mutation_sigma,
+            selection: GaSelection::Tournament { size: 2 },
+            crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
+            replacement: GaReplacement::Elitist { elitism_k: 2 },
+        },
+        FromLandscape::new(landscape),
+    );
+
+    for kind in [
+        EsKind::OnePlusOne,
+        EsKind::OnePlusLambda { lambda: 8 },
+        EsKind::MuPlusLambda { mu: 5, lambda: 20 },
+        EsKind::MuCommaLambda { mu: 5, lambda: 20 },
+    ] {
+        let mut params = EsConfig::default_for(kind, dim);
+        params.bounds = bounds;
+        let label = format!("ES/{kind:?}");
+        run(
+            &label,
+            EvolutionStrategy::<B>::new(),
+            params,
+            FromLandscape::new(landscape),
+        );
+    }
+
+    let mut ep_params = EpConfig::default_for(20, dim);
+    ep_params.bounds = bounds;
+    run(
+        "EP/fogel/μ=20/q=10",
+        EvolutionaryProgramming::<B>::new(),
+        ep_params,
+        FromLandscape::new(landscape),
+    );
+
+    for variant in [
+        DeVariant::Rand1Bin,
+        DeVariant::Best1Bin,
+        DeVariant::CurrentToBest1Bin,
+        DeVariant::Rand2Bin,
+        DeVariant::Rand1Exp,
+    ] {
+        let mut params = DeConfig::default_for(30, dim);
+        params.variant = variant;
+        params.bounds = bounds;
+        let label = format!("DE/{variant:?}");
+        run(
+            &label,
+            DifferentialEvolution::<B>::new(),
+            params,
+            FromLandscape::new(landscape),
+        );
+    }
+}

--- a/crates/rlevo/examples/evo/cross_in_tray_showcase.rs
+++ b/crates/rlevo/examples/evo/cross_in_tray_showcase.rs
@@ -1,0 +1,24 @@
+//! Cross-in-Tray landscape — A non-smooth absolute-value surface with four symmetric global minima.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example cross_in_tray_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Four equal global minima of value `f* ≈ −2.062612` at the sign combinations
+//! of `(±1.3494, ±1.3494)`, searched over `[-15, 15]²`. Cost is negative, so a
+//! more-negative `best` is better and `best ≈ −2.0626` is full convergence.
+//! The non-smooth absolute-value surface is otherwise near-flat, so a `best`
+//! close to `0` means the search never reached the central cross. See the
+//! `common` module's "Reading the output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::cross_in_tray::CrossInTray;
+
+fn main() {
+    let dim = 2;
+    let landscape = CrossInTray::new();
+    common::showcase("CrossInTray", dim, landscape.bounds(), 0.6, landscape);
+}

--- a/crates/rlevo/examples/evo/cross_in_tray_showcase.rs
+++ b/crates/rlevo/examples/evo/cross_in_tray_showcase.rs
@@ -3,21 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example cross_in_tray_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Four equal global minima of value `f* ≈ −2.062612` at the sign combinations
-//! of `(±1.3494, ±1.3494)`, searched over `[-15, 15]²`. Cost is negative, so a
-//! more-negative `best` is better and `best ≈ −2.0626` is full convergence.
-//! The non-smooth absolute-value surface is otherwise near-flat, so a `best`
-//! close to `0` means the search never reached the central cross. See the
-//! `common` module's "Reading the output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::cross_in_tray::CrossInTray;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Four equal global minima of value `f* ≈ −2.062612` at the sign combinations
+of `(±1.3494, ±1.3494)`, searched over `[-15, 15]²`. Cost is negative, so a
+more-negative `best` is better and `best ≈ −2.0626` is full convergence.
+The non-smooth absolute-value surface is otherwise near-flat, so a `best`
+close to `0` means the search never reached the central cross.\n\
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = CrossInTray::new();
     common::showcase("CrossInTray", dim, landscape.bounds(), 0.6, landscape);

--- a/crates/rlevo/examples/evo/deb1_showcase.rs
+++ b/crates/rlevo/examples/evo/deb1_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example deb1_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = −1`, attained at any of `10^n` equally deep optima
-//! (each `x_i ∈ {±0.1, ±0.3, …, ±0.9}`), searched over `[-1, 1]^10`. Cost is
-//! negative, so `best = −1` is full convergence. There is no global basin
-//! gradient — every optimum is equivalent and the rest of the surface is
-//! near-flat — so reaching `−1` is about landing on the regular grid, and a
-//! `best` near `0` means the search never did. See the `common` module's
-//! "Reading the output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::deb1::Deb1;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = −1`, attained at any of `10^n` equally deep optima
+(each `x_i ∈ {{±0.1, ±0.3, …, ±0.9}}`), searched over `[-1, 1]^10`. Cost is
+negative, so `best = −1` is full convergence. There is no global basin
+gradient — every optimum is equivalent and the rest of the surface is
+near-flat — so reaching `−1` is about landing on the regular grid, and a
+`best` near `0` means the search never did.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Deb1::new(dim);
     common::showcase("Deb1", dim, landscape.bounds(), 0.05, landscape);

--- a/crates/rlevo/examples/evo/deb1_showcase.rs
+++ b/crates/rlevo/examples/evo/deb1_showcase.rs
@@ -1,0 +1,25 @@
+//! Deb1 landscape — A regular grid of 10^n equally deep minima from a power-five sine; no global basin gradient to exploit.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example deb1_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = −1`, attained at any of `10^n` equally deep optima
+//! (each `x_i ∈ {±0.1, ±0.3, …, ±0.9}`), searched over `[-1, 1]^10`. Cost is
+//! negative, so `best = −1` is full convergence. There is no global basin
+//! gradient — every optimum is equivalent and the rest of the surface is
+//! near-flat — so reaching `−1` is about landing on the regular grid, and a
+//! `best` near `0` means the search never did. See the `common` module's
+//! "Reading the output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::deb1::Deb1;
+
+fn main() {
+    let dim = 10;
+    let landscape = Deb1::new(dim);
+    common::showcase("Deb1", dim, landscape.bounds(), 0.05, landscape);
+}

--- a/crates/rlevo/examples/evo/easom_showcase.rs
+++ b/crates/rlevo/examples/evo/easom_showcase.rs
@@ -1,0 +1,25 @@
+//! Easom landscape — A near-flat plane with a single sharp needle at (pi, pi) — pure exploration difficulty.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example easom_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = −1` at `(π, π)`, searched over `[-10, 10]²`. Cost is
+//! negative, so `best = −1` is full convergence and `best ≈ 0` means the search
+//! never found the needle. The surface is essentially flat at `0` everywhere
+//! except a single sharp dip, so there is almost no gradient to guide search —
+//! this is a pure-exploration test, and a `best` stuck at `0` is the common
+//! failure mode rather than a bug. See the `common` module's "Reading the
+//! output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::easom::Easom;
+
+fn main() {
+    let dim = 2;
+    let landscape = Easom::new();
+    common::showcase("Easom", dim, landscape.bounds(), 0.4, landscape);
+}

--- a/crates/rlevo/examples/evo/easom_showcase.rs
+++ b/crates/rlevo/examples/evo/easom_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example easom_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = −1` at `(π, π)`, searched over `[-10, 10]²`. Cost is
-//! negative, so `best = −1` is full convergence and `best ≈ 0` means the search
-//! never found the needle. The surface is essentially flat at `0` everywhere
-//! except a single sharp dip, so there is almost no gradient to guide search —
-//! this is a pure-exploration test, and a `best` stuck at `0` is the common
-//! failure mode rather than a bug. See the `common` module's "Reading the
-//! output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::easom::Easom;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = −1` at `(π, π)`, searched over `[-10, 10]²`. Cost is
+negative, so `best = −1` is full convergence and `best ≈ 0` means the search
+never found the needle. The surface is essentially flat at `0` everywhere
+except a single sharp dip, so there is almost no gradient to guide search —
+this is a pure-exploration test, and a `best` stuck at `0` is the common
+failure mode rather than a bug.\n\
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = Easom::new();
     common::showcase("Easom", dim, landscape.bounds(), 0.4, landscape);

--- a/crates/rlevo/examples/evo/eggholder_showcase.rs
+++ b/crates/rlevo/examples/evo/eggholder_showcase.rs
@@ -3,23 +3,26 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example eggholder_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Searched over `[-512, 512]^10`. Cost is negative, so a more-negative `best`
-//! is better. The certified optimum `f* ≈ −959.64` is the `n = 2` value with
-//! the optimum pinned to the boundary at `(512, 404.2318)`; the separable sum
-//! reaches still-lower totals at higher `n`, so treat `best` here as
-//! "how deep" rather than as a fixed target. Deep wells are separated by tall
-//! barriers, so a `best`–`mean` gap that stays wide means the population is
-//! scattered across competing wells. See the `common` module's "Reading the
-//! output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::eggholder::Eggholder;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Searched over `[-512, 512]^10`. Cost is negative, so a more-negative `best`
+is better. The certified optimum `f* ≈ −959.64` is the `n = 2` value with
+the optimum pinned to the boundary at `(512, 404.2318)`; the separable sum
+reaches still-lower totals at higher `n`, so treat `best` here as
+\"how deep\" rather than as a fixed target. Deep wells are separated by tall
+barriers, so a `best`–`mean` gap that stays wide means the population is
+scattered across competing wells. \n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Eggholder::new(dim);
     common::showcase("Eggholder", dim, landscape.bounds(), 20.0, landscape);

--- a/crates/rlevo/examples/evo/eggholder_showcase.rs
+++ b/crates/rlevo/examples/evo/eggholder_showcase.rs
@@ -1,0 +1,26 @@
+//! Eggholder landscape — Highly rugged with the optimum pinned to the domain boundary; deep wells separated by tall barriers.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example eggholder_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Searched over `[-512, 512]^10`. Cost is negative, so a more-negative `best`
+//! is better. The certified optimum `f* ≈ −959.64` is the `n = 2` value with
+//! the optimum pinned to the boundary at `(512, 404.2318)`; the separable sum
+//! reaches still-lower totals at higher `n`, so treat `best` here as
+//! "how deep" rather than as a fixed target. Deep wells are separated by tall
+//! barriers, so a `best`–`mean` gap that stays wide means the population is
+//! scattered across competing wells. See the `common` module's "Reading the
+//! output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::eggholder::Eggholder;
+
+fn main() {
+    let dim = 10;
+    let landscape = Eggholder::new(dim);
+    common::showcase("Eggholder", dim, landscape.bounds(), 20.0, landscape);
+}

--- a/crates/rlevo/examples/evo/goldstein_price_showcase.rs
+++ b/crates/rlevo/examples/evo/goldstein_price_showcase.rs
@@ -1,0 +1,24 @@
+//! Goldstein-Price landscape — Steep multiplicative polynomial valleys; global minimum f=3.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example goldstein_price_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 3` (not `0`) at `(0, −1)`, searched over `[-2, 2]²`. A
+//! `best` settling near `3` is full convergence. The value ranges up to
+//! `~1.3×10⁶`, so early `mean` readings can be enormous; a `mean` still in the
+//! thousands while `best ≈ 3` means most of the population sits on the steep
+//! outer walls and has not yet descended. See the `common` module's "Reading
+//! the output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::goldstein_price::GoldsteinPrice;
+
+fn main() {
+    let dim = 2;
+    let landscape = GoldsteinPrice::new();
+    common::showcase("GoldsteinPrice", dim, landscape.bounds(), 0.1, landscape);
+}

--- a/crates/rlevo/examples/evo/goldstein_price_showcase.rs
+++ b/crates/rlevo/examples/evo/goldstein_price_showcase.rs
@@ -3,21 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example goldstein_price_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 3` (not `0`) at `(0, −1)`, searched over `[-2, 2]²`. A
-//! `best` settling near `3` is full convergence. The value ranges up to
-//! `~1.3×10⁶`, so early `mean` readings can be enormous; a `mean` still in the
-//! thousands while `best ≈ 3` means most of the population sits on the steep
-//! outer walls and has not yet descended. See the `common` module's "Reading
-//! the output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::goldstein_price::GoldsteinPrice;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 3` (not `0`) at `(0, −1)`, searched over `[-2, 2]²`. A
+`best` settling near `3` is full convergence. The value ranges up to
+`~1.3×10⁶`, so early `mean` readings can be enormous; a `mean` still in the
+thousands while `best ≈ 3` means most of the population sits on the steep
+outer walls and has not yet descended.\n\
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = GoldsteinPrice::new();
     common::showcase("GoldsteinPrice", dim, landscape.bounds(), 0.1, landscape);

--- a/crates/rlevo/examples/evo/griewank_showcase.rs
+++ b/crates/rlevo/examples/evo/griewank_showcase.rs
@@ -3,21 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example griewank_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at the origin, searched over `[-600, 600]^10`. A
-//! `best` near `0` is full convergence. The dense cosine lattice creates many
-//! near-equal local minima, so a `best`–`mean` gap that stays open after 500
-//! generations signals the population trapped across several of them rather
-//! than settling in the central bowl. See the `common` module's "Reading the
-//! output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::griewank::Griewank;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at the origin, searched over `[-600, 600]^10`. A
+`best` near `0` is full convergence. The dense cosine lattice creates many
+near-equal local minima, so a `best`–`mean` gap that stays open after 500
+generations signals the population trapped across several of them rather
+than settling in the central bowl.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Griewank::new(dim);
     common::showcase("Griewank", dim, landscape.bounds(), 20.0, landscape);

--- a/crates/rlevo/examples/evo/griewank_showcase.rs
+++ b/crates/rlevo/examples/evo/griewank_showcase.rs
@@ -1,0 +1,24 @@
+//! Griewank landscape — A wide quadratic envelope dimpled by a product of cosines; many regular local minima over a large [-600, 600] domain.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example griewank_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at the origin, searched over `[-600, 600]^10`. A
+//! `best` near `0` is full convergence. The dense cosine lattice creates many
+//! near-equal local minima, so a `best`–`mean` gap that stays open after 500
+//! generations signals the population trapped across several of them rather
+//! than settling in the central bowl. See the `common` module's "Reading the
+//! output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::griewank::Griewank;
+
+fn main() {
+    let dim = 10;
+    let landscape = Griewank::new(dim);
+    common::showcase("Griewank", dim, landscape.bounds(), 20.0, landscape);
+}

--- a/crates/rlevo/examples/evo/himmelblau_showcase.rs
+++ b/crates/rlevo/examples/evo/himmelblau_showcase.rs
@@ -1,0 +1,25 @@
+//! Himmelblau landscape — Four identical global minima at f=0 — a multimodality and niching test.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example himmelblau_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Four equal global minima of value `f* = 0` arranged around the origin,
+//! searched over `[-6, 6]²`. A `best` near `0` means a run found one of the
+//! four basins — `best` alone cannot tell you *which*. Because the optima are
+//! symmetric and equally deep, `mean` reflects how the population spread across
+//! them; this is a niching test, and the single scalar summary deliberately
+//! does not distinguish multi-basin coverage. See the `common` module's
+//! "Reading the output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::himmelblau::Himmelblau;
+
+fn main() {
+    let dim = 2;
+    let landscape = Himmelblau::new();
+    common::showcase("Himmelblau", dim, landscape.bounds(), 0.3, landscape);
+}

--- a/crates/rlevo/examples/evo/himmelblau_showcase.rs
+++ b/crates/rlevo/examples/evo/himmelblau_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example himmelblau_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Four equal global minima of value `f* = 0` arranged around the origin,
-//! searched over `[-6, 6]²`. A `best` near `0` means a run found one of the
-//! four basins — `best` alone cannot tell you *which*. Because the optima are
-//! symmetric and equally deep, `mean` reflects how the population spread across
-//! them; this is a niching test, and the single scalar summary deliberately
-//! does not distinguish multi-basin coverage. See the `common` module's
-//! "Reading the output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::himmelblau::Himmelblau;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Four equal global minima of value `f* = 0` arranged around the origin,
+searched over `[-6, 6]²`. A `best` near `0` means a run found one of the
+four basins — `best` alone cannot tell you *which*. Because the optima are
+symmetric and equally deep, `mean` reflects how the population spread across
+them; this is a niching test, and the single scalar summary deliberately
+does not distinguish multi-basin coverage. \n\
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = Himmelblau::new();
     common::showcase("Himmelblau", dim, landscape.bounds(), 0.3, landscape);

--- a/crates/rlevo/examples/evo/lunacek_showcase.rs
+++ b/crates/rlevo/examples/evo/lunacek_showcase.rs
@@ -1,0 +1,24 @@
+//! Lunacek landscape — Two offset Rastrigin funnels: a deep global funnel competing with a broad deceptive one.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example lunacek_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at `x_i = μ₁ = 2.5`, searched over `[-5.12, 5.12]^10`.
+//! A `best` near `0` is full convergence. The landscape pairs a narrow global
+//! funnel against a broad deceptive one, so a `best` stuck at a positive plateau
+//! signals the search committed to the wrong (deceptive) funnel — the central
+//! difficulty this benchmark is designed to expose. See the `common` module's
+//! "Reading the output" section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::lunacek_bi_rastrigin::LunacekBiRastrigin;
+
+fn main() {
+    let dim = 10;
+    let landscape = LunacekBiRastrigin::new(dim);
+    common::showcase("Lunacek", dim, landscape.bounds(), 0.2, landscape);
+}

--- a/crates/rlevo/examples/evo/lunacek_showcase.rs
+++ b/crates/rlevo/examples/evo/lunacek_showcase.rs
@@ -3,21 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example lunacek_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at `x_i = μ₁ = 2.5`, searched over `[-5.12, 5.12]^10`.
-//! A `best` near `0` is full convergence. The landscape pairs a narrow global
-//! funnel against a broad deceptive one, so a `best` stuck at a positive plateau
-//! signals the search committed to the wrong (deceptive) funnel — the central
-//! difficulty this benchmark is designed to expose. See the `common` module's
-//! "Reading the output" section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::lunacek_bi_rastrigin::LunacekBiRastrigin;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at `x_i = μ₁ = 2.5`, searched over `[-5.12, 5.12]^10`.
+A `best` near `0` is full convergence. The landscape pairs a narrow global
+funnel against a broad deceptive one, so a `best` stuck at a positive plateau
+signals the search committed to the wrong (deceptive) funnel — the central
+difficulty this benchmark is designed to expose.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = LunacekBiRastrigin::new(dim);
     common::showcase("Lunacek", dim, landscape.bounds(), 0.2, landscape);

--- a/crates/rlevo/examples/evo/michalewicz_showcase.rs
+++ b/crates/rlevo/examples/evo/michalewicz_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example michalewicz_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Certified global optimum `f* ≈ −9.66015` for `n = 10` (steepness `m = 10`),
-//! searched over `[0, π]^10`. Cost is negative, so a more-negative `best` is
-//! better; `best ≈ −9.66` is full convergence. The surface is near-flat away
-//! from a few narrow optimal channels, giving almost no gradient to follow, so
-//! a `best` only reaching `−4` to `−6` is the expected outcome for a strategy
-//! that explored poorly. See the `common` module's "Reading the output"
-//! section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::michalewicz::Michalewicz;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Certified global optimum `f* ≈ −9.66015` for `n = 10` (steepness `m = 10`),
+searched over `[0, π]^10`. Cost is negative, so a more-negative `best` is
+better; `best ≈ −9.66` is full convergence. The surface is near-flat away
+from a few narrow optimal channels, giving almost no gradient to follow, so
+a `best` only reaching `−4` to `−6` is the expected outcome for a strategy
+that explored poorly.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Michalewicz::new(dim);
     common::showcase("Michalewicz", dim, landscape.bounds(), 0.1, landscape);

--- a/crates/rlevo/examples/evo/michalewicz_showcase.rs
+++ b/crates/rlevo/examples/evo/michalewicz_showcase.rs
@@ -1,0 +1,25 @@
+//! Michalewicz landscape — Steep ridges and flat valleys (m=10); near-zero gradient away from the narrow optimal channels.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example michalewicz_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Certified global optimum `f* ≈ −9.66015` for `n = 10` (steepness `m = 10`),
+//! searched over `[0, π]^10`. Cost is negative, so a more-negative `best` is
+//! better; `best ≈ −9.66` is full convergence. The surface is near-flat away
+//! from a few narrow optimal channels, giving almost no gradient to follow, so
+//! a `best` only reaching `−4` to `−6` is the expected outcome for a strategy
+//! that explored poorly. See the `common` module's "Reading the output"
+//! section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::michalewicz::Michalewicz;
+
+fn main() {
+    let dim = 10;
+    let landscape = Michalewicz::new(dim);
+    common::showcase("Michalewicz", dim, landscape.bounds(), 0.1, landscape);
+}

--- a/crates/rlevo/examples/evo/needle_eye_showcase.rs
+++ b/crates/rlevo/examples/evo/needle_eye_showcase.rs
@@ -1,0 +1,25 @@
+//! Needle-Eye landscape — A flat plateau punctured by a single narrow well (the eye) at the origin.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example needle_eye_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 1` inside a tiny hypercube of side `2×10⁻⁴` centred at
+//! the origin; everywhere outside that "eye" the value is `≥ 100`. Searched
+//! over `[-10, 10]^10`. The output is effectively binary: `best ≈ 1` means a
+//! run threaded the eye, while `best ≈ 100` (the usual result) means it never
+//! did. The plateau gives no gradient toward the well, so this is a near-pure
+//! luck-of-sampling test. See the `common` module's "Reading the output"
+//! section for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::needle_eye::Needle;
+
+fn main() {
+    let dim = 10;
+    let landscape = Needle::new(dim);
+    common::showcase("NeedleEye", dim, landscape.bounds(), 0.4, landscape);
+}

--- a/crates/rlevo/examples/evo/needle_eye_showcase.rs
+++ b/crates/rlevo/examples/evo/needle_eye_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example needle_eye_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 1` inside a tiny hypercube of side `2×10⁻⁴` centred at
-//! the origin; everywhere outside that "eye" the value is `≥ 100`. Searched
-//! over `[-10, 10]^10`. The output is effectively binary: `best ≈ 1` means a
-//! run threaded the eye, while `best ≈ 100` (the usual result) means it never
-//! did. The plateau gives no gradient toward the well, so this is a near-pure
-//! luck-of-sampling test. See the `common` module's "Reading the output"
-//! section for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::needle_eye::Needle;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 1` inside a tiny hypercube of side `2×10⁻⁴` centred at
+the origin; everywhere outside that \"eye\" the value is `≥ 100`. Searched
+over `[-10, 10]^10`. The output is effectively binary: `best ≈ 1` means a
+run threaded the eye, while `best ≈ 100` (the usual result) means it never
+did. The plateau gives no gradient toward the well, so this is a near-pure
+luck-of-sampling test.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Needle::new(dim);
     common::showcase("NeedleEye", dim, landscape.bounds(), 0.4, landscape);

--- a/crates/rlevo/examples/evo/penalized1_showcase.rs
+++ b/crates/rlevo/examples/evo/penalized1_showcase.rs
@@ -1,0 +1,25 @@
+//! Penalized1 landscape — Yao 1999 f14 — a coupled sine-penalty landscape with boundary penalties outside [-10, 10].
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example penalized1_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at `x_i = −1` (which zeroes every sinusoidal term),
+//! searched over `[-50, 50]^10`. A `best` near `0` is full convergence. The
+//! coupled sine terms plus the boundary penalty outside `[-10, 10]` punish
+//! out-of-range individuals heavily, so an inflated `mean` versus a small
+//! `best` usually means part of the population is still drifting in the
+//! penalized region. See the `common` module's "Reading the output" section
+//! for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::penalized1::Penalized1;
+
+fn main() {
+    let dim = 10;
+    let landscape = Penalized1::new(dim);
+    common::showcase("Penalized1", dim, landscape.bounds(), 2.0, landscape);
+}

--- a/crates/rlevo/examples/evo/penalized1_showcase.rs
+++ b/crates/rlevo/examples/evo/penalized1_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example penalized1_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at `x_i = −1` (which zeroes every sinusoidal term),
-//! searched over `[-50, 50]^10`. A `best` near `0` is full convergence. The
-//! coupled sine terms plus the boundary penalty outside `[-10, 10]` punish
-//! out-of-range individuals heavily, so an inflated `mean` versus a small
-//! `best` usually means part of the population is still drifting in the
-//! penalized region. See the `common` module's "Reading the output" section
-//! for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::penalized1::Penalized1;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at `x_i = −1` (which zeroes every sinusoidal term),
+searched over `[-50, 50]^10`. A `best` near `0` is full convergence. The
+coupled sine terms plus the boundary penalty outside `[-10, 10]` punish
+out-of-range individuals heavily, so an inflated `mean` versus a small
+`best` usually means part of the population is still drifting in the
+penalized region.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Penalized1::new(dim);
     common::showcase("Penalized1", dim, landscape.bounds(), 2.0, landscape);

--- a/crates/rlevo/examples/evo/rastrigin_showcase.rs
+++ b/crates/rlevo/examples/evo/rastrigin_showcase.rs
@@ -6,137 +6,35 @@
 //! than either Sphere or Ackley.
 //!
 //! Run with `cargo run --release -p rlevo --example rastrigin_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Each strategy prints one row: `label | gens | best | mean`. Fitness is the
-//! raw landscape cost under the minimization convention, so **lower is better**.
-//! `best` is `best_fitness_ever` — the lowest cost seen by any individual across
-//! all generations (a rolling minimum) — and `mean` is the average cost of the
-//! final generation. A small `best`–`mean` gap means the whole population
-//! converged; a large gap suggests premature convergence, with a few good
-//! individuals leading a still spread-out population. Values print in scientific
-//! notation, so `e-6` is near-converged and `e+2` is far off.
-//!
-//! Rastrigin has global optimum `f* = 0` at the origin, searched over
-//! `[-5.12, 5.12]^10`. A regular grid of deep local minima sits on a Sphere-like
-//! envelope, so each minimum is a genuine trap rather than a shallow ripple.
-//! A `best` near `0` is full convergence; a `best` resting at an integer-ish
-//! plateau (each trapped coordinate adds roughly `A = 10` to the cost) means a
-//! run settled into one of the off-origin minima.
 
-use burn::backend::Flex;
-use rlevo_environments::landscapes::rastrigin::Rastrigin;
-use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
-use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
-use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrategy};
-use rlevo_evolution::algorithms::ga::{
-    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
-};
-use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
-use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
+mod common;
 
-type B = Flex;
-
-const DIM: usize = 10;
-const GENS: usize = 500;
-const SEED: u64 = 42;
-
-fn run<S, F>(label: &str, strategy: S, params: S::Params, fitness_fn: F)
-where
-    S: Strategy<B>,
-    S::Params: std::fmt::Debug,
-    F: BatchFitnessFn<B, S::Genome>,
-    B: burn::tensor::backend::Backend,
-    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
-{
-    let device = Default::default();
-    let mut harness =
-        EvolutionaryHarness::<B, S, F>::new(strategy, params, fitness_fn, SEED, device, GENS);
-    harness.reset();
-    loop {
-        if harness.step(()).done {
-            break;
-        }
-    }
-    let m = harness
-        .latest_metrics()
-        .expect("at least one generation ran");
-    println!(
-        "{label:>30} | gens={:>4} | best={:>.6e} | mean={:>.6e}",
-        m.generation, m.best_fitness_ever, m.mean_fitness,
-    );
-}
+use rlevo::envs::landscapes::rastrigin::Rastrigin;
 
 fn main() {
-    let landscape = Rastrigin::new(DIM);
-    let (lo, hi) = landscape.bounds();
-    #[allow(clippy::cast_possible_truncation)]
-    let bounds = (lo as f32, hi as f32);
-
     println!(
-        "Rastrigin-D{DIM} showcase — {GENS} generations, Flex backend, seed={SEED}\n\
-         {:-<80}",
+        "
+Interpreting the output
+
+Each strategy prints one row: `label | gens | best | mean`. Fitness is the
+raw landscape cost under the minimization convention, so **lower is better**.
+`best` is `best_fitness_ever` — the lowest cost seen by any individual across
+all generations (a rolling minimum) — and `mean` is the average cost of the
+final generation. A small `best`–`mean` gap means the whole population
+converged; a large gap suggests premature convergence, with a few good
+individuals leading a still spread-out population. Values print in scientific
+notation, so `e-6` is near-converged and `e+2` is far off.
+
+Rastrigin has global optimum `f* = 0` at the origin, searched over
+`[-5.12, 5.12]^10`. A regular grid of deep local minima sits on a Sphere-like
+envelope, so each minimum is a genuine trap rather than a shallow ripple.
+A `best` near `0` is full convergence; a `best` resting at an integer-ish
+plateau (each trapped coordinate adds roughly `A = 10` to the cost) means a
+run settled into one of the off-origin minima.\n\n\
+{:-<80}",
         "",
     );
-
-    run(
-        "GA/real/tournament-blx-elite",
-        GeneticAlgorithm::<B>::new(),
-        GaConfig {
-            pop_size: 64,
-            genome_dim: DIM,
-            bounds,
-            mutation_sigma: 0.2,
-            selection: GaSelection::Tournament { size: 2 },
-            crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
-            replacement: GaReplacement::Elitist { elitism_k: 2 },
-        },
-        FromLandscape::new(landscape),
-    );
-
-    for kind in [
-        EsKind::OnePlusOne,
-        EsKind::OnePlusLambda { lambda: 8 },
-        EsKind::MuPlusLambda { mu: 5, lambda: 20 },
-        EsKind::MuCommaLambda { mu: 5, lambda: 20 },
-    ] {
-        let mut params = EsConfig::default_for(kind, DIM);
-        params.bounds = bounds;
-        let label = format!("ES/{kind:?}");
-        run(
-            &label,
-            EvolutionStrategy::<B>::new(),
-            params,
-            FromLandscape::new(landscape),
-        );
-    }
-
-    let mut ep_params = EpConfig::default_for(20, DIM);
-    ep_params.bounds = bounds;
-    run(
-        "EP/fogel/μ=20/q=10",
-        EvolutionaryProgramming::<B>::new(),
-        ep_params,
-        FromLandscape::new(landscape),
-    );
-
-    for variant in [
-        DeVariant::Rand1Bin,
-        DeVariant::Best1Bin,
-        DeVariant::CurrentToBest1Bin,
-        DeVariant::Rand2Bin,
-        DeVariant::Rand1Exp,
-    ] {
-        let mut params = DeConfig::default_for(30, DIM);
-        params.variant = variant;
-        params.bounds = bounds;
-        let label = format!("DE/{variant:?}");
-        run(
-            &label,
-            DifferentialEvolution::<B>::new(),
-            params,
-            FromLandscape::new(landscape),
-        );
-    }
+    let dim = 10;
+    let landscape = Rastrigin::new(dim);
+    common::showcase("Rastrigin", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/rastrigin_showcase.rs
+++ b/crates/rlevo/examples/evo/rastrigin_showcase.rs
@@ -5,7 +5,25 @@
 //! superimposed on a Sphere-like envelope — a harder convergence test
 //! than either Sphere or Ackley.
 //!
-//! Run with `cargo run --release -p rlevo-evolution --example rastrigin_showcase`.
+//! Run with `cargo run --release -p rlevo --example rastrigin_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Each strategy prints one row: `label | gens | best | mean`. Fitness is the
+//! raw landscape cost under the minimization convention, so **lower is better**.
+//! `best` is `best_fitness_ever` — the lowest cost seen by any individual across
+//! all generations (a rolling minimum) — and `mean` is the average cost of the
+//! final generation. A small `best`–`mean` gap means the whole population
+//! converged; a large gap suggests premature convergence, with a few good
+//! individuals leading a still spread-out population. Values print in scientific
+//! notation, so `e-6` is near-converged and `e+2` is far off.
+//!
+//! Rastrigin has global optimum `f* = 0` at the origin, searched over
+//! `[-5.12, 5.12]^10`. A regular grid of deep local minima sits on a Sphere-like
+//! envelope, so each minimum is a genuine trap rather than a shallow ripple.
+//! A `best` near `0` is full convergence; a `best` resting at an integer-ish
+//! plateau (each trapped coordinate adds roughly `A = 10` to the cost) means a
+//! run settled into one of the off-origin minima.
 
 use burn::backend::Flex;
 use rlevo_environments::landscapes::rastrigin::Rastrigin;

--- a/crates/rlevo/examples/evo/rosenbrock_flat_showcase.rs
+++ b/crates/rlevo/examples/evo/rosenbrock_flat_showcase.rs
@@ -3,22 +3,25 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example rosenbrock_flat_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at `x = (1, …, 1)`. Replacing the smooth square in
-//! standard Rosenbrock with an absolute value flattens the valley floor, so
-//! there is even less gradient to exploit and `best` typically descends more
-//! slowly than on the smooth variant. A `best` near `0` is full convergence; a
-//! lingering positive plateau is the expected signature of the flattened
-//! valley. See the `common` module's "Reading the output" section for the full
-//! column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::rosenbrock_flat::RosenbrockFlat;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at `x = (1, …, 1)`. Replacing the smooth square in
+standard Rosenbrock with an absolute value flattens the valley floor, so
+there is even less gradient to exploit and `best` typically descends more
+slowly than on the smooth variant. A `best` near `0` is full convergence; a
+lingering positive plateau is the expected signature of the flattened
+valley.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = RosenbrockFlat::new(dim);
     common::showcase("RosenbrockFlat", dim, landscape.bounds(), 1.0, landscape);

--- a/crates/rlevo/examples/evo/rosenbrock_flat_showcase.rs
+++ b/crates/rlevo/examples/evo/rosenbrock_flat_showcase.rs
@@ -1,0 +1,25 @@
+//! Modified (flat) Rosenbrock landscape — Modified Rosenbrock No.01 — the classic valley flattened to stress gradient-free exploration.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example rosenbrock_flat_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at `x = (1, …, 1)`. Replacing the smooth square in
+//! standard Rosenbrock with an absolute value flattens the valley floor, so
+//! there is even less gradient to exploit and `best` typically descends more
+//! slowly than on the smooth variant. A `best` near `0` is full convergence; a
+//! lingering positive plateau is the expected signature of the flattened
+//! valley. See the `common` module's "Reading the output" section for the full
+//! column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::rosenbrock_flat::RosenbrockFlat;
+
+fn main() {
+    let dim = 10;
+    let landscape = RosenbrockFlat::new(dim);
+    common::showcase("RosenbrockFlat", dim, landscape.bounds(), 1.0, landscape);
+}

--- a/crates/rlevo/examples/evo/rosenbrock_showcase.rs
+++ b/crates/rlevo/examples/evo/rosenbrock_showcase.rs
@@ -3,21 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example rosenbrock_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = 0` at `x = (1, …, 1)`, searched over `[-30, 30]^10`.
-//! A `best` column near `0` means the run reached the optimal basin; expect
-//! slow, grinding progress because the valley floor is nearly flat, and watch
-//! for stalls at the secondary local minimum near `(-1, 1, …, 1)` that appears
-//! for `n ≥ 4`. See the `common` module's "Reading the output" section for the
-//! full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::rosenbrock::Rosenbrock;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = 0` at `x = (1, …, 1)`, searched over `[-30, 30]^10`.
+A `best` column near `0` means the run reached the optimal basin; expect
+slow, grinding progress because the valley floor is nearly flat, and watch
+for stalls at the secondary local minimum near `(-1, 1, …, 1)` that appears
+for `n ≥ 4`.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Rosenbrock::new(dim);
     common::showcase("Rosenbrock", dim, landscape.bounds(), 1.0, landscape);

--- a/crates/rlevo/examples/evo/rosenbrock_showcase.rs
+++ b/crates/rlevo/examples/evo/rosenbrock_showcase.rs
@@ -1,0 +1,24 @@
+//! Rosenbrock landscape — A narrow, curved parabolic valley; the global optimum sits at all-ones, hard to track because the valley floor is nearly flat.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example rosenbrock_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = 0` at `x = (1, …, 1)`, searched over `[-30, 30]^10`.
+//! A `best` column near `0` means the run reached the optimal basin; expect
+//! slow, grinding progress because the valley floor is nearly flat, and watch
+//! for stalls at the secondary local minimum near `(-1, 1, …, 1)` that appears
+//! for `n ≥ 4`. See the `common` module's "Reading the output" section for the
+//! full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::rosenbrock::Rosenbrock;
+
+fn main() {
+    let dim = 10;
+    let landscape = Rosenbrock::new(dim);
+    common::showcase("Rosenbrock", dim, landscape.bounds(), 1.0, landscape);
+}

--- a/crates/rlevo/examples/evo/schwefel_showcase.rs
+++ b/crates/rlevo/examples/evo/schwefel_showcase.rs
@@ -1,0 +1,26 @@
+//! Schwefel landscape — Deceptive: the global optimum lies far from the origin near the domain edge, away from the next-best basins.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example schwefel_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* = −418.9829… · n ≈ −4189.83` (for `n = 10`) at
+//! `x_i ≈ 420.97`, searched over `[-500, 500]^10`. Because cost is negative
+//! here, `best` is "good" when it is *large in magnitude and negative* — i.e.
+//! the most-negative number wins. The optimum sits at ~84% of the domain away
+//! from the deceptive cluster of local minima near the origin, so a `best`
+//! stuck around `0` to a few hundred negative means the search never escaped
+//! the wrong basins. See the `common` module's "Reading the output" section
+//! for the full column legend.
+
+mod common;
+
+use rlevo_environments::landscapes::schwefel::Schwefel;
+
+fn main() {
+    let dim = 10;
+    let landscape = Schwefel::new(dim);
+    common::showcase("Schwefel", dim, landscape.bounds(), 20.0, landscape);
+}

--- a/crates/rlevo/examples/evo/schwefel_showcase.rs
+++ b/crates/rlevo/examples/evo/schwefel_showcase.rs
@@ -3,23 +3,26 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example schwefel_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* = −418.9829… · n ≈ −4189.83` (for `n = 10`) at
-//! `x_i ≈ 420.97`, searched over `[-500, 500]^10`. Because cost is negative
-//! here, `best` is "good" when it is *large in magnitude and negative* — i.e.
-//! the most-negative number wins. The optimum sits at ~84% of the domain away
-//! from the deceptive cluster of local minima near the origin, so a `best`
-//! stuck around `0` to a few hundred negative means the search never escaped
-//! the wrong basins. See the `common` module's "Reading the output" section
-//! for the full column legend.
 
 mod common;
 
 use rlevo_environments::landscapes::schwefel::Schwefel;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* = −418.9829… · n ≈ −4189.83` (for `n = 10`) at
+`x_i ≈ 420.97`, searched over `[-500, 500]^10`. Because cost is negative
+here, `best` is \"good\" when it is *large in magnitude and negative* — i.e.
+the most-negative number wins. The optimum sits at ~84% of the domain away
+from the deceptive cluster of local minima near the origin, so a `best`
+stuck around `0` to a few hundred negative means the search never escaped
+the wrong basins.\n\
+{:-<80}",
+        "",
+    );
     let dim = 10;
     let landscape = Schwefel::new(dim);
     common::showcase("Schwefel", dim, landscape.bounds(), 20.0, landscape);

--- a/crates/rlevo/examples/evo/six_hump_camel_showcase.rs
+++ b/crates/rlevo/examples/evo/six_hump_camel_showcase.rs
@@ -3,22 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example six_hump_camel_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* ≈ −1.031628` shared by two equivalent minima at
-//! `(±0.0898, ∓0.7127)`, searched over `[-2, 2]²`. Cost is negative, so a more-
-//! negative `best` is better and `best ≈ −1.0316` is full convergence. Of the
-//! six local minima, four are sub-optimal traps, so a `best` near `−1.0` but
-//! not quite reaching `−1.0316` usually means a run landed in one of those. See
-//! the `common` module's "Reading the output" section for the full column
-//! legend.
 
 mod common;
 
 use rlevo_environments::landscapes::six_hump_camel::SixHumpCamel;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* ≈ −1.031628` shared by two equivalent minima at
+`(±0.0898, ∓0.7127)`, searched over `[-2, 2]²`. Cost is negative, so a more-
+negative `best` is better and `best ≈ −1.0316` is full convergence. Of the
+six local minima, four are sub-optimal traps, so a `best` near `−1.0` but
+not quite reaching `−1.0316` usually means a run landed in one of those.\n\n
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = SixHumpCamel::new();
     common::showcase("SixHumpCamel", dim, landscape.bounds(), 0.1, landscape);

--- a/crates/rlevo/examples/evo/six_hump_camel_showcase.rs
+++ b/crates/rlevo/examples/evo/six_hump_camel_showcase.rs
@@ -1,0 +1,25 @@
+//! Six-Hump Camel landscape — Six local minima, two of them global; symmetric about the origin.
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example six_hump_camel_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* ≈ −1.031628` shared by two equivalent minima at
+//! `(±0.0898, ∓0.7127)`, searched over `[-2, 2]²`. Cost is negative, so a more-
+//! negative `best` is better and `best ≈ −1.0316` is full convergence. Of the
+//! six local minima, four are sub-optimal traps, so a `best` near `−1.0` but
+//! not quite reaching `−1.0316` usually means a run landed in one of those. See
+//! the `common` module's "Reading the output" section for the full column
+//! legend.
+
+mod common;
+
+use rlevo_environments::landscapes::six_hump_camel::SixHumpCamel;
+
+fn main() {
+    let dim = 2;
+    let landscape = SixHumpCamel::new();
+    common::showcase("SixHumpCamel", dim, landscape.bounds(), 0.1, landscape);
+}

--- a/crates/rlevo/examples/evo/sphere_showcase.rs
+++ b/crates/rlevo/examples/evo/sphere_showcase.rs
@@ -2,136 +2,34 @@
 //! landscape and prints a convergence summary.
 //!
 //! Run with `cargo run --release -p rlevo --example sphere_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Each strategy prints one row: `label | gens | best | mean`. Fitness is the
-//! raw landscape cost under the minimization convention, so **lower is better**.
-//! `best` is `best_fitness_ever` — the lowest cost seen by any individual across
-//! all generations (a rolling minimum) — and `mean` is the average cost of the
-//! final generation. A small `best`–`mean` gap means the whole population
-//! converged; a large gap means a few good individuals lead a still spread-out
-//! population. Values print in scientific notation, so `e-6` is near-converged
-//! and `e+2` is far off.
-//!
-//! Sphere is a smooth, unimodal, convex bowl with global optimum `f* = 0` at the
-//! origin, searched over `[-5.12, 5.12]^10`. It is the easy baseline: with no
-//! local minima to trap search, every strategy should drive `best` close to `0`,
-//! so this run mainly shows their relative *convergence speed* rather than
-//! whether they find the optimum at all.
 
-use burn::backend::Flex;
-use rlevo_environments::landscapes::sphere::Sphere;
-use rlevo_evolution::algorithms::de::{DeConfig, DeVariant, DifferentialEvolution};
-use rlevo_evolution::algorithms::ep::{EpConfig, EvolutionaryProgramming};
-use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrategy};
-use rlevo_evolution::algorithms::ga::{
-    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
-};
-use rlevo_evolution::fitness::{BatchFitnessFn, FromLandscape};
-use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
+mod common;
 
-type B = Flex;
-
-const DIM: usize = 10;
-const GENS: usize = 500;
-const SEED: u64 = 42;
-
-fn run<S, F>(label: &str, strategy: S, params: S::Params, fitness_fn: F)
-where
-    S: Strategy<B>,
-    S::Params: std::fmt::Debug,
-    F: BatchFitnessFn<B, S::Genome>,
-    B: burn::tensor::backend::Backend,
-    <B as burn::tensor::backend::BackendTypes>::Device: Clone + Default,
-{
-    let device = Default::default();
-    let mut harness =
-        EvolutionaryHarness::<B, S, F>::new(strategy, params, fitness_fn, SEED, device, GENS);
-    harness.reset();
-    loop {
-        if harness.step(()).done {
-            break;
-        }
-    }
-    let m = harness
-        .latest_metrics()
-        .expect("at least one generation ran");
-    println!(
-        "{label:>30} | gens={:>4} | best={:>.6e} | mean={:>.6e}",
-        m.generation, m.best_fitness_ever, m.mean_fitness,
-    );
-}
+use rlevo::envs::landscapes::rastrigin::Rastrigin;
 
 fn main() {
-    let landscape = Sphere::new(DIM);
-    let (lo, hi) = landscape.bounds();
-    #[allow(clippy::cast_possible_truncation)]
-    let bounds = (lo as f32, hi as f32);
-
     println!(
-        "Sphere-D{DIM} showcase — {GENS} generations, Flex backend, seed={SEED}\n\
-         {:-<80}",
+        "
+Interpreting the output
+
+Each strategy prints one row: `label | gens | best | mean`. Fitness is the
+raw landscape cost under the minimization convention, so **lower is better**.
+`best` is `best_fitness_ever` — the lowest cost seen by any individual across
+all generations (a rolling minimum) — and `mean` is the average cost of the
+final generation. A small `best`–`mean` gap means the whole population
+converged; a large gap means a few good individuals lead a still spread-out
+population. Values print in scientific notation, so `e-6` is near-converged
+and `e+2` is far off.
+
+Sphere is a smooth, unimodal, convex bowl with global optimum `f* = 0` at the
+origin, searched over `[-5.12, 5.12]^10`. It is the easy baseline: with no
+local minima to trap search, every strategy should drive `best` close to `0`,
+so this run mainly shows their relative *convergence speed* rather than
+whether they find the optimum at all.\n\n\
+{:-<80}",
         "",
     );
-
-    run(
-        "GA/real/tournament-blx-elite",
-        GeneticAlgorithm::<B>::new(),
-        GaConfig {
-            pop_size: 64,
-            genome_dim: DIM,
-            bounds,
-            mutation_sigma: 0.2,
-            selection: GaSelection::Tournament { size: 2 },
-            crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
-            replacement: GaReplacement::Elitist { elitism_k: 2 },
-        },
-        FromLandscape::new(landscape),
-    );
-
-    for kind in [
-        EsKind::OnePlusOne,
-        EsKind::OnePlusLambda { lambda: 8 },
-        EsKind::MuPlusLambda { mu: 5, lambda: 20 },
-        EsKind::MuCommaLambda { mu: 5, lambda: 20 },
-    ] {
-        let mut params = EsConfig::default_for(kind, DIM);
-        params.bounds = bounds;
-        let label = format!("ES/{kind:?}");
-        run(
-            &label,
-            EvolutionStrategy::<B>::new(),
-            params,
-            FromLandscape::new(landscape),
-        );
-    }
-
-    let mut ep_params = EpConfig::default_for(20, DIM);
-    ep_params.bounds = bounds;
-    run(
-        "EP/fogel/μ=20/q=10",
-        EvolutionaryProgramming::<B>::new(),
-        ep_params,
-        FromLandscape::new(landscape),
-    );
-
-    for variant in [
-        DeVariant::Rand1Bin,
-        DeVariant::Best1Bin,
-        DeVariant::CurrentToBest1Bin,
-        DeVariant::Rand2Bin,
-        DeVariant::Rand1Exp,
-    ] {
-        let mut params = DeConfig::default_for(30, DIM);
-        params.variant = variant;
-        params.bounds = bounds;
-        let label = format!("DE/{variant:?}");
-        run(
-            &label,
-            DifferentialEvolution::<B>::new(),
-            params,
-            FromLandscape::new(landscape),
-        );
-    }
+    let dim = 10;
+    let landscape = Rastrigin::new(dim);
+    common::showcase("Rastrigin", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/sphere_showcase.rs
+++ b/crates/rlevo/examples/evo/sphere_showcase.rs
@@ -1,7 +1,24 @@
 //! Runs every real-valued strategy in the crate on the Sphere-D10
 //! landscape and prints a convergence summary.
 //!
-//! Run with `cargo run --release -p rlevo-evolution --example sphere_showcase`.
+//! Run with `cargo run --release -p rlevo --example sphere_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Each strategy prints one row: `label | gens | best | mean`. Fitness is the
+//! raw landscape cost under the minimization convention, so **lower is better**.
+//! `best` is `best_fitness_ever` — the lowest cost seen by any individual across
+//! all generations (a rolling minimum) — and `mean` is the average cost of the
+//! final generation. A small `best`–`mean` gap means the whole population
+//! converged; a large gap means a few good individuals lead a still spread-out
+//! population. Values print in scientific notation, so `e-6` is near-converged
+//! and `e+2` is far off.
+//!
+//! Sphere is a smooth, unimodal, convex bowl with global optimum `f* = 0` at the
+//! origin, searched over `[-5.12, 5.12]^10`. It is the easy baseline: with no
+//! local minima to trap search, every strategy should drive `best` close to `0`,
+//! so this run mainly shows their relative *convergence speed* rather than
+//! whether they find the optimum at all.
 
 use burn::backend::Flex;
 use rlevo_environments::landscapes::sphere::Sphere;

--- a/crates/rlevo/examples/evo/trefethen_showcase.rs
+++ b/crates/rlevo/examples/evo/trefethen_showcase.rs
@@ -3,22 +3,24 @@
 //! Runs every real-valued strategy in `rlevo-evolution` and prints a
 //! convergence summary. Run with:
 //! `cargo run --release -p rlevo --example trefethen_showcase`.
-//!
-//! # Interpreting the output
-//!
-//! Global optimum `f* ≈ −3.3069` at `(−0.0244, 0.2106)`, searched over the
-//! EA-friendly extended box `[-4.5, 4.5]²`. Cost is negative, so a more-negative
-//! `best` is better and `best ≈ −3.31` is full convergence. Five superimposed
-//! frequencies make the surface densely rugged, so a `best` only reaching the
-//! `−2` range means the search settled in one of the many shallower dips. See
-//! the `common` module's "Reading the output" section for the full column
-//! legend.
 
 mod common;
 
 use rlevo_environments::landscapes::trefethen::Trefethen;
 
 fn main() {
+    println!(
+        "
+Interpreting the output
+
+Global optimum `f* ≈ −3.3069` at `(−0.0244, 0.2106)`, searched over the
+EA-friendly extended box `[-4.5, 4.5]²`. Cost is negative, so a more-negative
+`best` is better and `best ≈ −3.31` is full convergence. Five superimposed
+frequencies make the surface densely rugged, so a `best` only reaching the
+`−2` range means the search settled in one of the many shallower dips.\n\n
+{:-<80}",
+        "",
+    );
     let dim = 2;
     let landscape = Trefethen::new();
     common::showcase("Trefethen", dim, landscape.bounds(), 0.2, landscape);

--- a/crates/rlevo/examples/evo/trefethen_showcase.rs
+++ b/crates/rlevo/examples/evo/trefethen_showcase.rs
@@ -1,0 +1,25 @@
+//! Trefethen landscape — Five superimposed frequencies producing a dense rugged landscape (SIAM 100-digit challenge).
+//!
+//! Runs every real-valued strategy in `rlevo-evolution` and prints a
+//! convergence summary. Run with:
+//! `cargo run --release -p rlevo --example trefethen_showcase`.
+//!
+//! # Interpreting the output
+//!
+//! Global optimum `f* ≈ −3.3069` at `(−0.0244, 0.2106)`, searched over the
+//! EA-friendly extended box `[-4.5, 4.5]²`. Cost is negative, so a more-negative
+//! `best` is better and `best ≈ −3.31` is full convergence. Five superimposed
+//! frequencies make the surface densely rugged, so a `best` only reaching the
+//! `−2` range means the search settled in one of the many shallower dips. See
+//! the `common` module's "Reading the output" section for the full column
+//! legend.
+
+mod common;
+
+use rlevo_environments::landscapes::trefethen::Trefethen;
+
+fn main() {
+    let dim = 2;
+    let landscape = Trefethen::new();
+    common::showcase("Trefethen", dim, landscape.bounds(), 0.2, landscape);
+}

--- a/justfile
+++ b/justfile
@@ -35,6 +35,66 @@ evo-rastrigin:
 evo-sphere:
     cargo run -p rlevo --example sphere_showcase
 
+# Tier 1 — scalable n-D landscapes
+evo-rosenbrock:
+    cargo run -p rlevo --example rosenbrock_showcase
+
+evo-griewank:
+    cargo run -p rlevo --example griewank_showcase
+
+evo-schwefel:
+    cargo run -p rlevo --example schwefel_showcase
+
+evo-michalewicz:
+    cargo run -p rlevo --example michalewicz_showcase
+
+evo-penalized1:
+    cargo run -p rlevo --example penalized1_showcase
+
+# Tier 2 — classical 2-D landscapes
+evo-branin:
+    cargo run -p rlevo --example branin_showcase
+
+evo-himmelblau:
+    cargo run -p rlevo --example himmelblau_showcase
+
+evo-six-hump-camel:
+    cargo run -p rlevo --example six_hump_camel_showcase
+
+evo-easom:
+    cargo run -p rlevo --example easom_showcase
+
+evo-goldstein-price:
+    cargo run -p rlevo --example goldstein_price_showcase
+
+evo-cross-in-tray:
+    cargo run -p rlevo --example cross_in_tray_showcase
+
+evo-bukin6:
+    cargo run -p rlevo --example bukin6_showcase
+
+# Tier 3 — stress-test landscapes
+evo-lunacek:
+    cargo run -p rlevo --example lunacek_showcase
+
+evo-deb1:
+    cargo run -p rlevo --example deb1_showcase
+
+evo-needle-eye:
+    cargo run -p rlevo --example needle_eye_showcase
+
+evo-eggholder:
+    cargo run -p rlevo --example eggholder_showcase
+
+evo-alpine1:
+    cargo run -p rlevo --example alpine1_showcase
+
+evo-rosenbrock-flat:
+    cargo run -p rlevo --example rosenbrock_flat_showcase
+
+evo-trefethen:
+    cargo run -p rlevo --example trefethen_showcase
+
 cartpole-random:
     cargo run -p rlevo --example cartpole_random
 


### PR DESCRIPTION
- **feat(landscapes): add three-tier benchmark function suite**
- **docs(examples): add output-interpretation docs to landscape showcases**
- **refactor(examples): use common::showcase across evo landscape examples**

<!--
Before opening this PR, confirm you have:
  1. Opened (or linked) an issue discussing the change — required for anything beyond a one-line typo fix.
  2. Verified all three commands pass locally:
       cargo build --workspace
       cargo test --workspace
       cargo clippy --all-targets --all-features
  3. Confirmed the change is within the current contribution scope (examples, bug fixes,
     documentation corrections). See CONTRIBUTING.md § "What Contributions Are Welcome Right Now".

Draft PRs will not be reviewed. Mark as Ready for Review when the above is complete.
-->

## Summary

<!-- One paragraph: what changed and why. Be specific — e.g. "Fixes off-by-one in CartPole
termination condition that caused episodes to run one step past the pole-angle threshold." -->

Implements a three-tier benchmark function suite (19 landscapes total) in `rlevo-environments`, each conforming to the existing five-method shape (`const fn new`, `evaluate`, `const fn bounds`, private `evaluate_2d`, `AsciiRenderable`), plus five canonical tests and per-function additive tests. Adds a `common::showcase()` helper that wires any landscape through every real-valued evolutionary strategy (GA, four ES kinds, EP, five DE variants) and prints a one-line convergence summary, then rewires all 22 landscape showcase examples to use it—reducing each per-landscape file to ~30 lines.

## Change Type

<!-- Check all that apply. Remove lines that don't apply. -->

- [x] New example (self-contained, demonstrates existing API surface)

<!--
NOTE: New environments, new RL/evolutionary algorithms, refactors, new dependencies, and
CI/CD changes are out of scope during the alpha phase. If your change falls into one of
those categories, close this PR and open an issue to discuss it first.
-->

## Linked Issue

<!-- Paste the issue URL. If no issue exists and this is more than a typo fix, stop here,
open one, and return when there is prior discussion on record. -->

Closes #


## What Was Changed

<!-- Enumerate the files/modules touched and the specific modifications made.
     Concrete is better than vague: prefer "added `impl Reset for CartPole`" over "fixed the env". -->

- **`crates/rlevo-environments/src/landscapes/`** — added 19 new landscape modules:
  - Tier 1 (scalable n-D): `rosenbrock`, `griewank`, `schwefel`, `michalewicz`, `penalized1`
  - Tier 2 (classical 2-D): `branin`, `himmelblau`, `six_hump_camel`, `easom`, `goldstein_price`, `cross_in_tray`, `bukin6`
  - Tier 3 (stress tests): `lunacek_bi_rastrigin`, `deb1`, `needle_eye`, `eggholder`, `alpine1`, `rosenbrock_flat`, `trefethen`
- **`crates/rlevo-environments/src/bench/landscape.rs`** — extended `Landscape` trait/bounds to cover new functions
- **`crates/rlevo-environments/src/lib.rs`** — re-exported all 19 new landscape modules
- **`crates/rlevo/examples/evo/common.rs`** — new shared `showcase()` harness; runs all strategies, prints convergence rows, documents how to read `best_fitness_ever` vs `mean_fitness`
- **`crates/rlevo/examples/evo/*_showcase.rs`** — 19 new thin showcase binaries (Tiers 1–3); existing `ackley`, `rastrigin`, `sphere` showcases refactored to use `common::showcase()`
- **`crates/rlevo/Cargo.toml`** — added `[[example]]` entries for all new showcases
- **`crates/rlevo-evolution/src/strategy.rs`** — minor fixes surfaced while running all strategies against new landscapes
- **`justfile`** — added convenience recipes for running the landscape showcase suite


## How It Was Tested

<!-- Describe the exact commands run and their output, or paste the relevant test names.
     For bug fixes, identify the regression test added and the before/after behavior. -->

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

<!-- Add environment details if hardware-backend-specific (CPU / WGPU / CUDA, OS, Rust toolchain). -->

- Rust toolchain: `stable-aarch64-apple-darwin`
- Burn backend tested: `ndarray` (CPU)
- OS: macOS Darwin 25.5.0


## AI-Assisted Content

<!-- Per CONTRIBUTING.md § "Change Ownership": you are responsible for every line in this PR
     regardless of origin. If any part of this change was generated or significantly assisted
     by an AI tool, declare it here. You must be able to explain and defend the code on request. -->

- [x] AI tooling was used. Tool(s): Claude Code (claude-sonnet-4.6). Scope: PR description generativ; all implementation authored and reveiwed by Anthony Torlucci.


## Checklist

- [ ] `cargo build --workspace` passes with no errors.
- [ ] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

<!--any caveats, follow-up items, or migration steps if apparent from the diff; omit section if none-->
