### PR TITLE
perf(memetic): skip per-refine seeding eval via `refine_with_known_fitness`

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -102,9 +102,9 @@ impl Default for WritebackPolicy {
 /// # Cost and tuning
 ///
 /// Coverage is the dominant cost knob: each refined row spends up to
-/// `Params::max_iters` fitness evaluations (plus one mandatory seeding eval of
-/// its own input — see below), so [`Full`](Self::Full) costs `pop_size`× a
-/// [`TopK { k: 1 }`](Self::TopK) generation. When the budget that matters is
+/// `Params::max_iters` fitness evaluations, so [`Full`](Self::Full) costs
+/// `pop_size`× a [`TopK { k: 1 }`](Self::TopK) generation. When the budget that
+/// matters is
 /// *evaluations to reach a target* (not wall-clock or final-gen fitness), wide
 /// coverage with a heavy searcher can lose to bare evolution: it spends its
 /// eval budget polishing individuals that selection would have discarded
@@ -118,13 +118,10 @@ impl Default for WritebackPolicy {
 /// coverage with an untuned high-`max_iters` searcher can dominate. That is a
 /// landscape artifact, not a config to copy — re-tune per problem.
 ///
-/// Each refined row currently burns one extra eval re-scoring its own input,
-/// because [`LocalSearch::refine`] carries no input fitness. Under `TopK { k: 1 }` that is one wasted
-/// eval/generation; under `Full` it is `pop_size`/generation, which is part of
-/// what makes wide coverage expensive. The pre-cleared additive fix (ADR 0016,
-/// reversal criteria) is a defaulted `refine_with_known_fitness` method that
-/// seeds the searcher with the fitness the wrapper already holds; it is
-/// deferred until a second consumer of the seam lands.
+/// The wrapper avoids the seeding-eval waste that an unaware caller would pay:
+/// it hands each searcher the fitness the harness already computed via
+/// [`LocalSearch::refine_with_known_fitness`], so a refined row spends its evals
+/// on probes rather than re-scoring its own input (ADR 0016 reversal criteria).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CoveragePolicy {
     /// Refine every individual.
@@ -463,9 +460,19 @@ where
             for &i in &indices {
                 let start: usize = i * dim;
                 let row: Vec<f32> = flat[start..start + dim].to_vec();
-                let (refined, f_refined): (Vec<f32>, f32) =
-                    self.local
-                        .refine(&params.local, row, &mut row_fitness, &mut ls_rng);
+                // The harness already scored this row this generation; hand that
+                // fitness to the searcher so it skips the seeding eval instead of
+                // re-scoring its own input. `refined_fit[i]` still holds the
+                // original harness value — it is overwritten only below, and each
+                // covered index `i` is distinct.
+                let known_fit: f32 = refined_fit[i];
+                let (refined, f_refined): (Vec<f32>, f32) = self.local.refine_with_known_fitness(
+                    &params.local,
+                    row,
+                    known_fit,
+                    &mut row_fitness,
+                    &mut ls_rng,
+                );
                 debug_assert_eq!(refined.len(), dim, "local search must preserve genome length");
                 // Baldwinian keeps the original genome but pays refined fitness;
                 // Lamarckian writes the genome too. Either way the fitness is

--- a/crates/rlevo-evolution/src/local_search.rs
+++ b/crates/rlevo-evolution/src/local_search.rs
@@ -35,6 +35,11 @@
 //! (including the mandatory first re-evaluation of the input genome). The
 //! shared `BudgetedEval` helper enforces this so the bound holds structurally
 //! even on flat landscapes where no probe ever improves.
+//!
+//! [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness) skips
+//! that seeding eval when the caller already knows the input's fitness, so the
+//! same `max_iters` then buys one extra *probe* evaluation. The seeding eval
+//! consumes no rng, so skipping it never shifts a searcher's random stream.
 
 use burn::tensor::backend::Backend;
 use rand::Rng;
@@ -84,14 +89,20 @@ pub use simulated_annealing::{CoolingSchedule, SimulatedAnnealing, SimulatedAnne
 /// Because the input genome is always evaluated once (contract item 3), a
 /// `max_iters` of `0` cannot be honored honestly. Reference searchers treat
 /// `max_iters == 0` as an invalid configuration and **panic**; implementors
-/// should do the same rather than fabricate a fitness value.
+/// should do the same rather than fabricate a fitness value. This holds on the
+/// [`refine_with_known_fitness`](Self::refine_with_known_fitness) path too: the
+/// reference searchers keep the `max_iters >= 1` panic even though that path
+/// performs no seeding eval, so the two entry points share one budget contract.
 ///
 /// All reference searchers route every evaluation — including the seeding eval
-/// of the input — through a shared budget helper that maps a `NaN` fitness to
-/// [`f32::INFINITY`], so a `NaN` probe can never seed or displace a finite
-/// best-so-far and thus never propagates to the returned fitness. Custom
-/// implementors that probe a `fitness_fn` directly should apply the same
-/// sanitization rather than let a `NaN` seed their best-so-far tracker.
+/// of the input — through a shared budget helper that
+/// maps a `NaN` fitness to [`f32::INFINITY`], so a `NaN` probe can never seed or
+/// displace a finite best-so-far and thus never propagates to the returned
+/// fitness. The same rule applies to the `known_fitness` hint, which arrives
+/// from a path that does *not* flow through the budget helper: every reference
+/// override sanitizes the hint before seeding. Custom implementors that probe a
+/// `fitness_fn` directly — or seed from a hint — should apply the same
+/// sanitization rather than let a `NaN` reach their best-so-far tracker.
 ///
 /// # Type parameters
 ///
@@ -163,6 +174,37 @@ pub trait LocalSearch<B: Backend>: Send + Sync {
         fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
         rng: &mut dyn Rng,
     ) -> (Vec<f32>, f32);
+
+    /// Refines `genome`, seeding the best-so-far tracker with `known_fitness`
+    /// instead of re-evaluating the input — saving exactly one
+    /// [`FitnessFn::evaluate_one`] call per refinement.
+    ///
+    /// `known_fitness` **must** be the value `fitness_fn` assigns to `genome`
+    /// (for a stochastic `fitness_fn`, a value it plausibly assigned). A `NaN`
+    /// hint is sanitized to [`f32::INFINITY`] by the reference overrides, exactly
+    /// as a `NaN` probe would be (see the [contract](LocalSearch#contract)). All
+    /// other invariants — dimensionality, monotone non-worsening, budget, bounds
+    /// — are identical to [`refine`](Self::refine); the only difference is that
+    /// the seeding eval is elided, so a given `max_iters` buys one extra probe.
+    ///
+    /// Because the seeding eval consumes no rng, this method draws from the
+    /// supplied `rng` exactly as [`refine`](Self::refine) would, leaving
+    /// same-seed determinism intact.
+    ///
+    /// The default **ignores the hint** and delegates to
+    /// [`refine`](Self::refine), preserving current behavior (and the seeding
+    /// eval) for any implementor that does not override it.
+    fn refine_with_known_fitness(
+        &self,
+        params: &Self::Params,
+        genome: Vec<f32>,
+        known_fitness: f32,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        let _ = known_fitness;
+        self.refine(params, genome, fitness_fn, rng)
+    }
 }
 
 /// A fitness function wrapped with a hard evaluation budget.
@@ -193,28 +235,43 @@ impl<'a> BudgetedEval<'a> {
     /// Returns `Some(fitness)` while budget remains, or `None` once the budget
     /// is exhausted (in which case no underlying evaluation is performed).
     ///
-    /// A `NaN` fitness is sanitized to [`f32::INFINITY`] before it leaves this
-    /// method. Because every searcher routes *all* evaluations — including the
-    /// mandatory seeding eval of the input genome (contract item 3) — through
-    /// `BudgetedEval`, this is the single chokepoint that keeps `NaN` out of the
-    /// best-so-far trackers. Mapping `NaN` to `+inf` (the worst value under
-    /// minimization) means a `NaN` probe can never seed or displace a finite
-    /// best, so it never propagates to the returned fitness; if *every* probe is
-    /// `NaN` the searcher honestly returns `+inf` rather than `NaN`. For the
-    /// finite benchmark landscapes the searchers ship against this branch is
-    /// never taken, so it costs only one `is_nan` check per evaluation.
+    /// A `NaN` fitness is sanitized to [`f32::INFINITY`] via [`sanitize_fitness`]
+    /// before it leaves this method. Because every searcher routes *all*
+    /// evaluations — including the mandatory seeding eval of the input genome
+    /// (contract item 3) — through `BudgetedEval`, this is the single chokepoint
+    /// that keeps `NaN` out of the best-so-far trackers on the probe path; the
+    /// `refine_with_known_fitness` overrides apply the same helper to the
+    /// `known_fitness` hint. If *every* probe is `NaN` the searcher honestly
+    /// returns `+inf` rather than `NaN`.
     pub(crate) fn eval(&mut self, genome: &Vec<f32>) -> Option<f32> {
         if self.remaining == 0 {
             return None;
         }
         self.remaining -= 1;
-        let f: f32 = self.inner.evaluate_one(genome);
-        Some(if f.is_nan() { f32::INFINITY } else { f })
+        Some(sanitize_fitness(self.inner.evaluate_one(genome)))
     }
 
     /// Number of evaluations still permitted.
     pub(crate) fn remaining(&self) -> usize {
         self.remaining
+    }
+}
+
+/// Maps a `NaN` fitness to [`f32::INFINITY`], passing finite values through.
+///
+/// `+inf` is the worst value under minimization, so a sanitized `NaN` can never
+/// seed or displace a finite best-so-far and thus never propagates to a returned
+/// fitness. This is the single rule shared by [`BudgetedEval::eval`] (applied to
+/// every probe, including the seeding eval) and the searchers'
+/// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness)
+/// overrides (applied to the `known_fitness` hint, which does not flow through
+/// `BudgetedEval`). For the finite benchmark landscapes the searchers ship
+/// against this branch is never taken, so it costs only one `is_nan` check.
+pub(crate) fn sanitize_fitness(f: f32) -> f32 {
+    if f.is_nan() {
+        f32::INFINITY
+    } else {
+        f
     }
 }
 

--- a/crates/rlevo-evolution/src/local_search/hill_climbing.rs
+++ b/crates/rlevo-evolution/src/local_search/hill_climbing.rs
@@ -24,7 +24,7 @@ use burn::tensor::backend::Backend;
 use rand::{Rng, RngExt};
 
 use crate::fitness::FitnessFn;
-use crate::local_search::{clamp_vec, BudgetedEval, LocalSearch};
+use crate::local_search::{clamp_vec, sanitize_fitness, BudgetedEval, LocalSearch};
 
 /// Acceptance strategy for [`HillClimbing`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,18 +114,25 @@ impl HillClimbingParams {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HillClimbing;
 
-impl<B: Backend> LocalSearch<B> for HillClimbing {
-    type Params = HillClimbingParams;
-
+impl HillClimbing {
+    /// Shared body for [`refine`](LocalSearch::refine) and
+    /// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness).
+    ///
+    /// `known` is the input genome's fitness when the caller already holds it
+    /// (the hint path) or `None` when the input must be re-evaluated to seed the
+    /// tracker. Either way the seed is sanitized so a `NaN` never poisons the
+    /// best-so-far pair, and the budget meaning is identical: skipping the
+    /// seeding eval simply leaves one more probe within `max_iters`.
+    ///
     /// # Panics
     ///
     /// Panics if `params.max_iters == 0`: a zero evaluation budget makes it
     /// impossible to return an honestly evaluated fitness, so it is treated
     /// as an invalid configuration (programming error), not runtime data.
-    fn refine(
-        &self,
+    fn refine_impl(
         params: &HillClimbingParams,
         genome: Vec<f32>,
+        known: Option<f32>,
         fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
         rng: &mut dyn Rng,
     ) -> (Vec<f32>, f32) {
@@ -136,10 +143,17 @@ impl<B: Backend> LocalSearch<B> for HillClimbing {
         );
         let mut budget = BudgetedEval::new(fitness_fn, params.max_iters);
 
-        // First action: evaluate the input genome (1 eval) and seed the
-        // best-so-far tracker. The assert above guarantees this succeeds.
-        let Some(initial_fit) = budget.eval(&genome) else {
-            unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+        // First action: seed the best-so-far tracker. With a known fitness we
+        // reuse it (sanitizing NaN exactly as a probe would); otherwise we spend
+        // one eval scoring the input. The assert above guarantees the eval path
+        // succeeds.
+        let initial_fit: f32 = if let Some(f) = known {
+            sanitize_fitness(f)
+        } else {
+            let Some(f) = budget.eval(&genome) else {
+                unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+            };
+            f
         };
 
         let mut current: Vec<f32> = genome;
@@ -237,6 +251,40 @@ impl<B: Backend> LocalSearch<B> for HillClimbing {
         }
 
         (best, best_fit)
+    }
+}
+
+impl<B: Backend> LocalSearch<B> for HillClimbing {
+    type Params = HillClimbingParams;
+
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`; see `refine_impl`.
+    fn refine(
+        &self,
+        params: &HillClimbingParams,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        Self::refine_impl(params, genome, None, fitness_fn, rng)
+    }
+
+    /// Seeds the best-so-far tracker with `known_fitness` (sanitizing `NaN` to
+    /// `+inf`) instead of re-scoring the input, saving one eval.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`; see `refine_impl`.
+    fn refine_with_known_fitness(
+        &self,
+        params: &HillClimbingParams,
+        genome: Vec<f32>,
+        known_fitness: f32,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        Self::refine_impl(params, genome, Some(known_fitness), fitness_fn, rng)
     }
 }
 
@@ -501,5 +549,73 @@ mod tests {
 
         assert_eq!(g_a, g_b);
         assert_eq!(f_a, f_b);
+    }
+
+    #[test]
+    fn known_fitness_skips_exactly_the_seeding_eval() {
+        // On a flat landscape the search terminates by step-underflow long
+        // before a large budget, so the eval count is the probe walk plus the
+        // seed. The seeding eval draws no rng, so both entry points walk the
+        // identical probe sequence — the hint path simply omits the seed, i.e.
+        // exactly one fewer evaluation.
+        let searcher = HillClimbing;
+        let mut params = HillClimbingParams::default_for(BOUNDS);
+        params.max_iters = 10_000;
+        let start = vec![1.0_f32, 2.0, 3.0];
+
+        let refine_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(21);
+            let _ = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start.clone(),
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        let hint_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(21);
+            let _ = LocalSearch::<TestBackend>::refine_with_known_fitness(
+                &searcher,
+                &params,
+                start.clone(),
+                1.0, // Flat fitness of the start
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        assert_eq!(
+            hint_evals + 1,
+            refine_evals,
+            "hint path must skip exactly the seeding eval ({hint_evals} vs {refine_evals})"
+        );
+    }
+
+    #[test]
+    fn nan_hint_does_not_propagate() {
+        // A NaN hint must be sanitized to +inf so finite probes displace it; the
+        // returned fitness is finite and honest for the returned genome.
+        let searcher = HillClimbing;
+        let params = HillClimbingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(22);
+        let start = vec![2.0_f32, -1.0];
+        let (g, fit) = LocalSearch::<TestBackend>::refine_with_known_fitness(
+            &searcher,
+            &params,
+            start,
+            f32::NAN,
+            &mut fitness,
+            &mut rng,
+        );
+        assert!(fit.is_finite(), "NaN hint must be sanitized, got {fit}");
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/local_search/nelder_mead.rs
+++ b/crates/rlevo-evolution/src/local_search/nelder_mead.rs
@@ -33,7 +33,7 @@ use burn::tensor::backend::Backend;
 use rand::Rng;
 
 use crate::fitness::FitnessFn;
-use crate::local_search::{clamp_vec, BudgetedEval, LocalSearch};
+use crate::local_search::{clamp_vec, sanitize_fitness, BudgetedEval, LocalSearch};
 
 /// Static configuration for a [`NelderMead`] run.
 #[derive(Debug, Clone)]
@@ -133,21 +133,35 @@ struct Vertex {
     fitness: f32,
 }
 
-impl<B: Backend> LocalSearch<B> for NelderMead {
-    type Params = NelderMeadParams;
-
+impl NelderMead {
+    /// Shared body for [`refine`](LocalSearch::refine) and
+    /// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness).
+    ///
+    /// `known` is the input genome's fitness when the caller already holds it
+    /// (the hint path) or `None` when vertex 0 must be evaluated to seed the
+    /// tracker.
+    ///
+    /// # Hint validity and the clamp guard
+    ///
+    /// Nelder–Mead clamps the input into `bounds` to form vertex 0 *before*
+    /// scoring it, so `known_fitness` — which describes the *raw* input — is only
+    /// valid for vertex 0 when the input is already in bounds (the clamp is a
+    /// no-op). When the raw input lies outside `bounds`, the hint is discarded
+    /// and the clamped vertex 0 is evaluated honestly, falling back to the same
+    /// cost as [`refine`](LocalSearch::refine). A valid hint is sanitized (`NaN`
+    /// → `+inf`) before it seeds the tracker.
+    ///
     /// # Panics
     ///
     /// Panics if `params.max_iters == 0`: a zero evaluation budget makes it
     /// impossible to return an honestly evaluated fitness, so it is treated
     /// as an invalid configuration (programming error), not runtime data.
     #[allow(clippy::too_many_lines)]
-    fn refine(
-        &self,
+    fn refine_impl(
         params: &NelderMeadParams,
         genome: Vec<f32>,
+        known: Option<f32>,
         fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
-        _rng: &mut dyn Rng,
     ) -> (Vec<f32>, f32) {
         assert!(
             params.max_iters >= 1,
@@ -163,13 +177,25 @@ impl<B: Backend> LocalSearch<B> for NelderMead {
         // structurally. The input genome is the first point evaluated.
         let (lo, hi): (f32, f32) = params.bounds;
 
-        // First action: evaluate the input genome (1 eval), clamped to bounds.
+        // Is the raw input already feasible? A known-fitness hint describes the
+        // raw input, so it is valid for vertex 0 only when clamping is a no-op.
+        let in_bounds: bool = genome.iter().all(|&x| x >= lo && x <= hi);
+
+        // First action: clamp the input into bounds to form vertex 0, then seed
+        // the tracker. With a valid hint (input in bounds) we reuse it; otherwise
+        // we spend one eval scoring vertex 0. The assert guarantees the eval path
+        // succeeds.
         let mut vertex0: Vec<f32> = genome;
         clamp_vec(&mut vertex0, params.bounds);
         let mut best: Vec<f32> = vertex0.clone();
-        // The assert above guarantees the first eval succeeds.
-        let Some(initial_fit) = budget.eval(&vertex0) else {
-            unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+        let initial_fit: f32 = match known {
+            Some(f) if in_bounds => sanitize_fitness(f),
+            _ => {
+                let Some(f) = budget.eval(&vertex0) else {
+                    unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+                };
+                f
+            }
         };
         let mut best_fit: f32 = initial_fit;
 
@@ -318,6 +344,45 @@ impl<B: Backend> LocalSearch<B> for NelderMead {
         }
 
         (best, best_fit)
+    }
+}
+
+impl<B: Backend> LocalSearch<B> for NelderMead {
+    type Params = NelderMeadParams;
+
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`; see `refine_impl`.
+    fn refine(
+        &self,
+        params: &NelderMeadParams,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        _rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        Self::refine_impl(params, genome, None, fitness_fn)
+    }
+
+    /// Seeds vertex 0's fitness with `known_fitness` (sanitizing `NaN` to `+inf`)
+    /// instead of re-scoring the input, saving one eval — **but only when the
+    /// input is already in bounds**, since vertex 0 is the clamped input. An
+    /// out-of-bounds input falls back to evaluating the clamped vertex 0. See
+    /// `refine_impl`.
+    ///
+    /// Nelder–Mead is deterministic, so `rng` is unused on this path too.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`; see `refine_impl`.
+    fn refine_with_known_fitness(
+        &self,
+        params: &NelderMeadParams,
+        genome: Vec<f32>,
+        known_fitness: f32,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        _rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        Self::refine_impl(params, genome, Some(known_fitness), fitness_fn)
     }
 }
 
@@ -639,5 +704,116 @@ mod tests {
 
         assert_eq!(g_a, g_b);
         assert_eq!(f_a, f_b);
+    }
+
+    #[test]
+    fn known_fitness_skips_seeding_eval_when_in_bounds() {
+        // On a flat landscape the f-spread is zero, so the main loop breaks right
+        // after simplex initialization. Init scores vertex 0 plus `dim` nudged
+        // vertices; a valid (in-bounds) hint elides the vertex-0 eval, i.e. one
+        // fewer evaluation.
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let start = vec![1.0_f32, 2.0, 3.0]; // in bounds
+
+        let refine_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(41);
+            let _ = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start.clone(),
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        let hint_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(41);
+            let _ = LocalSearch::<TestBackend>::refine_with_known_fitness(
+                &searcher,
+                &params,
+                start.clone(),
+                1.0, // Flat fitness of the start
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        assert_eq!(
+            hint_evals + 1,
+            refine_evals,
+            "in-bounds hint must skip exactly the vertex-0 eval ({hint_evals} vs {refine_evals})"
+        );
+    }
+
+    #[test]
+    fn out_of_bounds_hint_is_ignored() {
+        // Vertex 0 is the *clamped* input, so a hint describing the raw
+        // out-of-bounds input is invalid and must be discarded: the searcher
+        // falls back to evaluating vertex 0, spending the same evals as `refine`
+        // and returning an honest fitness — never the bogus hint value.
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let start = vec![100.0_f32, 100.0]; // far above the upper bound
+
+        let refine_evals = {
+            let mut base = Sphere;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(42);
+            let _ = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start.clone(),
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        let (g, fit, hint_evals) = {
+            let mut base = Sphere;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(42);
+            let (g, fit) = LocalSearch::<TestBackend>::refine_with_known_fitness(
+                &searcher,
+                &params,
+                start.clone(),
+                -999.0, // bogus: must never be returned
+                &mut counting,
+                &mut rng,
+            );
+            (g, fit, counting.calls)
+        };
+        assert_eq!(
+            hint_evals, refine_evals,
+            "out-of-bounds hint must fall back to evaluating vertex 0"
+        );
+        let mut fresh_fn = Sphere;
+        let fresh = fresh_fn.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
+        assert!(fit >= 0.0, "sphere fitness is non-negative; bogus hint leaked: {fit}");
+    }
+
+    #[test]
+    fn nan_hint_does_not_propagate() {
+        let searcher = NelderMead;
+        let params = NelderMeadParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(43);
+        let start = vec![2.0_f32, -1.0]; // in bounds
+        let (g, fit) = LocalSearch::<TestBackend>::refine_with_known_fitness(
+            &searcher,
+            &params,
+            start,
+            f32::NAN,
+            &mut fitness,
+            &mut rng,
+        );
+        assert!(fit.is_finite(), "NaN hint must be sanitized, got {fit}");
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/local_search/random_restart.rs
+++ b/crates/rlevo-evolution/src/local_search/random_restart.rs
@@ -146,9 +146,17 @@ impl<L> RandomRestart<L> {
     }
 }
 
-impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
-    type Params = RandomRestartParams<L::Params>;
-
+impl<L> RandomRestart<L> {
+    /// Shared body for [`refine`](LocalSearch::refine) and
+    /// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness).
+    ///
+    /// A `known` fitness describes the *unperturbed* input, so it is forwarded
+    /// only to **run 0** (which refines that input); the `restarts` perturbed
+    /// runs start from jittered points with no known fitness and always take the
+    /// plain `inner.refine` path. Because the inner seeding eval draws no rng,
+    /// forwarding the hint leaves run 0's rng consumption — and thus the
+    /// load-bearing run-0-first ordering — bit-identical to the no-hint path.
+    ///
     /// # Panics
     ///
     /// Panics if `params.restarts > 0` and `params.perturbation` is not
@@ -158,13 +166,17 @@ impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
     /// duplicate runs. `restarts == 0` is a valid configuration (a plain inner
     /// run) and never panics here. The inner searcher enforces its own
     /// `max_iters >= 1` invariant and will panic on a zero inner budget.
-    fn refine(
+    fn refine_impl<B: Backend>(
         &self,
         params: &RandomRestartParams<L::Params>,
-        genome: Vec<f32>,
+        genome: &[f32],
+        known: Option<f32>,
         fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
         rng: &mut dyn Rng,
-    ) -> (Vec<f32>, f32) {
+    ) -> (Vec<f32>, f32)
+    where
+        L: LocalSearch<B>,
+    {
         assert!(
             params.restarts == 0 || params.perturbation > 0.0,
             "RandomRestartParams::perturbation must be > 0 when restarts > 0 \
@@ -175,9 +187,20 @@ impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
         // docs): it makes run 0 consume the rng stream exactly as a bare
         // `inner.refine` call would, so monotonicity is structural and the
         // `restarts > 0` result is bit-exactly `<=` the `restarts == 0` result
-        // on the same seed.
-        let (mut best_genome, mut best_fit): (Vec<f32>, f32) =
-            self.inner.refine(&params.inner, genome.clone(), fitness_fn, rng);
+        // on the same seed. A known fitness describes this unperturbed input, so
+        // it is forwarded here and nowhere else.
+        let (mut best_genome, mut best_fit): (Vec<f32>, f32) = match known {
+            Some(f) => self.inner.refine_with_known_fitness(
+                &params.inner,
+                genome.to_vec(),
+                f,
+                fitness_fn,
+                rng,
+            ),
+            None => self
+                .inner
+                .refine(&params.inner, genome.to_vec(), fitness_fn, rng),
+        };
 
         // Runs 1..=restarts: perturb the input with per-coordinate Gaussian
         // noise drawn through the passed rng, clamp to bounds, refine. Replace
@@ -187,7 +210,7 @@ impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
             let normal: Normal<f32> = Normal::new(0.0_f32, params.perturbation)
                 .expect("perturbation std-dev is strictly positive (asserted above)");
             for _ in 0..params.restarts {
-                let mut start: Vec<f32> = genome.clone();
+                let mut start: Vec<f32> = genome.to_vec();
                 for coord in &mut start {
                     *coord += normal.sample(rng);
                 }
@@ -203,6 +226,43 @@ impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
         }
 
         (best_genome, best_fit)
+    }
+}
+
+impl<B: Backend, L: LocalSearch<B>> LocalSearch<B> for RandomRestart<L> {
+    type Params = RandomRestartParams<L::Params>;
+
+    /// # Panics
+    ///
+    /// Panics if `params.restarts > 0` and `params.perturbation` is not strictly
+    /// positive; see `refine_impl`.
+    fn refine(
+        &self,
+        params: &RandomRestartParams<L::Params>,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        self.refine_impl::<B>(params, &genome, None, fitness_fn, rng)
+    }
+
+    /// Forwards `known_fitness` to **run 0** (the unperturbed input) so its inner
+    /// searcher skips its seeding eval; perturbed runs are unaffected. See
+    /// `refine_impl`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params.restarts > 0` and `params.perturbation` is not strictly
+    /// positive; see `refine_impl`.
+    fn refine_with_known_fitness(
+        &self,
+        params: &RandomRestartParams<L::Params>,
+        genome: Vec<f32>,
+        known_fitness: f32,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        self.refine_impl::<B>(params, &genome, Some(known_fitness), fitness_fn, rng)
     }
 }
 
@@ -529,5 +589,72 @@ mod tests {
 
         assert_eq!(g_a, g_b);
         assert_eq!(f_a, f_b);
+    }
+
+    #[test]
+    fn known_fitness_saves_exactly_one_eval_total() {
+        // The hint is forwarded only to run 0 (the unperturbed input); the
+        // perturbed runs are untouched. With an inner budget large enough that
+        // step-underflow (not the budget) terminates each run, total evals drop
+        // by exactly one: run 0's seeding eval.
+        let searcher = RandomRestart::new(HillClimbing);
+        let mut inner = HillClimbingParams::default_for(BOUNDS);
+        inner.max_iters = 10_000;
+        let params = rr_params(inner, 3);
+        let start = vec![1.0_f32, 2.0, 3.0];
+
+        let refine_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(51);
+            let _ = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start.clone(),
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        let hint_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(51);
+            let _ = LocalSearch::<TestBackend>::refine_with_known_fitness(
+                &searcher,
+                &params,
+                start.clone(),
+                1.0, // Flat fitness of the start
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        assert_eq!(
+            hint_evals + 1,
+            refine_evals,
+            "hint must save exactly run 0's seeding eval ({hint_evals} vs {refine_evals})"
+        );
+    }
+
+    #[test]
+    fn nan_hint_does_not_propagate() {
+        let searcher = RandomRestart::new(HillClimbing);
+        let inner = HillClimbingParams::default_for(BOUNDS);
+        let params = rr_params(inner, 3);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(52);
+        let start = vec![2.0_f32, -1.0];
+        let (g, fit) = LocalSearch::<TestBackend>::refine_with_known_fitness(
+            &searcher,
+            &params,
+            start,
+            f32::NAN,
+            &mut fitness,
+            &mut rng,
+        );
+        assert!(fit.is_finite(), "NaN hint must be sanitized, got {fit}");
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
+++ b/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
@@ -25,7 +25,7 @@ use rand::{Rng, RngExt};
 use rand_distr::{Distribution as _, Normal};
 
 use crate::fitness::FitnessFn;
-use crate::local_search::{clamp_vec, BudgetedEval, LocalSearch};
+use crate::local_search::{clamp_vec, sanitize_fitness, BudgetedEval, LocalSearch};
 
 /// Temperature-cooling schedule for [`SimulatedAnnealing`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -120,18 +120,24 @@ impl SimulatedAnnealingParams {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SimulatedAnnealing;
 
-impl<B: Backend> LocalSearch<B> for SimulatedAnnealing {
-    type Params = SimulatedAnnealingParams;
-
+impl SimulatedAnnealing {
+    /// Shared body for [`refine`](LocalSearch::refine) and
+    /// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness).
+    ///
+    /// `known` is the input genome's fitness when the caller already holds it
+    /// (the hint path) or `None` when the input must be re-evaluated to seed the
+    /// walker and the best-so-far tracker. The seed is sanitized either way so a
+    /// `NaN` never poisons the tracked best.
+    ///
     /// # Panics
     ///
     /// Panics if `params.max_iters == 0`: a zero evaluation budget makes it
     /// impossible to return an honestly evaluated fitness, so it is treated as
     /// an invalid configuration (programming error), not runtime data.
-    fn refine(
-        &self,
+    fn refine_impl(
         params: &SimulatedAnnealingParams,
         genome: Vec<f32>,
+        known: Option<f32>,
         fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
         rng: &mut dyn Rng,
     ) -> (Vec<f32>, f32) {
@@ -142,11 +148,16 @@ impl<B: Backend> LocalSearch<B> for SimulatedAnnealing {
         );
         let mut budget: BudgetedEval = BudgetedEval::new(fitness_fn, params.max_iters);
 
-        // First action: evaluate the input genome (1 eval) and seed both the
-        // walker and the best-so-far tracker. The assert above guarantees this
-        // succeeds.
-        let Some(initial_fit) = budget.eval(&genome) else {
-            unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+        // First action: seed both the walker and the best-so-far tracker. With a
+        // known fitness we reuse it (sanitizing NaN); otherwise we spend one eval
+        // scoring the input. The assert above guarantees the eval path succeeds.
+        let initial_fit: f32 = if let Some(f) = known {
+            sanitize_fitness(f)
+        } else {
+            let Some(f) = budget.eval(&genome) else {
+                unreachable!("budget of >= 1 cannot be exhausted before the first eval");
+            };
+            f
         };
 
         // The walker — may drift uphill when an uphill move is accepted.
@@ -213,6 +224,40 @@ impl<B: Backend> LocalSearch<B> for SimulatedAnnealing {
         }
 
         (best, best_fit)
+    }
+}
+
+impl<B: Backend> LocalSearch<B> for SimulatedAnnealing {
+    type Params = SimulatedAnnealingParams;
+
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`; see `refine_impl`.
+    fn refine(
+        &self,
+        params: &SimulatedAnnealingParams,
+        genome: Vec<f32>,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        Self::refine_impl(params, genome, None, fitness_fn, rng)
+    }
+
+    /// Seeds the walker and best-so-far tracker with `known_fitness` (sanitizing
+    /// `NaN` to `+inf`) instead of re-scoring the input, saving one eval.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `params.max_iters == 0`; see `refine_impl`.
+    fn refine_with_known_fitness(
+        &self,
+        params: &SimulatedAnnealingParams,
+        genome: Vec<f32>,
+        known_fitness: f32,
+        fitness_fn: &mut dyn FitnessFn<Vec<f32>>,
+        rng: &mut dyn Rng,
+    ) -> (Vec<f32>, f32) {
+        Self::refine_impl(params, genome, Some(known_fitness), fitness_fn, rng)
     }
 }
 
@@ -564,5 +609,70 @@ mod tests {
             "expected sustained uphill exploration at high temperature, saw {worse_than_best} \
              worse-than-best evaluations"
         );
+    }
+
+    #[test]
+    fn known_fitness_skips_exactly_the_seeding_eval() {
+        // With a large budget the walk terminates by `min_temp`, not the budget,
+        // after a fixed number of cooling steps (one proposal each). The seeding
+        // eval draws no rng, so both entry points draw the identical proposal
+        // sequence — the hint path simply omits the seed.
+        let searcher = SimulatedAnnealing;
+        let mut params = SimulatedAnnealingParams::default_for(BOUNDS);
+        params.max_iters = 10_000;
+        let start = vec![1.0_f32, 2.0, 3.0];
+
+        let refine_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(31);
+            let _ = LocalSearch::<TestBackend>::refine(
+                &searcher,
+                &params,
+                start.clone(),
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        let hint_evals = {
+            let mut base = Flat;
+            let mut counting = Counting::new(&mut base);
+            let mut rng = StdRng::seed_from_u64(31);
+            let _ = LocalSearch::<TestBackend>::refine_with_known_fitness(
+                &searcher,
+                &params,
+                start.clone(),
+                1.0, // Flat fitness of the start
+                &mut counting,
+                &mut rng,
+            );
+            counting.calls
+        };
+        assert_eq!(
+            hint_evals + 1,
+            refine_evals,
+            "hint path must skip exactly the seeding eval ({hint_evals} vs {refine_evals})"
+        );
+    }
+
+    #[test]
+    fn nan_hint_does_not_propagate() {
+        let searcher = SimulatedAnnealing;
+        let params = SimulatedAnnealingParams::default_for(BOUNDS);
+        let mut fitness = Sphere;
+        let mut rng = StdRng::seed_from_u64(32);
+        let start = vec![2.0_f32, -1.0];
+        let (g, fit) = LocalSearch::<TestBackend>::refine_with_known_fitness(
+            &searcher,
+            &params,
+            start,
+            f32::NAN,
+            &mut fitness,
+            &mut rng,
+        );
+        assert!(fit.is_finite(), "NaN hint must be sanitized, got {fit}");
+        let fresh = fitness.evaluate_one(&g);
+        approx::assert_relative_eq!(fit, fresh, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo/examples/evo/memetic_showcase.rs
+++ b/crates/rlevo/examples/evo/memetic_showcase.rs
@@ -29,8 +29,8 @@
 //! - The **headline** row (`TopK{1}`, best-improvement hill climbing,
 //!   `max_iters=20`, Lamarckian) reaches each target in substantially fewer
 //!   evaluations than bare DE — the same calibrated configuration pinned by
-//!   the `memetic_rastrigin` acceptance test (~54% fewer at target 30), which
-//!   verified the win across five seeds.
+//!   the `memetic_rastrigin` acceptance test (~74% fewer at target 30 on the
+//!   pinned seed), which verified the win across five seeds.
 //! - The **writeback** rows vary only `WritebackPolicy`. Lamarckian writes
 //!   refined genomes back into the population; Baldwinian keeps the genomes
 //!   untouched and only credits the refined fitness; `Partial(0.5)` (the
@@ -266,8 +266,8 @@ CR=0.9) and one seed.\n\n{:-<120}",
     println!(
         "{:-<120}
 Takeaway: the headline row is the robust, multi-seed-calibrated win the
-acceptance test pins (~54% fewer evals than bare DE to reach 30). The
-writeback rows show the policy choice alone can move — or lose — the
+acceptance test pins (~74% fewer evals than bare DE to reach 30 on the pinned
+seed). The writeback rows show the policy choice alone can move — or lose — the
 advantage at tight targets. The untuned-defaults row dominates only because
 Rastrigin is separable and axis-aligned hill climbing with basin-width steps
 exploits that perfectly; do not expect it to transfer to non-separable

--- a/crates/rlevo/tests/memetic_rastrigin.rs
+++ b/crates/rlevo/tests/memetic_rastrigin.rs
@@ -312,34 +312,45 @@ fn calibration_explorer() {
 // =====================================================================
 // Headline acceptance test (the only test that runs by default).
 //
-// Provenance (pinned from `calibration_explorer` output, 2026-06-10):
+// Provenance (re-pinned from `calibration_explorer` output, 2026-06-12, after
+// `refine_with_known_fitness` eliminated the per-refine seeding eval, issue #30):
 //   backend:   Flex (ndarray), rayon pinned to 1 thread, release profile.
 //   seed:      7
 //   target:    Rastrigin-D10 best_fitness_ever < 30.0
 //   inner DE:  pop=30, D=10, Rand1Bin, F=0.5, CR=0.9 (DeConfig::default_for).
 //   memetic:   HillClimbing BestImprovement, max_iters=20, step=0.4, decay=0.5,
 //              CoveragePolicy::TopK{1}, WritebackPolicy::Lamarckian.
-//   observed:  bare = 11_130 evals, memetic = 5_150 evals
-//              (memetic uses ~53.7% fewer evals than bare DE to reach 30.0).
+//   observed:  bare = 11_130 evals, memetic = 2_900 evals
+//              (memetic uses ~74% fewer evals than bare DE to reach 30.0).
+//
+// Why the pinned number dropped from 5_150 to 2_900:
+//   With max_iters=20 and D=10, one BestImprovement sweep costs 2*D = 20 evals.
+//   The old seeding eval left only 19 for the sweep, so it ran one probe short
+//   of completing and never committed a move; eliminating that eval lets the
+//   sweep finish and commit, so each refined generation makes real progress.
+//   The win is therefore larger than the bare "one eval/gen" saving — it crosses
+//   the sweep-granularity boundary.
 //
 // Why target=30 (not 20/10/5):
 //   - At target=10/5 bare DE often STALLS without ever reaching it (final
 //     best 6-17 on most seeds), so a "fewer evals to a SHARED target"
 //     comparison is not well-posed there — both configs must reach it.
-//   - At target=20 the `k1/it20/best/lam` config still wins on every seed but
-//     the headroom is thin on some (seed 101: only ~4% fewer).
-//   - At target=30 BOTH configs always reach the target and memetic has
-//     comfortable headroom on every calibration seed (ratio mem/bare ranged
-//     0.34-0.71; worst case still 29% fewer). Seed 7 sits mid-pack at 0.463.
+//   - At target=30 BOTH configs always reach the target and memetic WINS on
+//     every calibration seed {7,13,29,101,1234}, though the margin is now wider-
+//     spread than before: ratio mem/bare ranged ~0.08 (seed 29) to ~0.89
+//     (seed 101) — i.e. 11%-92% fewer. The spread comes from Lamarckian
+//     writeback: the extra committed sweep changes the genome fed back to DE, so
+//     each seed takes a genuinely different trajectory. Seed 7 is a strong,
+//     stable win at ~74% fewer (ratio 0.26).
 //
 // Margin choice:
-//   Calibration showed ≥30% fewer evals on every seed and ~54% on the pinned
-//   seed, so we assert the ≥30% margin via integer math
-//   `memetic_evals * 10 <= bare_evals * 7` (no float comparison). On the
-//   pinned data: 5_150*10 = 51_500 <= 11_130*7 = 77_910. We also assert an
-//   absolute tripwire `bare_evals >= 8_000` so a future regression that makes
-//   bare DE trivially slow (inflating the ratio) cannot mask a memetic
-//   slowdown.
+//   The cross-seed margin is no longer uniformly >=30% (seeds 101/1234 are now
+//   ~11%/~19% fewer), so the assertion is deliberately scoped to the PINNED seed,
+//   where the win is robust. We assert the >=30% margin via integer math
+//   `memetic_evals * 10 <= bare_evals * 7` (no float comparison). On the pinned
+//   data: 2_900*10 = 29_000 <= 11_130*7 = 77_910. We also assert an absolute
+//   tripwire `bare_evals >= 8_000` so a future regression that makes bare DE
+//   trivially slow (inflating the ratio) cannot mask a memetic slowdown.
 // =====================================================================
 
 const PINNED_SEED: u64 = 7;
@@ -381,7 +392,7 @@ fn memetic_beats_bare_de_on_rastrigin_evals_to_target() {
     );
 
     // (c) pinned margin: ≥30% fewer evals, integer math (no float comparison).
-    //     5_150*10 = 51_500 <= 11_130*7 = 77_910 on the pinned data.
+    //     2_900*10 = 29_000 <= 11_130*7 = 77_910 on the pinned data.
     assert!(
         memetic_evals * 10 <= bare_evals * 7,
         "memetic must use >=30% fewer evals: memetic={memetic_evals} bare={bare_evals} \


### PR DESCRIPTION
## Summary

Memetic local search wastes one fitness evaluation per refined individual per
generation: the frozen `LocalSearch::refine` signature carries no input fitness,
so every searcher's first action is to re-score its own input genome just to seed
its best-so-far tracker. `MemeticWrapper::tell` already holds that exact value
(the harness fitness tensor it reads as `refined_fit[i]`), so the re-evaluation is
avoidable. This PR adds a defaulted `LocalSearch::refine_with_known_fitness` trait
method that seeds the tracker from the supplied fitness instead of burning an
eval, overrides it in all four reference searchers, and wires the wrapper to pass
the fitness it already computed. The change is purely additive — the default
delegates to `refine`, so the `Strategy`/harness surface and every manifest are
byte-unchanged.

## Change Type

- [x] Other — _performance optimization of an existing API (memetic local
  search), pre-cleared by ADR 0016 §Reversal criteria. No new env/algorithm/dep;
  the only public-API change is one defaulted, backward-compatible trait method._

## Linked Issue

Closes #30

## What Was Changed

- **`crates/rlevo-evolution/src/local_search.rs`** — added the defaulted
  `LocalSearch::refine_with_known_fitness` trait method (delegates to `refine`);
  extracted a `pub(crate) sanitize_fitness` helper as the single `NaN → +inf`
  rule and routed `BudgetedEval::eval` through it; updated the trait contract,
  module "Evaluation budget" note, and `BudgetedEval` docs.
- **`local_search/hill_climbing.rs`, `simulated_annealing.rs`, `nelder_mead.rs`**
  — extracted each `refine` body into a private `refine_impl(known: Option<f32>)`
  associated function; `refine` passes `None`, `refine_with_known_fitness` passes
  `Some`. NelderMead additionally guards the hint behind an in-bounds check
  (vertex 0 is the *clamped* input, so the raw-input hint is only valid when
  clamping is a no-op; otherwise it falls back to evaluating).
- **`local_search/random_restart.rs`** — `refine_impl(&self, &[f32],
  Option<f32>)` forwards the hint to **run 0 only** (the unperturbed input);
  perturbed runs take the plain `refine` path.
- **`crates/rlevo-evolution/src/algorithms/memetic.rs`** — `tell` now calls
  `refine_with_known_fitness(refined_fit[i])`; reframed the `CoveragePolicy`
  rustdoc tuning note (the seeding-eval waste it described is now resolved).
- **`crates/rlevo/tests/memetic_rastrigin.rs`** — re-pinned the headline
  eval counts and provenance prose (5,150 → 2,900) and scoped the ≥30% margin
  rationale to the pinned seed.
- **`crates/rlevo/examples/evo/memetic_showcase.rs`** — updated stale `~54%`
  comments to `~74%`.
- **Tests added (9):** per searcher, a "skips exactly the seeding eval" count
  test and a "NaN hint does not propagate" test; NelderMead additionally gets an
  "out-of-bounds hint is ignored (falls back, returns honest fitness)" test.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo test -p rlevo-evolution        # 123 unit (+9 new) + determinism + 33 doctests
cargo test -p rlevo --test memetic_rastrigin -- --nocapture
RUSTDOCFLAGS="-D warnings" cargo doc -p rlevo-evolution --no-deps
cargo clippy -p rlevo-evolution -p rlevo --all-targets --all-features
cargo run -p rlevo --example memetic_showcase --release
```

Key results:
- `rlevo-evolution`: 123 unit tests (was 114; +9 hint-path tests), determinism
  integration test (run==rerun, unchanged — the seeding eval draws no RNG so
  skipping it shifts no stream), and 33 doctests — all pass.
- Headline `memetic_rastrigin` (pinned seed 7, target Rastrigin-D10 < 30):
  `bare_evals=11130 memetic_evals=2900` — **~74% fewer** (was ~54% / 5,150). The
  larger win is a sweep-granularity effect: best-improvement HC at `max_iters=20`
  on D=10 needs `2·D=20` evals per sweep, so the old seeding eval left each sweep
  one probe short of committing a move; eliminating it lets the sweep complete.
  Multi-seed `calibration_explorer` confirms memetic still wins on all five seeds
  {7,13,29,101,1234} (margin spread widened to ~11%–92% because Lamarckian
  writeback makes each seed's trajectory genuinely different).
- `RUSTDOCFLAGS="-D warnings" cargo doc`: clean.
- Clippy: zero warnings in the touched crates/files.

- Rust toolchain: `stable 1.94.1 (e408947bf 2026-03-25)`
- Burn backend tested: Flex (ndarray), rayon pinned to 1 thread
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: full
  implementation, tests, doc updates, and headline recalibration, authored under
  human review; submitter is responsible for and can defend every line.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings in the
  touched crates. _(Pre-existing pedantic warnings remain in unrelated targets,
  e.g. the `dqn_integration` test — not introduced or modified here.)_
- [x] Public API additions include doc comments explaining *what* and *why* (the
  new trait method, its NaN-sanitization contract, and the NelderMead clamp
  guard are all documented).
- [x] Regression/behavior tests added that exercise the new path (one-fewer-eval,
  NaN-hint sanitization, NelderMead out-of-bounds fallback).
- [x] This PR addresses a single concern (issue #30 only).
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- **Sequencing:** ADR 0016 originally gated this fix on a "second consumer of the
  seam." That consumer (phase 3d neuroevolution) has not landed; this PR pulls
  the optimization forward for the standalone eval-budget win, and the method
  shape is designed to still satisfy that future consumer. ADR 0016 is immutable
  and not edited.
- **NaN safety (load-bearing):** `known_fitness` arrives from the harness fitness
  tensor, a path that bypasses `BudgetedEval`'s `NaN → +inf` chokepoint (added in
  9744712). Every override sanitizes the hint via the shared `sanitize_fitness`
  so a `NaN` can never seed the tracker — preserving the invariant that commit
  established.
- **Deferred (not in scope):** the fresh-fitness invariant under *stochastic*
  fitness functions remains documented-as-deterministic-only; revisit when
  `rlevo-hybrid` first consumes the seam (phase 3d).

