### PR TITLE
feat(evolution): add memetic algorithms - phase 3a

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This is not a discouragement — it is transparency. A smaller number of high-qu
 
 To keep the review burden manageable during the alpha phase, contributions are currently scoped to:
 
-- **New examples** — clear, self-contained examples that demonstrate existing functionality
+- **New examples** — clear, self-contained examples that demonstrate existing functionality; lightweight env/evo/RL examples go in `crates/rlevo/examples/`, heavier viz or record examples go in `crates/rlevo-examples/`
 - **Bug fixes** — small, focused fixes with a clear description of the problem and a regression test
 - **Documentation corrections** — typos, broken links, misleading doc comments
 
@@ -37,31 +37,52 @@ If you have an idea that falls outside the current scope, please open an issue t
 ## Before You Open a PR
 
 1. **Open an issue first** for anything beyond a one-line typo fix. Describe what you want to change and why. This avoids wasted effort if the direction does not fit the current roadmap.
-2. **Read the codebase.** Skim `CLAUDE.md` for an overview of key traits and conventions.
+2. **Read the codebase.** Run `cargo doc --workspace --no-deps --open` for a navigable API reference. Key traits live in `crates/rlevo-core/src/` (`state.rs`, `action.rs`, `environment.rs`).
 3. **Keep it small.** One PR, one concern. If a fix naturally grows into a refactor, stop and discuss.
-4. **Verify it builds and tests pass.**
+4. **Verify it builds, tests pass, and formatting is clean.**
 
 ```bash
+cargo fmt --check
 cargo build --workspace
 cargo test --workspace
 cargo clippy --all-targets --all-features
 ```
 
-All three must succeed before submitting.
+All four must succeed before submitting.
 
 ---
 
 ## Pull Request Guidelines
 
 - Write a clear title and a short description: what changed, why, and how you tested it.
-- Link to the relevant issue if one exists.
-- Draft PRs are not ready for review — mark them ready when they are.
+- Link to the issue (required unless this is a trivial typo fix).
+- Convert from draft to ready-for-review only once all four checks pass.
 - Do not force-push during active review without a note explaining why.
 - PRs with no author response for **14 days** may be closed. You can always reopen them.
+
+### Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>): <Description>
+```
+
+- **Types**: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`
+- **Scope**: short crate name of the primary change site (e.g., `rlevo-core`, `rlevo-evolution`); use `workspace` for cross-crate changes; omit for repo-root-only changes
+- **Subject**: max 72 characters, imperative mood, no trailing punctuation
+- **Body** (optional): explain the *why* when motivation is non-obvious; wrap at 72 characters
+- Keep each commit self-contained — the build and tests must pass at every commit
 
 ### Change Ownership
 
 You are responsible for every line in your PR — regardless of whether you wrote it yourself, adapted it from another project, or generated it with an AI tool. Be prepared to explain and defend any change during review.
+
+---
+
+## Toolchain
+
+This project uses **Rust edition 2024**. There is no pinned toolchain file — latest stable is expected. Verify with `rustup update stable` before working on the codebase.
 
 ---
 
@@ -77,6 +98,12 @@ You are responsible for every line in your PR — regardless of whether you wrot
 ## Getting Help
 
 Open an issue or start a GitHub Discussion if you are unsure about anything. There is no Discord or chat at this time, but issues are monitored regularly.
+
+---
+
+## License
+
+By submitting a pull request you agree that your contribution is licensed under the same terms as this project.
 
 ---
 

--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -1,0 +1,1072 @@
+//! Memetic-algorithm strategy adapter.
+//!
+//! A *memetic algorithm* (MA) interleaves a population-level evolutionary
+//! [`Strategy`] with a per-individual [`LocalSearch`] that polishes promising
+//! genomes between an inner strategy's `ask` and `tell`. [`MemeticWrapper`]
+//! makes that interleaving a *zero-cost-to-adopt* upgrade: wrap any existing
+//! `Strategy<B, Genome = Tensor<B, 2>>` together with any
+//! [`LocalSearch<B>`](crate::local_search::LocalSearch) and the wrapper itself
+//! implements `Strategy<B>`, so it drops straight into
+//! [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness).
+//!
+//! # Lamarckian / Baldwinian / Partial refinement
+//!
+//! After the inner strategy proposes a population, the wrapper refines a subset
+//! of individuals (the [`CoveragePolicy`]) and then decides — per the
+//! [`WritebackPolicy`] — whether each refined genome is written *back* into the
+//! population handed to the inner `tell`:
+//!
+//! - **Lamarckian** — refined genome *and* refined fitness flow to `tell`. The
+//!   inherited traits (the genome) change.
+//! - **Baldwinian** — the *original* genome flows to `tell` but carries the
+//!   *refined* fitness. The phenotype's learned advantage shows up as fitness
+//!   pressure without altering the inherited genome.
+//! - **`Partial(p)`** — each refined individual is written back Lamarckian-style
+//!   with probability `p` (drawn per refined individual), Baldwinian otherwise.
+//!
+//! Regardless of policy, the refined fitness *always* replaces the original
+//! fitness for covered rows — Baldwinian differs only in that the genome is left
+//! untouched.
+//!
+//! # Intentional break of the `Strategy` purity convention
+//!
+//! [`Strategy`] documents itself as *pure*: `ask`/`tell` take `&self` and carry
+//! no interior mutability so many instances can run in parallel without locks.
+//! **This wrapper deliberately breaks that convention.** It holds a
+//! [`parking_lot::Mutex`] around its fitness function because local search needs
+//! `&mut F` (an [`FitnessFn`] is `&mut self`) while `tell` only has `&self`. The
+//! lock is wrapper-private and uncontended in the single-harness driving model
+//! (one `tell` in flight at a time), so it costs an uncontended lock/unlock per
+//! generation and never blocks. A reader writing code generic over
+//! `S: Strategy<B>` should be aware that `MemeticWrapper` is *not* a pure,
+//! lock-free strategy like the others in this crate.
+//!
+//! # RNG discipline
+//!
+//! All refinement randomness flows through [`seed_stream`]; the wrapper never
+//! touches the process-wide backend RNG. See the
+//! [`tell`](MemeticWrapper#impl-Strategy<B>-for-MemeticWrapper<B,+S,+L,+F>)
+//! flow for the two-stream scheme that makes `Partial(1.0)` bit-identical to
+//! `Lamarckian` and `Partial(0.0)` to `Baldwinian`.
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use burn::tensor::{Tensor, TensorData, backend::Backend};
+use parking_lot::Mutex;
+use rand::{Rng, RngExt};
+
+use crate::fitness::{BatchFitnessFn, FitnessFn};
+use crate::local_search::LocalSearch;
+use crate::rng::{SeedPurpose, seed_stream};
+use crate::strategy::{Strategy, StrategyMetrics};
+
+/// Controls how a refined genome's gains are written back into the population.
+///
+/// See the [module docs](self) for the semantics of each policy. The default,
+/// [`Partial(0.5)`](WritebackPolicy::Partial), is spec-mandated (research gate
+/// 3a-R2): half of refined individuals inherit their refined genome, the other
+/// half keep their original genome but pay the refined fitness — a pragmatic
+/// blend that avoids both Lamarckian premature convergence and the slow Baldwin
+/// effect.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WritebackPolicy {
+    /// Refined genome *and* refined fitness flow to the inner `tell`.
+    Lamarckian,
+    /// Original genome flows to the inner `tell`, carrying the refined fitness.
+    Baldwinian,
+    /// Per refined individual: write the refined genome back (Lamarckian) with
+    /// probability `p`, otherwise keep the original genome (Baldwinian). The
+    /// refined fitness is used either way.
+    ///
+    /// `p` is expected to lie in `[0, 1]`; values outside that range trip a
+    /// `debug_assert!` and otherwise saturate naturally (`rng < p` is always
+    /// true for `p >= 1`, always false for `p <= 0`).
+    ///
+    /// Because `Partial` writeback draws from a dedicated mask RNG stream that
+    /// is independent of the refinement stream, `Partial(1.0)` is
+    /// **bit-identical** to [`Lamarckian`](WritebackPolicy::Lamarckian) and
+    /// `Partial(0.0)` is bit-identical to
+    /// [`Baldwinian`](WritebackPolicy::Baldwinian) on the same seed.
+    Partial(f32),
+}
+
+impl Default for WritebackPolicy {
+    fn default() -> Self {
+        Self::Partial(0.5)
+    }
+}
+
+/// Determines which population members are refined each generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CoveragePolicy {
+    /// Refine every individual.
+    Full,
+    /// Refine only the `k` fittest (smallest-fitness) individuals, ties broken
+    /// by lower index. `k` is clamped to the population size.
+    TopK {
+        /// Number of fittest individuals to refine.
+        k: usize,
+    },
+}
+
+impl Default for CoveragePolicy {
+    fn default() -> Self {
+        Self::TopK { k: 1 }
+    }
+}
+
+/// Static parameters for a [`MemeticWrapper`] run.
+///
+/// Composes the inner strategy's parameters with the local searcher's, plus the
+/// two memetic policies.
+#[derive(Clone, Debug)]
+pub struct MemeticParams<SP, LP> {
+    /// Parameters forwarded verbatim to the inner [`Strategy`].
+    pub inner: SP,
+    /// Parameters forwarded verbatim to the [`LocalSearch`] on every `refine`.
+    pub local: LP,
+    /// How refined gains are written back. See [`WritebackPolicy`].
+    pub writeback: WritebackPolicy,
+    /// Which individuals are refined. See [`CoveragePolicy`].
+    pub coverage: CoveragePolicy,
+}
+
+/// Generation-to-generation state for a [`MemeticWrapper`].
+///
+/// Wraps the inner strategy's state and carries the memetic generation counter
+/// (used to derive deterministic per-generation refinement seeds).
+#[derive(Clone, Debug)]
+pub struct MemeticState<St> {
+    /// The wrapped inner [`Strategy`] state.
+    pub inner: St,
+    /// Number of completed `tell` calls — the generation index threaded into
+    /// [`seed_stream`] so each generation refines from an independent stream.
+    pub generation: u64,
+}
+
+/// Wraps an inner [`Strategy`] with per-individual [`LocalSearch`] refinement.
+///
+/// `MemeticWrapper` is itself a `Strategy<B, Genome = Tensor<B, 2>>`, so it
+/// composes with any real-valued strategy and drops into
+/// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness) unchanged.
+///
+/// # The two fitness instances
+///
+/// The harness owns *its own* fitness instance (it calls `evaluate_batch` once
+/// per generation to score the asked population); this wrapper owns a *separate*
+/// instance behind a [`Mutex`], used only to score local-search probes.
+///
+/// **If `F` is stateful (counters, caches, RNG), the two instances must share
+/// that state via interior mutability (e.g. `Arc<AtomicUsize>`) — otherwise
+/// they silently diverge.** A naive `#[derive(Clone)]`-then-pass approach gives
+/// each instance an independent counter, and an evaluation-budget accounting
+/// across both will under-count. The headline Rastrigin benchmark shares a
+/// single `Arc<AtomicUsize>` eval counter across both instances for exactly this
+/// reason.
+///
+/// # Example
+///
+/// Wrap Differential Evolution with hill-climbing refinement and drive a couple
+/// of generations by hand:
+///
+/// ```
+/// use burn::backend::Flex;
+/// use burn::tensor::{Tensor, TensorData, backend::Backend};
+/// use rand::{rngs::StdRng, SeedableRng};
+/// use rlevo_evolution::Strategy;
+/// use rlevo_evolution::algorithms::de::{DeConfig, DifferentialEvolution};
+/// use rlevo_evolution::algorithms::memetic::{
+///     CoveragePolicy, MemeticParams, MemeticWrapper, WritebackPolicy,
+/// };
+/// use rlevo_evolution::fitness::BatchFitnessFn;
+/// use rlevo_evolution::local_search::{HillClimbing, HillClimbingParams};
+///
+/// // Sphere objective: sum of squares per row.
+/// struct Sphere;
+/// impl<B: Backend> BatchFitnessFn<B, Tensor<B, 2>> for Sphere {
+///     fn evaluate_batch(
+///         &mut self,
+///         pop: &Tensor<B, 2>,
+///         device: &B::Device,
+///     ) -> Tensor<B, 1> {
+///         let squared = pop.clone() * pop.clone();
+///         squared.sum_dim(1).squeeze_dim::<1>(1)
+///     }
+/// }
+///
+/// let device = Default::default();
+/// let bounds = (-5.12_f32, 5.12);
+/// let strategy = MemeticWrapper::<Flex, _, _, _>::new(
+///     DifferentialEvolution::<Flex>::new(),
+///     HillClimbing,
+///     Sphere,
+/// );
+/// let params = MemeticParams {
+///     inner: DeConfig::default_for(16, 4),
+///     local: HillClimbingParams::default_for(bounds),
+///     writeback: WritebackPolicy::Lamarckian,
+///     coverage: CoveragePolicy::TopK { k: 2 },
+/// };
+///
+/// let mut rng = StdRng::seed_from_u64(0);
+/// let mut state = strategy.init(&params, &mut rng, &device);
+/// let mut scorer = Sphere;
+/// for _ in 0..3 {
+///     let (pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+///     // The harness would do this; here we score it ourselves.
+///     let fitness = scorer.evaluate_batch(&pop, &device);
+///     let (next, _metrics) = strategy.tell(&params, pop, fitness, asked, &mut rng);
+///     state = next;
+/// }
+/// assert!(strategy.best(&state).is_some());
+/// ```
+pub struct MemeticWrapper<B, S, L, F>
+where
+    B: Backend,
+    S: Strategy<B, Genome = Tensor<B, 2>>,
+    L: LocalSearch<B>,
+    F: BatchFitnessFn<B, Tensor<B, 2>>,
+{
+    inner: S,
+    local: L,
+    fitness: Mutex<F>,
+    _backend: PhantomData<fn() -> B>,
+}
+
+impl<B, S, L, F> MemeticWrapper<B, S, L, F>
+where
+    B: Backend,
+    S: Strategy<B, Genome = Tensor<B, 2>>,
+    L: LocalSearch<B>,
+    F: BatchFitnessFn<B, Tensor<B, 2>>,
+{
+    /// Builds a memetic wrapper from an inner strategy, a local searcher, and a
+    /// fitness function used **only** for local-search probes.
+    ///
+    /// The harness owns a separate fitness instance; **if `F` is stateful
+    /// (counters, caches, RNG), the two instances must share that state via
+    /// interior mutability (e.g. `Arc<AtomicUsize>`) — otherwise they silently
+    /// diverge.** See the [type-level docs](MemeticWrapper#the-two-fitness-instances).
+    pub fn new(inner: S, local: L, fitness: F) -> Self {
+        Self {
+            inner,
+            local,
+            fitness: Mutex::new(fitness),
+            _backend: PhantomData,
+        }
+    }
+}
+
+// `F` is not `Debug`; mirror the `EvolutionaryHarness` precedent and use
+// `finish_non_exhaustive()` so the `missing_debug_implementations` lint is
+// satisfied without bounding `F: Debug`.
+impl<B, S, L, F> Debug for MemeticWrapper<B, S, L, F>
+where
+    B: Backend,
+    S: Strategy<B, Genome = Tensor<B, 2>>,
+    L: LocalSearch<B>,
+    F: BatchFitnessFn<B, Tensor<B, 2>>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `S`/`L`/`F` are not bounded `Debug`; mirror `EvolutionaryHarness` and
+        // emit a non-exhaustive shell so the lint is satisfied without forcing
+        // those bounds onto the public type.
+        f.debug_struct("MemeticWrapper").finish_non_exhaustive()
+    }
+}
+
+/// Adapts a population-level [`BatchFitnessFn`] into a single-row
+/// [`FitnessFn`] for local search.
+///
+/// Each [`evaluate_one`](FitnessFn::evaluate_one) builds a `[1, D]` tensor from
+/// the host-side row, calls `evaluate_batch`, and pulls the single scalar back.
+/// This is deliberately the slow path — local search re-uploads one row at a
+/// time — and is private plumbing internal to the wrapper.
+struct RowFitness<'a, B: Backend, F> {
+    inner: &'a mut F,
+    device: &'a B::Device,
+}
+
+impl<B, F> FitnessFn<Vec<f32>> for RowFitness<'_, B, F>
+where
+    B: Backend,
+    F: BatchFitnessFn<B, Tensor<B, 2>>,
+{
+    fn evaluate_one(&mut self, member: &Vec<f32>) -> f32 {
+        let dim: usize = member.len();
+        let data: TensorData = TensorData::new(member.clone(), [1, dim]);
+        let row: Tensor<B, 2> = Tensor::<B, 2>::from_data(data, self.device);
+        let fitness: Tensor<B, 1> = self.inner.evaluate_batch(&row, self.device);
+        let values: Vec<f32> = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+        values.first().copied().unwrap_or(f32::INFINITY)
+    }
+}
+
+impl<B, S, L, F> Strategy<B> for MemeticWrapper<B, S, L, F>
+where
+    B: Backend,
+    S: Strategy<B, Genome = Tensor<B, 2>>,
+    L: LocalSearch<B>,
+    F: BatchFitnessFn<B, Tensor<B, 2>>,
+{
+    type Params = MemeticParams<S::Params, L::Params>;
+    type State = MemeticState<S::State>;
+    type Genome = Tensor<B, 2>;
+
+    /// Delegates to the inner strategy's `init` and seeds the memetic
+    /// generation counter to zero.
+    fn init(
+        &self,
+        params: &Self::Params,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let inner: S::State = self.inner.init(&params.inner, rng, device);
+        MemeticState {
+            inner,
+            generation: 0,
+        }
+    }
+
+    /// Pure delegation to the inner strategy's `ask`. The generation counter is
+    /// unchanged here — it increments only in [`tell`](Self::tell).
+    fn ask(
+        &self,
+        params: &Self::Params,
+        state: &Self::State,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> (Self::Genome, Self::State) {
+        let (population, inner): (Tensor<B, 2>, S::State) =
+            self.inner.ask(&params.inner, &state.inner, rng, device);
+        (
+            population,
+            MemeticState {
+                inner,
+                generation: state.generation,
+            },
+        )
+    }
+
+    /// Refines a covered subset of the population, writes back the refined gains
+    /// per the [`WritebackPolicy`], then delegates to the inner `tell`.
+    ///
+    /// # Flow
+    ///
+    /// 1. Host-pull the fitness vector and one flat read-only host copy of the
+    ///    population; read `[pop_size, dim]` and the device.
+    /// 2. Compute coverage indices ([`Full`](CoveragePolicy::Full) = all;
+    ///    [`TopK`](CoveragePolicy::TopK) = the `k` smallest fitnesses, ties by
+    ///    lower index), then process them in ascending index order so RNG
+    ///    consumption is a pure function of the `(fitness, index)` ranking.
+    /// 3. Draw **exactly one** `rng.next_u64()` unconditionally (so the harness
+    ///    RNG stream position is policy-invariant) and derive two independent
+    ///    sub-streams: `ls_rng` for refinement
+    ///    ([`SeedPurpose::LocalSearch`]) and `mask_rng` for the writeback
+    ///    Bernoulli ([`SeedPurpose::Replacement`]). The split is load-bearing:
+    ///    mask draws never perturb refinement draws, which makes `Partial(1.0)`
+    ///    bit-identical to `Lamarckian` and `Partial(0.0)` to `Baldwinian`.
+    /// 4. Lock the fitness once, refine each covered row, always set
+    ///    `refined_fit[i]` to the refined fitness, and decide writeback
+    ///    (Lamarckian → always; Baldwinian → never; `Partial(p)` → one
+    ///    `mask_rng` Bernoulli per refined index).
+    /// 5. Write back only Lamarckian rows via `slice_assign` onto the *original*
+    ///    population tensor. When there are zero writeback rows, the exact tensor
+    ///    returned by `ask` is handed to the inner `tell` — no host round-trip.
+    /// 6. Rebuild the fitness tensor and delegate to the inner `tell`, returning
+    ///    its metrics verbatim alongside `generation + 1`.
+    ///
+    /// Refinement runs on **every** `tell`, including the first. For a wrapped
+    /// DE this means gen-0 refinement happens before DE's empty-fitness sentinel
+    /// stash; under Baldwinian writeback the inner population still carries the
+    /// *unrefined* genomes but the *refined* fitness, which raises DE's greedy
+    /// replacement bar — the intended Baldwin effect.
+    ///
+    /// Refined fitness is **never** clamped against the old fitness: the
+    /// [`LocalSearch`] contract already guarantees monotone non-worsening, and
+    /// clamping would manufacture a stale fitness on Lamarckian rows.
+    fn tell(
+        &self,
+        params: &Self::Params,
+        population: Self::Genome,
+        fitness: Tensor<B, 1>,
+        state: Self::State,
+        rng: &mut dyn Rng,
+    ) -> (Self::State, StrategyMetrics) {
+        let generation: u64 = state.generation;
+
+        // (1) Host-pull fitness and one flat read-only host copy of the population.
+        let mut refined_fit: Vec<f32> = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+        let dims: [usize; 2] = population.dims();
+        let pop_size: usize = dims[0];
+        let dim: usize = dims[1];
+        let device: B::Device = population.device();
+        let flat: Vec<f32> = population
+            .clone()
+            .into_data()
+            .into_vec::<f32>()
+            .unwrap_or_default();
+
+        // (2) Coverage indices, processed in ascending index order.
+        let mut indices: Vec<usize> = coverage_indices(&params.coverage, &refined_fit, pop_size);
+        indices.sort_unstable();
+
+        // (3) Exactly one host RNG draw — unconditionally — so the harness
+        // stream position is policy- and coverage-invariant.
+        let base: u64 = rng.next_u64();
+        let mut ls_rng = seed_stream(base, generation, SeedPurpose::LocalSearch);
+        let mut mask_rng = seed_stream(base, generation, SeedPurpose::Replacement);
+
+        if let WritebackPolicy::Partial(p) = params.writeback {
+            debug_assert!(
+                (0.0..=1.0).contains(&p),
+                "WritebackPolicy::Partial probability {p} must lie in [0, 1]"
+            );
+        }
+
+        // (4) Refine each covered row; collect Lamarckian writebacks.
+        let mut writeback_rows: Vec<(usize, Vec<f32>)> = Vec::with_capacity(indices.len());
+        {
+            let mut guard = self.fitness.lock();
+            let mut row_fitness: RowFitness<'_, B, F> = RowFitness {
+                inner: &mut *guard,
+                device: &device,
+            };
+            for &i in &indices {
+                let start: usize = i * dim;
+                let row: Vec<f32> = flat[start..start + dim].to_vec();
+                let (refined, f_refined): (Vec<f32>, f32) =
+                    self.local
+                        .refine(&params.local, row, &mut row_fitness, &mut ls_rng);
+                debug_assert_eq!(refined.len(), dim, "local search must preserve genome length");
+                // Baldwinian keeps the original genome but pays refined fitness;
+                // Lamarckian writes the genome too. Either way the fitness is
+                // the refined value.
+                refined_fit[i] = f_refined;
+                let writeback: bool = match params.writeback {
+                    WritebackPolicy::Lamarckian => true,
+                    WritebackPolicy::Baldwinian => false,
+                    // One Bernoulli draw per refined index, from the dedicated
+                    // mask stream, so Lamarckian/Baldwinian runs share an
+                    // identical `ls_rng` schedule (they draw nothing here).
+                    WritebackPolicy::Partial(p) => mask_rng.random::<f32>() < p,
+                };
+                if writeback {
+                    writeback_rows.push((i, refined));
+                }
+            }
+        } // guard dropped before delegating to the inner tell.
+
+        // (5) Writeback. Start from the ORIGINAL population tensor (moved,
+        // untouched). With zero writeback rows the inner `tell` receives the
+        // exact tensor `ask` returned — no host round-trip, no rebuild.
+        let mut new_pop: Tensor<B, 2> = population;
+        for (i, row) in writeback_rows {
+            let data: TensorData = TensorData::new(row, [1, dim]);
+            let row_tensor: Tensor<B, 2> = Tensor::<B, 2>::from_data(data, &device);
+            new_pop = new_pop.slice_assign([i..i + 1, 0..dim], row_tensor);
+        }
+
+        // (6) Rebuild fitness and delegate.
+        let new_fit: Tensor<B, 1> =
+            Tensor::<B, 1>::from_data(TensorData::new(refined_fit, [pop_size]), &device);
+        let (inner, metrics): (S::State, StrategyMetrics) =
+            self.inner
+                .tell(&params.inner, new_pop, new_fit, state.inner, rng);
+        (
+            MemeticState {
+                inner,
+                generation: generation + 1,
+            },
+            metrics,
+        )
+    }
+
+    /// Delegates to the inner strategy's `best`.
+    fn best(&self, state: &Self::State) -> Option<(Self::Genome, f32)> {
+        self.inner.best(&state.inner)
+    }
+}
+
+/// Computes the refinement coverage indices for a generation (unsorted).
+///
+/// `Full` yields `0..pop_size`; `TopK { k }` yields the indices of the `k`
+/// smallest fitness values, ties broken by lower index (stable sort over
+/// `(fitness, index)`), with `k` clamped to `pop_size`. The caller is
+/// responsible for sorting the result into ascending index order.
+fn coverage_indices(policy: &CoveragePolicy, fitness: &[f32], pop_size: usize) -> Vec<usize> {
+    match *policy {
+        CoveragePolicy::Full => (0..pop_size).collect(),
+        CoveragePolicy::TopK { k } => {
+            let k: usize = k.min(pop_size);
+            let mut ranked: Vec<usize> = (0..pop_size).collect();
+            // Stable sort by (fitness, index): `total_cmp` orders NaN
+            // deterministically, and `sort_by` is stable so equal fitnesses keep
+            // ascending-index order — making ties break by lower index.
+            ranked.sort_by(|&a, &b| fitness[a].total_cmp(&fitness[b]));
+            ranked.truncate(k);
+            ranked
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithms::de::{DeConfig, DifferentialEvolution};
+    use crate::algorithms::ga::{GaConfig, GeneticAlgorithm};
+    use crate::local_search::{
+        HillClimbing, HillClimbingParams, SimulatedAnnealing, SimulatedAnnealingParams,
+    };
+    use crate::strategy::EvolutionaryHarness;
+    use burn::backend::Flex;
+    use burn::tensor::backend::BackendTypes;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    type TestBackend = Flex;
+
+    const BOUNDS: (f32, f32) = (-5.12, 5.12);
+
+    // ---------------------------------------------------------------------
+    // Probes.
+    // ---------------------------------------------------------------------
+
+    /// A strategy probe (mirrors the `strategy.rs` Constant-probe pattern):
+    /// `ask` returns a fixed population built from `state`; `tell` records the
+    /// exact population tensor + fitness it received so a test can assert on
+    /// them. No real evolutionary dynamics.
+    #[derive(Debug, Clone, Copy)]
+    struct RecordingStrategy;
+
+    #[derive(Debug, Clone)]
+    struct RecParams {
+        /// The fixed population every `ask` returns (row-major, `[pop, dim]`).
+        rows: Vec<f32>,
+        pop: usize,
+        dim: usize,
+    }
+
+    #[derive(Debug, Clone)]
+    struct RecState {
+        /// Population tensor handed to the most recent `tell`, as flat host f32.
+        received_pop: Option<Vec<f32>>,
+        /// Fitness handed to the most recent `tell`, as host f32.
+        received_fit: Option<Vec<f32>>,
+        best: f32,
+        generation: usize,
+    }
+
+    impl Strategy<TestBackend> for RecordingStrategy {
+        type Params = RecParams;
+        type State = RecState;
+        type Genome = Tensor<TestBackend, 2>;
+
+        fn init(
+            &self,
+            _params: &RecParams,
+            _rng: &mut dyn Rng,
+            _device: &<TestBackend as BackendTypes>::Device,
+        ) -> RecState {
+            RecState {
+                received_pop: None,
+                received_fit: None,
+                best: f32::INFINITY,
+                generation: 0,
+            }
+        }
+
+        fn ask(
+            &self,
+            params: &RecParams,
+            state: &RecState,
+            _rng: &mut dyn Rng,
+            device: &<TestBackend as BackendTypes>::Device,
+        ) -> (Tensor<TestBackend, 2>, RecState) {
+            let data = TensorData::new(params.rows.clone(), [params.pop, params.dim]);
+            let pop = Tensor::<TestBackend, 2>::from_data(data, device);
+            (pop, state.clone())
+        }
+
+        fn tell(
+            &self,
+            _params: &RecParams,
+            population: Tensor<TestBackend, 2>,
+            fitness: Tensor<TestBackend, 1>,
+            mut state: RecState,
+            _rng: &mut dyn Rng,
+        ) -> (RecState, StrategyMetrics) {
+            let pop_host = population.into_data().into_vec::<f32>().unwrap();
+            let fit_host = fitness.into_data().into_vec::<f32>().unwrap();
+            state.received_pop = Some(pop_host);
+            state.received_fit = Some(fit_host.clone());
+            state.generation += 1;
+            let metrics =
+                StrategyMetrics::from_host_fitness(state.generation, &fit_host, state.best);
+            state.best = metrics.best_fitness_ever;
+            (state, metrics)
+        }
+
+        fn best(&self, _state: &RecState) -> Option<(Tensor<TestBackend, 2>, f32)> {
+            None
+        }
+    }
+
+    /// Sphere fitness counting the total number of evaluated ROWS. Each
+    /// `RowFitness::evaluate_one` is one `[1, D]` batch, so refinement evals are
+    /// counted too.
+    #[derive(Debug, Default)]
+    struct CountingBatchFitness {
+        rows: usize,
+    }
+
+    impl<B: Backend> BatchFitnessFn<B, Tensor<B, 2>> for CountingBatchFitness {
+        fn evaluate_batch(
+            &mut self,
+            population: &Tensor<B, 2>,
+            device: &<B as BackendTypes>::Device,
+        ) -> Tensor<B, 1> {
+            let dims = population.dims();
+            self.rows += dims[0];
+            let flat = population.clone().into_data().into_vec::<f32>().unwrap();
+            let (pop, dim) = (dims[0], dims[1]);
+            let mut out = Vec::with_capacity(pop);
+            for r in 0..pop {
+                let start = r * dim;
+                let f: f32 = flat[start..start + dim].iter().map(|v| v * v).sum();
+                out.push(f);
+            }
+            Tensor::<B, 1>::from_data(TensorData::new(out, [pop]), device)
+        }
+    }
+
+    /// Sphere on a flat host genome — for re-deriving expected fitness.
+    fn sphere(row: &[f32]) -> f32 {
+        row.iter().map(|v| v * v).sum()
+    }
+
+    fn rec_params(rows: Vec<f32>, pop: usize, dim: usize) -> RecParams {
+        RecParams { rows, pop, dim }
+    }
+
+    /// A deterministic, spread-out population whose fitnesses are all distinct.
+    fn fixed_population(pop: usize, dim: usize) -> Vec<f32> {
+        let mut rows = Vec::with_capacity(pop * dim);
+        for r in 0..pop {
+            for c in 0..dim {
+                #[allow(clippy::cast_precision_loss)]
+                let v = 0.5 + (r as f32) * 0.37 + (c as f32) * 0.11;
+                rows.push(v);
+            }
+        }
+        rows
+    }
+
+    // ---------------------------------------------------------------------
+    // 0. Spec-mandated defaults (falsifiable equality checks).
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn writeback_policy_default_is_partial_half() {
+        assert_eq!(WritebackPolicy::default(), WritebackPolicy::Partial(0.5));
+    }
+
+    #[test]
+    fn coverage_policy_default_is_top_k_one() {
+        assert_eq!(CoveragePolicy::default(), CoveragePolicy::TopK { k: 1 });
+    }
+
+    // ---------------------------------------------------------------------
+    // 1. Baldwinian bit-identity.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn baldwinian_population_bit_identical_to_ask() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let (pop, dim) = (5usize, 3usize);
+        let rows = fixed_population(pop, dim);
+
+        let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+            RecordingStrategy,
+            HillClimbing,
+            CountingBatchFitness::default(),
+        );
+        let params = MemeticParams {
+            inner: rec_params(rows.clone(), pop, dim),
+            local: HillClimbingParams::default_for(BOUNDS),
+            writeback: WritebackPolicy::Baldwinian,
+            coverage: CoveragePolicy::TopK { k: 2 },
+        };
+
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = strategy.init(&params, &mut rng, &device);
+        let (ask_pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+        let ask_bytes = ask_pop.clone().into_data().into_vec::<f32>().unwrap();
+        // Original fitness for the asked population.
+        let mut orig_fit = CountingBatchFitness::default();
+        let orig =
+            <CountingBatchFitness as BatchFitnessFn<TestBackend, _>>::evaluate_batch(
+                &mut orig_fit,
+                &ask_pop,
+                &device,
+            )
+            .into_data()
+            .into_vec::<f32>()
+            .unwrap();
+        let fit = Tensor::<TestBackend, 1>::from_data(TensorData::new(orig.clone(), [pop]), &device);
+
+        let (next, _m) = strategy.tell(&params, ask_pop, fit, asked, &mut rng);
+
+        // Population handed to RecordingStrategy::tell is byte-identical to ask.
+        let recv_pop = next.inner.received_pop.clone().unwrap();
+        assert_eq!(recv_pop, ask_bytes, "Baldwinian must not alter the genome");
+
+        // Covered rows (TopK{2} = the two smallest-fitness rows) have refined
+        // fitness <= original; all others unchanged. Covered = indices 0,1 here
+        // (fitness increases with row index for this population).
+        let recv_fit = next.inner.received_fit.clone().unwrap();
+        for i in 0..pop {
+            if i < 2 {
+                assert!(
+                    recv_fit[i] <= orig[i],
+                    "covered row {i}: refined {} must be <= original {}",
+                    recv_fit[i],
+                    orig[i]
+                );
+                // Equals a fresh eval of the (unchanged) original row's refined
+                // value: the refined fitness is honest for the genome stored,
+                // but the genome is unchanged, so recv_fit[i] <= sphere(orig row).
+                let start = i * dim;
+                assert!(recv_fit[i] <= sphere(&rows[start..start + dim]) + 1e-6);
+            } else {
+                assert_eq!(recv_fit[i], orig[i], "uncovered row {i} must be unchanged");
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 2. Lamarckian row equality.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn lamarckian_covered_rows_change_uncovered_identical() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let (pop, dim) = (5usize, 3usize);
+        let rows = fixed_population(pop, dim);
+
+        let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+            RecordingStrategy,
+            HillClimbing,
+            CountingBatchFitness::default(),
+        );
+        let params = MemeticParams {
+            inner: rec_params(rows.clone(), pop, dim),
+            local: HillClimbingParams::default_for(BOUNDS),
+            writeback: WritebackPolicy::Lamarckian,
+            coverage: CoveragePolicy::TopK { k: 2 },
+        };
+
+        let mut rng = StdRng::seed_from_u64(11);
+        let state = strategy.init(&params, &mut rng, &device);
+        let (ask_pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+        let ask_bytes = ask_pop.clone().into_data().into_vec::<f32>().unwrap();
+        let mut fitfn = CountingBatchFitness::default();
+        let orig =
+            <CountingBatchFitness as BatchFitnessFn<TestBackend, _>>::evaluate_batch(
+                &mut fitfn, &ask_pop, &device,
+            )
+            .into_data()
+            .into_vec::<f32>()
+            .unwrap();
+        let fit = Tensor::<TestBackend, 1>::from_data(TensorData::new(orig, [pop]), &device);
+
+        let (next, _m) = strategy.tell(&params, ask_pop, fit, asked, &mut rng);
+        let recv_pop = next.inner.received_pop.clone().unwrap();
+        let recv_fit = next.inner.received_fit.clone().unwrap();
+
+        // Indexing several parallel host buffers by row; an iterator over one of
+        // them would not read more clearly than the explicit row index.
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..pop {
+            let start = i * dim;
+            let recv_row = &recv_pop[start..start + dim];
+            let ask_row = &ask_bytes[start..start + dim];
+            if i < 2 {
+                // Covered rows changed (HillClimbing improves the sphere from a
+                // non-optimal start).
+                assert_ne!(recv_row, ask_row, "covered row {i} should have changed");
+                // received fitness[i] equals a fresh eval of received row i.
+                approx::assert_relative_eq!(recv_fit[i], sphere(recv_row), epsilon = 1e-5);
+            } else {
+                assert_eq!(recv_row, ask_row, "uncovered row {i} must be bit-identical");
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 3. Partial boundaries (stochastic searcher pins the two-stream split).
+    // ---------------------------------------------------------------------
+
+    /// Drives `gens` wrapper tell cycles and returns the full trajectory of
+    /// (received population, received fitness) the `RecordingStrategy` saw.
+    fn sa_trajectory(
+        writeback: WritebackPolicy,
+        seed: u64,
+        gens: usize,
+    ) -> Vec<(Vec<f32>, Vec<f32>)> {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let (pop, dim) = (4usize, 3usize);
+        let rows = fixed_population(pop, dim);
+        let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+            RecordingStrategy,
+            SimulatedAnnealing,
+            CountingBatchFitness::default(),
+        );
+        let params = MemeticParams {
+            inner: rec_params(rows, pop, dim),
+            local: SimulatedAnnealingParams::default_for(BOUNDS),
+            writeback,
+            coverage: CoveragePolicy::Full,
+        };
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        let mut trajectory = Vec::with_capacity(gens);
+        for _ in 0..gens {
+            let (ask_pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+            let mut fitfn = CountingBatchFitness::default();
+            let orig =
+                <CountingBatchFitness as BatchFitnessFn<TestBackend, _>>::evaluate_batch(
+                    &mut fitfn, &ask_pop, &device,
+                );
+            let (next, _m) = strategy.tell(&params, ask_pop, orig, asked, &mut rng);
+            trajectory.push((
+                next.inner.received_pop.clone().unwrap(),
+                next.inner.received_fit.clone().unwrap(),
+            ));
+            state = next;
+        }
+        trajectory
+    }
+
+    #[test]
+    fn partial_one_equals_lamarckian_partial_zero_equals_baldwinian() {
+        let lam = sa_trajectory(WritebackPolicy::Lamarckian, 33, 3);
+        let p1 = sa_trajectory(WritebackPolicy::Partial(1.0), 33, 3);
+        assert_eq!(lam, p1, "Partial(1.0) must be bit-identical to Lamarckian");
+
+        let bald = sa_trajectory(WritebackPolicy::Baldwinian, 33, 3);
+        let p0 = sa_trajectory(WritebackPolicy::Partial(0.0), 33, 3);
+        assert_eq!(bald, p0, "Partial(0.0) must be bit-identical to Baldwinian");
+    }
+
+    // ---------------------------------------------------------------------
+    // 4. Partial mask seeded-replay.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn partial_is_seed_reproducible_and_seed_sensitive() {
+        let a = sa_trajectory(WritebackPolicy::Partial(0.5), 55, 3);
+        let b = sa_trajectory(WritebackPolicy::Partial(0.5), 55, 3);
+        assert_eq!(a, b, "same seed must replay identically");
+
+        // A different seed (almost surely) yields a different writeback pattern.
+        let c = sa_trajectory(WritebackPolicy::Partial(0.5), 56, 3);
+        assert_ne!(a, c, "different seed should diverge");
+    }
+
+    // ---------------------------------------------------------------------
+    // 5. TopK count.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn topk_refines_exactly_k_rows_and_k_ge_pop_equals_full() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let (pop, dim) = (6usize, 2usize);
+        let rows = fixed_population(pop, dim);
+
+        let run = |coverage: CoveragePolicy| -> Vec<bool> {
+            let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+                RecordingStrategy,
+                HillClimbing,
+                CountingBatchFitness::default(),
+            );
+            let params = MemeticParams {
+                inner: rec_params(rows.clone(), pop, dim),
+                local: HillClimbingParams::default_for(BOUNDS),
+                writeback: WritebackPolicy::Lamarckian,
+                coverage,
+            };
+            let mut rng = StdRng::seed_from_u64(3);
+            let state = strategy.init(&params, &mut rng, &device);
+            let (ask_pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+            let ask_bytes = ask_pop.clone().into_data().into_vec::<f32>().unwrap();
+            let mut fitfn = CountingBatchFitness::default();
+            let orig =
+                <CountingBatchFitness as BatchFitnessFn<TestBackend, _>>::evaluate_batch(
+                    &mut fitfn, &ask_pop, &device,
+                );
+            let (next, _m) = strategy.tell(&params, ask_pop, orig, asked, &mut rng);
+            let recv = next.inner.received_pop.clone().unwrap();
+            // A row "changed" iff its bytes differ from ask.
+            (0..pop)
+                .map(|i| {
+                    let s = i * dim;
+                    recv[s..s + dim] != ask_bytes[s..s + dim]
+                })
+                .collect()
+        };
+
+        let changed_k3 = run(CoveragePolicy::TopK { k: 3 });
+        assert_eq!(
+            changed_k3.iter().filter(|&&c| c).count(),
+            3,
+            "TopK{{3}} must refine exactly 3 rows"
+        );
+
+        let changed_full = run(CoveragePolicy::Full);
+        let changed_big_k = run(CoveragePolicy::TopK { k: pop + 4 });
+        assert_eq!(changed_full, changed_big_k, "TopK{{k>=pop}} must equal Full");
+    }
+
+    // ---------------------------------------------------------------------
+    // 6. DE round-trip.
+    // ---------------------------------------------------------------------
+
+    /// Inline sphere `BatchFitnessFn` evaluated on-device.
+    #[derive(Debug, Default)]
+    struct SphereBatch;
+    impl<B: Backend> BatchFitnessFn<B, Tensor<B, 2>> for SphereBatch {
+        fn evaluate_batch(
+            &mut self,
+            population: &Tensor<B, 2>,
+            device: &<B as BackendTypes>::Device,
+        ) -> Tensor<B, 1> {
+            let dims = population.dims();
+            let flat = population.clone().into_data().into_vec::<f32>().unwrap();
+            let (pop, dim) = (dims[0], dims[1]);
+            let mut out: Vec<f32> = Vec::with_capacity(pop);
+            for r in 0..pop {
+                let start = r * dim;
+                out.push(flat[start..start + dim].iter().map(|v| v * v).sum());
+            }
+            Tensor::<B, 1>::from_data(TensorData::new(out, [pop]), device)
+        }
+    }
+
+    #[test]
+    fn de_roundtrip_improves_over_generations() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let dim = 4usize;
+        let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+            DifferentialEvolution::<TestBackend>::new(),
+            HillClimbing,
+            SphereBatch,
+        );
+        let params = MemeticParams {
+            inner: DeConfig::default_for(20, dim),
+            local: HillClimbingParams::default_for(BOUNDS),
+            writeback: WritebackPolicy::Lamarckian,
+            coverage: CoveragePolicy::TopK { k: 3 },
+        };
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            strategy, params, SphereBatch, 17, device, 20,
+        );
+        harness.reset();
+        let _ = harness.step(());
+        let first: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        loop {
+            if harness.step(()).done {
+                break;
+            }
+        }
+        let last: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        assert!(last.is_finite(), "best must stay finite");
+        assert!(last <= first, "best_fitness_ever must improve: {last} <= {first}");
+    }
+
+    // ---------------------------------------------------------------------
+    // 7. GA round-trip smoke.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn ga_roundtrip_smoke() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let dim = 4usize;
+        let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+            GeneticAlgorithm::<TestBackend>::new(),
+            HillClimbing,
+            SphereBatch,
+        );
+        let params = MemeticParams {
+            inner: GaConfig::default_for(16, dim),
+            local: HillClimbingParams::default_for(BOUNDS),
+            writeback: WritebackPolicy::default(),
+            coverage: CoveragePolicy::default(),
+        };
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            strategy, params, SphereBatch, 5, device, 5,
+        );
+        harness.reset();
+        for _ in 0..5 {
+            let _ = harness.step(());
+        }
+        assert!(harness.latest_metrics().unwrap().best_fitness_ever.is_finite());
+    }
+
+    // ---------------------------------------------------------------------
+    // 8. One-draw invariance: the harness RNG advances identically regardless
+    //    of policy/coverage.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn one_draw_invariant_across_policies() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let (pop, dim) = (5usize, 3usize);
+        let rows = fixed_population(pop, dim);
+
+        // For RecordingStrategy, `tell` never draws from the rng, so the only
+        // wrapper-side consumption is the single `next_u64()`. After one tell
+        // the rng's next value must be equal across every policy/coverage.
+        let next_after = |writeback: WritebackPolicy, coverage: CoveragePolicy| -> u64 {
+            let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+                RecordingStrategy,
+                HillClimbing,
+                CountingBatchFitness::default(),
+            );
+            let params = MemeticParams {
+                inner: rec_params(rows.clone(), pop, dim),
+                local: HillClimbingParams::default_for(BOUNDS),
+                writeback,
+                coverage,
+            };
+            let mut rng = StdRng::seed_from_u64(101);
+            let state = strategy.init(&params, &mut rng, &device);
+            let (ask_pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+            let mut fitfn = CountingBatchFitness::default();
+            let orig =
+                <CountingBatchFitness as BatchFitnessFn<TestBackend, _>>::evaluate_batch(
+                    &mut fitfn, &ask_pop, &device,
+                );
+            let (_next, _m) = strategy.tell(&params, ask_pop, orig, asked, &mut rng);
+            rng.next_u64()
+        };
+
+        let baseline = next_after(WritebackPolicy::Lamarckian, CoveragePolicy::TopK { k: 1 });
+        assert_eq!(
+            baseline,
+            next_after(WritebackPolicy::Baldwinian, CoveragePolicy::TopK { k: 1 }),
+        );
+        assert_eq!(
+            baseline,
+            next_after(WritebackPolicy::Partial(0.5), CoveragePolicy::Full),
+        );
+        assert_eq!(
+            baseline,
+            next_after(WritebackPolicy::Lamarckian, CoveragePolicy::Full),
+        );
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -98,6 +98,33 @@ impl Default for WritebackPolicy {
 }
 
 /// Determines which population members are refined each generation.
+///
+/// # Cost and tuning
+///
+/// Coverage is the dominant cost knob: each refined row spends up to
+/// `Params::max_iters` fitness evaluations (plus one mandatory seeding eval of
+/// its own input — see below), so [`Full`](Self::Full) costs `pop_size`× a
+/// [`TopK { k: 1 }`](Self::TopK) generation. When the budget that matters is
+/// *evaluations to reach a target* (not wall-clock or final-gen fitness), wide
+/// coverage with a heavy searcher can lose to bare evolution: it spends its
+/// eval budget polishing individuals that selection would have discarded
+/// anyway. **Tune against evals-to-target**, not against a fixed generation
+/// count — a fixed-gens comparison hides the refinement evals and flatters wide
+/// coverage. The default, [`TopK { k: 1 }`](Self::TopK), refines only the
+/// single best individual and is the cheapest sane starting point.
+///
+/// One caveat cuts the other way: on a *separable* landscape with basin-width
+/// search steps, axis-aligned hill climbing is nearly a direct solver, so wide
+/// coverage with an untuned high-`max_iters` searcher can dominate. That is a
+/// landscape artifact, not a config to copy — re-tune per problem.
+///
+/// Each refined row currently burns one extra eval re-scoring its own input,
+/// because [`LocalSearch::refine`] carries no input fitness. Under `TopK { k: 1 }` that is one wasted
+/// eval/generation; under `Full` it is `pop_size`/generation, which is part of
+/// what makes wide coverage expensive. The pre-cleared additive fix (ADR 0016,
+/// reversal criteria) is a defaulted `refine_with_known_fitness` method that
+/// seeds the searcher with the fitness the wrapper already holds; it is
+/// deferred until a second consumer of the seam lands.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CoveragePolicy {
     /// Refine every individual.

--- a/crates/rlevo-evolution/src/algorithms/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/mod.rs
@@ -11,6 +11,12 @@
 //! # Swarm / nature-inspired metaheuristics
 //!
 //! - [`metaheuristic`] — PSO, `ACO_R`, ABC, GWO, WOA, CS, FA, BA, SSA.
+//!
+//! # Hybrid / composite strategies
+//!
+//! - [`memetic`] — [`MemeticWrapper`](memetic::MemeticWrapper): wraps any
+//!   real-valued strategy with per-individual local-search refinement
+//!   (Lamarckian / Baldwinian / Partial writeback).
 
 pub mod de;
 pub mod ep;
@@ -18,4 +24,5 @@ pub mod es_classical;
 pub mod ga;
 pub mod ga_binary;
 pub mod gp_cgp;
+pub mod memetic;
 pub mod metaheuristic;

--- a/crates/rlevo-evolution/src/lib.rs
+++ b/crates/rlevo-evolution/src/lib.rs
@@ -30,11 +30,15 @@
 //! - [`rng`] — deterministic seed streams (splitmix64) for reproducibility.
 //! - [`shaping`] — fitness shaping transforms (centered rank, z-score).
 //! - [`ops`] — selection, crossover, mutation, and replacement operators.
+//! - [`local_search`] — host-side, gradient-free refinement
+//!   ([`LocalSearch`] and the four reference
+//!   searchers) for memetic algorithms.
 //! - [`algorithms`] — concrete strategies.
 
 pub mod algorithms;
 pub mod fitness;
 pub mod genome;
+pub mod local_search;
 pub mod observer;
 pub mod ops;
 pub mod population;
@@ -42,5 +46,9 @@ pub mod rng;
 pub mod shaping;
 pub mod strategy;
 
+pub use algorithms::memetic::{CoveragePolicy, MemeticWrapper, WritebackPolicy};
+pub use local_search::{
+    HillClimbing, LocalSearch, NelderMead, RandomRestart, SimulatedAnnealing,
+};
 pub use observer::{PopulationObserver, PopulationSnapshot, SharedPopulationObserver};
 pub use strategy::{EvolutionaryHarness, Strategy, StrategyMetrics};

--- a/crates/rlevo-evolution/src/local_search.rs
+++ b/crates/rlevo-evolution/src/local_search.rs
@@ -86,6 +86,13 @@ pub use simulated_annealing::{CoolingSchedule, SimulatedAnnealing, SimulatedAnne
 /// `max_iters == 0` as an invalid configuration and **panic**; implementors
 /// should do the same rather than fabricate a fitness value.
 ///
+/// All reference searchers route every evaluation — including the seeding eval
+/// of the input — through a shared budget helper that maps a `NaN` fitness to
+/// [`f32::INFINITY`], so a `NaN` probe can never seed or displace a finite
+/// best-so-far and thus never propagates to the returned fitness. Custom
+/// implementors that probe a `fitness_fn` directly should apply the same
+/// sanitization rather than let a `NaN` seed their best-so-far tracker.
+///
 /// # Type parameters
 ///
 /// - `B`: Burn backend. **Currently unused** by every reference searcher (they
@@ -185,12 +192,24 @@ impl<'a> BudgetedEval<'a> {
     ///
     /// Returns `Some(fitness)` while budget remains, or `None` once the budget
     /// is exhausted (in which case no underlying evaluation is performed).
+    ///
+    /// A `NaN` fitness is sanitized to [`f32::INFINITY`] before it leaves this
+    /// method. Because every searcher routes *all* evaluations — including the
+    /// mandatory seeding eval of the input genome (contract item 3) — through
+    /// `BudgetedEval`, this is the single chokepoint that keeps `NaN` out of the
+    /// best-so-far trackers. Mapping `NaN` to `+inf` (the worst value under
+    /// minimization) means a `NaN` probe can never seed or displace a finite
+    /// best, so it never propagates to the returned fitness; if *every* probe is
+    /// `NaN` the searcher honestly returns `+inf` rather than `NaN`. For the
+    /// finite benchmark landscapes the searchers ship against this branch is
+    /// never taken, so it costs only one `is_nan` check per evaluation.
     pub(crate) fn eval(&mut self, genome: &Vec<f32>) -> Option<f32> {
         if self.remaining == 0 {
             return None;
         }
         self.remaining -= 1;
-        Some(self.inner.evaluate_one(genome))
+        let f: f32 = self.inner.evaluate_one(genome);
+        Some(if f.is_nan() { f32::INFINITY } else { f })
     }
 
     /// Number of evaluations still permitted.
@@ -236,6 +255,27 @@ mod tests {
         assert_eq!(budget.remaining(), 0);
         // Budget exhausted: no further evaluation, returns None.
         assert_eq!(budget.eval(&vec![0.0, 0.0]), None);
+    }
+
+    /// Returns `NaN` for the origin, sphere otherwise — exercises the
+    /// `BudgetedEval` NaN sanitization at the single evaluation chokepoint.
+    struct NanAtOrigin;
+    impl FitnessFn<Vec<f32>> for NanAtOrigin {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            let s: f32 = x.iter().map(|v| v * v).sum();
+            if s == 0.0 { f32::NAN } else { s }
+        }
+    }
+
+    #[test]
+    fn budgeted_eval_sanitizes_nan_to_infinity() {
+        let mut f = NanAtOrigin;
+        let mut budget = BudgetedEval::new(&mut f, 2);
+        // A NaN probe is mapped to +inf (the worst value under minimization),
+        // so it can never seed or displace a finite best-so-far.
+        assert_eq!(budget.eval(&vec![0.0, 0.0]), Some(f32::INFINITY));
+        // A finite probe is passed through unchanged.
+        assert_eq!(budget.eval(&vec![3.0, 4.0]), Some(25.0));
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/local_search.rs
+++ b/crates/rlevo-evolution/src/local_search.rs
@@ -1,0 +1,247 @@
+//! Host-side local-search refinement for memetic algorithms.
+//!
+//! A *memetic algorithm* (MA) interleaves a population-level evolutionary
+//! strategy with a per-individual **local search** that polishes promising
+//! genomes between generations. This module defines the local-search seam —
+//! the [`LocalSearch`] trait — together with the four reference searchers
+//! ([`HillClimbing`], [`NelderMead`], [`SimulatedAnnealing`],
+//! [`RandomRestart`]) that a `MemeticWrapper` can compose with any existing
+//! [`Strategy`](crate::strategy::Strategy).
+//!
+//! # Design seam
+//!
+//! Local search here is **host-side and gradient-free**. Searchers operate on
+//! a flat `Vec<f32>` genome and a single-member
+//! [`FitnessFn`], never touching device tensors or
+//! computing gradients. This keeps refinement trivially reproducible and
+//! independent of the Burn backend: it is pure host arithmetic plus calls to
+//! the supplied fitness function.
+//!
+//! # Stochasticity convention
+//!
+//! Every searcher takes a `&mut dyn Rng` and **all** randomness flows through
+//! it. Searchers never seed the process-wide backend RNG (`B::seed` +
+//! `Tensor::random`) and never reach for `rand::rng()` / thread-local RNGs —
+//! that would race the global Flex mutex under the parallel test runner and
+//! destroy reproducibility (see [`crate::rng`] for the host-RNG convention).
+//! A memetic wrapper derives a dedicated stream via
+//! `seed_stream(base, generation, SeedPurpose::LocalSearch)` and threads it in
+//! here.
+//!
+//! # Evaluation budget
+//!
+//! Each `refine` call is bounded by `Params::max_iters` **total**
+//! [`FitnessFn::evaluate_one`] calls
+//! (including the mandatory first re-evaluation of the input genome). The
+//! shared `BudgetedEval` helper enforces this so the bound holds structurally
+//! even on flat landscapes where no probe ever improves.
+
+use burn::tensor::backend::Backend;
+use rand::Rng;
+
+use crate::fitness::FitnessFn;
+
+pub mod hill_climbing;
+pub mod nelder_mead;
+pub mod random_restart;
+pub mod simulated_annealing;
+
+pub use hill_climbing::{HillClimbVariant, HillClimbing, HillClimbingParams};
+pub use nelder_mead::{NelderMead, NelderMeadParams};
+pub use random_restart::{RandomRestart, RandomRestartParams};
+pub use simulated_annealing::{CoolingSchedule, SimulatedAnnealing, SimulatedAnnealingParams};
+
+/// A gradient-free, host-side local search over real-valued genomes.
+///
+/// Implementors refine a single genome by repeatedly probing the supplied
+/// [`FitnessFn`] and returning the best point found, subject to a strict
+/// evaluation budget. They are the *meme* in a memetic algorithm: a
+/// `MemeticWrapper` invokes `refine` on selected population members between an
+/// inner strategy's `ask` and `tell`.
+///
+/// # Contract
+///
+/// For an input `genome` of length `D`, `refine` **must**:
+///
+/// 1. **Preserve dimensionality** — the returned `Vec<f32>` has length `D`.
+/// 2. **Return a fresh, honest fitness** — the returned `f32` is the actual
+///    value the supplied `fitness_fn` assigns to the returned genome (never a
+///    stale or estimated value). For a deterministic `fitness_fn` this is
+///    exact; for a stochastic one it is the value observed on the evaluation
+///    that produced the returned genome.
+/// 3. **Never worsen the input** (minimization, monotone non-worsening) — the
+///    returned fitness is `<=` the fitness of the *input* `genome` under the
+///    same `fitness_fn`. Implementors guarantee this structurally by
+///    evaluating the input genome first and tracking a best-so-far pair that is
+///    updated on *every* evaluation; the returned pair is always that tracked
+///    best.
+/// 4. **Terminate within budget** — make at most `Params::max_iters` total
+///    `evaluate_one` calls, even on a perfectly flat landscape where no probe
+///    ever improves.
+/// 5. **Respect bounds** — every coordinate of the returned genome lies within
+///    the `bounds` carried by `Params`.
+///
+/// Because the input genome is always evaluated once (contract item 3), a
+/// `max_iters` of `0` cannot be honored honestly. Reference searchers treat
+/// `max_iters == 0` as an invalid configuration and **panic**; implementors
+/// should do the same rather than fabricate a fitness value.
+///
+/// # Type parameters
+///
+/// - `B`: Burn backend. **Currently unused** by every reference searcher (they
+///   are pure host code) and present only to reserve the seam for future
+///   on-device searchers — e.g. a batched line search that materializes probe
+///   tensors directly. Keeping `B` on the trait now avoids a breaking signature
+///   change when such a searcher lands.
+///
+/// # Example
+///
+/// A one-line searcher that simply re-evaluates the input (the trivial,
+/// always-valid refinement) illustrates the contract:
+///
+/// ```
+/// use burn::backend::Flex;
+/// use rand::{rngs::StdRng, Rng, SeedableRng};
+/// use rlevo_evolution::fitness::FitnessFn;
+/// use rlevo_evolution::local_search::LocalSearch;
+///
+/// struct Identity;
+/// impl<B: burn::tensor::backend::Backend> LocalSearch<B> for Identity {
+///     type Params = ();
+///     fn refine(
+///         &self,
+///         _params: &(),
+///         genome: Vec<f32>,
+///         fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+///         _rng: &mut dyn Rng,
+///     ) -> (Vec<f32>, f32) {
+///         let f = fitness_fn.evaluate_one(&genome); // fresh fitness
+///         (genome, f)                               // same length, no worsening
+///     }
+/// }
+///
+/// struct Sphere;
+/// impl FitnessFn<Vec<f32>> for Sphere {
+///     fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+///         x.iter().map(|v| v * v).sum()
+///     }
+/// }
+///
+/// let searcher = Identity;
+/// let mut fitness = Sphere;
+/// let mut rng = StdRng::seed_from_u64(0);
+/// let (refined, fit) = LocalSearch::<Flex>::refine(
+///     &searcher,
+///     &(),
+///     vec![3.0, 4.0],
+///     &mut fitness,
+///     &mut rng,
+/// );
+/// assert_eq!(refined.len(), 2);
+/// assert_eq!(fit, 25.0);
+/// ```
+pub trait LocalSearch<B: Backend>: Send + Sync {
+    /// Static configuration for a refinement run (bounds, budget, step
+    /// sizes, …). Cloned by a memetic wrapper once per generation.
+    type Params: Clone + core::fmt::Debug + Send + Sync;
+
+    /// Refines `genome` and returns `(refined_genome, refined_fitness)`.
+    ///
+    /// See the [trait-level contract](LocalSearch#contract) for the full set
+    /// of invariants every implementation must uphold.
+    fn refine(
+        &self,
+        params: &Self::Params,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32);
+}
+
+/// A fitness function wrapped with a hard evaluation budget.
+///
+/// `BudgetedEval` decrements its `remaining` counter on every successful
+/// [`eval`](Self::eval) call and refuses further evaluations once the budget
+/// is exhausted. Searchers route *all* their `evaluate_one` calls through it so
+/// the [`LocalSearch`] budget invariant holds structurally rather than relying
+/// on each searcher's loop bound being correct.
+pub(crate) struct BudgetedEval<'a> {
+    /// The underlying single-member fitness function.
+    inner: &'a mut dyn FitnessFn<Vec<f32>>,
+    /// Remaining permitted `evaluate_one` calls.
+    remaining: usize,
+}
+
+impl<'a> BudgetedEval<'a> {
+    /// Wraps `inner` with a budget of `max_evals` total evaluations.
+    pub(crate) fn new(inner: &'a mut dyn FitnessFn<Vec<f32>>, max_evals: usize) -> Self {
+        Self {
+            inner,
+            remaining: max_evals,
+        }
+    }
+
+    /// Evaluates `genome`, consuming one unit of budget.
+    ///
+    /// Returns `Some(fitness)` while budget remains, or `None` once the budget
+    /// is exhausted (in which case no underlying evaluation is performed).
+    pub(crate) fn eval(&mut self, genome: &Vec<f32>) -> Option<f32> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        Some(self.inner.evaluate_one(genome))
+    }
+
+    /// Number of evaluations still permitted.
+    pub(crate) fn remaining(&self) -> usize {
+        self.remaining
+    }
+}
+
+/// Clamps every coordinate of `genome` into the inclusive range `bounds`.
+///
+/// `bounds` is `(lo, hi)`; coordinates below `lo` are raised to `lo` and those
+/// above `hi` are lowered to `hi`. Uses `x.max(lo).min(hi)`, so a degenerate
+/// range where `lo > hi` collapses every coordinate to `hi` — the `min` is
+/// applied last and wins. Callers are expected to supply valid bounds.
+pub(crate) fn clamp_vec(genome: &mut [f32], bounds: (f32, f32)) {
+    let (lo, hi) = bounds;
+    for x in genome.iter_mut() {
+        *x = x.max(lo).min(hi);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Counts the genome length each `evaluate_one` sees; returns the sum of
+    /// squares (sphere). Used to exercise the shared helpers in isolation.
+    struct Sphere;
+    impl FitnessFn<Vec<f32>> for Sphere {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            x.iter().map(|v| v * v).sum()
+        }
+    }
+
+    #[test]
+    fn budgeted_eval_decrements_and_exhausts() {
+        let mut sphere = Sphere;
+        let mut budget = BudgetedEval::new(&mut sphere, 2);
+        assert_eq!(budget.remaining(), 2);
+        assert_eq!(budget.eval(&vec![1.0, 0.0]), Some(1.0));
+        assert_eq!(budget.remaining(), 1);
+        assert_eq!(budget.eval(&vec![3.0, 4.0]), Some(25.0));
+        assert_eq!(budget.remaining(), 0);
+        // Budget exhausted: no further evaluation, returns None.
+        assert_eq!(budget.eval(&vec![0.0, 0.0]), None);
+    }
+
+    #[test]
+    fn clamp_vec_respects_bounds() {
+        let mut g = vec![-10.0_f32, 0.5, 10.0, -0.5];
+        clamp_vec(&mut g, (-1.0, 1.0));
+        assert_eq!(g, vec![-1.0, 0.5, 1.0, -0.5]);
+    }
+}

--- a/crates/rlevo-evolution/src/local_search/hill_climbing.rs
+++ b/crates/rlevo-evolution/src/local_search/hill_climbing.rs
@@ -1,0 +1,505 @@
+//! Coordinate-wise hill climbing.
+//!
+//! A simple, robust gradient-free local search: from the input genome, probe
+//! neighbours one coordinate at a time and move whenever a probe strictly
+//! improves the objective. Two acceptance strategies are offered via
+//! [`HillClimbVariant`]:
+//!
+//! - [`FirstImprovement`](HillClimbVariant::FirstImprovement) — each iteration
+//!   perturbs one randomly chosen coordinate by `±step_size` and accepts the
+//!   move on the first strict improvement seen. Cheap per step; good when the
+//!   budget is small.
+//! - [`BestImprovement`](HillClimbVariant::BestImprovement) — each *sweep*
+//!   probes `±step_size` along every coordinate (`2·dim` evaluations) and moves
+//!   to the single best strict improver. More evaluations per move, but each
+//!   move is greedier.
+//!
+//! Both variants shrink `step_size` by `step_decay` once a probe budget passes
+//! without improvement, letting the search settle into a basin. The returned
+//! pair is always the best `(genome, fitness)` observed across all evaluations,
+//! which makes the [`LocalSearch`]
+//! monotone-non-worsening and fresh-fitness invariants hold structurally.
+
+use burn::tensor::backend::Backend;
+use rand::{Rng, RngExt};
+
+use crate::fitness::FitnessFn;
+use crate::local_search::{clamp_vec, BudgetedEval, LocalSearch};
+
+/// Acceptance strategy for [`HillClimbing`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HillClimbVariant {
+    /// Probe one random coordinate per iteration; accept the first strict
+    /// improvement.
+    FirstImprovement,
+    /// Probe `±step` along every coordinate per sweep; move to the best strict
+    /// improver.
+    BestImprovement,
+}
+
+/// Static configuration for a [`HillClimbing`] run.
+#[derive(Debug, Clone)]
+pub struct HillClimbingParams {
+    /// Inclusive search-space bounds `(lo, hi)`; refined genomes are clamped
+    /// here.
+    pub bounds: (f32, f32),
+    /// Hard cap on the **total** number of `evaluate_one` calls per `refine`,
+    /// including the mandatory initial re-evaluation of the input genome.
+    /// Default `100`.
+    pub max_iters: usize,
+    /// Per-coordinate perturbation magnitude. Default `0.1 * (hi - lo)` via
+    /// [`HillClimbingParams::default_for`].
+    pub step_size: f32,
+    /// Multiplicative shrink applied to `step_size` after a failed probe
+    /// budget. `0.5` halves the step; `1.0` keeps it fixed. Default `0.5`.
+    pub step_decay: f32,
+    /// Acceptance strategy. Default
+    /// [`FirstImprovement`](HillClimbVariant::FirstImprovement).
+    pub variant: HillClimbVariant,
+}
+
+impl HillClimbingParams {
+    /// Default parameters derived from the search-space `bounds`.
+    ///
+    /// `step_size = 0.1 * (hi - lo)`, `step_decay = 0.5`, `max_iters = 100`,
+    /// variant [`FirstImprovement`](HillClimbVariant::FirstImprovement).
+    #[must_use]
+    pub fn default_for(bounds: (f32, f32)) -> Self {
+        let (lo, hi) = bounds;
+        Self {
+            bounds,
+            max_iters: 100,
+            step_size: 0.1 * (hi - lo),
+            step_decay: 0.5,
+            variant: HillClimbVariant::FirstImprovement,
+        }
+    }
+}
+
+/// Coordinate-wise hill-climbing local search.
+///
+/// A unit struct: all configuration lives in [`HillClimbingParams`], so one
+/// instance can refine many genomes. See the [module docs](self) for the two
+/// acceptance variants.
+///
+/// # Example
+///
+/// ```
+/// use burn::backend::Flex;
+/// use rand::{rngs::StdRng, SeedableRng};
+/// use rlevo_evolution::fitness::FitnessFn;
+/// use rlevo_evolution::local_search::{HillClimbing, HillClimbingParams, LocalSearch};
+///
+/// // Minimize the 2-D sphere; the optimum is the origin with fitness 0.
+/// struct Sphere;
+/// impl FitnessFn<Vec<f32>> for Sphere {
+///     fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+///         x.iter().map(|v| v * v).sum()
+///     }
+/// }
+///
+/// let searcher = HillClimbing;
+/// let params = HillClimbingParams::default_for((-5.12, 5.12));
+/// let mut fitness = Sphere;
+/// let mut rng = StdRng::seed_from_u64(7);
+///
+/// let start = vec![2.5_f32, -1.5];
+/// let start_fit: f32 = start.iter().map(|v| v * v).sum();
+/// let (refined, refined_fit) =
+///     LocalSearch::<Flex>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+///
+/// assert_eq!(refined.len(), 2);          // dimensionality preserved
+/// assert!(refined_fit <= start_fit);     // monotone non-worsening
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HillClimbing;
+
+impl<B: Backend> LocalSearch<B> for HillClimbing {
+    type Params = HillClimbingParams;
+
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`: a zero evaluation budget makes it
+    /// impossible to return an honestly evaluated fitness, so it is treated
+    /// as an invalid configuration (programming error), not runtime data.
+    fn refine(
+        &self,
+        params: &HillClimbingParams,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        assert!(
+            params.max_iters >= 1,
+            "HillClimbingParams::max_iters must be >= 1 (the input genome is \
+             always evaluated once to seed the best-so-far tracker)"
+        );
+        let mut budget = BudgetedEval::new(fitness_fn, params.max_iters);
+
+        // First action: evaluate the input genome (1 eval) and seed the
+        // best-so-far tracker. The assert above guarantees this succeeds.
+        let Some(initial_fit) = budget.eval(&genome) else {
+            unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+        };
+
+        let mut current: Vec<f32> = genome;
+        let mut current_fit = initial_fit;
+        // The tracked best — always returned. Updated on EVERY evaluation, so
+        // the monotone + fresh-fitness invariants hold structurally.
+        let mut best: Vec<f32> = current.clone();
+        let mut best_fit = current_fit;
+
+        let mut step = params.step_size;
+        let dim = current.len();
+        if dim == 0 {
+            return (best, best_fit);
+        }
+
+        match params.variant {
+            HillClimbVariant::FirstImprovement => {
+                // After `2 * dim` consecutive non-improving probes, shrink the
+                // step. This budget gives every coordinate a chance in both
+                // directions before concluding the current step is too coarse.
+                let mut consecutive_failures: usize = 0;
+                let failure_budget = 2 * dim;
+                loop {
+                    let coord = rng.random_range(0..dim);
+                    let sign: f32 = if rng.random::<bool>() { 1.0 } else { -1.0 };
+                    let mut candidate = current.clone();
+                    candidate[coord] += sign * step;
+                    clamp_vec(&mut candidate, params.bounds);
+
+                    let Some(cand_fit) = budget.eval(&candidate) else {
+                        break;
+                    };
+                    if cand_fit < best_fit {
+                        best_fit = cand_fit;
+                        best.clone_from(&candidate);
+                    }
+                    if cand_fit < current_fit {
+                        current = candidate;
+                        current_fit = cand_fit;
+                        consecutive_failures = 0;
+                    } else {
+                        consecutive_failures += 1;
+                        if consecutive_failures >= failure_budget {
+                            step *= params.step_decay;
+                            consecutive_failures = 0;
+                            // Step underflowed to ~0: no neighbour will ever
+                            // differ from `current`. Early-stop; the eval bound
+                            // is the hard guarantee, this is just a courtesy.
+                            if step <= f32::EPSILON {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            HillClimbVariant::BestImprovement => {
+                'sweeps: loop {
+                    if budget.remaining() == 0 {
+                        break;
+                    }
+                    let mut sweep_best_fit = current_fit;
+                    let mut sweep_best: Option<Vec<f32>> = None;
+                    for coord in 0..dim {
+                        for &sign in &[1.0_f32, -1.0_f32] {
+                            let mut candidate = current.clone();
+                            candidate[coord] += sign * step;
+                            clamp_vec(&mut candidate, params.bounds);
+                            let Some(cand_fit) = budget.eval(&candidate) else {
+                                // Budget ran out mid-sweep: commit whatever the
+                                // partial sweep found and stop.
+                                break 'sweeps;
+                            };
+                            if cand_fit < best_fit {
+                                best_fit = cand_fit;
+                                best.clone_from(&candidate);
+                            }
+                            if cand_fit < sweep_best_fit {
+                                sweep_best_fit = cand_fit;
+                                sweep_best = Some(candidate);
+                            }
+                        }
+                    }
+                    if let Some(next) = sweep_best {
+                        current = next;
+                        current_fit = sweep_best_fit;
+                    } else {
+                        // No coordinate improved this sweep: shrink the step.
+                        step *= params.step_decay;
+                        if step <= f32::EPSILON {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        (best, best_fit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    type TestBackend = Flex;
+
+    /// `f(x) = Σ x_i²` — convex, unimodal, optimum at the origin.
+    struct Sphere;
+    impl FitnessFn<Vec<f32>> for Sphere {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            x.iter().map(|v| v * v).sum()
+        }
+    }
+
+    /// 2-D Rosenbrock — curved valley, optimum at `(1, 1)` with value 0.
+    struct Rosenbrock;
+    impl FitnessFn<Vec<f32>> for Rosenbrock {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            let a = 1.0 - x[0];
+            let b = x[1] - x[0] * x[0];
+            a * a + 100.0 * b * b
+        }
+    }
+
+    /// Constant 1.0 — perfectly flat; no probe ever improves.
+    struct Flat;
+    impl FitnessFn<Vec<f32>> for Flat {
+        fn evaluate_one(&mut self, _x: &Vec<f32>) -> f32 {
+            1.0
+        }
+    }
+
+    /// Wraps a fitness function and counts `evaluate_one` calls.
+    struct Counting<'a> {
+        inner: &'a mut dyn FitnessFn<Vec<f32>>,
+        calls: usize,
+    }
+    impl<'a> Counting<'a> {
+        fn new(inner: &'a mut dyn FitnessFn<Vec<f32>>) -> Self {
+            Self { inner, calls: 0 }
+        }
+    }
+    impl FitnessFn<Vec<f32>> for Counting<'_> {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            self.calls += 1;
+            self.inner.evaluate_one(x)
+        }
+    }
+
+    const BOUNDS: (f32, f32) = (-5.12, 5.12);
+
+    fn random_start(rng: &mut StdRng, dim: usize, bounds: (f32, f32)) -> Vec<f32> {
+        let (lo, hi) = bounds;
+        (0..dim).map(|_| lo + (hi - lo) * rng.random::<f32>()).collect()
+    }
+
+    #[test]
+    fn sphere_d2_converges_below_threshold() {
+        let searcher = HillClimbing;
+        let mut params = HillClimbingParams::default_for(BOUNDS);
+        params.max_iters = 100;
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(1);
+        let start = random_start(&mut rng, 2, BOUNDS);
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        assert!(fit < 1e-3, "sphere D=2 should converge: best={fit}");
+    }
+
+    #[test]
+    fn sphere_d10_strictly_improves() {
+        let searcher = HillClimbing;
+        let params = HillClimbingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(2);
+        let start = random_start(&mut rng, 10, BOUNDS);
+        let start_fit: f32 = start.iter().map(|v| v * v).sum();
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        assert!(fit < start_fit, "expected improvement: {fit} < {start_fit}");
+    }
+
+    #[test]
+    fn output_len_equals_input_len() {
+        let searcher = HillClimbing;
+        let params = HillClimbingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(3);
+        for dim in [1_usize, 2, 5, 10] {
+            let start = random_start(&mut rng, dim, BOUNDS);
+            let (g, _f) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert_eq!(g.len(), dim);
+        }
+    }
+
+    #[test]
+    fn returned_fitness_matches_fresh_eval() {
+        let searcher = HillClimbing;
+        let params = HillClimbingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(4);
+        let start = random_start(&mut rng, 4, BOUNDS);
+        let (g, fit) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness,
+            &mut rng,
+        );
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn rosenbrock_monotone_non_worsening() {
+        let searcher = HillClimbing;
+        let params = HillClimbingParams::default_for(BOUNDS);
+        let mut rng = StdRng::seed_from_u64(5);
+        for _ in 0..6 {
+            let start = random_start(&mut rng, 2, BOUNDS);
+            let mut fitness = Rosenbrock;
+            let start_fit = fitness.evaluate_one(&start);
+            let (_g, fit) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert!(fit <= start_fit, "monotone: {fit} <= {start_fit}");
+        }
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn flat_landscape_terminates_within_budget() {
+        let searcher = HillClimbing;
+        let mut params = HillClimbingParams::default_for(BOUNDS);
+        params.max_iters = 37;
+        let mut base = Flat;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(6);
+        let start = vec![1.0_f32, 2.0, 3.0];
+        let (g, fit) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut counting,
+            &mut rng,
+        );
+        assert!(
+            counting.calls <= params.max_iters,
+            "evals {} must not exceed budget {}",
+            counting.calls,
+            params.max_iters
+        );
+        // On a flat landscape nothing improves: the returned genome is the
+        // input and its fitness is the constant 1.0.
+        assert_eq!(g, start);
+        assert_eq!(fit, 1.0);
+    }
+
+    #[test]
+    fn boundary_start_stays_within_bounds() {
+        let searcher = HillClimbing;
+        let mut params = HillClimbingParams::default_for(BOUNDS);
+        // Big step relative to range, no decay, so probes push hard on bounds.
+        params.step_size = 4.0;
+        params.step_decay = 1.0;
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(8);
+        // Start at the upper boundary in every coordinate.
+        let start = vec![BOUNDS.1; 4];
+        let (g, _f) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness,
+            &mut rng,
+        );
+        for &x in &g {
+            assert!(
+                x >= BOUNDS.0 && x <= BOUNDS.1,
+                "coord {x} out of bounds {BOUNDS:?}"
+            );
+        }
+    }
+
+    /// Evaluations the given variant needs to drive 2-D sphere below `tol`
+    /// from a fixed start/seed, or `None` if it never reaches `tol`.
+    fn evals_to_tolerance(variant: HillClimbVariant, tol: f32) -> Option<usize> {
+        let searcher = HillClimbing;
+        let mut params = HillClimbingParams::default_for(BOUNDS);
+        params.variant = variant;
+        params.max_iters = 400;
+        let mut base = Sphere;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(99);
+        let start = vec![3.0_f32, -2.0];
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut counting, &mut rng);
+        if fit < tol {
+            Some(counting.calls)
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn best_improvement_competitive_with_first_improvement() {
+        // On a smooth unimodal landscape, BestImprovement should reach the
+        // same tolerance using no more evaluations than FirstImprovement.
+        let tol = 1e-2_f32;
+        let first = evals_to_tolerance(HillClimbVariant::FirstImprovement, tol)
+            .expect("first-improvement should reach tolerance");
+        let best = evals_to_tolerance(HillClimbVariant::BestImprovement, tol)
+            .expect("best-improvement should reach tolerance");
+        assert!(
+            best <= first,
+            "best-improvement evals {best} should be <= first-improvement evals {first}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn same_seed_is_bit_identical() {
+        let searcher = HillClimbing;
+        let params = HillClimbingParams::default_for(BOUNDS);
+        let start = vec![2.0_f32, -3.0, 1.5];
+
+        let mut fitness_a = Sphere;
+        let mut rng_a = StdRng::seed_from_u64(123);
+        let (g_a, f_a) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut fitness_a,
+            &mut rng_a,
+        );
+
+        let mut fitness_b = Sphere;
+        let mut rng_b = StdRng::seed_from_u64(123);
+        let (g_b, f_b) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness_b,
+            &mut rng_b,
+        );
+
+        assert_eq!(g_a, g_b);
+        assert_eq!(f_a, f_b);
+    }
+}

--- a/crates/rlevo-evolution/src/local_search/nelder_mead.rs
+++ b/crates/rlevo-evolution/src/local_search/nelder_mead.rs
@@ -1,0 +1,643 @@
+//! Nelder–Mead downhill simplex.
+//!
+//! The Nelder–Mead method maintains a simplex of `n + 1` vertices in an
+//! `n`-dimensional space and refines it via reflection, expansion,
+//! contraction, and shrink steps until the spread of vertex fitnesses falls
+//! below a tolerance or the evaluation budget is exhausted.
+//!
+//! # Algorithm
+//!
+//! Each iteration sorts the simplex by fitness and, using the centroid of all
+//! but the worst vertex, attempts (in order) a **reflection** of the worst
+//! vertex through that centroid, an **expansion** further along the reflection
+//! ray when reflection produced a new best, a **contraction** toward the
+//! centroid when reflection is no better than the second-worst vertex, and
+//! finally a **shrink** of every vertex toward the current best when even
+//! contraction fails. Every trial point is clamped into [`NelderMeadParams`]
+//! `bounds` *before* evaluation, so the fitness always corresponds to a
+//! feasible point.
+//!
+//! # Invariants
+//!
+//! The input genome is the first simplex vertex and is therefore the first
+//! point evaluated; a best-so-far `(genome, fitness)` pair is updated on every
+//! evaluation and is what `refine` returns. This makes the
+//! [`LocalSearch`]
+//! monotone-non-worsening and fresh-fitness invariants hold structurally, and
+//! keeps even degenerate budgets (fewer evaluations than `n + 1`) safe — they
+//! simply return the best vertex evaluated before the budget ran out.
+//!
+//! Nelder–Mead is fully deterministic: the `rng` argument is unused.
+
+use burn::tensor::backend::Backend;
+use rand::Rng;
+
+use crate::fitness::FitnessFn;
+use crate::local_search::{clamp_vec, BudgetedEval, LocalSearch};
+
+/// Static configuration for a [`NelderMead`] run.
+#[derive(Debug, Clone)]
+pub struct NelderMeadParams {
+    /// Inclusive search-space bounds `(lo, hi)`; refined genomes are clamped
+    /// here and simplex vertices are flipped inward at the boundary.
+    pub bounds: (f32, f32),
+    /// Hard cap on the **total** number of `evaluate_one` calls per `refine`,
+    /// counting the up-to-`n + 1` simplex-initialization evaluations.
+    /// Default `200`.
+    pub max_iters: usize,
+    /// Reflection coefficient (α). Standard value `1.0`.
+    pub alpha: f32,
+    /// Expansion coefficient (γ). Standard value `2.0`.
+    pub gamma: f32,
+    /// Contraction coefficient (ρ). Standard value `0.5`.
+    pub rho: f32,
+    /// Shrink coefficient (σ). Standard value `0.5`.
+    pub sigma: f32,
+    /// Axis nudge used to build the initial simplex from the input vertex.
+    /// Vertex `j` (for `j` in `1..=n`) perturbs coordinate `j - 1` of the input
+    /// by `+initial_step`, flipped to `-initial_step` when the forward nudge
+    /// would leave `bounds`. Default `0.05 * (hi - lo)`.
+    pub initial_step: f32,
+    /// Early-stop tolerance on the spread of vertex fitnesses (best vs worst).
+    /// The main loop terminates once `f_worst - f_best < tolerance`.
+    /// Default `1e-8`.
+    pub tolerance: f32,
+}
+
+impl NelderMeadParams {
+    /// Default parameters derived from the search-space `bounds`.
+    ///
+    /// `alpha = 1.0`, `gamma = 2.0`, `rho = 0.5`, `sigma = 0.5`,
+    /// `initial_step = 0.05 * (hi - lo)`, `tolerance = 1e-8`,
+    /// `max_iters = 200`.
+    #[must_use]
+    pub fn default_for(bounds: (f32, f32)) -> Self {
+        let (lo, hi) = bounds;
+        Self {
+            bounds,
+            max_iters: 200,
+            alpha: 1.0,
+            gamma: 2.0,
+            rho: 0.5,
+            sigma: 0.5,
+            initial_step: 0.05 * (hi - lo),
+            tolerance: 1e-8,
+        }
+    }
+}
+
+/// Nelder–Mead downhill-simplex local search.
+///
+/// A unit struct: all configuration lives in [`NelderMeadParams`], so one
+/// instance can refine many genomes. The method is gradient-free, host-side,
+/// and fully deterministic — see the [module docs](self) for the per-iteration
+/// reflection/expansion/contraction/shrink schedule.
+///
+/// # Example
+///
+/// ```
+/// use burn::backend::Flex;
+/// use rand::{rngs::StdRng, SeedableRng};
+/// use rlevo_evolution::fitness::FitnessFn;
+/// use rlevo_evolution::local_search::{LocalSearch, NelderMead, NelderMeadParams};
+///
+/// // Minimize the 2-D sphere; the optimum is the origin with fitness 0.
+/// struct Sphere;
+/// impl FitnessFn<Vec<f32>> for Sphere {
+///     fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+///         x.iter().map(|v| v * v).sum()
+///     }
+/// }
+///
+/// let searcher = NelderMead;
+/// let params = NelderMeadParams::default_for((-5.12, 5.12));
+/// let mut fitness = Sphere;
+/// let mut rng = StdRng::seed_from_u64(7);
+///
+/// let start = vec![2.5_f32, -1.5];
+/// let start_fit: f32 = start.iter().map(|v| v * v).sum();
+/// let (refined, refined_fit) =
+///     LocalSearch::<Flex>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+///
+/// assert_eq!(refined.len(), 2);          // dimensionality preserved
+/// assert!(refined_fit <= start_fit);     // monotone non-worsening
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NelderMead;
+
+/// One simplex vertex: a clamped, feasible point and its (fresh) fitness.
+struct Vertex {
+    /// Coordinates, always within `bounds`.
+    point: Vec<f32>,
+    /// Fitness of `point` under the budgeted fitness function.
+    fitness: f32,
+}
+
+impl<B: Backend> LocalSearch<B> for NelderMead {
+    type Params = NelderMeadParams;
+
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`: a zero evaluation budget makes it
+    /// impossible to return an honestly evaluated fitness, so it is treated
+    /// as an invalid configuration (programming error), not runtime data.
+    #[allow(clippy::too_many_lines)]
+    fn refine(
+        &self,
+        params: &NelderMeadParams,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        _rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        assert!(
+            params.max_iters >= 1,
+            "NelderMeadParams::max_iters must be >= 1 (the input genome is \
+             always evaluated once to seed the best-so-far tracker)"
+        );
+        let mut budget: BudgetedEval<'_> = BudgetedEval::new(fitness_fn, params.max_iters);
+
+        let dim: usize = genome.len();
+
+        // The tracked best — always returned. Updated on EVERY evaluation via
+        // `evaluate`, so the monotone + fresh-fitness invariants hold
+        // structurally. The input genome is the first point evaluated.
+        let (lo, hi): (f32, f32) = params.bounds;
+
+        // First action: evaluate the input genome (1 eval), clamped to bounds.
+        let mut vertex0: Vec<f32> = genome;
+        clamp_vec(&mut vertex0, params.bounds);
+        let mut best: Vec<f32> = vertex0.clone();
+        // The assert above guarantees the first eval succeeds.
+        let Some(initial_fit) = budget.eval(&vertex0) else {
+            unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+        };
+        let mut best_fit: f32 = initial_fit;
+
+        // A zero-dimensional genome has no neighbours to explore: the single
+        // (empty) point is already the answer.
+        if dim == 0 {
+            return (best, best_fit);
+        }
+
+        // Build the simplex: vertex 0 is the (clamped) input; vertices 1..=dim
+        // each nudge one coordinate by `initial_step`, flipped inward at a
+        // bound. Each costs one eval, truncated by the budget — a budget too
+        // small to finish initialization simply returns the best vertex
+        // evaluated so far.
+        let mut simplex: Vec<Vertex> = Vec::with_capacity(dim + 1);
+        simplex.push(Vertex {
+            point: vertex0.clone(),
+            fitness: initial_fit,
+        });
+
+        for j in 0..dim {
+            let mut point: Vec<f32> = vertex0.clone();
+            let forward: f32 = point[j] + params.initial_step;
+            if forward > hi || forward < lo {
+                point[j] -= params.initial_step;
+            } else {
+                point[j] = forward;
+            }
+            clamp_vec(&mut point, params.bounds);
+
+            let Some(fitness) = budget.eval(&point) else {
+                // Budget exhausted mid-initialization: return the best vertex
+                // found so far (never worse than the input).
+                update_best(&mut best, &mut best_fit, &simplex);
+                return (best, best_fit);
+            };
+            if fitness < best_fit {
+                best_fit = fitness;
+                best.clone_from(&point);
+            }
+            simplex.push(Vertex { point, fitness });
+        }
+
+        // Main Nelder–Mead loop. Every `eval_clamped` call updates the
+        // best-so-far tracker and consumes budget; a `None` return means the
+        // budget is exhausted and we stop immediately.
+        let n: usize = simplex.len(); // == dim + 1
+        loop {
+            // Sort ascending by fitness: index 0 is best, last is worst.
+            simplex.sort_by(|a, b| {
+                a.fitness
+                    .partial_cmp(&b.fitness)
+                    .unwrap_or(core::cmp::Ordering::Equal)
+            });
+
+            let f_best: f32 = simplex[0].fitness;
+            let f_worst: f32 = simplex[n - 1].fitness;
+            let f_second_worst: f32 = simplex[n - 2].fitness;
+
+            // f-spread convergence test.
+            if f_worst - f_best < params.tolerance {
+                break;
+            }
+            if budget.remaining() == 0 {
+                break;
+            }
+
+            // Centroid of all vertices except the worst.
+            let centroid: Vec<f32> = centroid_excluding_worst(&simplex, dim);
+            let worst_point: &[f32] = &simplex[n - 1].point;
+
+            // Reflection: x_r = centroid + alpha * (centroid - worst).
+            let reflected: Vec<f32> =
+                affine(&centroid, &centroid, worst_point, params.alpha, params.bounds);
+            let Some(f_reflected) =
+                eval_clamped(&mut budget, &reflected, &mut best, &mut best_fit)
+            else {
+                break;
+            };
+
+            if f_reflected < f_best {
+                // Reflection improved on the best: try to expand further.
+                let expanded: Vec<f32> = affine(
+                    &centroid,
+                    &reflected,
+                    &centroid,
+                    params.gamma,
+                    params.bounds,
+                );
+                let Some(f_expanded) =
+                    eval_clamped(&mut budget, &expanded, &mut best, &mut best_fit)
+                else {
+                    break;
+                };
+                if f_expanded < f_reflected {
+                    replace_worst(&mut simplex, expanded, f_expanded);
+                } else {
+                    replace_worst(&mut simplex, reflected, f_reflected);
+                }
+            } else if f_reflected < f_second_worst {
+                // Reflection is a middling improvement: accept it.
+                replace_worst(&mut simplex, reflected, f_reflected);
+            } else {
+                // Reflection is no better than the second-worst: contract.
+                // Outside contraction if reflection still beats the worst,
+                // otherwise inside contraction toward the centroid.
+                let (target, target_fit): (&[f32], f32) = if f_reflected < f_worst {
+                    (&reflected, f_reflected)
+                } else {
+                    (worst_point, f_worst)
+                };
+                let contracted: Vec<f32> =
+                    affine(&centroid, target, &centroid, params.rho, params.bounds);
+                let Some(f_contracted) =
+                    eval_clamped(&mut budget, &contracted, &mut best, &mut best_fit)
+                else {
+                    break;
+                };
+
+                if f_contracted < target_fit {
+                    replace_worst(&mut simplex, contracted, f_contracted);
+                } else {
+                    // Contraction failed: shrink every non-best vertex toward
+                    // the best. Costs up to n - 1 evals, truncated by budget.
+                    let best_point: Vec<f32> = simplex[0].point.clone();
+                    for v in simplex.iter_mut().skip(1) {
+                        let mut shrunk: Vec<f32> = Vec::with_capacity(dim);
+                        for (b, c) in best_point.iter().zip(v.point.iter()) {
+                            shrunk.push(b + params.sigma * (c - b));
+                        }
+                        clamp_vec(&mut shrunk, params.bounds);
+                        let Some(f_shrunk) =
+                            eval_clamped(&mut budget, &shrunk, &mut best, &mut best_fit)
+                        else {
+                            // Budget exhausted mid-shrink: the partially shrunk
+                            // simplex is fine; we return the tracked best next
+                            // loop iteration once `remaining() == 0` is hit.
+                            // Commit what we computed for this vertex and stop.
+                            return (best, best_fit);
+                        };
+                        v.point = shrunk;
+                        v.fitness = f_shrunk;
+                    }
+                }
+            }
+        }
+
+        (best, best_fit)
+    }
+}
+
+/// Evaluates `point` through the budget, updating the best-so-far tracker.
+///
+/// `point` is assumed already clamped. Returns `None` (without touching the
+/// tracker) once the budget is exhausted.
+fn eval_clamped(
+    budget: &mut BudgetedEval<'_>,
+    point: &Vec<f32>,
+    best: &mut Vec<f32>,
+    best_fit: &mut f32,
+) -> Option<f32> {
+    let fitness: f32 = budget.eval(point)?;
+    if fitness < *best_fit {
+        *best_fit = fitness;
+        best.clone_from(point);
+    }
+    Some(fitness)
+}
+
+/// Folds the simplex into the best-so-far tracker (used on early init exit).
+fn update_best(best: &mut Vec<f32>, best_fit: &mut f32, simplex: &[Vertex]) {
+    for v in simplex {
+        if v.fitness < *best_fit {
+            *best_fit = v.fitness;
+            best.clone_from(&v.point);
+        }
+    }
+}
+
+/// Centroid of every simplex vertex except the worst (the last, after sorting).
+fn centroid_excluding_worst(simplex: &[Vertex], dim: usize) -> Vec<f32> {
+    let count: usize = simplex.len() - 1;
+    #[allow(clippy::cast_precision_loss)]
+    let inv: f32 = 1.0 / count as f32;
+    let mut centroid: Vec<f32> = vec![0.0; dim];
+    for v in &simplex[..count] {
+        for (c, &p) in centroid.iter_mut().zip(v.point.iter()) {
+            *c += p;
+        }
+    }
+    for c in &mut centroid {
+        *c *= inv;
+    }
+    centroid
+}
+
+/// Computes `base + coeff * (a - b)`, then clamps into `bounds`.
+///
+/// This is the shared shape of the reflection, expansion, and contraction
+/// updates; the caller picks `base`, `a`, `b`, and `coeff` accordingly.
+fn affine(base: &[f32], a: &[f32], b: &[f32], coeff: f32, bounds: (f32, f32)) -> Vec<f32> {
+    let mut out: Vec<f32> = Vec::with_capacity(base.len());
+    for k in 0..base.len() {
+        out.push(base[k] + coeff * (a[k] - b[k]));
+    }
+    clamp_vec(&mut out, bounds);
+    out
+}
+
+/// Overwrites the worst (last, after sorting) vertex with a new point/fitness.
+fn replace_worst(simplex: &mut [Vertex], point: Vec<f32>, fitness: f32) {
+    let last: usize = simplex.len() - 1;
+    simplex[last] = Vertex { point, fitness };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+
+    type TestBackend = Flex;
+
+    /// `f(x) = Σ x_i²` — convex, unimodal, optimum at the origin.
+    struct Sphere;
+    impl FitnessFn<Vec<f32>> for Sphere {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            x.iter().map(|v| v * v).sum()
+        }
+    }
+
+    /// 2-D Rosenbrock — curved valley, optimum at `(1, 1)` with value 0.
+    struct Rosenbrock;
+    impl FitnessFn<Vec<f32>> for Rosenbrock {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            let a = 1.0 - x[0];
+            let b = x[1] - x[0] * x[0];
+            a * a + 100.0 * b * b
+        }
+    }
+
+    /// Constant 1.0 — perfectly flat; no probe ever improves.
+    struct Flat;
+    impl FitnessFn<Vec<f32>> for Flat {
+        fn evaluate_one(&mut self, _x: &Vec<f32>) -> f32 {
+            1.0
+        }
+    }
+
+    /// Wraps a fitness function and counts `evaluate_one` calls.
+    struct Counting<'a> {
+        inner: &'a mut dyn FitnessFn<Vec<f32>>,
+        calls: usize,
+    }
+    impl<'a> Counting<'a> {
+        fn new(inner: &'a mut dyn FitnessFn<Vec<f32>>) -> Self {
+            Self { inner, calls: 0 }
+        }
+    }
+    impl FitnessFn<Vec<f32>> for Counting<'_> {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            self.calls += 1;
+            self.inner.evaluate_one(x)
+        }
+    }
+
+    const BOUNDS: (f32, f32) = (-5.12, 5.12);
+
+    fn random_start(rng: &mut StdRng, dim: usize, bounds: (f32, f32)) -> Vec<f32> {
+        let (lo, hi) = bounds;
+        (0..dim)
+            .map(|_| lo + (hi - lo) * rng.random::<f32>())
+            .collect()
+    }
+
+    #[test]
+    fn sphere_d2_converges_below_threshold() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(1);
+        let start = random_start(&mut rng, 2, BOUNDS);
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        assert!(fit < 1e-6, "sphere D=2 should converge: best={fit}");
+    }
+
+    #[test]
+    fn sphere_d10_strictly_improves() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(2);
+        let start = random_start(&mut rng, 10, BOUNDS);
+        let start_fit: f32 = start.iter().map(|v| v * v).sum();
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        assert!(fit < start_fit, "expected improvement: {fit} < {start_fit}");
+    }
+
+    #[test]
+    fn output_len_equals_input_len() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(3);
+        for dim in [1_usize, 2, 5, 10] {
+            let start = random_start(&mut rng, dim, BOUNDS);
+            let (g, _f) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert_eq!(g.len(), dim);
+        }
+    }
+
+    #[test]
+    fn returned_fitness_matches_fresh_eval() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(4);
+        let start = random_start(&mut rng, 4, BOUNDS);
+        let (g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn rosenbrock_monotone_non_worsening() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut rng = StdRng::seed_from_u64(5);
+        for _ in 0..6 {
+            let start = random_start(&mut rng, 2, BOUNDS);
+            let mut fitness = Rosenbrock;
+            let start_fit = fitness.evaluate_one(&start);
+            let (_g, fit) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert!(fit <= start_fit, "monotone: {fit} <= {start_fit}");
+        }
+    }
+
+    #[test]
+    fn eval_count_never_exceeds_budget() {
+        let searcher = NelderMead;
+        let mut params = NelderMeadParams::default_for(BOUNDS);
+        params.max_iters = 37;
+        let mut base = Flat;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(6);
+        let start = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let (g, _f) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut counting,
+            &mut rng,
+        );
+        assert!(
+            counting.calls <= params.max_iters,
+            "evals {} must not exceed budget {}",
+            counting.calls,
+            params.max_iters
+        );
+        assert_eq!(g.len(), start.len());
+    }
+
+    #[test]
+    fn degenerate_budget_no_worse_than_input() {
+        // D = 5 needs n + 1 = 6 evals just to initialize the simplex; a budget
+        // of 2 dies mid-init and must still return a safe result.
+        let searcher = NelderMead;
+        let mut params = NelderMeadParams::default_for(BOUNDS);
+        params.max_iters = 2;
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(7);
+        let start = random_start(&mut rng, 5, BOUNDS);
+        let start_fit: f32 = start.iter().map(|v| v * v).sum();
+        let (g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        assert_eq!(g.len(), 5, "dimensionality preserved");
+        assert!(fit <= start_fit, "no worse than input: {fit} <= {start_fit}");
+    }
+
+    #[test]
+    fn tolerance_early_stops_before_budget() {
+        // With a generous budget on the smooth sphere, the f-spread tolerance
+        // test should fire well before `max_iters` evaluations are spent.
+        let searcher = NelderMead;
+        let mut params = NelderMeadParams::default_for(BOUNDS);
+        params.max_iters = 1000;
+        let mut base = Sphere;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(8);
+        let start = vec![1.0_f32, -0.5];
+        let (_g, _f) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut counting,
+            &mut rng,
+        );
+        assert!(
+            counting.calls < params.max_iters,
+            "tolerance should early-stop: evals {} < budget {}",
+            counting.calls,
+            params.max_iters
+        );
+    }
+
+    #[test]
+    fn boundary_start_stays_within_bounds() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(9);
+        // Start at the upper boundary in every coordinate, so the forward axis
+        // nudge would leave bounds and must flip inward.
+        let start = vec![BOUNDS.1; 4];
+        let (g, _f) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        for &x in &g {
+            assert!(
+                x >= BOUNDS.0 && x <= BOUNDS.1,
+                "coord {x} out of bounds {BOUNDS:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn same_seed_is_bit_identical() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let start = vec![2.0_f32, -3.0, 1.5];
+
+        let mut fitness_a = Sphere;
+        let mut rng_a = StdRng::seed_from_u64(123);
+        let (g_a, f_a) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut fitness_a,
+            &mut rng_a,
+        );
+
+        let mut fitness_b = Sphere;
+        let mut rng_b = StdRng::seed_from_u64(123);
+        let (g_b, f_b) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness_b,
+            &mut rng_b,
+        );
+
+        assert_eq!(g_a, g_b);
+        assert_eq!(f_a, f_b);
+    }
+}

--- a/crates/rlevo-evolution/src/local_search/random_restart.rs
+++ b/crates/rlevo-evolution/src/local_search/random_restart.rs
@@ -1,0 +1,533 @@
+//! Random-restart meta-search.
+//!
+//! Random restart wraps an inner
+//! [`LocalSearch`] and runs it several times
+//! from perturbed starting points, returning the best refinement found. Run `0`
+//! starts from the unperturbed input (guaranteeing the
+//! monotone-non-worsening invariant); runs `1..=restarts` start from the input
+//! plus zero-mean Gaussian noise, clamped to bounds. This escapes the inner
+//! searcher's local basins on multimodal landscapes.
+//!
+//! # Run-0-first ordering (load-bearing)
+//!
+//! Run `0` is executed **before any rng value is drawn for perturbation**, and
+//! it refines the *unperturbed* input genome. This ordering is deliberate and
+//! has two consequences that the contract and tests rely on:
+//!
+//! 1. Run `0` consumes the rng stream exactly as a bare
+//!    `inner.refine(&params.inner, genome, fitness_fn, rng)` call would. Hence
+//!    a `RandomRestart` with `restarts > 0` returns a result **bit-identical to
+//!    or strictly better than** `restarts == 0` on the same seed: run `0` is
+//!    shared between the two, and additional restarts only ever replace it on a
+//!    strict improvement.
+//! 2. Monotonicity versus the input is *structural*: run `0` already satisfies
+//!    the [`LocalSearch`]
+//!    monotone-non-worsening invariant (the inner searcher guarantees it), and
+//!    the argmin over all runs can only be `<=` run `0`.
+//!
+//! # Evaluation budget
+//!
+//! `RandomRestart` owns **no cap of its own**. The total number of
+//! `evaluate_one` calls is exactly the product
+//! `(restarts + 1) * inner.max_iters`: one unperturbed run plus `restarts`
+//! perturbed runs, each bounded by the inner searcher's own `max_iters`. The
+//! inner searcher enforces its `max_iters >= 1` panic; `restarts == 0` is a
+//! valid configuration equivalent to a plain inner run.
+
+use core::fmt::Debug;
+
+use burn::tensor::backend::Backend;
+use rand::Rng;
+use rand_distr::{Distribution as _, Normal};
+
+use crate::fitness::FitnessFn;
+use crate::local_search::{clamp_vec, LocalSearch};
+
+/// Static configuration for a [`RandomRestart`] run.
+///
+/// The total evaluation budget is the product `(restarts + 1) * inner.max_iters`:
+/// one unperturbed run plus `restarts` perturbed runs, each bounded by the inner
+/// searcher's own `max_iters`. There is no second, outer cap.
+///
+/// # Type parameters
+///
+/// - `LP`: the inner searcher's `Params` type.
+#[derive(Debug, Clone)]
+pub struct RandomRestartParams<LP: Clone + Debug + Send + Sync> {
+    /// Configuration handed to the inner searcher on every run.
+    pub inner: LP,
+    /// Number of *perturbed* restarts in addition to the unperturbed run `0`.
+    /// Default `2` (so 3 runs total).
+    ///
+    /// Because `RandomRestart` adds no cap of its own, this directly scales the
+    /// total evaluation budget: `(restarts + 1) * inner.max_iters` total
+    /// `evaluate_one` calls. `0` is valid and reduces to a plain inner run.
+    pub restarts: usize,
+    /// Inclusive search-space bounds `(lo, hi)`; perturbed starts are clamped
+    /// here.
+    pub bounds: (f32, f32),
+    /// Standard deviation of the Gaussian perturbation applied to the input
+    /// genome for runs `1..=restarts`. Default `0.1 * (hi - lo)`.
+    pub perturbation: f32,
+}
+
+impl<LP: Clone + Debug + Send + Sync> RandomRestartParams<LP> {
+    /// Default parameters: `restarts = 2`, `perturbation = 0.1 * (hi - lo)`,
+    /// wrapping the supplied inner `params`.
+    #[must_use]
+    pub fn default_for(inner: LP, bounds: (f32, f32)) -> Self {
+        let (lo, hi) = bounds;
+        Self {
+            inner,
+            restarts: 2,
+            bounds,
+            perturbation: 0.1 * (hi - lo),
+        }
+    }
+}
+
+/// Random-restart wrapper around an inner [`LocalSearch`].
+///
+/// Runs the wrapped searcher `restarts + 1` times — once from the unperturbed
+/// input and `restarts` times from Gaussian-perturbed, bounds-clamped starting
+/// points — and returns the argmin over all runs (ties broken toward the
+/// earliest run). The total evaluation budget is the product
+/// `(restarts + 1) * inner.max_iters`; this wrapper adds no cap of its own.
+///
+/// # Type parameters
+///
+/// - `L`: the wrapped inner searcher.
+///
+/// # Example
+///
+/// ```
+/// use burn::backend::Flex;
+/// use rand::{rngs::StdRng, SeedableRng};
+/// use rlevo_evolution::fitness::FitnessFn;
+/// use rlevo_evolution::local_search::{
+///     HillClimbing, HillClimbingParams, LocalSearch, RandomRestart, RandomRestartParams,
+/// };
+///
+/// // Minimize the 2-D sphere; the optimum is the origin with fitness 0.
+/// struct Sphere;
+/// impl FitnessFn<Vec<f32>> for Sphere {
+///     fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+///         x.iter().map(|v| v * v).sum()
+///     }
+/// }
+///
+/// // Wrap hill climbing in random restart: 3 perturbed restarts + run 0.
+/// let searcher = RandomRestart::new(HillClimbing);
+/// let inner = HillClimbingParams::default_for((-5.12, 5.12));
+/// let mut params = RandomRestartParams::default_for(inner, (-5.12, 5.12));
+/// params.restarts = 3;
+/// let mut fitness = Sphere;
+/// let mut rng = StdRng::seed_from_u64(7);
+///
+/// let start = vec![2.5_f32, -1.5];
+/// let start_fit: f32 = start.iter().map(|v| v * v).sum();
+/// let (refined, refined_fit) =
+///     LocalSearch::<Flex>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+///
+/// assert_eq!(refined.len(), 2); // dimensionality preserved
+/// assert!(refined_fit <= start_fit); // monotone non-worsening
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct RandomRestart<L> {
+    /// The wrapped inner searcher, invoked once per run.
+    inner: L,
+}
+
+impl<L> RandomRestart<L> {
+    /// Wraps `inner` for multi-start refinement.
+    #[must_use]
+    pub fn new(inner: L) -> Self {
+        Self { inner }
+    }
+}
+
+impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
+    type Params = RandomRestartParams<L::Params>;
+
+    /// # Panics
+    ///
+    /// Panics if `params.restarts > 0` and `params.perturbation` is not
+    /// strictly positive: a zero (or negative/non-finite) standard deviation
+    /// cannot parameterize the Gaussian restart jitter, and silently degrading
+    /// to unperturbed restarts would waste the entire restart budget on
+    /// duplicate runs. `restarts == 0` is a valid configuration (a plain inner
+    /// run) and never panics here. The inner searcher enforces its own
+    /// `max_iters >= 1` invariant and will panic on a zero inner budget.
+    fn refine(
+        &self,
+        params: &RandomRestartParams<L::Params>,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        assert!(
+            params.restarts == 0 || params.perturbation > 0.0,
+            "RandomRestartParams::perturbation must be > 0 when restarts > 0 \
+             (zero jitter would make every restart a duplicate of run 0)"
+        );
+        // Run 0 FIRST, from the UNPERTURBED input, before drawing ANY rng
+        // values for perturbation. This ordering is load-bearing (see module
+        // docs): it makes run 0 consume the rng stream exactly as a bare
+        // `inner.refine` call would, so monotonicity is structural and the
+        // `restarts > 0` result is bit-exactly `<=` the `restarts == 0` result
+        // on the same seed.
+        let (mut best_genome, mut best_fit): (Vec<f32>, f32) =
+            self.inner.refine(&params.inner, genome.clone(), fitness_fn, rng);
+
+        // Runs 1..=restarts: perturb the input with per-coordinate Gaussian
+        // noise drawn through the passed rng, clamp to bounds, refine. Replace
+        // the incumbent only on a STRICT improvement, so ties keep the earliest
+        // run (run 0 wins ties).
+        if params.restarts > 0 {
+            let normal: Normal<f32> = Normal::new(0.0_f32, params.perturbation)
+                .expect("perturbation std-dev is strictly positive (asserted above)");
+            for _ in 0..params.restarts {
+                let mut start: Vec<f32> = genome.clone();
+                for coord in &mut start {
+                    *coord += normal.sample(rng);
+                }
+                clamp_vec(&mut start, params.bounds);
+
+                let (run_genome, run_fit): (Vec<f32>, f32) =
+                    self.inner.refine(&params.inner, start, fitness_fn, rng);
+                if run_fit < best_fit {
+                    best_fit = run_fit;
+                    best_genome = run_genome;
+                }
+            }
+        }
+
+        (best_genome, best_fit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::local_search::{HillClimbing, HillClimbingParams};
+    use burn::backend::Flex;
+    use rand::rngs::StdRng;
+    use rand::{RngExt as _, SeedableRng};
+
+    type TestBackend = Flex;
+
+    const BOUNDS: (f32, f32) = (-5.12, 5.12);
+
+    /// `f(x) = Σ x_i²` — convex, unimodal, optimum at the origin.
+    struct Sphere;
+    impl FitnessFn<Vec<f32>> for Sphere {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            x.iter().map(|v| v * v).sum()
+        }
+    }
+
+    /// 2-D Rastrigin — highly multimodal, optimum at the origin with value 0.
+    struct Rastrigin;
+    impl FitnessFn<Vec<f32>> for Rastrigin {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            use core::f32::consts::PI;
+            let a = 10.0_f32;
+            // `a * D` constant folded per-coordinate to avoid a usize->f32 cast.
+            x.iter()
+                .map(|&xi| a + xi * xi - a * (2.0 * PI * xi).cos())
+                .sum::<f32>()
+        }
+    }
+
+    /// 2-D Rosenbrock — curved valley, optimum at `(1, 1)` with value 0.
+    struct Rosenbrock;
+    impl FitnessFn<Vec<f32>> for Rosenbrock {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            let a = 1.0 - x[0];
+            let b = x[1] - x[0] * x[0];
+            a * a + 100.0 * b * b
+        }
+    }
+
+    /// Constant 1.0 — perfectly flat; no probe ever improves.
+    struct Flat;
+    impl FitnessFn<Vec<f32>> for Flat {
+        fn evaluate_one(&mut self, _x: &Vec<f32>) -> f32 {
+            1.0
+        }
+    }
+
+    /// Wraps a fitness function and counts `evaluate_one` calls.
+    struct Counting<'a> {
+        inner: &'a mut dyn FitnessFn<Vec<f32>>,
+        calls: usize,
+    }
+    impl<'a> Counting<'a> {
+        fn new(inner: &'a mut dyn FitnessFn<Vec<f32>>) -> Self {
+            Self { inner, calls: 0 }
+        }
+    }
+    impl FitnessFn<Vec<f32>> for Counting<'_> {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            self.calls += 1;
+            self.inner.evaluate_one(x)
+        }
+    }
+
+    /// Builds a `RandomRestart<HillClimbing>` params set with the given restart
+    /// count, sharing the supplied inner `HillClimbingParams`.
+    fn rr_params(
+        inner: HillClimbingParams,
+        restarts: usize,
+    ) -> RandomRestartParams<HillClimbingParams> {
+        let mut params: RandomRestartParams<HillClimbingParams> =
+            RandomRestartParams::default_for(inner, BOUNDS);
+        params.restarts = restarts;
+        params
+    }
+
+    #[test]
+    fn budget_is_product_of_runs_and_inner_max_iters() {
+        // On a flat landscape no probe ever improves, so every run burns its
+        // full inner budget. Total evals must respect the product formula and
+        // exceed a single inner run (proving the restarts actually ran).
+        let searcher = RandomRestart::new(HillClimbing);
+        let mut inner = HillClimbingParams::default_for(BOUNDS);
+        inner.max_iters = 20;
+        let restarts = 3_usize;
+        let params = rr_params(inner.clone(), restarts);
+
+        let mut base = Flat;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(1);
+        let start = vec![1.0_f32, 2.0, 3.0];
+        let _ = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut counting,
+            &mut rng,
+        );
+
+        let upper = (restarts + 1) * inner.max_iters;
+        assert!(
+            counting.calls <= upper,
+            "evals {} must not exceed product budget {}",
+            counting.calls,
+            upper
+        );
+        assert!(
+            counting.calls > inner.max_iters,
+            "evals {} must exceed a single inner run ({}) — restarts must run",
+            counting.calls,
+            inner.max_iters
+        );
+    }
+
+    #[test]
+    fn restarts_never_worse_than_zero_same_seed() {
+        // On a multimodal landscape, restarts > 0 must never return a worse
+        // result than restarts == 0 with the same seed (run 0 is shared).
+        let searcher = RandomRestart::new(HillClimbing);
+        let inner = HillClimbingParams::default_for(BOUNDS);
+        let start = vec![3.7_f32, -2.9];
+
+        let params_zero = rr_params(inner.clone(), 0);
+        let mut fit_zero = Rastrigin;
+        let mut rng_zero = StdRng::seed_from_u64(42);
+        let (_g0, f0) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params_zero,
+            start.clone(),
+            &mut fit_zero,
+            &mut rng_zero,
+        );
+
+        let params_three = rr_params(inner, 3);
+        let mut fit_three = Rastrigin;
+        let mut rng_three = StdRng::seed_from_u64(42);
+        let (_g3, f3) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params_three,
+            start,
+            &mut fit_three,
+            &mut rng_three,
+        );
+
+        assert!(
+            f3 <= f0,
+            "restarts=3 ({f3}) must not be worse than restarts=0 ({f0})"
+        );
+    }
+
+    #[test]
+    fn restarts_escape_local_basin() {
+        // From a start trapped in a non-global Rastrigin basin, a single inner
+        // run (restarts=0) settles into that basin; restarts with healthy
+        // perturbation escape to a strictly better fitness.
+        let searcher = RandomRestart::new(HillClimbing);
+        let mut inner = HillClimbingParams::default_for(BOUNDS);
+        // Small step so run 0 stays trapped near the start basin.
+        inner.step_size = 0.25;
+        inner.max_iters = 120;
+        // Start near a non-global Rastrigin minimum (the lattice point (4, -3)).
+        let start = vec![4.0_f32, -3.0];
+
+        let params_zero = rr_params(inner.clone(), 0);
+        let mut fit_zero = Rastrigin;
+        let mut rng_zero = StdRng::seed_from_u64(7);
+        let (_g0, f0) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params_zero,
+            start.clone(),
+            &mut fit_zero,
+            &mut rng_zero,
+        );
+
+        // Healthy perturbation lets restarts jump basins.
+        let mut params_five = rr_params(inner, 5);
+        params_five.perturbation = 2.5;
+        let mut fit_five = Rastrigin;
+        let mut rng_five = StdRng::seed_from_u64(7);
+        let (_g5, f5) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params_five,
+            start,
+            &mut fit_five,
+            &mut rng_five,
+        );
+
+        assert!(
+            f5 < f0,
+            "restarts=5 ({f5}) should strictly beat restarts=0 ({f0})"
+        );
+    }
+
+    #[test]
+    fn rosenbrock_monotone_non_worsening() {
+        let searcher = RandomRestart::new(HillClimbing);
+        let inner = HillClimbingParams::default_for(BOUNDS);
+        let params = rr_params(inner, 2);
+        let mut rng = StdRng::seed_from_u64(11);
+        let (lo, hi) = BOUNDS;
+        for _ in 0..5 {
+            let start: Vec<f32> = (0..2)
+                .map(|_| lo + (hi - lo) * rng.random::<f32>())
+                .collect();
+            let mut fitness = Rosenbrock;
+            let start_fit = fitness.evaluate_one(&start);
+            let (_g, fit) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert!(fit <= start_fit, "monotone: {fit} <= {start_fit}");
+        }
+    }
+
+    #[test]
+    fn output_len_equals_input_len() {
+        let searcher = RandomRestart::new(HillClimbing);
+        let inner = HillClimbingParams::default_for(BOUNDS);
+        let params = rr_params(inner, 2);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(3);
+        let (lo, hi) = BOUNDS;
+        for dim in [1_usize, 2, 5, 10] {
+            let start: Vec<f32> = (0..dim)
+                .map(|_| lo + (hi - lo) * rng.random::<f32>())
+                .collect();
+            let (g, _f) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert_eq!(g.len(), dim);
+        }
+    }
+
+    #[test]
+    fn returned_fitness_matches_fresh_eval() {
+        let searcher = RandomRestart::new(HillClimbing);
+        let inner = HillClimbingParams::default_for(BOUNDS);
+        let params = rr_params(inner, 3);
+        let mut fitness = Rastrigin;
+        let mut rng = StdRng::seed_from_u64(4);
+        let start = vec![1.3_f32, -2.7];
+        let (g, fit) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness,
+            &mut rng,
+        );
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn boundary_start_with_large_perturbation_stays_within_bounds() {
+        let searcher = RandomRestart::new(HillClimbing);
+        let mut inner = HillClimbingParams::default_for(BOUNDS);
+        // Big inner step, no decay, so probes push hard on bounds too.
+        inner.step_size = 4.0;
+        inner.step_decay = 1.0;
+        let mut params = rr_params(inner, 4);
+        // Large perturbation relative to range: starts will spill past bounds
+        // before clamping.
+        params.perturbation = 10.0;
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(5);
+        // Start at the upper boundary in every coordinate.
+        let start = vec![BOUNDS.1; 4];
+        let (g, _f) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness,
+            &mut rng,
+        );
+        for &x in &g {
+            assert!(
+                x >= BOUNDS.0 && x <= BOUNDS.1,
+                "coord {x} out of bounds {BOUNDS:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn same_seed_is_bit_identical() {
+        let searcher = RandomRestart::new(HillClimbing);
+        let inner = HillClimbingParams::default_for(BOUNDS);
+        let params = rr_params(inner, 4);
+        let start = vec![2.0_f32, -3.0, 1.5];
+
+        let mut fitness_a = Rastrigin;
+        let mut rng_a = StdRng::seed_from_u64(123);
+        let (g_a, f_a) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut fitness_a,
+            &mut rng_a,
+        );
+
+        let mut fitness_b = Rastrigin;
+        let mut rng_b = StdRng::seed_from_u64(123);
+        let (g_b, f_b) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness_b,
+            &mut rng_b,
+        );
+
+        assert_eq!(g_a, g_b);
+        assert_eq!(f_a, f_b);
+    }
+}

--- a/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
+++ b/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
@@ -1,0 +1,568 @@
+//! Simulated annealing.
+//!
+//! Simulated annealing performs a stochastic walk that accepts worsening moves
+//! with probability `exp(-Δf / T)`, cooling the temperature `T` over time so
+//! the walk gradually concentrates on improving moves. This lets it escape
+//! shallow local minima that strict hill climbing gets stuck in, at the cost of
+//! being a coarse explorer rather than a precision finisher.
+//!
+//! Each iteration proposes a neighbour by adding per-coordinate Gaussian noise
+//! `N(0, step_size)` to the current walker position (sampled through the
+//! supplied `rng`), clamps it to bounds, and evaluates it. A non-worsening move
+//! is always accepted; a worsening move of size `Δf` is accepted iff a uniform
+//! draw `rng.random::<f32>()` falls below `exp(-Δf / T)`. The temperature is
+//! cooled once per iteration via the configured [`CoolingSchedule`], and the
+//! walk early-stops once `T < min_temp`.
+//!
+//! The returned pair is always the best `(genome, fitness)` observed across all
+//! evaluations — **not** the final walker position, which may sit at an uphill
+//! point it accepted. Tracking the global best on every evaluation is what makes
+//! the [`LocalSearch`] monotone-non-worsening
+//! and fresh-fitness invariants hold structurally despite uphill acceptance.
+
+use burn::tensor::backend::Backend;
+use rand::{Rng, RngExt};
+use rand_distr::{Distribution as _, Normal};
+
+use crate::fitness::FitnessFn;
+use crate::local_search::{clamp_vec, BudgetedEval, LocalSearch};
+
+/// Temperature-cooling schedule for [`SimulatedAnnealing`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CoolingSchedule {
+    /// Geometric cooling: `T <- T * factor` each step. `factor` in `(0, 1)`.
+    Geometric {
+        /// Multiplicative cooling factor per step.
+        factor: f32,
+    },
+    /// Linear cooling: `T <- T - delta` each step (floored at `0`).
+    Linear {
+        /// Temperature decrement per step.
+        delta: f32,
+    },
+}
+
+/// Static configuration for a [`SimulatedAnnealing`] run.
+#[derive(Debug, Clone)]
+pub struct SimulatedAnnealingParams {
+    /// Inclusive search-space bounds `(lo, hi)`; proposals are clamped here.
+    pub bounds: (f32, f32),
+    /// Hard cap on the **total** number of `evaluate_one` calls per `refine`,
+    /// including the initial evaluation of the input genome. Default `200`.
+    pub max_iters: usize,
+    /// Starting temperature. Default `1.0`.
+    pub initial_temp: f32,
+    /// Cooling schedule. Default `Geometric { factor: 0.95 }`.
+    pub cooling: CoolingSchedule,
+    /// Early-stop temperature floor — the walk stops once `T < min_temp`.
+    /// Default `1e-6`.
+    pub min_temp: f32,
+    /// Standard deviation of the Gaussian proposal step. Default
+    /// `0.1 * (hi - lo)`.
+    pub step_size: f32,
+}
+
+impl SimulatedAnnealingParams {
+    /// Default parameters derived from the search-space `bounds`.
+    ///
+    /// `initial_temp = 1.0`, `cooling = Geometric { factor: 0.95 }`,
+    /// `min_temp = 1e-6`, `step_size = 0.1 * (hi - lo)`, `max_iters = 200`.
+    #[must_use]
+    pub fn default_for(bounds: (f32, f32)) -> Self {
+        let (lo, hi) = bounds;
+        Self {
+            bounds,
+            max_iters: 200,
+            initial_temp: 1.0,
+            cooling: CoolingSchedule::Geometric { factor: 0.95 },
+            min_temp: 1e-6,
+            step_size: 0.1 * (hi - lo),
+        }
+    }
+}
+
+/// Simulated-annealing local search.
+///
+/// A unit struct: all configuration lives in [`SimulatedAnnealingParams`], so
+/// one instance can refine many genomes. See the [module docs](self) for the
+/// acceptance rule and the best-so-far tracking that upholds the
+/// [`LocalSearch`] contract.
+///
+/// # Example
+///
+/// ```
+/// use burn::backend::Flex;
+/// use rand::{rngs::StdRng, SeedableRng};
+/// use rlevo_evolution::fitness::FitnessFn;
+/// use rlevo_evolution::local_search::{LocalSearch, SimulatedAnnealing, SimulatedAnnealingParams};
+///
+/// // Minimize the 2-D sphere; the optimum is the origin with fitness 0.
+/// struct Sphere;
+/// impl FitnessFn<Vec<f32>> for Sphere {
+///     fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+///         x.iter().map(|v| v * v).sum()
+///     }
+/// }
+///
+/// let searcher = SimulatedAnnealing;
+/// let params = SimulatedAnnealingParams::default_for((-5.12, 5.12));
+/// let mut fitness = Sphere;
+/// let mut rng = StdRng::seed_from_u64(7);
+///
+/// let start = vec![2.5_f32, -1.5];
+/// let start_fit: f32 = start.iter().map(|v| v * v).sum();
+/// let (refined, refined_fit) =
+///     LocalSearch::<Flex>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+///
+/// assert_eq!(refined.len(), 2);          // dimensionality preserved
+/// assert!(refined_fit <= start_fit);     // monotone non-worsening
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SimulatedAnnealing;
+
+impl<B: Backend> LocalSearch<B> for SimulatedAnnealing {
+    type Params = SimulatedAnnealingParams;
+
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`: a zero evaluation budget makes it
+    /// impossible to return an honestly evaluated fitness, so it is treated as
+    /// an invalid configuration (programming error), not runtime data.
+    fn refine(
+        &self,
+        params: &SimulatedAnnealingParams,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        assert!(
+            params.max_iters >= 1,
+            "SimulatedAnnealingParams::max_iters must be >= 1 (the input genome \
+             is always evaluated once to seed the best-so-far tracker)"
+        );
+        let mut budget: BudgetedEval = BudgetedEval::new(fitness_fn, params.max_iters);
+
+        // First action: evaluate the input genome (1 eval) and seed both the
+        // walker and the best-so-far tracker. The assert above guarantees this
+        // succeeds.
+        let Some(initial_fit) = budget.eval(&genome) else {
+            unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+        };
+
+        // The walker — may drift uphill when an uphill move is accepted.
+        let mut current: Vec<f32> = genome;
+        let mut current_fit: f32 = initial_fit;
+        // The tracked best — always returned. Updated on EVERY evaluation, so
+        // the monotone + fresh-fitness invariants hold structurally regardless
+        // of how far uphill the walker wanders.
+        let mut best: Vec<f32> = current.clone();
+        let mut best_fit: f32 = current_fit;
+
+        let dim: usize = current.len();
+        if dim == 0 {
+            return (best, best_fit);
+        }
+
+        // Unit Gaussian sampled through the passed rng (same path as the crate's
+        // `gaussian_mutation`); scaled by `step_size` per coordinate to realise
+        // an `N(0, step_size)` proposal step.
+        let normal: Normal<f32> =
+            Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
+
+        let mut temp: f32 = params.initial_temp;
+
+        loop {
+            // Propose: current walker + per-coordinate Gaussian noise.
+            let mut candidate: Vec<f32> = current.clone();
+            for x in &mut candidate {
+                *x += params.step_size * normal.sample(rng);
+            }
+            clamp_vec(&mut candidate, params.bounds);
+
+            // Evaluate the proposal (stop if the budget is exhausted).
+            let Some(cand_fit) = budget.eval(&candidate) else {
+                break;
+            };
+
+            // Track the global best on every evaluation.
+            if cand_fit < best_fit {
+                best_fit = cand_fit;
+                best.clone_from(&candidate);
+            }
+
+            // Metropolis acceptance: always take a non-worsening move; take a
+            // worsening move of size `delta` with probability `exp(-delta / T)`.
+            // Both the comparison and the uphill draw flow through the passed
+            // rng so all stochasticity is reproducible.
+            let delta: f32 = cand_fit - current_fit;
+            let accept: bool =
+                delta <= 0.0 || rng.random::<f32>() < (-delta / temp).exp();
+            if accept {
+                current = candidate;
+                current_fit = cand_fit;
+            }
+
+            // Cool once per iteration, then early-stop below the floor.
+            match params.cooling {
+                CoolingSchedule::Geometric { factor } => temp *= factor,
+                CoolingSchedule::Linear { delta } => temp = (temp - delta).max(0.0),
+            }
+            if temp < params.min_temp {
+                break;
+            }
+        }
+
+        (best, best_fit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    type TestBackend = Flex;
+
+    /// `f(x) = Σ x_i²` — convex, unimodal, optimum at the origin.
+    struct Sphere;
+    impl FitnessFn<Vec<f32>> for Sphere {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            x.iter().map(|v| v * v).sum()
+        }
+    }
+
+    /// 2-D Rosenbrock — curved valley, optimum at `(1, 1)` with value 0.
+    struct Rosenbrock;
+    impl FitnessFn<Vec<f32>> for Rosenbrock {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            let a = 1.0 - x[0];
+            let b = x[1] - x[0] * x[0];
+            a * a + 100.0 * b * b
+        }
+    }
+
+    /// Constant 1.0 — perfectly flat; no probe ever improves.
+    struct Flat;
+    impl FitnessFn<Vec<f32>> for Flat {
+        fn evaluate_one(&mut self, _x: &Vec<f32>) -> f32 {
+            1.0
+        }
+    }
+
+    /// Wraps a fitness function and counts `evaluate_one` calls.
+    struct Counting<'a> {
+        inner: &'a mut dyn FitnessFn<Vec<f32>>,
+        calls: usize,
+    }
+    impl<'a> Counting<'a> {
+        fn new(inner: &'a mut dyn FitnessFn<Vec<f32>>) -> Self {
+            Self { inner, calls: 0 }
+        }
+    }
+    impl FitnessFn<Vec<f32>> for Counting<'_> {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            self.calls += 1;
+            self.inner.evaluate_one(x)
+        }
+    }
+
+    /// Records, for every evaluation, whether it was strictly worse than the
+    /// previous evaluation's fitness. Lets a test observe uphill *proposals*
+    /// reaching the acceptance test; combined with a tiny step it pins that
+    /// the walker actually accepts some of them at high temperature.
+    struct Recording<'a> {
+        inner: &'a mut dyn FitnessFn<Vec<f32>>,
+        fitnesses: Vec<f32>,
+    }
+    impl<'a> Recording<'a> {
+        fn new(inner: &'a mut dyn FitnessFn<Vec<f32>>) -> Self {
+            Self {
+                inner,
+                fitnesses: Vec::new(),
+            }
+        }
+    }
+    impl FitnessFn<Vec<f32>> for Recording<'_> {
+        fn evaluate_one(&mut self, x: &Vec<f32>) -> f32 {
+            let f = self.inner.evaluate_one(x);
+            self.fitnesses.push(f);
+            f
+        }
+    }
+
+    const BOUNDS: (f32, f32) = (-5.12, 5.12);
+
+    fn random_start(rng: &mut StdRng, dim: usize, bounds: (f32, f32)) -> Vec<f32> {
+        let (lo, hi) = bounds;
+        (0..dim)
+            .map(|_| lo + (hi - lo) * rng.random::<f32>())
+            .collect()
+    }
+
+    #[test]
+    fn sphere_d2_improves_substantially() {
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(1);
+        let start = random_start(&mut rng, 2, BOUNDS);
+        let start_fit: f32 = start.iter().map(|v| v * v).sum();
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        // SA is a coarse explorer, not a precision finisher: assert a large
+        // relative improvement, not 1e-6 convergence.
+        assert!(
+            fit < 0.1 * start_fit,
+            "sphere D=2 should improve substantially: best={fit}, start={start_fit}"
+        );
+    }
+
+    #[test]
+    fn sphere_d10_strictly_improves() {
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(2);
+        let start = random_start(&mut rng, 10, BOUNDS);
+        let start_fit: f32 = start.iter().map(|v| v * v).sum();
+        let (_g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        assert!(fit < start_fit, "expected improvement: {fit} < {start_fit}");
+    }
+
+    #[test]
+    fn output_len_equals_input_len() {
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(3);
+        for dim in [1_usize, 2, 5, 10] {
+            let start = random_start(&mut rng, dim, BOUNDS);
+            let (g, _f) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert_eq!(g.len(), dim);
+        }
+    }
+
+    #[test]
+    fn returned_fitness_matches_fresh_eval() {
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(4);
+        let start = random_start(&mut rng, 4, BOUNDS);
+        let (g, fit) =
+            LocalSearch::<TestBackend>::refine(&searcher, &params, start, &mut fitness, &mut rng);
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn rosenbrock_monotone_non_worsening() {
+        // Pins that the tracked best (not the uphill-drifting walker) is what
+        // gets returned: despite accepting worsening moves, `f_out <= f_in`.
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let mut rng = StdRng::seed_from_u64(5);
+        for _ in 0..6 {
+            let start = random_start(&mut rng, 2, BOUNDS);
+            let mut fitness = Rosenbrock;
+            let start_fit = fitness.evaluate_one(&start);
+            let (_g, fit) = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start,
+                &mut fitness,
+                &mut rng,
+            );
+            assert!(fit <= start_fit, "monotone: {fit} <= {start_fit}");
+        }
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn flat_landscape_terminates_within_budget() {
+        let searcher = SimulatedAnnealing;
+        let mut params = SimulatedAnnealingParams::default_for(BOUNDS);
+        params.max_iters = 37;
+        let mut base = Flat;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(6);
+        let start = vec![1.0_f32, 2.0, 3.0];
+        let (g, fit) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut counting,
+            &mut rng,
+        );
+        assert!(
+            counting.calls <= params.max_iters,
+            "evals {} must not exceed budget {}",
+            counting.calls,
+            params.max_iters
+        );
+        // On a flat landscape nothing improves: the returned genome is the
+        // input and its fitness is the honest constant 1.0.
+        assert_eq!(g, start);
+        assert_eq!(fit, 1.0);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn same_seed_bit_identical_different_seed_differs() {
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let start = vec![2.0_f32, -3.0, 1.5];
+
+        let mut fitness_a = Sphere;
+        let mut rng_a = StdRng::seed_from_u64(123);
+        let (g_a, f_a) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut fitness_a,
+            &mut rng_a,
+        );
+
+        let mut fitness_b = Sphere;
+        let mut rng_b = StdRng::seed_from_u64(123);
+        let (g_b, f_b) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start.clone(),
+            &mut fitness_b,
+            &mut rng_b,
+        );
+
+        // Same seed ⇒ bit-identical genome AND fitness: all stochasticity flows
+        // through the passed rng.
+        assert_eq!(g_a, g_b);
+        assert_eq!(f_a, f_b);
+
+        let mut fitness_c = Sphere;
+        let mut rng_c = StdRng::seed_from_u64(999);
+        let (g_c, _f_c) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness_c,
+            &mut rng_c,
+        );
+        // Different seed ⇒ (almost surely) a different trajectory and output.
+        assert_ne!(g_a, g_c);
+    }
+
+    #[test]
+    fn min_temp_early_stop_below_budget() {
+        // A tiny initial temperature plus aggressive geometric cooling drops
+        // below `min_temp` long before the evaluation budget is spent.
+        let searcher = SimulatedAnnealing;
+        let mut params = SimulatedAnnealingParams::default_for(BOUNDS);
+        params.max_iters = 1000;
+        params.initial_temp = 1e-3;
+        params.min_temp = 1e-1;
+        params.cooling = CoolingSchedule::Geometric { factor: 0.5 };
+        let mut base = Sphere;
+        let mut counting = Counting::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(7);
+        let start = vec![1.0_f32, -1.0];
+        let _ = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut counting,
+            &mut rng,
+        );
+        assert!(
+            counting.calls < params.max_iters,
+            "min_temp early stop: evals {} should be < budget {}",
+            counting.calls,
+            params.max_iters
+        );
+    }
+
+    #[test]
+    fn boundary_start_stays_within_bounds() {
+        let searcher = SimulatedAnnealing;
+        let mut params = SimulatedAnnealingParams::default_for(BOUNDS);
+        // Large step relative to range pushes proposals hard against bounds.
+        params.step_size = 4.0;
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(8);
+        // Start at the upper boundary in every coordinate.
+        let start = vec![BOUNDS.1; 4];
+        let (g, _f) = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut fitness,
+            &mut rng,
+        );
+        for &x in &g {
+            assert!(
+                x >= BOUNDS.0 && x <= BOUNDS.1,
+                "coord {x} out of bounds {BOUNDS:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn uphill_moves_accepted_at_high_temperature() {
+        // With a huge initial temperature, exp(-Δf / T) ≈ 1, so the walker
+        // should accept worsening moves. We detect acceptance indirectly: the
+        // returned best is the tracked minimum, but if NO uphill move were ever
+        // accepted the walker would behave like a pure descent and the recorded
+        // evaluation sequence would be (weakly) monotone after the first
+        // improvement. Instead we assert the walker visits a fitness strictly
+        // worse than the running minimum more than once — only possible if an
+        // earlier worsening move was accepted, moving the walker uphill so its
+        // next proposal is centred on a worse point.
+        let searcher = SimulatedAnnealing;
+        let mut params = SimulatedAnnealingParams::default_for(BOUNDS);
+        params.max_iters = 200;
+        params.initial_temp = 1e9;
+        params.min_temp = 1e-9;
+        params.step_size = 0.5;
+        let mut base = Sphere;
+        let mut recording = Recording::new(&mut base);
+        let mut rng = StdRng::seed_from_u64(11);
+        let start = vec![0.05_f32, -0.05];
+        let _ = LocalSearch::<TestBackend>::refine(
+            &searcher,
+            &params,
+            start,
+            &mut recording,
+            &mut rng,
+        );
+
+        // Count evaluations that were strictly worse than the best-so-far at the
+        // time they were seen. A pure greedy descent (no uphill acceptance) can
+        // produce such evaluations too — but with a near-origin start and a
+        // large step on the sphere, sustained worse-than-best proposals are only
+        // explored because accepted uphill moves keep re-centring the walker on
+        // worse points. Require several to make the assertion robust.
+        let mut running_best = f32::INFINITY;
+        let mut worse_than_best = 0_usize;
+        for &f in &recording.fitnesses {
+            if f > running_best {
+                worse_than_best += 1;
+            }
+            if f < running_best {
+                running_best = f;
+            }
+        }
+        assert!(
+            worse_than_best >= 3,
+            "expected sustained uphill exploration at high temperature, saw {worse_than_best} \
+             worse-than-best evaluations"
+        );
+    }
+}

--- a/crates/rlevo-evolution/src/rng.rs
+++ b/crates/rlevo-evolution/src/rng.rs
@@ -41,6 +41,12 @@ pub enum SeedPurpose {
     Trial = 5,
     /// Catch-all for strategy-specific stochastic steps.
     Other = 6,
+    /// Local-search refinement (memetic algorithms).
+    ///
+    /// Used by [`crate::local_search`] searchers so a memetic wrapper's
+    /// per-individual refinement draws from a stream independent of the
+    /// inner strategy's selection/mutation/crossover/replacement streams.
+    LocalSearch = 7,
 }
 
 impl SeedPurpose {
@@ -53,6 +59,7 @@ impl SeedPurpose {
             SeedPurpose::Replacement => 0x0123_4567_89AB_CDEF,
             SeedPurpose::Trial => 0xBAAD_F00D_DEAD_C0DE,
             SeedPurpose::Other => 0x9E37_79B9_7F4A_7C15,
+            SeedPurpose::LocalSearch => 0xC0FF_EE15_600D_F00D,
         }
     }
 }
@@ -120,9 +127,13 @@ mod tests {
         let a = seed_stream(42, 0, SeedPurpose::Init).next_u64();
         let b = seed_stream(42, 0, SeedPurpose::Selection).next_u64();
         let c = seed_stream(42, 0, SeedPurpose::Mutation).next_u64();
+        let d = seed_stream(42, 0, SeedPurpose::LocalSearch).next_u64();
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
+        assert_ne!(a, d);
+        assert_ne!(b, d);
+        assert_ne!(c, d);
     }
 
     #[test]

--- a/crates/rlevo-evolution/tests/determinism.rs
+++ b/crates/rlevo-evolution/tests/determinism.rs
@@ -29,7 +29,14 @@ use rlevo_evolution::algorithms::metaheuristic::gwo::{GreyWolfOptimizer, GwoConf
 use rlevo_evolution::algorithms::metaheuristic::pso::{ParticleSwarm, PsoConfig};
 use rlevo_evolution::algorithms::metaheuristic::salp::{SalpConfig, SalpSwarm};
 use rlevo_evolution::algorithms::metaheuristic::woa::{WhaleOptimization, WoaConfig};
+use rlevo_evolution::algorithms::de::{DeConfig, DifferentialEvolution};
+use rlevo_evolution::algorithms::memetic::{
+    CoveragePolicy, MemeticParams, MemeticWrapper, WritebackPolicy,
+};
 use rlevo_evolution::fitness::{BatchFitnessFn, FromFitnessEvaluable};
+use rlevo_evolution::local_search::{
+    HillClimbing, HillClimbingParams, SimulatedAnnealing, SimulatedAnnealingParams,
+};
 use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
 
 type B = Flex;
@@ -136,6 +143,91 @@ fn run_firefly(seed: u64, gens: usize) -> Vec<f32> {
     run(FireflyAlgorithm::<B>::new(), params, seed, gens)
 }
 
+/// Drive a `MemeticWrapper<DE, HillClimbing>` for `gens` generations and
+/// collect the per-generation best-fitness trajectory.
+///
+/// Unlike [`run`], this builds the harness inline: a `MemeticWrapper` holds its
+/// *own* fitness instance (used to score local-search probes) in addition to
+/// the harness's, so it cannot go through the generic [`run`] path that supplies
+/// a single fitness. Both instances are independent `FromFitnessEvaluable`
+/// values over the same stateless [`SphereFit`], so they never diverge.
+fn run_memetic_de(seed: u64, gens: usize) -> Vec<f32> {
+    let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
+    let dim: usize = 5;
+    let bounds: (f32, f32) = (-5.12, 5.12);
+    let strategy: MemeticWrapper<B, _, _, _> = MemeticWrapper::<B, _, _, _>::new(
+        DifferentialEvolution::<B>::new(),
+        HillClimbing,
+        FromFitnessEvaluable::new(SphereFit, Sphere),
+    );
+    let params: MemeticParams<DeConfig, HillClimbingParams> = MemeticParams {
+        inner: DeConfig::default_for(16, dim),
+        local: HillClimbingParams::default_for(bounds),
+        writeback: WritebackPolicy::Partial(0.5),
+        coverage: CoveragePolicy::TopK { k: 2 },
+    };
+    let mut harness = EvolutionaryHarness::<B, _, _>::new(
+        strategy,
+        params,
+        FromFitnessEvaluable::new(SphereFit, Sphere),
+        seed,
+        device,
+        gens,
+    );
+    harness.reset();
+    let mut trajectory: Vec<f32> = Vec::with_capacity(gens);
+    loop {
+        let step = harness.step(());
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        if step.done {
+            break;
+        }
+    }
+    trajectory
+}
+
+/// Drive a `MemeticWrapper<DE, SimulatedAnnealing>` for `gens` generations and
+/// collect the per-generation best-fitness trajectory.
+///
+/// Exercises the stochastic-searcher determinism path: SA draws Gaussian
+/// proposals and Metropolis acceptance probabilities through the wrapper's
+/// `seed_stream`-derived `ls_rng`, so a same-seed replay must still be
+/// bit-identical. See [`run_memetic_de`] for the two-fitness-instance note.
+fn run_memetic_sa(seed: u64, gens: usize) -> Vec<f32> {
+    let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
+    let dim: usize = 5;
+    let bounds: (f32, f32) = (-5.12, 5.12);
+    let strategy: MemeticWrapper<B, _, _, _> = MemeticWrapper::<B, _, _, _>::new(
+        DifferentialEvolution::<B>::new(),
+        SimulatedAnnealing,
+        FromFitnessEvaluable::new(SphereFit, Sphere),
+    );
+    let params: MemeticParams<DeConfig, SimulatedAnnealingParams> = MemeticParams {
+        inner: DeConfig::default_for(16, dim),
+        local: SimulatedAnnealingParams::default_for(bounds),
+        writeback: WritebackPolicy::Partial(0.5),
+        coverage: CoveragePolicy::TopK { k: 2 },
+    };
+    let mut harness = EvolutionaryHarness::<B, _, _>::new(
+        strategy,
+        params,
+        FromFitnessEvaluable::new(SphereFit, Sphere),
+        seed,
+        device,
+        gens,
+    );
+    harness.reset();
+    let mut trajectory: Vec<f32> = Vec::with_capacity(gens);
+    loop {
+        let step = harness.step(());
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        if step.done {
+            break;
+        }
+    }
+    trajectory
+}
+
 #[test]
 fn same_seed_same_generations() {
     const SEED: u64 = 1_234_567;
@@ -177,4 +269,23 @@ fn same_seed_same_generations() {
     check!(run_aco_r, "ACO_R");
     check!(run_cuckoo, "Cuckoo");
     check!(run_firefly, "Firefly");
+
+    // Memetic wrappers. `MemeticWrapper<DE, HillClimbing>` and
+    // `MemeticWrapper<DE, SimulatedAnnealing>` route all refinement randomness
+    // through `seed_stream`, so same-seed runs must be bit-identical too — even
+    // for the stochastic SA searcher, whose Gaussian proposals and Metropolis
+    // acceptance draws flow through the wrapper's deterministic `ls_rng`.
+    let mem_de_a = run_memetic_de(SEED, GENS);
+    let mem_de_b = run_memetic_de(SEED, GENS);
+    assert_eq!(
+        mem_de_a, mem_de_b,
+        "MemeticWrapper<DE, HillClimbing> trajectories diverge under the same seed"
+    );
+
+    let mem_sa_a = run_memetic_sa(SEED, GENS);
+    let mem_sa_b = run_memetic_sa(SEED, GENS);
+    assert_eq!(
+        mem_sa_a, mem_sa_b,
+        "MemeticWrapper<DE, SimulatedAnnealing> trajectories diverge under the same seed"
+    );
 }

--- a/crates/rlevo/Cargo.toml
+++ b/crates/rlevo/Cargo.toml
@@ -165,6 +165,13 @@ path = "examples/evo/rosenbrock_flat_showcase.rs"
 name = "trefethen_showcase"
 path = "examples/evo/trefethen_showcase.rs"
 
+# Memetic algorithms — evals-to-target comparison, not part of the
+# fixed-generation `common::showcase` panel (the panel's generation budget
+# would hide the extra evaluations local search spends per generation).
+[[example]]
+name = "memetic_showcase"
+path = "examples/evo/memetic_showcase.rs"
+
 # Random-baseline-vs-learned benches. Each prints a reward/success quality
 # comparison, then times per-step rollout throughput for both policies.
 # Shared DQN model + Polyak scaffolding lives in `benches/support/dqn.rs`.

--- a/crates/rlevo/examples/evo/memetic_showcase.rs
+++ b/crates/rlevo/examples/evo/memetic_showcase.rs
@@ -1,0 +1,279 @@
+//! Memetic-algorithm showcase: bare DE vs `MemeticWrapper<DE, HillClimbing>`
+//! on Rastrigin-D10, compared by **evaluations-to-target**.
+//!
+//! The other `*_showcase` examples give every strategy the same *generation*
+//! budget. That comparison would flatter a memetic strategy: local refinement
+//! spends extra fitness evaluations inside every generation (here `TopK{1}` ×
+//! `max_iters=20` adds up to 20 evals on top of DE's 30), so its
+//! per-generation `best` is bought with a bigger budget. The honest question
+//! is the one this example asks: *how many total fitness evaluations does each
+//! configuration need to first reach a shared target cost?*
+//!
+//! Evaluations are counted by a fitness wrapper that increments a shared
+//! counter per row of every `evaluate_batch`. Each `MemeticWrapper`
+//! local-search probe routes through a `[1, D]` batch, so refinement
+//! evaluations are captured automatically; the memetic runs share one counter
+//! across both fitness instances they own (harness + wrapper).
+//!
+//! # Reading the output
+//!
+//! Each configuration prints one row: the eval-counter reading at the first
+//! generation where `best_fitness_ever` crossed below each target, then the
+//! final best after the full generation budget. Lower eval counts are better;
+//! `miss` means the target was never reached. Rastrigin-D10 has `f* = 0` over
+//! `[-5.12, 5.12]^10`; targets below ~10 are deliberately absent because bare
+//! DE often stalls there, making "fewer evals to a shared target" ill-posed.
+//!
+//! What to look for:
+//!
+//! - The **headline** row (`TopK{1}`, best-improvement hill climbing,
+//!   `max_iters=20`, Lamarckian) reaches each target in substantially fewer
+//!   evaluations than bare DE — the same calibrated configuration pinned by
+//!   the `memetic_rastrigin` acceptance test (~54% fewer at target 30), which
+//!   verified the win across five seeds.
+//! - The **writeback** rows vary only `WritebackPolicy`. Lamarckian writes
+//!   refined genomes back into the population; Baldwinian keeps the genomes
+//!   untouched and only credits the refined fitness; `Partial(0.5)` (the
+//!   default) flips a seeded coin per refined row. The policy visibly moves
+//!   the eval counts — refinement overhead is paid either way, so a policy
+//!   that exploits the refined genomes poorly can even fall behind bare DE at
+//!   tight targets.
+//! - The **untuned-defaults** row (`TopK{3}` × `default_for` hill climbing:
+//!   `max_iters=100`, step ≈ 1.0) dominates everything on *this* landscape —
+//!   and that is the trap. Rastrigin is fully **separable** with local minima
+//!   on a unit grid, so axis-aligned hill climbing with basin-width steps is
+//!   almost a direct solver for it; the same configuration's advantage
+//!   collapses on non-separable or rotated landscapes (the reason benchmark
+//!   suites include rotated variants). Treat that row as a demonstration that
+//!   memetic performance is landscape-dependent, not as a config to copy.
+//!
+//! Rayon is pinned to one thread and every run shares the same seed, so the
+//! printed numbers are bit-reproducible across invocations.
+//!
+//! Run with `cargo run --release -p rlevo --example memetic_showcase`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use burn::backend::Flex;
+use burn::tensor::{Tensor, TensorData, backend::Backend, backend::BackendTypes};
+
+use rlevo::envs::landscapes::rastrigin::Rastrigin;
+use rlevo::evo::algorithms::de::{DeConfig, DifferentialEvolution};
+use rlevo::evo::algorithms::memetic::{
+    CoveragePolicy, MemeticParams, MemeticWrapper, WritebackPolicy,
+};
+use rlevo::evo::fitness::BatchFitnessFn;
+use rlevo::evo::local_search::{HillClimbVariant, HillClimbing, HillClimbingParams};
+use rlevo::evo::strategy::{EvolutionaryHarness, Strategy};
+
+type B = Flex;
+
+const DIM: usize = 10;
+const BOUNDS: (f32, f32) = (-5.12, 5.12);
+/// The seed pinned by the `memetic_rastrigin` acceptance test, so this
+/// example's headline row reproduces the test's provenance numbers.
+const SEED: u64 = 7;
+/// Generation budget; generous enough that every configuration converges past
+/// the easiest target long before exhausting it.
+const MAX_GENS: usize = 600;
+/// Shared target costs, in crossing order (best-so-far only decreases).
+const TARGETS: [f32; 3] = [40.0, 30.0, 20.0];
+
+/// Row-counting Rastrigin fitness: increments `evals` by the number of rows in
+/// each `evaluate_batch`, so `MemeticWrapper`'s `[1, D]` local-search probes
+/// are counted alongside full population scorings.
+struct CountingRastrigin {
+    landscape: Rastrigin,
+    evals: Arc<AtomicUsize>,
+}
+
+impl<Bk: Backend> BatchFitnessFn<Bk, Tensor<Bk, 2>> for CountingRastrigin {
+    fn evaluate_batch(
+        &mut self,
+        population: &Tensor<Bk, 2>,
+        device: &<Bk as BackendTypes>::Device,
+    ) -> Tensor<Bk, 1> {
+        let dims: [usize; 2] = population.dims();
+        let (pop, dim): (usize, usize) = (dims[0], dims[1]);
+        self.evals.fetch_add(pop, Ordering::Relaxed);
+        let flat: Vec<f32> = population.clone().into_data().into_vec::<f32>().unwrap();
+        let mut out: Vec<f32> = Vec::with_capacity(pop);
+        for r in 0..pop {
+            let start: usize = r * dim;
+            let row: Vec<f64> = flat[start..start + dim].iter().map(|&v| f64::from(v)).collect();
+            #[allow(clippy::cast_possible_truncation)]
+            out.push(self.landscape.evaluate(&row) as f32);
+        }
+        Tensor::<Bk, 1>::from_data(TensorData::new(out, [pop]), device)
+    }
+}
+
+/// Drives one strategy for [`MAX_GENS`] generations and prints its row: the
+/// eval count at the first crossing of each entry in [`TARGETS`], then the
+/// final `best_fitness_ever`. `evals` must be the same counter the strategy's
+/// own fitness instances feed (for the memetic rows) so refinement
+/// evaluations are included.
+fn run_row<S>(label: &str, strategy: S, params: S::Params, evals: &Arc<AtomicUsize>)
+where
+    S: Strategy<B, Genome = Tensor<B, 2>>,
+    S::Params: std::fmt::Debug,
+{
+    let device: <B as BackendTypes>::Device = Default::default();
+    let fitness: CountingRastrigin = CountingRastrigin {
+        landscape: Rastrigin::new(DIM),
+        evals: evals.clone(),
+    };
+    let mut harness = EvolutionaryHarness::<B, S, CountingRastrigin>::new(
+        strategy, params, fitness, SEED, device, MAX_GENS,
+    );
+    harness.reset();
+    let mut crossings: [Option<usize>; TARGETS.len()] = [None; TARGETS.len()];
+    loop {
+        let step = harness.step(());
+        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        for (slot, &target) in crossings.iter_mut().zip(TARGETS.iter()) {
+            if slot.is_none() && best < target {
+                *slot = Some(evals.load(Ordering::Relaxed));
+            }
+        }
+        if step.done {
+            break;
+        }
+    }
+    let final_best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+    let cells: String = TARGETS
+        .iter()
+        .zip(crossings.iter())
+        .map(|(&target, crossing)| match crossing {
+            Some(e) => format!("→{target:>2.0}: {e:>7} evals"),
+            None => format!("→{target:>2.0}: {:>7}      ", "miss"),
+        })
+        .collect::<Vec<String>>()
+        .join(" | ");
+    println!("{label:>45} | {cells} | final best={final_best:.4e}");
+}
+
+/// One memetic row: wraps a fresh DE in `MemeticWrapper` with the given
+/// hill-climbing params and policies. The wrapper's fitness instance shares
+/// the row's eval counter, so harness scorings and local-search probes land
+/// in one budget.
+fn run_memetic_row(
+    label: &str,
+    de: &DeConfig,
+    hc: HillClimbingParams,
+    writeback: WritebackPolicy,
+    coverage: CoveragePolicy,
+) {
+    let evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let wrapper_fitness: CountingRastrigin = CountingRastrigin {
+        landscape: Rastrigin::new(DIM),
+        evals: evals.clone(),
+    };
+    let strategy: MemeticWrapper<B, _, _, _> = MemeticWrapper::<B, _, _, _>::new(
+        DifferentialEvolution::<B>::new(),
+        HillClimbing,
+        wrapper_fitness,
+    );
+    let params: MemeticParams<DeConfig, HillClimbingParams> = MemeticParams {
+        inner: de.clone(),
+        local: hc,
+        writeback,
+        coverage,
+    };
+    run_row(label, strategy, params, &evals);
+}
+
+/// The calibrated headline hill-climbing config from the acceptance test:
+/// cheap enough per generation that refinement overhead never erases DE's
+/// progress, greedy enough that each polished elite pulls the population
+/// toward a basin.
+fn headline_hc() -> HillClimbingParams {
+    let mut hc: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
+    hc.max_iters = 20;
+    hc.step_size = 0.4;
+    hc.step_decay = 0.5;
+    hc.variant = HillClimbVariant::BestImprovement;
+    hc
+}
+
+fn main() {
+    // One thread keeps the Flex backend bit-reproducible run to run.
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build_global()
+        .ok();
+
+    println!(
+        "
+Memetic showcase — Rastrigin-D{DIM}, evals-to-target, Flex backend, seed={SEED}
+
+Each row reports the TOTAL fitness evaluations consumed when best-so-far
+first crossed below each target cost (lower is better; `miss` = never
+reached within {MAX_GENS} generations), then the final best. Unlike the
+fixed-generation showcases, this counts every evaluation — including the
+ones MemeticWrapper's local search spends — so the comparison is
+budget-fair. All rows share one DE config (pop=30, Rand1Bin, F=0.5,
+CR=0.9) and one seed.\n\n{:-<120}",
+        "",
+    );
+
+    let de: DeConfig = DeConfig::default_for(30, DIM);
+
+    let bare_evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    run_row(
+        "bare DE/Rand1Bin",
+        DifferentialEvolution::<B>::new(),
+        de.clone(),
+        &bare_evals,
+    );
+
+    run_memetic_row(
+        "memetic k=1/it=20/best/Lamarckian (headline)",
+        &de,
+        headline_hc(),
+        WritebackPolicy::Lamarckian,
+        CoveragePolicy::TopK { k: 1 },
+    );
+    run_memetic_row(
+        "memetic k=1/it=20/best/Baldwinian",
+        &de,
+        headline_hc(),
+        WritebackPolicy::Baldwinian,
+        CoveragePolicy::TopK { k: 1 },
+    );
+    run_memetic_row(
+        "memetic k=1/it=20/best/Partial(0.5) (default)",
+        &de,
+        headline_hc(),
+        WritebackPolicy::default(),
+        CoveragePolicy::TopK { k: 1 },
+    );
+
+    // Untuned `default_for` hill climbing (max_iters=100, step ≈ 1.0,
+    // first-improvement) on three rows per generation — up to ~300 refinement
+    // evals/gen on top of DE's 30. Dominates here because Rastrigin is
+    // separable; see the module docs before copying it.
+    let heavy: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
+    run_memetic_row(
+        "memetic k=3/untuned HC defaults (it=100)",
+        &de,
+        heavy,
+        WritebackPolicy::Lamarckian,
+        CoveragePolicy::TopK { k: 3 },
+    );
+
+    println!(
+        "{:-<120}
+Takeaway: the headline row is the robust, multi-seed-calibrated win the
+acceptance test pins (~54% fewer evals than bare DE to reach 30). The
+writeback rows show the policy choice alone can move — or lose — the
+advantage at tight targets. The untuned-defaults row dominates only because
+Rastrigin is separable and axis-aligned hill climbing with basin-width steps
+exploits that perfectly; do not expect it to transfer to non-separable
+problems. The general recipe: pick a target cost, count evaluations to reach
+it (as this example does), and tune writeback/coverage/budget against that
+number rather than against per-generation best.",
+        "",
+    );
+}

--- a/crates/rlevo/tests/memetic_rastrigin.rs
+++ b/crates/rlevo/tests/memetic_rastrigin.rs
@@ -1,0 +1,412 @@
+//! Headline memetic-algorithm acceptance test (phase 3a).
+//!
+//! Goal: prove that wrapping Differential Evolution with hill-climbing
+//! refinement — `MemeticWrapper<DE, HillClimbing>` — reaches a target
+//! Rastrigin-D10 fitness in **strictly fewer total fitness evaluations** than
+//! bare DE under an *identical* `DeConfig` and *identical* seed, reproducibly.
+//!
+//! # Why this file runs a single test
+//!
+//! The Burn Flex backend seeds its tensor RNG through a process-wide
+//! `Mutex<Option<FlexRng>>`. Two tests racing on that mutex interleave their
+//! `Tensor::random` draws and destroy bit-equality across runs — the same
+//! rationale documented in `rlevo-evolution/tests/determinism.rs`. This file
+//! therefore contains exactly one `#[test]` so the cargo runner cannot execute
+//! anything in parallel with it; within the single body every run is strictly
+//! sequential. (The `#[ignore]`d `calibration_explorer` below is an
+//! exploration-only scaffold that is never part of the default test run.)
+//!
+//! # Eval-count accounting
+//!
+//! Both the bare-DE harness and the memetic harness are driven with a
+//! [`CountingRastrigin`] fitness that increments a shared `Arc<AtomicUsize>` by
+//! one *per row* of every `evaluate_batch`. Every `MemeticWrapper` local-search
+//! probe routes through a `[1, D]` `evaluate_batch`, so row-counting captures
+//! refinement evaluations automatically. The memetic run shares **one** counter
+//! across both fitness instances it owns (harness + wrapper); the bare-DE run
+//! uses a separate counter.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use burn::backend::Flex;
+use burn::tensor::{Tensor, TensorData, backend::Backend, backend::BackendTypes};
+
+use rlevo_environments::landscapes::rastrigin::Rastrigin;
+use rlevo_evolution::algorithms::de::{DeConfig, DifferentialEvolution};
+use rlevo_evolution::algorithms::memetic::{
+    CoveragePolicy, MemeticParams, MemeticWrapper, WritebackPolicy,
+};
+use rlevo_evolution::fitness::BatchFitnessFn;
+use rlevo_evolution::local_search::{HillClimbVariant, HillClimbing, HillClimbingParams};
+use rlevo_evolution::strategy::EvolutionaryHarness;
+
+type B = Flex;
+
+const DIM: usize = 10;
+const BOUNDS: (f32, f32) = (-5.12, 5.12);
+
+/// Row-counting Rastrigin fitness.
+///
+/// Implements only [`BatchFitnessFn`] and increments `evals` by the number of
+/// rows in each `evaluate_batch`. Because every `MemeticWrapper` local-search
+/// probe is a `[1, D]` batch, refinement evaluations are counted too. Two
+/// instances that share one `Arc<AtomicUsize>` (e.g. the harness's and the
+/// wrapper's) report a single combined evaluation budget.
+struct CountingRastrigin {
+    landscape: Rastrigin,
+    evals: Arc<AtomicUsize>,
+}
+
+impl CountingRastrigin {
+    fn new(landscape: Rastrigin, evals: Arc<AtomicUsize>) -> Self {
+        Self { landscape, evals }
+    }
+}
+
+impl<Bk: Backend> BatchFitnessFn<Bk, Tensor<Bk, 2>> for CountingRastrigin {
+    fn evaluate_batch(
+        &mut self,
+        population: &Tensor<Bk, 2>,
+        device: &<Bk as BackendTypes>::Device,
+    ) -> Tensor<Bk, 1> {
+        let dims: [usize; 2] = population.dims();
+        let (pop, dim): (usize, usize) = (dims[0], dims[1]);
+        self.evals.fetch_add(pop, Ordering::Relaxed);
+        let flat: Vec<f32> = population.clone().into_data().into_vec::<f32>().unwrap();
+        let mut out: Vec<f32> = Vec::with_capacity(pop);
+        for r in 0..pop {
+            let start: usize = r * dim;
+            let row: Vec<f64> = flat[start..start + dim].iter().map(|&v| f64::from(v)).collect();
+            #[allow(clippy::cast_possible_truncation)]
+            out.push(self.landscape.evaluate(&row) as f32);
+        }
+        Tensor::<Bk, 1>::from_data(TensorData::new(out, [pop]), device)
+    }
+}
+
+/// Result of one `evals_to_target` run: the eval counter when the best-so-far
+/// first crossed below `target`, plus the per-generation best-fitness-ever
+/// trajectory (for determinism assertions).
+struct RunResult {
+    /// Total fitness-row evaluations consumed at the first crossing of
+    /// `best_fitness_ever < target`, or `None` if never reached.
+    evals_at_target: Option<usize>,
+    /// Per-generation `best_fitness_ever` trajectory.
+    trajectory: Vec<f32>,
+}
+
+/// Drive bare DE to a target Rastrigin fitness, counting evaluations.
+fn de_evals_to_target(seed: u64, de: &DeConfig, target: f32, max_gens: usize) -> RunResult {
+    let device: <B as BackendTypes>::Device = Default::default();
+    let evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let fitness: CountingRastrigin =
+        CountingRastrigin::new(Rastrigin::new(DIM), evals.clone());
+    let strategy: DifferentialEvolution<B> = DifferentialEvolution::<B>::new();
+    let mut harness = EvolutionaryHarness::<B, _, _>::new(
+        strategy,
+        de.clone(),
+        fitness,
+        seed,
+        device,
+        max_gens,
+    );
+    harness.reset();
+    let mut trajectory: Vec<f32> = Vec::with_capacity(max_gens);
+    let mut evals_at_target: Option<usize> = None;
+    loop {
+        let step = harness.step(());
+        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        trajectory.push(best);
+        if evals_at_target.is_none() && best < target {
+            evals_at_target = Some(evals.load(Ordering::Relaxed));
+        }
+        if step.done {
+            break;
+        }
+    }
+    RunResult {
+        evals_at_target,
+        trajectory,
+    }
+}
+
+/// Drive `MemeticWrapper<DE, HillClimbing>` to a target Rastrigin fitness,
+/// counting evaluations across BOTH fitness instances via one shared counter.
+fn memetic_evals_to_target(
+    seed: u64,
+    de: &DeConfig,
+    hc: &HillClimbingParams,
+    writeback: WritebackPolicy,
+    coverage: CoveragePolicy,
+    target: f32,
+    max_gens: usize,
+) -> RunResult {
+    let device: <B as BackendTypes>::Device = Default::default();
+    // One shared counter feeds both fitness instances: the harness's (population
+    // scoring) and the wrapper's (local-search probes).
+    let evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+    let harness_fitness: CountingRastrigin =
+        CountingRastrigin::new(Rastrigin::new(DIM), evals.clone());
+    let wrapper_fitness: CountingRastrigin =
+        CountingRastrigin::new(Rastrigin::new(DIM), evals.clone());
+
+    let strategy: MemeticWrapper<B, _, _, _> = MemeticWrapper::<B, _, _, _>::new(
+        DifferentialEvolution::<B>::new(),
+        HillClimbing,
+        wrapper_fitness,
+    );
+    let params: MemeticParams<DeConfig, HillClimbingParams> = MemeticParams {
+        inner: de.clone(),
+        local: hc.clone(),
+        writeback,
+        coverage,
+    };
+    let mut harness = EvolutionaryHarness::<B, _, _>::new(
+        strategy,
+        params,
+        harness_fitness,
+        seed,
+        device,
+        max_gens,
+    );
+    harness.reset();
+    let mut trajectory: Vec<f32> = Vec::with_capacity(max_gens);
+    let mut evals_at_target: Option<usize> = None;
+    loop {
+        let step = harness.step(());
+        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        trajectory.push(best);
+        if evals_at_target.is_none() && best < target {
+            evals_at_target = Some(evals.load(Ordering::Relaxed));
+        }
+        if step.done {
+            break;
+        }
+    }
+    RunResult {
+        evals_at_target,
+        trajectory,
+    }
+}
+
+/// Shared bare-DE config: pop 30, D=10, the crate default (`Rand1Bin`, F=0.5,
+/// CR=0.9). The memetic run reuses this verbatim as its inner config.
+fn shared_de_config() -> DeConfig {
+    DeConfig::default_for(30, DIM)
+}
+
+/// Shared hill-climbing config used by the headline memetic run.
+///
+/// `max_iters=20` / `BestImprovement` / `step=0.4` / `TopK{1}` (coverage is set
+/// at the call site) is the calibrated sweet spot: cheap enough per generation
+/// that the refinement overhead never erases DE's progress, greedy enough that
+/// each polished elite pulls the whole population toward a basin. See the
+/// provenance block on the headline test for the eval-count data behind this.
+fn shared_hc_config() -> HillClimbingParams {
+    let mut hc: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
+    hc.max_iters = 20;
+    hc.step_size = 0.4;
+    hc.step_decay = 0.5;
+    hc.variant = HillClimbVariant::BestImprovement;
+    hc
+}
+
+// =====================================================================
+// Calibration explorer (NOT part of the default test run).
+//
+// Run with: cargo test -p rlevo --test memetic_rastrigin -- --ignored --nocapture
+// Prints bare-vs-memetic eval counts across several seeds and targets so the
+// pinned constants below can be chosen from real data, then deleted/ignored.
+// =====================================================================
+
+#[test]
+#[ignore = "calibration explorer: multi-seed eval-count sweep for pinning the headline margin; run with --ignored --nocapture"]
+fn calibration_explorer() {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build_global()
+        .ok();
+
+    let de: DeConfig = shared_de_config();
+    let max_gens: usize = 600;
+    let seeds: [u64; 5] = [7, 13, 29, 101, 1234];
+    let targets: [f32; 3] = [30.0, 20.0, 10.0];
+
+    // Candidate HC configs (cheaper per-gen overhead than the original
+    // max_iters=25/TopK{3} sweep, which was dominated by refinement cost on
+    // easy targets).
+    let make_hc = |max_iters: usize, step: f32, variant: HillClimbVariant| -> HillClimbingParams {
+        let mut hc: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
+        hc.max_iters = max_iters;
+        hc.step_size = step;
+        hc.step_decay = 0.5;
+        hc.variant = variant;
+        hc
+    };
+    let configs: Vec<(&str, HillClimbingParams, WritebackPolicy, CoveragePolicy)> = vec![
+        (
+            "k1/it10/first/lam",
+            make_hc(10, 0.4, HillClimbVariant::FirstImprovement),
+            WritebackPolicy::Lamarckian,
+            CoveragePolicy::TopK { k: 1 },
+        ),
+        (
+            "k1/it20/best/lam",
+            make_hc(20, 0.4, HillClimbVariant::BestImprovement),
+            WritebackPolicy::Lamarckian,
+            CoveragePolicy::TopK { k: 1 },
+        ),
+        (
+            "k1/it15/first/p0.3",
+            make_hc(15, 0.4, HillClimbVariant::FirstImprovement),
+            WritebackPolicy::Partial(0.3),
+            CoveragePolicy::TopK { k: 1 },
+        ),
+        (
+            "k2/it10/first/lam",
+            make_hc(10, 0.4, HillClimbVariant::FirstImprovement),
+            WritebackPolicy::Lamarckian,
+            CoveragePolicy::TopK { k: 2 },
+        ),
+    ];
+
+    println!("\n=== calibration: bare DE vs MemeticWrapper<DE, HillClimbing> ===");
+    println!("DE: pop=30 D=10 Rand1Bin F=0.5 CR=0.9");
+    for &target in &targets {
+        println!("\n========== target = {target} ==========");
+        // Bare DE once per seed/target (config-independent).
+        let bare: Vec<(u64, Option<usize>, f32)> = seeds
+            .iter()
+            .map(|&seed| {
+                let r: RunResult = de_evals_to_target(seed, &de, target, max_gens);
+                (seed, r.evals_at_target, r.trajectory.last().copied().unwrap_or(f32::NAN))
+            })
+            .collect();
+        for &(seed, bare_e, bare_f) in &bare {
+            println!("  bare    seed={seed:>5}: {bare_e:>9?} (final={bare_f:.4})");
+        }
+        for (name, hc, wb, cov) in &configs {
+            println!("  -- HC config: {name} --");
+            for &seed in &seeds {
+                let mem: RunResult =
+                    memetic_evals_to_target(seed, &de, hc, *wb, *cov, target, max_gens);
+                let bare_e: Option<usize> =
+                    bare.iter().find(|(s, _, _)| *s == seed).and_then(|(_, e, _)| *e);
+                let verdict: &str = match (bare_e, mem.evals_at_target) {
+                    (Some(b), Some(m)) if m < b => "WIN",
+                    (Some(_), Some(_)) => "lose",
+                    (None, Some(_)) => "WIN(bare-miss)",
+                    (_, None) => "mem-miss",
+                };
+                println!(
+                    "     seed={seed:>5}: memetic={:>9?} bare={bare_e:>9?} [{verdict}] (mem_final={:.4})",
+                    mem.evals_at_target,
+                    mem.trajectory.last().copied().unwrap_or(f32::NAN),
+                );
+            }
+        }
+    }
+}
+
+// =====================================================================
+// Headline acceptance test (the only test that runs by default).
+//
+// Provenance (pinned from `calibration_explorer` output, 2026-06-10):
+//   backend:   Flex (ndarray), rayon pinned to 1 thread, release profile.
+//   seed:      7
+//   target:    Rastrigin-D10 best_fitness_ever < 30.0
+//   inner DE:  pop=30, D=10, Rand1Bin, F=0.5, CR=0.9 (DeConfig::default_for).
+//   memetic:   HillClimbing BestImprovement, max_iters=20, step=0.4, decay=0.5,
+//              CoveragePolicy::TopK{1}, WritebackPolicy::Lamarckian.
+//   observed:  bare = 11_130 evals, memetic = 5_150 evals
+//              (memetic uses ~53.7% fewer evals than bare DE to reach 30.0).
+//
+// Why target=30 (not 20/10/5):
+//   - At target=10/5 bare DE often STALLS without ever reaching it (final
+//     best 6-17 on most seeds), so a "fewer evals to a SHARED target"
+//     comparison is not well-posed there — both configs must reach it.
+//   - At target=20 the `k1/it20/best/lam` config still wins on every seed but
+//     the headroom is thin on some (seed 101: only ~4% fewer).
+//   - At target=30 BOTH configs always reach the target and memetic has
+//     comfortable headroom on every calibration seed (ratio mem/bare ranged
+//     0.34-0.71; worst case still 29% fewer). Seed 7 sits mid-pack at 0.463.
+//
+// Margin choice:
+//   Calibration showed ≥30% fewer evals on every seed and ~54% on the pinned
+//   seed, so we assert the ≥30% margin via integer math
+//   `memetic_evals * 10 <= bare_evals * 7` (no float comparison). On the
+//   pinned data: 5_150*10 = 51_500 <= 11_130*7 = 77_910. We also assert an
+//   absolute tripwire `bare_evals >= 8_000` so a future regression that makes
+//   bare DE trivially slow (inflating the ratio) cannot mask a memetic
+//   slowdown.
+// =====================================================================
+
+const PINNED_SEED: u64 = 7;
+const TARGET: f32 = 30.0;
+const MAX_GENS: usize = 600;
+
+#[test]
+fn memetic_beats_bare_de_on_rastrigin_evals_to_target() {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build_global()
+        .ok();
+
+    let de: DeConfig = shared_de_config();
+    let hc: HillClimbingParams = shared_hc_config();
+    let writeback: WritebackPolicy = WritebackPolicy::Lamarckian;
+    let coverage: CoveragePolicy = CoveragePolicy::TopK { k: 1 };
+
+    // Bare DE and memetic share IDENTICAL DeConfig and IDENTICAL seed.
+    let bare: RunResult = de_evals_to_target(PINNED_SEED, &de, TARGET, MAX_GENS);
+    let mem: RunResult = memetic_evals_to_target(
+        PINNED_SEED, &de, &hc, writeback, coverage, TARGET, MAX_GENS,
+    );
+
+    // (a) both configs reach the target.
+    let bare_evals: usize = bare
+        .evals_at_target
+        .unwrap_or_else(|| panic!("bare DE never reached target {TARGET} in {MAX_GENS} gens"));
+    let memetic_evals: usize = mem
+        .evals_at_target
+        .unwrap_or_else(|| panic!("memetic never reached target {TARGET} in {MAX_GENS} gens"));
+
+    println!("bare_evals={bare_evals} memetic_evals={memetic_evals} target={TARGET}");
+
+    // (b) memetic strictly fewer total evals.
+    assert!(
+        memetic_evals < bare_evals,
+        "memetic must use strictly fewer evals: memetic={memetic_evals} bare={bare_evals}"
+    );
+
+    // (c) pinned margin: ≥30% fewer evals, integer math (no float comparison).
+    //     5_150*10 = 51_500 <= 11_130*7 = 77_910 on the pinned data.
+    assert!(
+        memetic_evals * 10 <= bare_evals * 7,
+        "memetic must use >=30% fewer evals: memetic={memetic_evals} bare={bare_evals} \
+         (need memetic*10 <= bare*7, i.e. {} <= {})",
+        memetic_evals * 10,
+        bare_evals * 7,
+    );
+    // Absolute tripwire: bare DE must actually take a meaningful number of
+    // evals, so the ratio cannot be inflated by a bare-DE slowdown regression.
+    assert!(
+        bare_evals >= 8_000,
+        "bare DE eval count {bare_evals} fell below the 8_000 tripwire — \
+         a bare-DE regression may be masking a memetic slowdown"
+    );
+
+    // (d) determinism: same seed → identical trajectory AND identical eval count.
+    let mem2: RunResult = memetic_evals_to_target(
+        PINNED_SEED, &de, &hc, writeback, coverage, TARGET, MAX_GENS,
+    );
+    assert_eq!(
+        mem.trajectory, mem2.trajectory,
+        "memetic best-fitness trajectory must be reproducible under the same seed"
+    );
+    assert_eq!(
+        mem.evals_at_target, mem2.evals_at_target,
+        "memetic eval count at target must be reproducible under the same seed"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -95,6 +95,10 @@ evo-rosenbrock-flat:
 evo-trefethen:
     cargo run -p rlevo --example trefethen_showcase
 
+# Memetic: bare DE vs MemeticWrapper<DE, HillClimbing>, Rastrigin-D10 evals-to-target.
+evo-memetic:
+    cargo run --release -p rlevo --example memetic_showcase
+
 cartpole-random:
     cargo run -p rlevo --example cartpole_random
 
@@ -171,6 +175,14 @@ test-rastrigin:
 # Every shipping swarm strategy on Rastrigin-D10 and Ackley-D10.
 test-swarm:
     cargo test -p rlevo --test swarm_rastrigin_suite
+
+# Memetic headline acceptance: wrapper beats bare DE on evals-to-target (>=30% fewer).
+test-memetic:
+    cargo test -p rlevo --test memetic_rastrigin
+
+# Memetic calibration explorer [ignored: multi-seed sweep for re-pinning the margin].
+test-memetic-calibration:
+    cargo test -p rlevo --test memetic_rastrigin --release -- calibration_explorer --ignored --nocapture
 
 # Post-run record → report pipeline smoke [requires viz-report feature].
 test-report-smoke:


### PR DESCRIPTION
- **feat(evolution): add memetic algorithms — LocalSearch seam + MemeticWrapper (phase 3a)**
- **docs(examples): add memetic_showcase — evals-to-target DE vs MemeticWrapper**
- **chore(justfile): Add memetic evolution development recipes**
- **docs(workspace): Improve CONTRIBUTING.md for external contributors**
- **fix(local_search): sanitize NaN fitness at the budget chokepoint**

<!--
Before opening this PR, confirm you have:
  1. Opened (or linked) an issue discussing the change — required for anything beyond a one-line typo fix.
  2. Verified all three commands pass locally:
       cargo build --workspace
       cargo test --workspace
       cargo clippy --all-targets --all-features
  3. Confirmed the change is within the current contribution scope (examples, bug fixes,
     documentation corrections). See CONTRIBUTING.md § "What Contributions Are Welcome Right Now".

Draft PRs will not be reviewed. Mark as Ready for Review when the above is complete.
-->

## Summary

Adds phase 3a memetic algorithm support to `rlevo-evolution`: a host-side
`LocalSearch<B>` trait seam plus four gradient-free searchers (Hill
Climbing, Nelder-Mead, Simulated Annealing, Random Restart), and a
`MemeticWrapper<B, S, L, F>` adapter that interleaves per-individual
local refinement with any existing `Strategy<B>`. The wrapper drops
straight into `EvolutionaryHarness` with no changes to the harness or
manifests. Includes a NaN-sanitization fix at the `BudgetedEval`
chokepoint, a cross-crate integration test on Rastrigin, and a
`memetic_showcase` example benchmarking DE vs `MemeticWrapper`.

Architectural decisions recorded in ADR-0016.


## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — New evolutionary algorithm family (`LocalSearch` seam +
  `MemeticWrapper`). Discussed and spec'd in ADR-0016 prior to
  implementation; purely additive, no existing public API changed.


<!--
NOTE: New environments, new RL/evolutionary algorithms, refactors, new dependencies, and
CI/CD changes are out of scope during the alpha phase. If your change falls into one of
those categories, close this PR and open an issue to discuss it first.
-->

## Linked Issue

None


## What Was Changed

- `crates/rlevo-evolution/src/local_search.rs` — added `LocalSearch<B>`
  trait, `FitnessFn` budget wrapper (`BudgetedEval`), and
  `SeedPurpose::LocalSearch` RNG stream variant
- `crates/rlevo-evolution/src/local_search/hill_climbing.rs` — `HillClimbing`
  with `HillClimbVariant` (basic, momentum, adaptive step)
- `crates/rlevo-evolution/src/local_search/nelder_mead.rs` — `NelderMead`
  simplex searcher
- `crates/rlevo-evolution/src/local_search/simulated_annealing.rs` —
  `SimulatedAnnealing` with `CoolingSchedule` (geometric, linear, adaptive)
- `crates/rlevo-evolution/src/local_search/random_restart.rs` —
  `RandomRestart` wrapper that re-seeds and re-runs an inner searcher
- `crates/rlevo-evolution/src/algorithms/memetic.rs` — `MemeticWrapper`,
  `WritebackPolicy` (Lamarckian / Baldwinian / `Partial(p)`),
  `CoveragePolicy`, two-stream RNG scheme; `parking_lot::Mutex<F>` for
  interior-mutable fitness access from `&self tell`
- `crates/rlevo-evolution/src/rng.rs` — added `SeedPurpose::LocalSearch`
  and `SeedPurpose::Replacement` variants
- `crates/rlevo-evolution/tests/determinism.rs` — determinism tests for
  `Partial(1.0)` ≡ Lamarckian and `Partial(0.0)` ≡ Baldwinian
- `crates/rlevo/tests/memetic_rastrigin.rs` — cross-crate integration test
  verifying `MemeticWrapper` finds the Rastrigin global minimum
- `crates/rlevo/examples/evo/memetic_showcase.rs` — standalone example
  comparing raw DE vs `MemeticWrapper<DE>` to a fitness target
- `CONTRIBUTING.md` — improved contributor guidance for external contributors
- `justfile` — added `memetic-*` development recipes


## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable
- Burn backend tested: `ndarray` (CPU)
- OS: macOS Darwin 25.5.0


## AI-Assisted Content

<!-- Per CONTRIBUTING.md § "Change Ownership": you are responsible for every line in this PR
     regardless of origin. If any part of this change was generated or significantly assisted
     by an AI tool, declare it here. You must be able to explain and defend the code on request. -->

- [x] AI tooling was used.  Tool(s): Claude Sonnet 4.6 (Claude Code).
  Scope: implementation of all new files on this branch under author
  direction and review. Author is responsible for all code.


## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [ ] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

The template flags new evolutionary algorithms as out of scope during
alpha. This change was pre-approved via ADR-0016, which was accepted
before implementation began. The `Strategy` trait and all existing
manifests are unchanged; `MemeticWrapper` is purely additive.

One known design tension: `MemeticWrapper` holds a
`parking_lot::Mutex<F>` to satisfy `&self tell`, deliberately breaking
the lock-free `Strategy` purity convention. This is documented in the
module header and in ADR-0016 as an accepted trade-off for the
single-harness driving model.
