### PR TITLE
feat(eda): Add ProbabilityModel trait and EDA strategies (phase 3b)

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
@@ -1,0 +1,332 @@
+//! Compact Genetic Algorithm (cGA) model for binary search spaces.
+//!
+//! cGA represents a virtual binary population as a per-gene probability vector
+//! and emulates a steady-state GA of size `virtual_pop_size` without storing
+//! the population explicitly. [`fit`] competes the **winner** (best fitness)
+//! against the **loser** (worst fitness) of the truncation-selected subset: on
+//! every gene where they disagree the probability is nudged by
+//! `±1 / virtual_pop_size` toward the winner's bit. [`sample`] emits raw
+//! `{0, 1}` `f32` genes; [`EdaParams::bounds`](crate::algorithms::eda::EdaParams::bounds) clamps are therefore no-ops.
+//!
+//! # Deviation from classic cGA
+//!
+//! The textbook cGA (Harik et al., 1999) draws *two* individuals uniformly at
+//! random from the whole population and competes them. Here the winner and
+//! loser are the best and worst of the **truncation-selected subset** handed to
+//! [`fit`](ProbabilityModel::fit) by
+//! [`EdaStrategy`](crate::algorithms::eda::EdaStrategy), so the update is
+//! biased by the selection pressure already applied upstream.
+//!
+//! # References
+//!
+//! - Harik, Lobo & Goldberg (1999), *The compact genetic algorithm*.
+//!
+//! [`fit`]: crate::ProbabilityModel::fit
+//! [`sample`]: crate::ProbabilityModel::sample
+
+use burn::tensor::{Tensor, TensorData, backend::Backend};
+use rand::{Rng, RngExt};
+
+use crate::probability_model::ProbabilityModel;
+
+/// Per-run configuration for the [`CompactGenetic`] model.
+///
+/// Held inside [`EdaParams::model`](crate::algorithms::eda::EdaParams::model)
+/// for the lifetime of a run. Use [`CompactGeneticParams::default_for`] for
+/// typical cGA defaults.
+#[derive(Debug, Clone)]
+pub struct CompactGeneticParams {
+    /// Number of bits per genome; determines the length of
+    /// [`CompactGeneticState::prob`].
+    pub genome_dim: usize,
+    /// Size of the virtual population being emulated; the per-generation
+    /// probability step is `1 / virtual_pop_size`. Larger values slow
+    /// convergence and preserve diversity; the original paper uses values in
+    /// the range `[50, 200]`.
+    pub virtual_pop_size: usize,
+}
+
+impl CompactGeneticParams {
+    /// Sensible cGA defaults for a `genome_dim`-bit problem.
+    #[must_use]
+    pub fn default_for(genome_dim: usize) -> Self {
+        Self {
+            genome_dim,
+            virtual_pop_size: 50,
+        }
+    }
+}
+
+/// Fitted state for the [`CompactGenetic`] model after one call to
+/// [`ProbabilityModel::fit`].
+///
+/// The vector has length `genome_dim`. On the prior path (`prev = None`) it
+/// is uniformly `0.5`; on subsequent calls entries are nudged by
+/// `±1 / virtual_pop_size` and clamped to `[0, 1]`.
+#[derive(Debug, Clone)]
+pub struct CompactGeneticState {
+    /// Per-gene probability of sampling a `1.0` (always in `[0, 1]`).
+    pub prob: Vec<f32>,
+}
+
+/// Compact Genetic Algorithm for binary spaces (cGA).
+///
+/// Implements [`ProbabilityModel`] with a per-gene probability vector updated
+/// by winner/loser competition from the truncation-selected subset. Samples
+/// are raw `{0, 1}` `f32` values; [`EdaParams::bounds`](crate::algorithms::eda::EdaParams::bounds)
+/// clamps are no-ops for this model.
+///
+/// See the [module docs](self) for the update rule, the deviation from classic
+/// cGA, and the reference.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CompactGenetic;
+
+impl<B: Backend> ProbabilityModel<B> for CompactGenetic {
+    type Params = CompactGeneticParams;
+    type State = CompactGeneticState;
+
+    /// Update the per-gene probability vector by winner/loser competition.
+    ///
+    /// When `prev = None` returns the uniform-`0.5` prior; `population` and
+    /// `fitness` are ignored on that path. Otherwise finds the argmin (winner)
+    /// and argmax (loser) of the fitness vector, then nudges each gene where
+    /// winner and loser disagree by `±1 / virtual_pop_size` (toward the
+    /// winner), clamped to `[0, 1]`.
+    fn fit(
+        &self,
+        params: &Self::Params,
+        prev: Option<&Self::State>,
+        population: Tensor<B, 2>,
+        fitness: Tensor<B, 1>,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let _ = device;
+        let Some(prev) = prev else {
+            // Prior path: uniform 0.5 per gene; population/fitness ignored.
+            let _ = (population, fitness);
+            return CompactGeneticState {
+                prob: vec![0.5; params.genome_dim],
+            };
+        };
+
+        let [k, d] = population.dims();
+        let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
+        let fit_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+
+        // Winner = argmin, loser = argmax; ties → lowest index.
+        let mut winner_idx = 0_usize;
+        let mut loser_idx = 0_usize;
+        let mut best_f = f32::INFINITY;
+        let mut worst_f = f32::NEG_INFINITY;
+        for i in 0..k {
+            let f = fit_host.get(i).copied().unwrap_or(f32::INFINITY);
+            if f.total_cmp(&best_f) == std::cmp::Ordering::Less {
+                best_f = f;
+                winner_idx = i;
+            }
+            if f.total_cmp(&worst_f) == std::cmp::Ordering::Greater {
+                worst_f = f;
+                loser_idx = i;
+            }
+        }
+
+        // virtual_pop_size is a small tunable count, far below f32's 2^24
+        // exact-integer limit; the cast is lossless in practice.
+        #[allow(clippy::cast_precision_loss)]
+        let step = 1.0 / params.virtual_pop_size as f32;
+        let mut prob = prev.prob.clone();
+        for j in 0..d {
+            let winner = rows[winner_idx * d + j];
+            let loser = rows[loser_idx * d + j];
+            // Only nudge genes where winner and loser disagree.
+            if (winner - loser).abs() > 0.5 {
+                if winner > 0.5 {
+                    prob[j] += step;
+                } else {
+                    prob[j] -= step;
+                }
+                prob[j] = prob[j].clamp(0.0, 1.0);
+            }
+        }
+
+        CompactGeneticState { prob }
+    }
+
+    /// Draw `n` binary genomes from the per-gene Bernoulli probabilities.
+    ///
+    /// Each gene is sampled independently as `1.0` with probability `prob[j]`,
+    /// `0.0` otherwise, using the supplied host RNG (never `Tensor::random` /
+    /// `B::seed`). The returned tensor has shape `(n, D)` and contains only
+    /// `0.0` and `1.0` values.
+    fn sample(
+        &self,
+        state: &Self::State,
+        n: usize,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Tensor<B, 2> {
+        let d = state.prob.len();
+        let mut rows = Vec::with_capacity(n * d);
+        // Row-major: outer individuals, inner dimensions.
+        for _ in 0..n {
+            for &p in &state.prob {
+                let gene = if rng.random::<f32>() < p { 1.0 } else { 0.0 };
+                rows.push(gene);
+            }
+        }
+        Tensor::<B, 2>::from_data(TensorData::new(rows, [n, d]), device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestBackend = Flex;
+
+    fn pop(rows: Vec<f32>, n: usize, d: usize) -> Tensor<TestBackend, 2> {
+        let device = Default::default();
+        Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [n, d]), &device)
+    }
+
+    fn fitness(values: Vec<f32>) -> Tensor<TestBackend, 1> {
+        let device = Default::default();
+        let n = values.len();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(values, [n]), &device)
+    }
+
+    fn fit_prior(p: &CompactGeneticParams) -> CompactGeneticState {
+        let device = Default::default();
+        <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        )
+    }
+
+    #[test]
+    fn prior_is_half() {
+        let p = CompactGeneticParams::default_for(3);
+        assert_eq!(fit_prior(&p).prob, vec![0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn nudge_is_exactly_one_over_vps() {
+        let device = Default::default();
+        let p = CompactGeneticParams {
+            genome_dim: 2,
+            virtual_pop_size: 10,
+        };
+        let prior = fit_prior(&p);
+        // winner = row 0 (fitness 0): genes [1, 0]. loser = row 1: genes [0, 1].
+        // Both genes differ: gene 0 winner=1 → +0.1; gene 1 winner=0 → -0.1.
+        let state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 0.0, 0.0, 1.0], 2, 2),
+            fitness(vec![0.0, 1.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.prob[0], 0.6, epsilon = 1e-6);
+        approx::assert_relative_eq!(state.prob[1], 0.4, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn clamp_at_zero_and_one() {
+        let device = Default::default();
+        let p = CompactGeneticParams {
+            genome_dim: 2,
+            virtual_pop_size: 2,
+        };
+        let mut state = CompactGeneticState {
+            prob: vec![0.9, 0.1],
+        };
+        // gene 0: winner=1 → +0.5 → 1.4 clamped to 1.0.
+        // gene 1: winner=0 → -0.5 → -0.4 clamped to 0.0.
+        for _ in 0..3 {
+            state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+                &CompactGenetic,
+                &p,
+                Some(&state),
+                pop(vec![1.0, 0.0, 0.0, 1.0], 2, 2),
+                fitness(vec![0.0, 1.0]),
+                &device,
+            );
+        }
+        approx::assert_relative_eq!(state.prob[0], 1.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(state.prob[1], 0.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn genes_where_winner_equals_loser_untouched() {
+        let device = Default::default();
+        let p = CompactGeneticParams {
+            genome_dim: 2,
+            virtual_pop_size: 10,
+        };
+        let prior = fit_prior(&p);
+        // gene 0: winner=1, loser=1 (same) → untouched at 0.5.
+        // gene 1: winner=1, loser=0 (differ) → +0.1 → 0.6.
+        let state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 1.0, 1.0, 0.0], 2, 2),
+            fitness(vec![0.0, 1.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.prob[0], 0.5, epsilon = 1e-6);
+        approx::assert_relative_eq!(state.prob[1], 0.6, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn not_the_column_mean() {
+        let device = Default::default();
+        let p = CompactGeneticParams {
+            genome_dim: 1,
+            virtual_pop_size: 10,
+        };
+        let prior = fit_prior(&p);
+        // Column mean of [1, 0, 0] is 1/3 ≈ 0.333. cGA instead nudges 0.5 by
+        // +0.1 to 0.6 (winner=row 0 with gene 1, loser=row 2 with gene 0).
+        let state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 0.0, 0.0], 3, 1),
+            fitness(vec![0.0, 1.0, 2.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.prob[0], 0.6, epsilon = 1e-6);
+        assert!((state.prob[0] - 1.0 / 3.0).abs() > 0.2);
+    }
+
+    #[test]
+    fn samples_are_binary() {
+        let device = Default::default();
+        let state = CompactGeneticState {
+            prob: vec![0.2, 0.8],
+        };
+        let mut rng = StdRng::seed_from_u64(11);
+        let samples = <CompactGenetic as ProbabilityModel<TestBackend>>::sample(
+            &CompactGenetic,
+            &state,
+            300,
+            &mut rng,
+            &device,
+        );
+        for v in samples.into_data().into_vec::<f32>().unwrap() {
+            // Exact float compare is correct: sample() writes literal 0.0/1.0.
+            #[allow(clippy::float_cmp)]
+            let is_binary = v == 0.0 || v == 1.0;
+            assert!(is_binary);
+        }
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
@@ -1,0 +1,544 @@
+//! Continuous-Gaussian dependency-chain model (MIMIC-style EDA) for continuous
+//! search spaces.
+//!
+//! Unlike [`super::univariate_gaussian`], this model captures *pairwise*
+//! dependencies. [`fit`] estimates per-dimension Gaussians **and** builds a
+//! dimension ordering (chain `c₀ → c₁ → … → c_{D-1}`) that maximises captured
+//! mutual information, then represents the joint as a first-order chain: each
+//! dimension is conditionally Gaussian given its predecessor. [`sample`] walks
+//! the chain, drawing each gene from the conditional Gaussian of its parent's
+//! sampled value.
+//!
+//! The chain is built greedily à la MIMIC (De Bonet et al., 1997): the root
+//! is the dimension with the smallest marginal standard deviation (lowest
+//! marginal entropy), and each subsequent link is the unvisited dimension with
+//! the highest mutual information to the last chosen one.
+//!
+//! The `fitness` tensor is accepted by the [`ProbabilityModel`] interface but
+//! always ignored; the fit is unweighted.
+//!
+//! # Estimator regularisation
+//!
+//! Sample Pearson correlations from `k` selected rows have a standard error
+//! of approximately `1/√k` under the null hypothesis of independence. Treating
+//! those spurious correlations as real dependency injects noise into every
+//! conditional mean — a penalty the univariate model never pays. To suppress
+//! this effect, any Pearson `|r| < 2/√k` is zeroed before the chain is built,
+//! causing the affected link to degenerate to independent marginal sampling
+//! exactly where no statistically detectable dependency exists. Correlations
+//! that survive this threshold are clamped to `[−0.9999, 0.9999]` to keep
+//! conditional variances positive.
+//!
+//! # Complexity
+//!
+//! [`fit`] is `O(k · D²)`: it forms the full `D × D` mutual-information matrix
+//! from the `k` selected rows and greedily orders the `D` dimensions.
+//! [`sample`] is `O(D)` per individual: one conditional Gaussian draw per
+//! chain link.
+//!
+//! # References
+//!
+//! - De Bonet, Isbell & Viola (1997), *MIMIC: Finding optima by estimating
+//!   probability densities*.
+//!
+//! [`fit`]: crate::ProbabilityModel::fit
+//! [`sample`]: crate::ProbabilityModel::sample
+
+use burn::tensor::{Tensor, TensorData, backend::Backend};
+use rand::Rng;
+use rand_distr::{Distribution as _, Normal};
+
+use crate::probability_model::ProbabilityModel;
+
+/// Per-run configuration for the [`DependencyChain`] model.
+///
+/// Held inside [`EdaParams::model`](crate::algorithms::eda::EdaParams::model)
+/// for the lifetime of a run. Use [`DependencyChainParams::default_for`] for
+/// typical continuous-optimisation defaults.
+#[derive(Debug, Clone)]
+pub struct DependencyChainParams {
+    /// Number of genes per genome; determines the length of all vectors in
+    /// [`DependencyChainState`] and the chain dimension `D`.
+    pub genome_dim: usize,
+    /// Prior mean for every dimension, used when `prev = None`.
+    pub init_mean: f32,
+    /// Prior standard deviation for every dimension, used when `prev = None`.
+    pub init_std: f32,
+    /// Minimum per-dimension variance; prevents the model from collapsing to a
+    /// point mass and keeps conditional standard deviations positive.
+    pub min_variance: f32,
+}
+
+impl DependencyChainParams {
+    /// Sensible defaults for a `genome_dim`-dimensional continuous problem.
+    #[must_use]
+    pub fn default_for(genome_dim: usize) -> Self {
+        Self {
+            genome_dim,
+            init_mean: 0.0,
+            init_std: 2.0,
+            min_variance: 1e-6,
+        }
+    }
+}
+
+/// Fitted state for the [`DependencyChain`] model after one call to
+/// [`ProbabilityModel::fit`].
+///
+/// All four vectors have length `genome_dim` and are indexed by **dimension**
+/// (not chain position), except `chain` which is indexed by chain position.
+/// On the prior path (`prev = None`) the chain is the natural order
+/// `[0, 1, …, D-1]`, all means are `init_mean`, all standard deviations are
+/// `init_std`, and all `link_corr` entries are `0.0`.
+#[derive(Debug, Clone)]
+pub struct DependencyChainState {
+    /// Dimension permutation: `chain[t]` is the dimension index sampled at
+    /// chain position `t`. `chain[0]` is the root (marginal Gaussian).
+    pub chain: Vec<usize>,
+    /// Per-dimension MLE mean (indexed by dimension, not chain position).
+    pub mean: Vec<f32>,
+    /// Per-dimension standard deviation, floored at
+    /// [`DependencyChainParams::min_variance`]`.sqrt()` (indexed by
+    /// dimension).
+    pub std: Vec<f32>,
+    /// Pearson correlation of dimension `d` with its chain parent, after the
+    /// `|r| < 2/√k` significance filter and `[-0.9999, 0.9999]` clamp.
+    /// The root dimension's entry is `0.0` (unused in sampling).
+    pub link_corr: Vec<f32>,
+}
+
+/// MIMIC-style dependency-chain model for continuous spaces.
+///
+/// Implements [`ProbabilityModel`] by fitting a greedy first-order dependency
+/// chain over dimensions (see [module docs](self) for the algorithm, estimator
+/// regularisation, and references). Fitness is accepted but ignored; the fit
+/// is always unweighted.
+///
+/// [`fit`](ProbabilityModel::fit) is `O(k · D²)`; [`sample`](ProbabilityModel::sample)
+/// is `O(D)` per individual.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DependencyChain;
+
+impl<B: Backend> ProbabilityModel<B> for DependencyChain {
+    type Params = DependencyChainParams;
+    type State = DependencyChainState;
+
+    /// Fit the dependency-chain model to the selected population.
+    ///
+    /// When `prev = None` returns the prior (natural-order chain, uniform
+    /// `init_mean` / `init_std`, zero correlations). Otherwise:
+    ///
+    /// 1. Computes per-dimension MLE means and standard deviations
+    ///    (`÷k` variance, floored at `min_variance`).
+    /// 2. Builds the full `D × D` Pearson correlation matrix.
+    /// 3. Applies the `|r| < 2/√k` significance filter (see [module docs](self)
+    ///    for the estimator regularisation rationale) and clamps surviving
+    ///    correlations to `[−0.9999, 0.9999]`.
+    /// 4. Converts to mutual information `MI = −0.5 · ln(1 − r²)`.
+    /// 5. Builds the chain greedily: root = minimum-σ dimension, each
+    ///    subsequent link = unvisited dimension with the highest MI to the
+    ///    last chosen one.
+    ///
+    /// The `fitness` argument is accepted but always ignored.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic. The `unwrap()` on the last greedy-chain iteration is
+    /// safe because at least one unvisited dimension remains when `d > 1`.
+    // The MI matrix, greedy chain ordering, and per-link conditional
+    // extraction form one coherent algorithmic unit; splitting it would
+    // scatter the shared intermediate buffers without aiding readability.
+    #[allow(clippy::too_many_lines)]
+    fn fit(
+        &self,
+        params: &Self::Params,
+        prev: Option<&Self::State>,
+        population: Tensor<B, 2>,
+        fitness: Tensor<B, 1>,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let _ = device;
+        // Fitness is accepted but ignored: the fit is unweighted.
+        let _ = fitness;
+        let Some(_prev) = prev else {
+            // Prior path: independent dimensions in natural order; population
+            // and fitness ignored.
+            let d = params.genome_dim;
+            return DependencyChainState {
+                chain: (0..d).collect(),
+                mean: vec![params.init_mean; d],
+                std: vec![params.init_std; d],
+                link_corr: vec![0.0; d],
+            };
+        };
+
+        let [k, d] = population.dims();
+        let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
+        // k is a selected-population count, far below f32's 2^24 exact-integer
+        // limit; the cast is lossless in practice.
+        #[allow(clippy::cast_precision_loss)]
+        let kf = k as f32;
+
+        // Column means.
+        let mut mean = vec![0.0_f32; d];
+        for i in 0..k {
+            for j in 0..d {
+                mean[j] += rows[i * d + j];
+            }
+        }
+        for m in &mut mean {
+            *m /= kf;
+        }
+
+        // Raw MLE variances (unfloored) for the correlation guard, plus the
+        // floored std stored in state.
+        let mut raw_var = vec![0.0_f32; d];
+        for i in 0..k {
+            for j in 0..d {
+                let diff = rows[i * d + j] - mean[j];
+                raw_var[j] += diff * diff;
+            }
+        }
+        for v in &mut raw_var {
+            *v /= kf;
+        }
+        let std: Vec<f32> = raw_var
+            .iter()
+            .map(|&v| v.max(params.min_variance).sqrt())
+            .collect();
+
+        // Pairwise covariances → Pearson correlations.
+        // cov[a][b] = Σ (x_a - μ_a)(x_b - μ_b) / k.
+        let mut cov = vec![0.0_f32; d * d];
+        for i in 0..k {
+            for a in 0..d {
+                let da = rows[i * d + a] - mean[a];
+                for b in 0..d {
+                    let db = rows[i * d + b] - mean[b];
+                    cov[a * d + b] += da * db;
+                }
+            }
+        }
+        for c in &mut cov {
+            *c /= kf;
+        }
+
+        // r[a][b] = cov / (raw_σ_a · raw_σ_b); guarded and clamped.
+        //
+        // Sample correlations from k rows are noisy with std ≈ 1/√k under
+        // independence; conditioning the chain on spurious correlations
+        // injects that noise into every conditional mean — a penalty a
+        // univariate model never pays. Estimates below the ~2σ significance
+        // threshold are therefore zeroed, so the chain degenerates to
+        // independent sampling exactly where no dependency is detectable.
+        let significance = 2.0 / kf.sqrt();
+        let mut corr = vec![0.0_f32; d * d];
+        // Mutual information MI[a][b] = -0.5 ln(1 - r²); computed explicitly
+        // for fidelity though it is monotone in r².
+        let mut mi = vec![0.0_f32; d * d];
+        for a in 0..d {
+            for b in 0..d {
+                let r = if raw_var[a] < params.min_variance || raw_var[b] < params.min_variance {
+                    0.0
+                } else {
+                    let raw = cov[a * d + b] / (raw_var[a].sqrt() * raw_var[b].sqrt());
+                    if raw.abs() < significance {
+                        0.0
+                    } else {
+                        raw.clamp(-0.9999, 0.9999)
+                    }
+                };
+                corr[a * d + b] = r;
+                mi[a * d + b] = -0.5 * (1.0 - r * r).ln();
+            }
+        }
+
+        // Root: smallest floored std (Gaussian entropy is monotone in σ, so the
+        // lowest-σ dimension has the smallest marginal entropy); tie → lowest
+        // index.
+        let mut root = 0_usize;
+        let mut root_std = f32::INFINITY;
+        for (j, &sj) in std.iter().enumerate() {
+            if sj < root_std {
+                root_std = sj;
+                root = j;
+            }
+        }
+
+        // Greedy chain: append the unvisited dimension with maximal MI to the
+        // last chosen one; tie → lowest index.
+        let mut visited = vec![false; d];
+        let mut chain = Vec::with_capacity(d);
+        chain.push(root);
+        visited[root] = true;
+        for _ in 1..d {
+            let last = *chain.last().unwrap();
+            let mut best_j = usize::MAX;
+            let mut best_mi = f32::NEG_INFINITY;
+            for j in 0..d {
+                if visited[j] {
+                    continue;
+                }
+                if mi[last * d + j] > best_mi {
+                    best_mi = mi[last * d + j];
+                    best_j = j;
+                }
+            }
+            chain.push(best_j);
+            visited[best_j] = true;
+        }
+
+        // link_corr[chain[t]] = r[chain[t-1]][chain[t]]; root entry stays 0.
+        let mut link_corr = vec![0.0_f32; d];
+        for t in 1..chain.len() {
+            let parent = chain[t - 1];
+            let cur = chain[t];
+            link_corr[cur] = corr[parent * d + cur];
+        }
+
+        DependencyChainState {
+            chain,
+            mean,
+            std,
+            link_corr,
+        }
+    }
+
+    /// Draw `n` genomes by ancestral sampling along the fitted chain.
+    ///
+    /// The root dimension is sampled from its marginal Gaussian; each
+    /// subsequent dimension is sampled from the conditional Gaussian given its
+    /// parent's sampled value:
+    ///
+    /// ```text
+    /// μ_cond = μ_c + r · (σ_c / σ_p) · (x_parent − μ_p)
+    /// σ_cond = σ_c · √(1 − r²)
+    /// ```
+    ///
+    /// All randomness is drawn from `rng` (host RNG only; never
+    /// `Tensor::random` / `B::seed`). The returned tensor has shape `(n, D)`.
+    /// This is `O(D)` per individual drawn.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic under normal operation. The `Normal::new` calls are
+    /// guarded: `σ_c` is floored at `min_variance.sqrt()` during `fit`, and
+    /// `r` is clamped to `[-0.9999, 0.9999]` so `1 − r² ≥ 0.0002 > 0`.
+    fn sample(
+        &self,
+        state: &Self::State,
+        n: usize,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Tensor<B, 2> {
+        let d = state.mean.len();
+        let mut rows = vec![0.0_f32; n * d];
+        for i in 0..n {
+            let base = i * d;
+            // Root: marginal Gaussian.
+            let root = state.chain[0];
+            let root_normal = Normal::new(state.mean[root], state.std[root])
+                .expect("floored std is positive and finite");
+            rows[base + root] = root_normal.sample(rng);
+            // Subsequent links: conditional Gaussian given the chain parent.
+            for t in 1..state.chain.len() {
+                let parent = state.chain[t - 1];
+                let cur = state.chain[t];
+                let r = state.link_corr[cur];
+                let mu_c = state.mean[cur];
+                let mu_p = state.mean[parent];
+                let sigma_c = state.std[cur];
+                let sigma_p = state.std[parent]; // > 0 by floor.
+                let cond_mean = mu_c + r * (sigma_c / sigma_p) * (rows[base + parent] - mu_p);
+                // 1 - r² ≥ 1 - 0.9999² > 0.
+                let cond_std = (sigma_c * sigma_c * (1.0 - r * r)).sqrt();
+                let normal = Normal::new(cond_mean, cond_std)
+                    .expect("conditional std is positive and finite");
+                rows[base + cur] = normal.sample(rng);
+            }
+        }
+        Tensor::<B, 2>::from_data(TensorData::new(rows, [n, d]), device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestBackend = Flex;
+
+    fn pop(rows: Vec<f32>, n: usize, d: usize) -> Tensor<TestBackend, 2> {
+        let device = Default::default();
+        Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [n, d]), &device)
+    }
+
+    fn fitness(values: Vec<f32>) -> Tensor<TestBackend, 1> {
+        let device = Default::default();
+        let n = values.len();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(values, [n]), &device)
+    }
+
+    fn fit_prior(p: &DependencyChainParams) -> DependencyChainState {
+        let device = Default::default();
+        <DependencyChain as ProbabilityModel<TestBackend>>::fit(
+            &DependencyChain,
+            p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        )
+    }
+
+    fn refit(p: &DependencyChainParams, rows: Vec<f32>, n: usize, d: usize) -> DependencyChainState {
+        let device = Default::default();
+        let prior = fit_prior(p);
+        // Test row counts are tiny; the cast is lossless.
+        #[allow(clippy::cast_precision_loss)]
+        let fit_values: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        <DependencyChain as ProbabilityModel<TestBackend>>::fit(
+            &DependencyChain,
+            p,
+            Some(&prior),
+            pop(rows, n, d),
+            fitness(fit_values),
+            &device,
+        )
+    }
+
+    #[test]
+    fn prior_is_natural_order_independent() {
+        let p = DependencyChainParams::default_for(3);
+        let state = fit_prior(&p);
+        assert_eq!(state.chain, vec![0, 1, 2]);
+        assert_eq!(state.mean, vec![0.0, 0.0, 0.0]);
+        assert_eq!(state.std, vec![2.0, 2.0, 2.0]);
+        assert_eq!(state.link_corr, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn chain_links_correlated_dimensions_adjacently() {
+        // x0 spread; x1 = x0 + tiny noise (strongly correlated with x0);
+        // x2 independent. The chain should place 0 and 1 adjacently.
+        let p = DependencyChainParams::default_for(3);
+        let rows = vec![
+            -2.0, -2.01, 5.0, //
+            -1.0, -0.99, -3.0, //
+            0.0, 0.01, 1.0, //
+            1.0, 1.02, -4.0, //
+            2.0, 1.98, 0.5, //
+        ];
+        let state = refit(&p, rows, 5, 3);
+        // Find positions of dims 0 and 1 in the chain; they must be adjacent.
+        let pos0 = state.chain.iter().position(|&x| x == 0).unwrap();
+        let pos1 = state.chain.iter().position(|&x| x == 1).unwrap();
+        assert_eq!(
+            pos0.abs_diff(pos1),
+            1,
+            "dims 0 and 1 should be adjacent in chain {:?}",
+            state.chain
+        );
+        // Whichever of 0/1 is the child (later in the chain) carries a high
+        // link correlation.
+        let child = usize::from(pos0 <= pos1);
+        assert!(
+            state.link_corr[child].abs() > 0.99,
+            "expected strong link corr, got {}",
+            state.link_corr[child]
+        );
+    }
+
+    #[test]
+    fn zero_variance_column_yields_zero_correlation() {
+        let p = DependencyChainParams::default_for(2);
+        // Column 1 is constant → raw variance 0 → r guarded to 0.
+        let rows = vec![0.0, 5.0, 1.0, 5.0, 2.0, 5.0, 3.0, 5.0];
+        let state = refit(&p, rows, 4, 2);
+        for &r in &state.link_corr {
+            approx::assert_relative_eq!(r, 0.0, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn perfect_correlation_is_clamped() {
+        let p = DependencyChainParams::default_for(2);
+        // Column 1 is an exact copy of column 0 → r would be 1, clamped to
+        // 0.9999.
+        let rows = vec![0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0];
+        let state = refit(&p, rows, 4, 2);
+        let child = *state.chain.last().unwrap();
+        assert!(state.link_corr[child].abs() <= 0.9999 + 1e-6);
+        assert!(state.link_corr[child].abs() > 0.99);
+    }
+
+    #[test]
+    fn link_corr_matches_expected_pearson() {
+        let p = DependencyChainParams::default_for(2);
+        // Column 1 = 2 * column 0 → Pearson r = 1, clamped to 0.9999.
+        let rows = vec![-2.0, -4.0, -1.0, -2.0, 0.0, 0.0, 1.0, 2.0, 2.0, 4.0];
+        let state = refit(&p, rows, 5, 2);
+        let child = *state.chain.last().unwrap();
+        approx::assert_relative_eq!(state.link_corr[child], 0.9999, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn sampling_respects_chain_correlation() {
+        // Two strongly-correlated dimensions → sampled values must track.
+        let p = DependencyChainParams::default_for(2);
+        let rows = vec![-2.0, -2.0, -1.0, -1.0, 0.0, 0.0, 1.0, 1.0, 2.0, 2.0];
+        let state = refit(&p, rows, 5, 2);
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(99);
+        let n = 5_000;
+        let samples = <DependencyChain as ProbabilityModel<TestBackend>>::sample(
+            &DependencyChain,
+            &state,
+            n,
+            &mut rng,
+            &device,
+        );
+        let data = samples.into_data().into_vec::<f32>().unwrap();
+        // Pearson correlation of sampled columns 0 and 1.
+        let mut s0 = 0.0_f64;
+        let mut s1 = 0.0_f64;
+        for i in 0..n {
+            s0 += f64::from(data[i * 2]);
+            s1 += f64::from(data[i * 2 + 1]);
+        }
+        // n = 5_000 fits f64 exactly; the cast is lossless here.
+        #[allow(clippy::cast_precision_loss)]
+        let nf = n as f64;
+        let m0 = s0 / nf;
+        let m1 = s1 / nf;
+        let (mut cov, mut v0, mut v1) = (0.0_f64, 0.0_f64, 0.0_f64);
+        for i in 0..n {
+            let a = f64::from(data[i * 2]) - m0;
+            let b = f64::from(data[i * 2 + 1]) - m1;
+            cov += a * b;
+            v0 += a * a;
+            v1 += b * b;
+        }
+        let corr = cov / (v0.sqrt() * v1.sqrt());
+        assert!(corr > 0.9, "sampled correlation too low: {corr}");
+    }
+
+    #[test]
+    fn two_fits_same_data_identical_state() {
+        let p = DependencyChainParams::default_for(3);
+        let rows = vec![
+            -2.0, 1.0, 0.5, //
+            -1.0, 2.0, -0.5, //
+            0.0, 0.0, 1.0, //
+            1.0, -1.0, -1.0, //
+        ];
+        let a = refit(&p, rows.clone(), 4, 3);
+        let b = refit(&p, rows, 4, 3);
+        assert_eq!(a.chain, b.chain);
+        assert_eq!(a.mean, b.mean);
+        assert_eq!(a.std, b.std);
+        assert_eq!(a.link_corr, b.link_corr);
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/eda/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/mod.rs
@@ -1,0 +1,479 @@
+//! Estimation-of-distribution algorithms (EDAs).
+//!
+//! An EDA replaces the crossover and mutation operators of a classical GA
+//! with an explicit probabilistic model of the promising region of search
+//! space. Each generation runs a `fit` → `sample` loop:
+//!
+//! 1. Evaluate the current population (done externally by the harness).
+//! 2. Truncation-select the best fraction of the population.
+//! 3. [`fit`](crate::ProbabilityModel::fit) the model to those survivors.
+//! 4. [`sample`](crate::ProbabilityModel::sample) a fresh population.
+//!
+//! The model is supplied as a [`ProbabilityModel`]; the generic
+//! [`EdaStrategy`] driver is model-agnostic. Four reference models ship here:
+//!
+//! - [`UnivariateGaussian`] — UMDA, a per-dimension Gaussian (unweighted MLE,
+//!   `÷k` variance, `min_variance` floor; fitness is accepted but ignored).
+//! - [`UnivariateBernoulli`] — PBIL, a per-bit probability vector (no
+//!   classic probability-mutation step; fitness is used only to identify
+//!   the best/worst individual).
+//! - [`CompactGenetic`] — cGA, a virtual-population probability vector
+//!   (winner/loser come from the truncation-selected subset, not a fresh
+//!   pairwise draw as in classic cGA).
+//! - [`DependencyChain`] — a continuous-Gaussian MIMIC chain capturing
+//!   pairwise dependencies (fitness accepted but ignored).
+//!
+//! Both binary models ([`UnivariateBernoulli`] and [`CompactGenetic`]) emit
+//! raw `{0, 1}` genes; the [`EdaParams::bounds`] clamp is therefore a no-op
+//! for them.
+//!
+//! # References
+//!
+//! - Mühlenbein & Paaß (1996), *From recombination of genes to the
+//!   estimation of distributions I. Binary parameters*.
+//! - Baluja (1994), *Population-based incremental learning: a method for
+//!   integrating genetic search based function optimization and competitive
+//!   learning*.
+//! - Harik, Lobo & Goldberg (1999), *The compact genetic algorithm*.
+//! - De Bonet, Isbell & Viola (1997), *MIMIC: Finding optima by estimating
+//!   probability densities*.
+
+pub mod compact_genetic;
+pub mod dependency_chain;
+pub mod univariate_bernoulli;
+pub mod univariate_gaussian;
+
+pub use compact_genetic::{CompactGenetic, CompactGeneticParams, CompactGeneticState};
+pub use dependency_chain::{DependencyChain, DependencyChainParams, DependencyChainState};
+pub use univariate_bernoulli::{
+    UnivariateBernoulli, UnivariateBernoulliParams, UnivariateBernoulliState,
+};
+pub use univariate_gaussian::{UnivariateGaussian, UnivariateGaussianParams, UnivariateGaussianState};
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
+use rand::Rng;
+
+use crate::probability_model::ProbabilityModel;
+use crate::rng::{SeedPurpose, seed_stream};
+use crate::strategy::{Strategy, StrategyMetrics};
+
+/// Static configuration for an [`EdaStrategy`] run.
+///
+/// All fields are public so callers can use struct-literal construction or
+/// update syntax. The only runtime contract enforced at call time is that
+/// `selection_ratio` lies strictly in `(0, 1)` (checked by a
+/// `debug_assert!` in [`EdaStrategy::init`]).
+#[derive(Debug, Clone)]
+pub struct EdaParams<MP> {
+    /// Number of individuals sampled per generation.
+    pub pop_size: usize,
+    /// Fraction of the population kept by truncation selection; must lie
+    /// strictly in `(0, 1)`. The effective `k` is
+    /// `ceil(selection_ratio · pop_size)` clamped to `[2, pop_size]`.
+    pub selection_ratio: f32,
+    /// Optional inclusive `[lo, hi]` clamp applied to each gene after
+    /// sampling. A no-op for binary models ([`UnivariateBernoulli`],
+    /// [`CompactGenetic`]) whose genes are already `{0, 1}`.
+    pub bounds: Option<(f32, f32)>,
+    /// Model-specific parameters (includes `genome_dim`).
+    pub model: MP,
+}
+
+/// Generation-to-generation state carried by [`EdaStrategy`].
+///
+/// The driver updates this in `tell` and passes it back through `ask` unchanged.
+/// Callers should treat it as an opaque blob; the public fields are exposed to
+/// enable checkpointing and observability, not mutation.
+#[derive(Debug, Clone)]
+pub struct EdaState<B: Backend, MS> {
+    /// Current fitted model state (updated once per [`EdaStrategy::tell`] call).
+    pub model_state: MS,
+    /// Best genome ever observed, shape `(genome_dim,)`. `None` before the
+    /// first [`EdaStrategy::tell`] call.
+    pub best_genome: Option<Tensor<B, 1>>,
+    /// Smallest (best) fitness ever observed across all generations
+    /// (minimization convention). Starts at `f32::INFINITY`.
+    pub best_fitness_ever: f32,
+    /// Number of completed generations (incremented by each `tell` call).
+    pub generation: usize,
+}
+
+/// Generic estimation-of-distribution strategy.
+///
+/// Drives the `fit` → `sample` loop of any [`ProbabilityModel`]. The strategy
+/// itself is stateless (the model is held by value; all mutable generation
+/// state lives in the returned [`EdaState`]), so it slots straight into
+/// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness).
+///
+/// Type parameter `M` must implement [`ProbabilityModel<B>`]; in practice
+/// this is one of [`UnivariateGaussian`], [`UnivariateBernoulli`],
+/// [`CompactGenetic`], or [`DependencyChain`].
+///
+/// # Example
+///
+/// ```no_run
+/// use burn::backend::Flex;
+/// use rlevo_evolution::algorithms::eda::{EdaParams, EdaStrategy, UnivariateGaussian};
+/// use rlevo_evolution::algorithms::eda::univariate_gaussian::UnivariateGaussianParams;
+///
+/// let strategy = EdaStrategy::<Flex, _>::new(UnivariateGaussian);
+/// let params = EdaParams {
+///     pop_size: 32,
+///     selection_ratio: 0.5,
+///     bounds: Some((-5.12, 5.12)),
+///     model: UnivariateGaussianParams::default_for(8),
+/// };
+/// let _ = (strategy, params);
+/// ```
+pub struct EdaStrategy<B: Backend, M> {
+    model: M,
+    _backend: PhantomData<fn() -> B>,
+}
+
+impl<B: Backend, M: Debug> Debug for EdaStrategy<B, M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EdaStrategy")
+            .field("model", &self.model)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend, M> EdaStrategy<B, M> {
+    /// Build a new EDA strategy around `model`.
+    #[must_use]
+    pub fn new(model: M) -> Self {
+        Self {
+            model,
+            _backend: PhantomData,
+        }
+    }
+}
+
+impl<B: Backend, M: ProbabilityModel<B>> Strategy<B> for EdaStrategy<B, M> {
+    type Params = EdaParams<M::Params>;
+    type State = EdaState<B, M::State>;
+    type Genome = Tensor<B, 2>;
+
+    /// Build the initial state.
+    ///
+    /// Fits the model's prior from `params.model` (passing `prev = None` and
+    /// empty `0 × 0` / length-`0` population and fitness tensors, per the
+    /// [`ProbabilityModel`] invariants). The `rng` is unused — the prior is
+    /// deterministic. The best-so-far trackers start empty.
+    ///
+    /// # Panics
+    ///
+    /// Debug-asserts that `params.selection_ratio` lies strictly in `(0, 1)`.
+    /// A ratio of `0.0` would select no parents and a ratio of `1.0` would
+    /// defeat truncation selection entirely.
+    fn init(
+        &self,
+        params: &Self::Params,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        debug_assert!(
+            params.selection_ratio > 0.0 && params.selection_ratio < 1.0,
+            "selection_ratio must lie strictly in (0, 1), got {}",
+            params.selection_ratio
+        );
+        let _ = rng;
+        let model_state = self.model.fit(
+            &params.model,
+            None,
+            Tensor::empty([0, 0], device),
+            Tensor::empty([0], device),
+            device,
+        );
+        EdaState {
+            model_state,
+            best_genome: None,
+            best_fitness_ever: f32::INFINITY,
+            generation: 0,
+        }
+    }
+
+    /// Sample the next candidate population from the current model.
+    ///
+    /// Draws exactly one `u64` from `rng` to seed a per-generation
+    /// [`SeedPurpose::EdaSampling`] stream, samples `params.pop_size`
+    /// individuals from the model through that host stream, and applies the
+    /// optional `params.bounds` clamp. The state is returned unchanged.
+    fn ask(
+        &self,
+        params: &Self::Params,
+        state: &Self::State,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> (Self::Genome, Self::State) {
+        let draw = rng.next_u64();
+        let mut stream = seed_stream(draw, state.generation as u64, SeedPurpose::EdaSampling);
+        let mut pop = self
+            .model
+            .sample(&state.model_state, params.pop_size, &mut stream, device);
+        if let Some((lo, hi)) = params.bounds {
+            pop = pop.clamp(lo, hi);
+        }
+        (pop, state.clone())
+    }
+
+    /// Consume the population's fitness and refit the model.
+    ///
+    /// Pulls fitness to host, sanitizes `NaN` → `+inf` via the crate's
+    /// `sanitize_fitness` helper, updates the best-so-far tracker,
+    /// truncation-selects the best `k` rows (ascending fitness order, with
+    /// `k = ceil(selection_ratio · pop_size)` clamped to `[2, pop_size]`),
+    /// and refits the model to them (passing `prev = Some(model_state)`).
+    ///
+    /// The `fitness` tensor is forwarded to [`ProbabilityModel::fit`]; models
+    /// that weight or rank their selected individuals can use it. The four
+    /// built-in models ([`UnivariateGaussian`], [`UnivariateBernoulli`],
+    /// [`CompactGenetic`], [`DependencyChain`]) all perform an unweighted fit
+    /// and ignore it.
+    fn tell(
+        &self,
+        params: &Self::Params,
+        population: Self::Genome,
+        fitness: Tensor<B, 1>,
+        mut state: Self::State,
+        _rng: &mut dyn Rng,
+    ) -> (Self::State, StrategyMetrics) {
+        let raw = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+        let sanitized: Vec<f32> = raw
+            .iter()
+            .map(|&f| crate::local_search::sanitize_fitness(f))
+            .collect();
+        let n = sanitized.len();
+        let device = population.device();
+
+        // Argmin (ties → lowest index) for the best-so-far update.
+        let mut best_idx = 0_usize;
+        let mut best_f = f32::INFINITY;
+        for (i, &f) in sanitized.iter().enumerate() {
+            if f.total_cmp(&best_f) == std::cmp::Ordering::Less {
+                best_f = f;
+                best_idx = i;
+            }
+        }
+        if best_f < state.best_fitness_ever {
+            // usize → i64 for the Burn Int index tensor; population indices are
+            // far below i64::MAX so the cast never wraps.
+            #[allow(clippy::cast_possible_wrap)]
+            let idx = Tensor::<B, 1, Int>::from_data(
+                TensorData::new(vec![best_idx as i64], [1]),
+                &device,
+            );
+            let row = population.clone().select(0, idx).squeeze_dim::<1>(0);
+            state.best_genome = Some(row);
+        }
+
+        // Truncation selection: keep the best `k` rows in ascending fitness
+        // order so the model sees a deterministic, best-first population.
+        #[allow(clippy::cast_precision_loss)]
+        let target = (params.selection_ratio * params.pop_size as f32).ceil();
+        // ceil of a finite non-negative product → small usize; never truncates
+        // meaningfully for any realistic population size.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let k = (target as usize).max(2).min(n.max(1));
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by(|&a, &b| {
+            sanitized[a]
+                .total_cmp(&sanitized[b])
+                .then(a.cmp(&b))
+        });
+        order.truncate(k);
+
+        // usize → i64 index tensor (see best-so-far note above).
+        #[allow(clippy::cast_possible_wrap)]
+        let idx_vec: Vec<i64> = order.iter().map(|&i| i as i64).collect();
+        let idx = Tensor::<B, 1, Int>::from_data(TensorData::new(idx_vec, [k]), &device);
+        let selected = population.clone().select(0, idx);
+        let selected_fitness_host: Vec<f32> = order.iter().map(|&i| sanitized[i]).collect();
+        let selected_fitness =
+            Tensor::<B, 1>::from_data(TensorData::new(selected_fitness_host, [k]), &device);
+
+        let model_state = self.model.fit(
+            &params.model,
+            Some(&state.model_state),
+            selected,
+            selected_fitness,
+            &device,
+        );
+        state.model_state = model_state;
+        state.generation += 1;
+        let metrics =
+            StrategyMetrics::from_host_fitness(state.generation, &sanitized, state.best_fitness_ever);
+        state.best_fitness_ever = metrics.best_fitness_ever;
+        (state, metrics)
+    }
+
+    /// Return the best-so-far genome (shape `(1, D)`) and its fitness.
+    ///
+    /// Returns `None` before the first [`tell`](Self::tell) call. The genome is
+    /// stored internally as a `(D,)` vector and unsqueezed to `(1, D)` here to
+    /// match the `Genome = Tensor<B, 2>` container.
+    fn best(&self, state: &Self::State) -> Option<(Self::Genome, f32)> {
+        state
+            .best_genome
+            .as_ref()
+            .map(|g| (g.clone().unsqueeze::<2>(), state.best_fitness_ever))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestBackend = Flex;
+
+    fn make_pop(rows: &[f32], n: usize, d: usize) -> Tensor<TestBackend, 2> {
+        let device = Default::default();
+        Tensor::<TestBackend, 2>::from_data(TensorData::new(rows.to_vec(), [n, d]), &device)
+    }
+
+    fn make_fitness(values: &[f32]) -> Tensor<TestBackend, 1> {
+        let device = Default::default();
+        let n = values.len();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(values.to_vec(), [n]), &device)
+    }
+
+    fn params(pop_size: usize, ratio: f32, dim: usize) -> EdaParams<UnivariateGaussianParams> {
+        EdaParams {
+            pop_size,
+            selection_ratio: ratio,
+            bounds: None,
+            model: UnivariateGaussianParams::default_for(dim),
+        }
+    }
+
+    #[test]
+    fn best_is_none_before_tell_some_after() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let p = params(4, 0.5, 2);
+        let mut rng = StdRng::seed_from_u64(0);
+        let state = strategy.init(&p, &mut rng, &device);
+        assert!(strategy.best(&state).is_none());
+
+        let pop = make_pop(&[0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0], 4, 2);
+        let fitness = make_fitness(&[5.0, 1.0, 9.0, 7.0]);
+        let (state, _m) = strategy.tell(&p, pop, fitness, state, &mut rng);
+        let best = strategy.best(&state);
+        assert!(best.is_some());
+        let (genome, f) = best.unwrap();
+        assert_eq!(genome.dims(), [1, 2]);
+        approx::assert_relative_eq!(f, 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn k_is_clamped_to_at_least_two_and_at_most_n() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(0);
+
+        // ratio 0.1 of 5 = ceil(0.5) = 1, clamped up to 2.
+        let p = params(5, 0.1, 1);
+        let state = strategy.init(&p, &mut rng, &device);
+        let pop = make_pop(&[5.0, 4.0, 3.0, 2.0, 1.0], 5, 1);
+        let fitness = make_fitness(&[5.0, 4.0, 3.0, 2.0, 1.0]);
+        // Refit must not panic with k clamped to 2.
+        let (state, _m) = strategy.tell(&p, pop, fitness, state, &mut rng);
+        assert_eq!(state.generation, 1);
+
+        // ratio 0.99 of 3 = ceil(2.97) = 3, clamped to n = 3.
+        let p2 = params(3, 0.99, 1);
+        let state2 = strategy.init(&p2, &mut rng, &device);
+        let pop2 = make_pop(&[1.0, 2.0, 3.0], 3, 1);
+        let fitness2 = make_fitness(&[1.0, 2.0, 3.0]);
+        let (state2, _m) = strategy.tell(&p2, pop2, fitness2, state2, &mut rng);
+        assert_eq!(state2.generation, 1);
+    }
+
+    #[test]
+    fn tie_breaking_prefers_lowest_index() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(0);
+        let p = params(4, 0.5, 1);
+        let state = strategy.init(&p, &mut rng, &device);
+        // Two individuals tie for best fitness (1.0) at indices 1 and 3; the
+        // best-so-far must be index 1 (genome value 10.0), not 30.0.
+        let pop = make_pop(&[0.0, 10.0, 20.0, 30.0], 4, 1);
+        let fitness = make_fitness(&[5.0, 1.0, 5.0, 1.0]);
+        let (state, _m) = strategy.tell(&p, pop, fitness, state, &mut rng);
+        let (genome, _f) = strategy.best(&state).unwrap();
+        let v = genome.into_data().into_vec::<f32>().unwrap();
+        approx::assert_relative_eq!(v[0], 10.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn nan_fitness_never_becomes_best_and_does_not_break_ordering() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(0);
+        let p = params(4, 0.5, 1);
+        let state = strategy.init(&p, &mut rng, &device);
+        // index 0 is NaN (→ +inf); the finite best (2.0) is at index 2.
+        let pop = make_pop(&[0.0, 1.0, 2.0, 3.0], 4, 1);
+        let fitness = make_fitness(&[f32::NAN, 9.0, 2.0, 7.0]);
+        let (state, m) = strategy.tell(&p, pop, fitness, state, &mut rng);
+        let (genome, f) = strategy.best(&state).unwrap();
+        let v = genome.into_data().into_vec::<f32>().unwrap();
+        approx::assert_relative_eq!(v[0], 2.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(f, 2.0, epsilon = 1e-6);
+        assert!(m.best_fitness.is_finite());
+    }
+
+    #[test]
+    fn bounds_clamp_is_applied_in_ask() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(7);
+        // Wide init std so unclamped draws routinely exceed the bounds.
+        let p = EdaParams {
+            pop_size: 64,
+            selection_ratio: 0.5,
+            bounds: Some((-0.5, 0.5)),
+            model: UnivariateGaussianParams {
+                genome_dim: 3,
+                init_mean: 0.0,
+                init_std: 5.0,
+                min_variance: 1e-6,
+            },
+        };
+        let state = strategy.init(&p, &mut rng, &device);
+        let (pop, _s) = strategy.ask(&p, &state, &mut rng, &device);
+        let values = pop.into_data().into_vec::<f32>().unwrap();
+        for v in values {
+            assert!((-0.5..=0.5).contains(&v), "value {v} escaped the clamp");
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "selection_ratio")]
+    fn selection_ratio_zero_panics() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(0);
+        let p = params(4, 0.0, 1);
+        let _ = strategy.init(&p, &mut rng, &device);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "selection_ratio")]
+    fn selection_ratio_one_panics() {
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(0);
+        let p = params(4, 1.0, 1);
+        let _ = strategy.init(&p, &mut rng, &device);
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
@@ -1,0 +1,315 @@
+//! Univariate Bernoulli model (PBIL — Population-Based Incremental Learning)
+//! for binary search spaces.
+//!
+//! Each gene is an independent Bernoulli variable with a learned probability
+//! of being `1`. [`fit`] nudges the probability vector toward the **best**
+//! individual of the selected subset (positive update at rate
+//! [`UnivariateBernoulliParams::learning_rate`]) and away from the **worst**
+//! on genes where best and worst disagree (negative update at rate
+//! [`UnivariateBernoulliParams::negative_learning_rate`]). The classic PBIL
+//! probability-mutation step is **not** implemented. [`sample`] emits a fresh
+//! tensor of raw `{0, 1}` `f32` genes; [`EdaParams::bounds`](crate::algorithms::eda::EdaParams::bounds)
+//! clamps are therefore no-ops.
+//!
+//! The best and worst individuals are the argmin and argmax of the fitness
+//! vector over the truncation-selected subset, not over the full population.
+//! This departs slightly from the original Baluja formulation, which drew a
+//! fresh sample for comparison, but is consistent with the upstream selection
+//! already performed by [`EdaStrategy`](crate::algorithms::eda::EdaStrategy).
+//!
+//! # References
+//!
+//! - Baluja (1994), *Population-based incremental learning: a method for
+//!   integrating genetic search based function optimization and competitive
+//!   learning*.
+//!
+//! [`fit`]: crate::ProbabilityModel::fit
+//! [`sample`]: crate::ProbabilityModel::sample
+
+use burn::tensor::{Tensor, TensorData, backend::Backend};
+use rand::{Rng, RngExt};
+
+use crate::probability_model::ProbabilityModel;
+
+/// Per-run configuration for the [`UnivariateBernoulli`] model.
+///
+/// Held inside [`EdaParams::model`](crate::algorithms::eda::EdaParams::model)
+/// for the lifetime of a run. Use
+/// [`UnivariateBernoulliParams::default_for`] for typical PBIL defaults.
+#[derive(Debug, Clone)]
+pub struct UnivariateBernoulliParams {
+    /// Number of bits per genome; determines the length of
+    /// [`UnivariateBernoulliState::prob`].
+    pub genome_dim: usize,
+    /// Interpolation rate toward the best individual's gene value per
+    /// generation (`0 < learning_rate < 1`; original Baluja uses 0.1).
+    pub learning_rate: f32,
+    /// Additional interpolation rate applied on genes where the best and
+    /// worst individuals disagree. The extra step interpolates toward the
+    /// *best* individual's gene — identical, for binary `{0, 1}` genes, to
+    /// moving away from the worst's value, since the two differ
+    /// (`0 ≤ negative_learning_rate < 1`; original uses 0.075).
+    pub negative_learning_rate: f32,
+}
+
+impl UnivariateBernoulliParams {
+    /// Sensible PBIL defaults for a `genome_dim`-bit problem.
+    #[must_use]
+    pub fn default_for(genome_dim: usize) -> Self {
+        Self {
+            genome_dim,
+            learning_rate: 0.1,
+            negative_learning_rate: 0.075,
+        }
+    }
+}
+
+/// Fitted state for the [`UnivariateBernoulli`] model after one call to
+/// [`ProbabilityModel::fit`].
+///
+/// The vector has length `genome_dim`. On the prior path (`prev = None`) it
+/// is uniformly `0.5`; on subsequent calls the entries are nudged by the PBIL
+/// update rule (see [module docs](self)).
+#[derive(Debug, Clone)]
+pub struct UnivariateBernoulliState {
+    /// Per-gene probability of sampling a `1.0` (always in `[0, 1]`).
+    pub prob: Vec<f32>,
+}
+
+/// Population-Based Incremental Learning model for binary spaces (PBIL).
+///
+/// Implements [`ProbabilityModel`] with a per-gene Bernoulli probability vector
+/// updated by nudging toward the best (and away from the worst) of the
+/// truncation-selected subset. The classic probability-mutation step is omitted.
+/// Samples are raw `{0, 1}` `f32` values;
+/// [`EdaParams::bounds`](crate::algorithms::eda::EdaParams::bounds) clamps
+/// are no-ops for this model.
+///
+/// See the [module docs](self) for the update rule and references.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UnivariateBernoulli;
+
+impl<B: Backend> ProbabilityModel<B> for UnivariateBernoulli {
+    type Params = UnivariateBernoulliParams;
+    type State = UnivariateBernoulliState;
+
+    /// Update the per-gene probability vector from the selected population.
+    ///
+    /// When `prev = None` returns the uniform-`0.5` prior; `population` and
+    /// `fitness` are ignored on that path. Otherwise locates the argmin
+    /// (best) and argmax (worst) individuals by fitness, applies the positive
+    /// PBIL interpolation toward the best's genes, and applies the negative
+    /// update on genes where the best and worst disagree. Does **not** apply
+    /// the classic Baluja probability-mutation step.
+    fn fit(
+        &self,
+        params: &Self::Params,
+        prev: Option<&Self::State>,
+        population: Tensor<B, 2>,
+        fitness: Tensor<B, 1>,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let _ = device;
+        let Some(prev) = prev else {
+            // Prior path: uniform 0.5 per gene; population/fitness ignored.
+            let _ = (population, fitness);
+            return UnivariateBernoulliState {
+                prob: vec![0.5; params.genome_dim],
+            };
+        };
+
+        let [k, d] = population.dims();
+        let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
+        let fit_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+
+        // Argmin (best) and argmax (worst), ties → lowest index.
+        let mut best_idx = 0_usize;
+        let mut worst_idx = 0_usize;
+        let mut best_f = f32::INFINITY;
+        let mut worst_f = f32::NEG_INFINITY;
+        for i in 0..k {
+            let f = fit_host.get(i).copied().unwrap_or(f32::INFINITY);
+            if f.total_cmp(&best_f) == std::cmp::Ordering::Less {
+                best_f = f;
+                best_idx = i;
+            }
+            if f.total_cmp(&worst_f) == std::cmp::Ordering::Greater {
+                worst_f = f;
+                worst_idx = i;
+            }
+        }
+
+        let lr = params.learning_rate;
+        let neg_lr = params.negative_learning_rate;
+        let mut prob = prev.prob.clone();
+        for j in 0..d {
+            let best_gene = rows[best_idx * d + j];
+            let worst_gene = rows[worst_idx * d + j];
+            // Positive update: interpolate toward the best individual's gene.
+            let mut updated = prob[j] * (1.0 - lr) + lr * best_gene;
+            // Negative update only where best and worst disagree.
+            if (best_gene - worst_gene).abs() > 0.5 {
+                updated = updated * (1.0 - neg_lr) + neg_lr * best_gene;
+            }
+            prob[j] = updated;
+        }
+
+        UnivariateBernoulliState { prob }
+    }
+
+    /// Draw `n` binary genomes from the per-gene Bernoulli probabilities.
+    ///
+    /// Each gene is sampled independently as `1.0` with probability `p[j]`,
+    /// `0.0` otherwise, using the supplied host RNG (never `Tensor::random` /
+    /// `B::seed`). The returned tensor has shape `(n, D)` and contains only
+    /// `0.0` and `1.0` values.
+    fn sample(
+        &self,
+        state: &Self::State,
+        n: usize,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Tensor<B, 2> {
+        let d = state.prob.len();
+        let mut rows = Vec::with_capacity(n * d);
+        // Row-major: outer individuals, inner dimensions.
+        for _ in 0..n {
+            for &p in &state.prob {
+                let gene = if rng.random::<f32>() < p { 1.0 } else { 0.0 };
+                rows.push(gene);
+            }
+        }
+        Tensor::<B, 2>::from_data(TensorData::new(rows, [n, d]), device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestBackend = Flex;
+
+    fn pop(rows: Vec<f32>, n: usize, d: usize) -> Tensor<TestBackend, 2> {
+        let device = Default::default();
+        Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [n, d]), &device)
+    }
+
+    fn fitness(values: Vec<f32>) -> Tensor<TestBackend, 1> {
+        let device = Default::default();
+        let n = values.len();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(values, [n]), &device)
+    }
+
+    fn fit_prior(p: &UnivariateBernoulliParams) -> UnivariateBernoulliState {
+        let device = Default::default();
+        <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateBernoulli,
+            p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        )
+    }
+
+    #[test]
+    fn prior_is_half() {
+        let p = UnivariateBernoulliParams::default_for(4);
+        let state = fit_prior(&p);
+        assert_eq!(state.prob, vec![0.5, 0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn interpolation_not_overwrite() {
+        let device = Default::default();
+        let p = UnivariateBernoulliParams {
+            genome_dim: 1,
+            learning_rate: 0.1,
+            negative_learning_rate: 0.0,
+        };
+        let prior = fit_prior(&p);
+        // best = row 0 (gene 1), worst = row 1 (gene 0). neg_lr = 0 so only the
+        // positive update fires: p = 0.5*0.9 + 0.1*1 = 0.55, strictly in (0.5, 1).
+        let state = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateBernoulli,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 0.0], 2, 1),
+            fitness(vec![0.0, 1.0]),
+            &device,
+        );
+        assert!(state.prob[0] > 0.5 && state.prob[0] < 1.0);
+        approx::assert_relative_eq!(state.prob[0], 0.55, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn neg_lr_applies_only_to_differing_genes() {
+        let device = Default::default();
+        let p = UnivariateBernoulliParams {
+            genome_dim: 2,
+            learning_rate: 0.1,
+            negative_learning_rate: 0.2,
+        };
+        let prior = fit_prior(&p);
+        // gene 0: best=1, worst=1 (same) → only positive update.
+        // gene 1: best=1, worst=0 (differ) → positive then negative update.
+        let state = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateBernoulli,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 1.0, 1.0, 0.0], 2, 2),
+            fitness(vec![0.0, 1.0]),
+            &device,
+        );
+        // gene 0: 0.5*0.9 + 0.1 = 0.55.
+        approx::assert_relative_eq!(state.prob[0], 0.55, epsilon = 1e-6);
+        // gene 1: 0.55 then 0.55*0.8 + 0.2 = 0.64.
+        approx::assert_relative_eq!(state.prob[1], 0.64, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn convergence_direction_toward_zeros() {
+        let device = Default::default();
+        let p = UnivariateBernoulliParams::default_for(1);
+        let mut state = fit_prior(&p);
+        // Best individual is all-zeros; repeated fits must drive p down.
+        for _ in 0..50 {
+            state = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+                &UnivariateBernoulli,
+                &p,
+                Some(&state),
+                pop(vec![0.0, 1.0], 2, 1),
+                fitness(vec![0.0, 1.0]),
+                &device,
+            );
+        }
+        assert!(state.prob[0] < 0.1, "p did not converge toward 0, got {}", state.prob[0]);
+    }
+
+    #[test]
+    fn samples_are_binary() {
+        let device = Default::default();
+        let state = UnivariateBernoulliState {
+            prob: vec![0.3, 0.7, 0.5],
+        };
+        let mut rng = StdRng::seed_from_u64(5);
+        let samples = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::sample(
+            &UnivariateBernoulli,
+            &state,
+            500,
+            &mut rng,
+            &device,
+        );
+        let data = samples.into_data().into_vec::<f32>().unwrap();
+        for v in data {
+            // Exact float compare is correct here: sample() writes literal 0.0
+            // or 1.0, never a computed value.
+            #[allow(clippy::float_cmp)]
+            let is_binary = v == 0.0 || v == 1.0;
+            assert!(is_binary, "non-binary gene {v}");
+        }
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
@@ -1,0 +1,350 @@
+//! Univariate Gaussian model (UMDA — Univariate Marginal Distribution
+//! Algorithm) for continuous search spaces.
+//!
+//! Each dimension is modelled by an independent Gaussian. [`fit`] performs an
+//! unweighted maximum-likelihood estimate over the `k` selected rows: the
+//! per-column mean and variance are computed via `÷k` (not `÷(k-1)`), and the
+//! variance is floored at [`UnivariateGaussianParams::min_variance`] to prevent
+//! collapse to a point mass. The `fitness` tensor is accepted by the
+//! [`ProbabilityModel`] interface but ignored; the fit is unweighted.
+//! [`sample`] draws each gene from its dimension's fitted Gaussian using the
+//! supplied host RNG (never `Tensor::random` / `B::seed`).
+//!
+//! Cross-dimension dependencies are not captured — for those, see
+//! [`super::dependency_chain`].
+//!
+//! # References
+//!
+//! - Mühlenbein & Paaß (1996), *From recombination of genes to the
+//!   estimation of distributions I. Binary parameters*.
+//!
+//! [`fit`]: crate::ProbabilityModel::fit
+//! [`sample`]: crate::ProbabilityModel::sample
+
+use burn::tensor::{Tensor, TensorData, backend::Backend};
+use rand::Rng;
+use rand_distr::{Distribution as _, Normal};
+
+use crate::probability_model::ProbabilityModel;
+
+/// Per-run configuration for the [`UnivariateGaussian`] model.
+///
+/// Held inside [`EdaParams::model`](crate::algorithms::eda::EdaParams::model)
+/// for the lifetime of a run. All fields are `pub` for struct-literal
+/// construction; use [`UnivariateGaussianParams::default_for`] for typical
+/// continuous-optimisation defaults.
+#[derive(Debug, Clone)]
+pub struct UnivariateGaussianParams {
+    /// Number of genes per genome; determines the length of
+    /// [`UnivariateGaussianState::mean`] and [`UnivariateGaussianState::variance`].
+    pub genome_dim: usize,
+    /// Prior mean for every dimension, used when `prev = None`.
+    pub init_mean: f32,
+    /// Prior standard deviation for every dimension, used when `prev = None`.
+    /// The prior variance is `init_std²`.
+    pub init_std: f32,
+    /// Minimum variance for any dimension; prevents the model from collapsing
+    /// to a point mass. The MLE estimate is floored at this value after each
+    /// [`ProbabilityModel::fit`] call.
+    pub min_variance: f32,
+}
+
+impl UnivariateGaussianParams {
+    /// Sensible defaults for a `genome_dim`-dimensional continuous problem.
+    #[must_use]
+    pub fn default_for(genome_dim: usize) -> Self {
+        Self {
+            genome_dim,
+            init_mean: 0.0,
+            init_std: 2.0,
+            min_variance: 1e-6,
+        }
+    }
+}
+
+/// Fitted statistics for the [`UnivariateGaussian`] model after one call to
+/// [`ProbabilityModel::fit`].
+///
+/// Both vectors have length `genome_dim`. On the prior path (`prev = None`)
+/// they are initialised from [`UnivariateGaussianParams::init_mean`] /
+/// `init_std²`; on subsequent calls they hold the unweighted MLE estimates
+/// computed from the truncation-selected population.
+#[derive(Debug, Clone)]
+pub struct UnivariateGaussianState {
+    /// Per-dimension MLE mean.
+    pub mean: Vec<f32>,
+    /// Per-dimension MLE variance, floored at
+    /// [`UnivariateGaussianParams::min_variance`].
+    pub variance: Vec<f32>,
+}
+
+/// Univariate Marginal Distribution Algorithm for continuous spaces (UMDA).
+///
+/// Implements [`ProbabilityModel`] with an unweighted per-dimension Gaussian
+/// fit (`÷k` MLE variance, [`UnivariateGaussianParams::min_variance`] floor)
+/// and independent per-dimension Gaussian sampling via the host RNG.
+/// The fitness tensor passed to [`ProbabilityModel::fit`] is accepted but
+/// ignored; the estimate is always unweighted.
+///
+/// See the [module docs](self) for the algorithm description and references.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UnivariateGaussian;
+
+impl<B: Backend> ProbabilityModel<B> for UnivariateGaussian {
+    type Params = UnivariateGaussianParams;
+    type State = UnivariateGaussianState;
+
+    /// Fit per-dimension Gaussian statistics to the selected population.
+    ///
+    /// When `prev = None` returns the prior (length-`genome_dim` vectors of
+    /// `init_mean` and `init_std²`); `population` and `fitness` are ignored
+    /// on that path. Otherwise computes the unweighted `÷k` MLE mean and
+    /// variance for every column and floors each variance at `min_variance`.
+    /// The `fitness` argument is accepted but always ignored.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic. The `expect` inside `sample` (not `fit`) is guarded
+    /// by the variance floor, which guarantees a positive, finite standard
+    /// deviation for every dimension.
+    fn fit(
+        &self,
+        params: &Self::Params,
+        prev: Option<&Self::State>,
+        population: Tensor<B, 2>,
+        fitness: Tensor<B, 1>,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let _ = device;
+        // Fitness is accepted but ignored: the MLE fit is unweighted.
+        let _ = fitness;
+        let Some(_prev) = prev else {
+            // Prior path: build purely from params, ignore population/fitness.
+            let d = params.genome_dim;
+            return UnivariateGaussianState {
+                mean: vec![params.init_mean; d],
+                variance: vec![params.init_std * params.init_std; d],
+            };
+        };
+        // `prev`'s contents are unused on this path — UMDA is a full refit.
+
+        let [k, d] = population.dims();
+        let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
+        // k is a selected-population count, far below f32's 2^24 exact-integer
+        // limit; the cast is lossless in practice.
+        #[allow(clippy::cast_precision_loss)]
+        let kf = k as f32;
+
+        let mut mean = vec![0.0_f32; d];
+        for i in 0..k {
+            for j in 0..d {
+                mean[j] += rows[i * d + j];
+            }
+        }
+        for m in &mut mean {
+            *m /= kf;
+        }
+
+        let mut variance = vec![0.0_f32; d];
+        for i in 0..k {
+            for j in 0..d {
+                let diff = rows[i * d + j] - mean[j];
+                variance[j] += diff * diff;
+            }
+        }
+        for v in &mut variance {
+            *v = (*v / kf).max(params.min_variance);
+        }
+
+        UnivariateGaussianState { mean, variance }
+    }
+
+    /// Draw `n` genomes from the fitted per-dimension Gaussians.
+    ///
+    /// All randomness is drawn from `rng` (host RNG only; never
+    /// `Tensor::random` / `B::seed`). The returned tensor has shape `(n, D)`.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic under normal operation. The internal `Normal::new`
+    /// constructor is guarded by `min_variance`, ensuring the standard
+    /// deviation is always strictly positive and finite.
+    fn sample(
+        &self,
+        state: &Self::State,
+        n: usize,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Tensor<B, 2> {
+        let d = state.mean.len();
+        // One Normal per dimension; the floored std is positive and finite.
+        let normals: Vec<Normal<f32>> = (0..d)
+            .map(|j| {
+                Normal::new(state.mean[j], state.variance[j].sqrt())
+                    .expect("floored std is positive and finite")
+            })
+            .collect();
+        // Row-major fill: outer loop individuals, inner loop dimensions.
+        let mut rows = Vec::with_capacity(n * d);
+        for _ in 0..n {
+            for normal in &normals {
+                rows.push(normal.sample(rng));
+            }
+        }
+        Tensor::<B, 2>::from_data(TensorData::new(rows, [n, d]), device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestBackend = Flex;
+
+    fn pop(rows: Vec<f32>, n: usize, d: usize) -> Tensor<TestBackend, 2> {
+        let device = Default::default();
+        Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [n, d]), &device)
+    }
+
+    fn fitness(values: Vec<f32>) -> Tensor<TestBackend, 1> {
+        let device = Default::default();
+        let n = values.len();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(values, [n]), &device)
+    }
+
+    #[test]
+    fn prior_from_params() {
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let p = UnivariateGaussianParams::default_for(3);
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        );
+        assert_eq!(state.mean, vec![0.0, 0.0, 0.0]);
+        for v in &state.variance {
+            approx::assert_relative_eq!(*v, 4.0, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn mle_matches_hand_computed() {
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let p = UnivariateGaussianParams::default_for(2);
+        // Column 0: [0, 2, 4] → mean 2, var = (4+0+4)/3 = 8/3.
+        // Column 1: [1, 1, 4] → mean 2, var = (1+1+4)/3 = 2.
+        let population = pop(vec![0.0, 1.0, 2.0, 1.0, 4.0, 4.0], 3, 2);
+        let prior = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        );
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            Some(&prior),
+            population,
+            fitness(vec![0.0, 1.0, 2.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.mean[0], 2.0, epsilon = 1e-5);
+        approx::assert_relative_eq!(state.mean[1], 2.0, epsilon = 1e-5);
+        approx::assert_relative_eq!(state.variance[0], 8.0 / 3.0, epsilon = 1e-5);
+        approx::assert_relative_eq!(state.variance[1], 2.0, epsilon = 1e-5);
+    }
+
+    #[test]
+    fn variance_floor_engages_on_constant_column() {
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let p = UnivariateGaussianParams::default_for(1);
+        let prior = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        );
+        // Constant column → raw variance 0, floored to min_variance.
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            Some(&prior),
+            pop(vec![3.0, 3.0, 3.0], 3, 1),
+            fitness(vec![0.0, 0.0, 0.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.variance[0], p.min_variance, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn fitness_is_ignored() {
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let p = UnivariateGaussianParams::default_for(2);
+        let prior = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        );
+        let rows = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let a = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            Some(&prior),
+            pop(rows.clone(), 3, 2),
+            fitness(vec![0.0, 1.0, 2.0]),
+            &device,
+        );
+        let b = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            Some(&prior),
+            pop(rows, 3, 2),
+            fitness(vec![100.0, -7.0, 42.0]),
+            &device,
+        );
+        assert_eq!(a.mean, b.mean);
+        assert_eq!(a.variance, b.variance);
+    }
+
+    #[test]
+    fn seeded_sampling_mean_matches_state() {
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let state = UnivariateGaussianState {
+            mean: vec![3.0, -1.0],
+            variance: vec![1.0, 0.25],
+        };
+        let mut rng = StdRng::seed_from_u64(123);
+        let samples = <UnivariateGaussian as ProbabilityModel<TestBackend>>::sample(
+            &model, &state, 10_000, &mut rng, &device,
+        );
+        let dims = samples.dims();
+        assert_eq!(dims, [10_000, 2]);
+        let data = samples.into_data().into_vec::<f32>().unwrap();
+        let mut sum0 = 0.0_f32;
+        let mut sum1 = 0.0_f32;
+        for i in 0..10_000 {
+            sum0 += data[i * 2];
+            sum1 += data[i * 2 + 1];
+        }
+        approx::assert_relative_eq!(sum0 / 10_000.0, 3.0, epsilon = 0.1);
+        approx::assert_relative_eq!(sum1 / 10_000.0, -1.0, epsilon = 0.1);
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/mod.rs
@@ -12,6 +12,12 @@
 //!
 //! - [`metaheuristic`] — PSO, `ACO_R`, ABC, GWO, WOA, CS, FA, BA, SSA.
 //!
+//! # Estimation-of-distribution algorithms
+//!
+//! - [`eda`] — [`EdaStrategy`](eda::EdaStrategy) over a
+//!   [`ProbabilityModel`](crate::ProbabilityModel): UMDA, PBIL, compact-GA,
+//!   and a dependency-chain MIMIC model.
+//!
 //! # Hybrid / composite strategies
 //!
 //! - [`memetic`] — [`MemeticWrapper`](memetic::MemeticWrapper): wraps any
@@ -19,6 +25,7 @@
 //!   (Lamarckian / Baldwinian / Partial writeback).
 
 pub mod de;
+pub mod eda;
 pub mod ep;
 pub mod es_classical;
 pub mod ga;

--- a/crates/rlevo-evolution/src/lib.rs
+++ b/crates/rlevo-evolution/src/lib.rs
@@ -33,6 +33,8 @@
 //! - [`local_search`] — host-side, gradient-free refinement
 //!   ([`LocalSearch`] and the four reference
 //!   searchers) for memetic algorithms.
+//! - [`probability_model`] — the [`ProbabilityModel`] trait shared by the
+//!   estimation-of-distribution (EDA) strategies.
 //! - [`algorithms`] — concrete strategies.
 
 pub mod algorithms;
@@ -42,11 +44,18 @@ pub mod local_search;
 pub mod observer;
 pub mod ops;
 pub mod population;
+pub mod probability_model;
 pub mod rng;
 pub mod shaping;
 pub mod strategy;
 
+pub use algorithms::eda::{
+    CompactGenetic, CompactGeneticParams, DependencyChain, DependencyChainParams, EdaParams,
+    EdaState, EdaStrategy, UnivariateBernoulli, UnivariateBernoulliParams, UnivariateGaussian,
+    UnivariateGaussianParams,
+};
 pub use algorithms::memetic::{CoveragePolicy, MemeticWrapper, WritebackPolicy};
+pub use probability_model::ProbabilityModel;
 pub use local_search::{
     HillClimbing, LocalSearch, NelderMead, RandomRestart, SimulatedAnnealing,
 };

--- a/crates/rlevo-evolution/src/local_search.rs
+++ b/crates/rlevo-evolution/src/local_search.rs
@@ -262,10 +262,14 @@ impl<'a> BudgetedEval<'a> {
 /// `+inf` is the worst value under minimization, so a sanitized `NaN` can never
 /// seed or displace a finite best-so-far and thus never propagates to a returned
 /// fitness. This is the single rule shared by [`BudgetedEval::eval`] (applied to
-/// every probe, including the seeding eval) and the searchers'
+/// every probe, including the seeding eval), the searchers'
 /// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness)
 /// overrides (applied to the `known_fitness` hint, which does not flow through
-/// `BudgetedEval`). For the finite benchmark landscapes the searchers ship
+/// `BudgetedEval`), and the EDA `tell` chokepoint
+/// ([`crate::algorithms::eda::EdaStrategy`]), which sanitizes the whole
+/// per-generation fitness vector before argmin/selection so a `NaN` can neither
+/// become the best-so-far nor corrupt the truncation ordering. For the finite
+/// benchmark landscapes the searchers ship
 /// against this branch is never taken, so it costs only one `is_nan` check.
 pub(crate) fn sanitize_fitness(f: f32) -> f32 {
     if f.is_nan() {

--- a/crates/rlevo-evolution/src/probability_model.rs
+++ b/crates/rlevo-evolution/src/probability_model.rs
@@ -1,0 +1,160 @@
+//! The [`ProbabilityModel`] trait shared by estimation-of-distribution
+//! algorithms (EDAs).
+//!
+//! An EDA replaces an explicit recombination operator with an explicit
+//! probabilistic model of the promising region of search space. Each
+//! generation fits a model to the selected individuals and then samples a
+//! fresh population from it. This module defines the seam between the
+//! generic [`crate::algorithms::eda::EdaStrategy`] driver and the concrete
+//! model implementations (univariate Gaussian, Bernoulli, compact-GA, and a
+//! dependency-chain MIMIC model).
+
+use std::fmt::Debug;
+
+use burn::tensor::{Tensor, backend::Backend};
+use rand::Rng;
+
+/// A probabilistic model of a promising region of search space.
+///
+/// EDAs run a `fit` → `sample` loop: each generation, [`fit`](Self::fit)
+/// estimates model parameters from the (already truncation-selected)
+/// population, then [`sample`](Self::sample) draws the next candidate
+/// population from the fitted model. The model fully replaces the crossover
+/// and mutation operators of a classical GA.
+///
+/// The two associated types separate *static* per-model configuration
+/// ([`Params`](Self::Params), e.g. learning rates, initial means) from the
+/// *evolving* fitted statistics ([`State`](Self::State), e.g. per-dimension
+/// means and variances). [`State`](Self::State) is deliberately `Sync` (a
+/// stronger bound than the `Send`-only [`crate::Strategy::State`]) so a future
+/// covariance-carrying CMA-ES state can be shared across threads; the same
+/// `fit`/`sample` shape is intended to host that model unchanged.
+///
+/// The `fitness` tensor is passed to [`fit`](Self::fit) so models that weight
+/// or rank the selected individuals (rank-μ updates, weighted MLE) can use it.
+/// The univariate models shipped here perform an unweighted maximum-likelihood
+/// fit and ignore it.
+///
+/// # Invariants
+///
+/// - **Prior path.** When `prev = None`, the model builds its prior *purely*
+///   from [`params`](Self::Params). On this path the `population` and
+///   `fitness` tensors are ignored; [`EdaStrategy`](crate::algorithms::eda::EdaStrategy)'s
+///   `init` passes them as a `0 × 0` population and a length-`0` fitness tensor,
+///   so a model must never read their contents when `prev` is `None`.
+/// - **Host RNG only.** All randomness in [`sample`](Self::sample) must come
+///   from the supplied `rng`. Implementations must never call `Tensor::random`
+///   or `B::seed`: Burn's GPU PRNG kernels are seeded through process-global
+///   state, which interleaves across parallel strategy calls and breaks the
+///   per-stream determinism the crate guarantees. Sample on the host and upload
+///   with `Tensor::from_data`.
+/// - **Selection order.** The population rows handed to [`fit`](Self::fit) by
+///   [`EdaStrategy`](crate::algorithms::eda::EdaStrategy)'s `tell` arrive in
+///   *ascending-fitness*
+///   order (best first), deterministically. Models that need the best or worst
+///   row (e.g. PBIL, cGA) must still compute argmin/argmax themselves rather
+///   than assume a fixed index — the ascending order is a convenience, not a
+///   contract a model may hard-code against.
+/// - **`Sync` state.** [`State`](Self::State) requires `Sync`, deliberately
+///   exceeding [`crate::Strategy::State`]'s `Send`-only bound, to leave room for
+///   a future thread-shared CMA-ES state.
+///
+/// # Examples
+///
+/// ```
+/// use burn::backend::Flex;
+/// use burn::tensor::{Tensor, TensorData};
+/// use rand::{rngs::StdRng, SeedableRng};
+/// use rlevo_evolution::ProbabilityModel;
+/// use rlevo_evolution::algorithms::eda::{UnivariateGaussian, UnivariateGaussianParams};
+///
+/// let device = Default::default();
+/// let model = UnivariateGaussian;
+/// let params = UnivariateGaussianParams::default_for(2);
+///
+/// // Fit to a tiny two-row, two-column selected population.
+/// let pop = Tensor::<Flex, 2>::from_data(
+///     TensorData::new(vec![0.0_f32, 0.0, 2.0, 2.0], [2, 2]),
+///     &device,
+/// );
+/// let fitness = Tensor::<Flex, 1>::from_data(TensorData::new(vec![0.0_f32, 8.0], [2]), &device);
+/// let state =
+///     ProbabilityModel::<Flex>::fit(&model, &params, None, pop.clone(), fitness.clone(), &device);
+/// let next = ProbabilityModel::<Flex>::fit(&model, &params, Some(&state), pop, fitness, &device);
+///
+/// // Sample a fresh population from the fitted model.
+/// let mut rng = StdRng::seed_from_u64(0);
+/// let drawn: Tensor<Flex, 2> = model.sample(&next, 4, &mut rng, &device);
+/// assert_eq!(drawn.dims(), [4, 2]);
+/// ```
+pub trait ProbabilityModel<B: Backend>: Send + Sync {
+    /// Static, per-run model configuration (learning rates, priors, …).
+    type Params: Clone + Debug + Send + Sync;
+
+    /// Evolving fitted statistics carried generation to generation.
+    type State: Clone + Debug + Send + Sync;
+
+    /// Fit the model to the selected population.
+    ///
+    /// When `prev = None` the returned state is a prior derived purely from
+    /// `params` (see the trait [`Invariants`](Self#invariants)); `population`
+    /// and `fitness` are ignored on that path. Otherwise the model is refit to
+    /// the supplied selected rows (ascending fitness order). `fitness` is
+    /// available for weighted or rank-based updates; unweighted models ignore
+    /// it.
+    fn fit(
+        &self,
+        params: &Self::Params,
+        prev: Option<&Self::State>,
+        population: Tensor<B, 2>,
+        fitness: Tensor<B, 1>,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State;
+
+    /// Draw `n` candidate genomes from the fitted model.
+    ///
+    /// All randomness must be drawn from `rng` (host RNG only — never
+    /// `Tensor::random`/`B::seed`). The returned tensor has shape `(n, D)`
+    /// where `D` is the model's genome dimensionality.
+    fn sample(
+        &self,
+        state: &Self::State,
+        n: usize,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Tensor<B, 2>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithms::eda::{UnivariateGaussian, UnivariateGaussianParams};
+    use burn::backend::Flex;
+
+    type TestBackend = Flex;
+
+    #[test]
+    fn prior_ignores_empty_population_and_fitness() {
+        // Pin the `prev = None` invariant: a 0×0 population and 0-length
+        // fitness tensor (exactly what `EdaStrategy::init` passes) must be
+        // ignored, with the prior built purely from `params`.
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let params = UnivariateGaussianParams::default_for(3);
+
+        let empty_pop = Tensor::<TestBackend, 2>::empty([0, 0], &device);
+        let empty_fitness = Tensor::<TestBackend, 1>::empty([0], &device);
+
+        let state = model.fit(&params, None, empty_pop, empty_fitness, &device);
+
+        assert_eq!(state.mean.len(), 3);
+        assert_eq!(state.variance.len(), 3);
+        for &m in &state.mean {
+            approx::assert_relative_eq!(m, params.init_mean, epsilon = 1e-6);
+        }
+        let expected_var = params.init_std * params.init_std;
+        for &v in &state.variance {
+            approx::assert_relative_eq!(v, expected_var, epsilon = 1e-6);
+        }
+    }
+}

--- a/crates/rlevo-evolution/src/rng.rs
+++ b/crates/rlevo-evolution/src/rng.rs
@@ -47,6 +47,12 @@ pub enum SeedPurpose {
     /// per-individual refinement draws from a stream independent of the
     /// inner strategy's selection/mutation/crossover/replacement streams.
     LocalSearch = 7,
+    /// Model sampling in estimation-of-distribution (EDA) strategies.
+    ///
+    /// Used by [`crate::algorithms::eda`] so each generation draws its new
+    /// population from an independent per-generation stream, isolated from
+    /// every other operator purpose.
+    EdaSampling = 8,
 }
 
 impl SeedPurpose {
@@ -60,6 +66,7 @@ impl SeedPurpose {
             SeedPurpose::Trial => 0xBAAD_F00D_DEAD_C0DE,
             SeedPurpose::Other => 0x9E37_79B9_7F4A_7C15,
             SeedPurpose::LocalSearch => 0xC0FF_EE15_600D_F00D,
+            SeedPurpose::EdaSampling => 0xEDA0_5EED_BEEF_CAFE,
         }
     }
 }
@@ -122,18 +129,26 @@ mod tests {
         }
     }
 
+    // One single-letter binding per purpose under test; the names index the
+    // purpose list rather than carrying independent meaning.
+    #[allow(clippy::many_single_char_names)]
     #[test]
     fn different_purposes_produce_different_streams() {
         let a = seed_stream(42, 0, SeedPurpose::Init).next_u64();
         let b = seed_stream(42, 0, SeedPurpose::Selection).next_u64();
         let c = seed_stream(42, 0, SeedPurpose::Mutation).next_u64();
         let d = seed_stream(42, 0, SeedPurpose::LocalSearch).next_u64();
+        let e = seed_stream(42, 0, SeedPurpose::EdaSampling).next_u64();
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
         assert_ne!(a, d);
         assert_ne!(b, d);
         assert_ne!(c, d);
+        assert_ne!(a, e);
+        assert_ne!(b, e);
+        assert_ne!(c, e);
+        assert_ne!(d, e);
     }
 
     #[test]

--- a/crates/rlevo-evolution/tests/eda_smoke.rs
+++ b/crates/rlevo-evolution/tests/eda_smoke.rs
@@ -1,0 +1,115 @@
+//! Smoke integration tests for the estimation-of-distribution strategies.
+//!
+//! Each test drives an [`EdaStrategy`] over one [`ProbabilityModel`] through
+//! the [`EvolutionaryHarness`] for a handful of generations and asserts the
+//! plumbing holds: no panic, metrics and best-so-far become available, and the
+//! best fitness stays finite. These are not convergence tests — they only
+//! exercise the full ask → evaluate → tell loop end to end.
+
+use burn::backend::Flex;
+use rlevo_core::fitness::FitnessEvaluable;
+
+use rlevo_evolution::algorithms::eda::{
+    CompactGenetic, CompactGeneticParams, DependencyChain, DependencyChainParams, EdaParams,
+    EdaStrategy, UnivariateBernoulli, UnivariateBernoulliParams, UnivariateGaussian,
+    UnivariateGaussianParams,
+};
+use rlevo_evolution::fitness::{BatchFitnessFn, FromFitnessEvaluable};
+use rlevo_evolution::probability_model::ProbabilityModel;
+use rlevo_evolution::strategy::{EvolutionaryHarness, Strategy};
+
+type B = Flex;
+
+struct Sphere;
+struct SphereFit;
+impl FitnessEvaluable for SphereFit {
+    type Individual = Vec<f64>;
+    type Landscape = Sphere;
+    fn evaluate(&self, x: &Self::Individual, _: &Self::Landscape) -> f64 {
+        x.iter().map(|v| v * v).sum()
+    }
+}
+
+/// Drive an EDA strategy for ten generations and assert the plumbing holds.
+fn smoke<M>(model: M, params: EdaParams<M::Params>)
+where
+    M: ProbabilityModel<B> + 'static,
+    EdaStrategy<B, M>: Strategy<
+            B,
+            Genome = burn::tensor::Tensor<B, 2>,
+            Params = EdaParams<<M as ProbabilityModel<B>>::Params>,
+        >,
+    FromFitnessEvaluable<SphereFit, Sphere>:
+        BatchFitnessFn<B, <EdaStrategy<B, M> as Strategy<B>>::Genome>,
+{
+    let device = Default::default();
+    let strategy = EdaStrategy::<B, M>::new(model);
+    let mut harness = EvolutionaryHarness::<B, _, _>::new(
+        strategy,
+        params,
+        FromFitnessEvaluable::new(SphereFit, Sphere),
+        7,
+        device,
+        10,
+    );
+    harness.reset();
+    loop {
+        let step = harness.step(());
+        if step.done {
+            break;
+        }
+    }
+    let metrics = harness.latest_metrics();
+    assert!(metrics.is_some(), "latest_metrics must be Some after a run");
+    assert!(
+        metrics.unwrap().best_fitness_ever.is_finite(),
+        "best fitness must be finite"
+    );
+    let best = harness.best();
+    assert!(best.is_some(), "best() must be Some after the first tell");
+    assert!(best.unwrap().1.is_finite(), "best genome fitness must be finite");
+}
+
+#[test]
+fn smoke_univariate_gaussian() {
+    let params = EdaParams {
+        pop_size: 20,
+        selection_ratio: 0.5,
+        bounds: Some((-5.12, 5.12)),
+        model: UnivariateGaussianParams::default_for(8),
+    };
+    smoke(UnivariateGaussian, params);
+}
+
+#[test]
+fn smoke_dependency_chain() {
+    let params = EdaParams {
+        pop_size: 20,
+        selection_ratio: 0.5,
+        bounds: Some((-5.12, 5.12)),
+        model: DependencyChainParams::default_for(8),
+    };
+    smoke(DependencyChain, params);
+}
+
+#[test]
+fn smoke_univariate_bernoulli() {
+    let params = EdaParams {
+        pop_size: 20,
+        selection_ratio: 0.5,
+        bounds: None,
+        model: UnivariateBernoulliParams::default_for(8),
+    };
+    smoke(UnivariateBernoulli, params);
+}
+
+#[test]
+fn smoke_compact_genetic() {
+    let params = EdaParams {
+        pop_size: 20,
+        selection_ratio: 0.5,
+        bounds: None,
+        model: CompactGeneticParams::default_for(8),
+    };
+    smoke(CompactGenetic, params);
+}

--- a/crates/rlevo-examples/Cargo.toml
+++ b/crates/rlevo-examples/Cargo.toml
@@ -84,3 +84,8 @@ path = "examples/harness/ga_rastrigin.rs"
 [[example]]
 name = "tabular_bandit"
 path = "examples/harness/tabular_bandit.rs"
+
+# Examples — evolution (EDA probability models)
+[[example]]
+name = "eda_showcase"
+path = "examples/evolution/eda_showcase.rs"

--- a/crates/rlevo-examples/examples/evolution/eda_showcase.rs
+++ b/crates/rlevo-examples/examples/evolution/eda_showcase.rs
@@ -1,0 +1,409 @@
+//! EDA showcase: estimation-of-distribution algorithms *learn a model* of the
+//! search space instead of recombining individuals.
+//!
+//! A classical GA produces the next generation by crossing over and mutating
+//! parents. An EDA throws that away: each generation it (1) truncation-selects
+//! the best individuals, (2) **fits a probability model** to them, and (3)
+//! **samples** a fresh population from that model. The model *is* the algorithm,
+//! so this example prints the model's internals as they evolve rather than
+//! hiding them behind the [`EvolutionaryHarness`]. It drives the
+//! [`Strategy`] `ask` → evaluate → `tell` loop by hand for exactly that reason.
+//!
+//! Two demos, each paired with the problem that actually exercises its models:
+//!
+//! ## Demo 1 — continuous, Rosenbrock-D10: why dependencies matter
+//!
+//! Compares [`UnivariateGaussian`] (UMDA, models each dimension independently)
+//! against [`DependencyChain`] (MIMIC, models a first-order chain of pairwise
+//! dependencies). Rosenbrock's `x_{i+1} ≈ x_i²` ridge *couples* adjacent
+//! variables — structure a univariate model literally cannot represent. Watch
+//! MIMIC's `link_corr` vector light up as it discovers the coupling, then beat
+//! UMDA's final fitness. (The calibrated prior — `init_mean = 0.5`,
+//! `min_variance = 1e-3`, `selection_ratio = 0.3`, de Jong bounds ±2.048 — puts
+//! the population on the valley limb where the coupling is locally linear;
+//! centred at the origin the ridge's tangent is flat and there is nothing to
+//! model. See `crates/rlevo/tests/eda_convergence.rs` for the full rationale.)
+//!
+//! ## Demo 2 — binary, `OneMax`-D20: the probability-vector mechanic
+//!
+//! Runs [`UnivariateBernoulli`] (PBIL) and [`CompactGenetic`] (cGA) on `OneMax`
+//! (maximise the number of 1-bits). Both emit raw `{0, 1}` genes and carry a
+//! per-gene probability vector; watch it march to all-ones. `OneMax` is fully
+//! *separable*, so a univariate model is already optimal here — the binary
+//! analogue of "dependencies matter" needs a deceptive problem **and** a
+//! multivariate binary model (BOA), which is deferred to issue #37.
+//!
+//! # Running
+//!
+//! ```text
+//! cargo run --release -p rlevo-examples --example eda_showcase
+//! ```
+//!
+//! No feature flags are required. Release is recommended — the run drives a few
+//! thousand generations of Burn tensor ops.
+
+use burn::backend::Flex;
+use burn::tensor::backend::BackendTypes;
+use burn::tensor::{Tensor, TensorData};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_environments::landscapes::rosenbrock::Rosenbrock;
+use rlevo_evolution::algorithms::eda::{
+    CompactGeneticState, DependencyChainState, UnivariateBernoulliState, UnivariateGaussianState,
+};
+use rlevo_evolution::{
+    CompactGenetic, CompactGeneticParams, DependencyChain, DependencyChainParams, EdaParams,
+    EdaStrategy, ProbabilityModel, Strategy, UnivariateBernoulli, UnivariateBernoulliParams,
+    UnivariateGaussian, UnivariateGaussianParams,
+};
+
+type B = Flex;
+
+/// Rosenbrock under the EDA minimization convention. The host genome row is
+/// `f32`; widen to `f64` for the landscape, then narrow the scalar back.
+#[allow(clippy::cast_possible_truncation)]
+fn rosenbrock_fitness(landscape: Rosenbrock, row: &[f32]) -> f32 {
+    let point: Vec<f64> = row.iter().map(|&g| f64::from(g)).collect();
+    landscape.evaluate(&point) as f32
+}
+
+/// Evaluate every row of a `(pop_size, D)` population tensor with a host-side
+/// scalar fitness closure and return the `(pop_size,)` fitness tensor.
+///
+/// This mirrors what [`rlevo_evolution::fitness::FromLandscape`] does inside
+/// the harness; we inline it so the binary `OneMax` demo needs no `Landscape`
+/// impl and both demos read identically.
+#[allow(clippy::trivially_copy_pass_by_ref)] // device is a ZST; &-passing reads clearer
+fn eval_population<F>(
+    pop: &Tensor<B, 2>,
+    device: &<B as BackendTypes>::Device,
+    mut fitness: F,
+) -> Tensor<B, 1>
+where
+    F: FnMut(&[f32]) -> f32,
+{
+    let [n, d] = pop.dims();
+    let flat = pop.clone().into_data().into_vec::<f32>().unwrap();
+    let values: Vec<f32> = flat.chunks(d).map(&mut fitness).collect();
+    Tensor::<B, 1>::from_data(TensorData::new(values, [n]), device)
+}
+
+/// Drive an EDA model for `gens` generations via the bare `Strategy` loop,
+/// calling `report(generation, &model_state)` after every `tell` so the caller
+/// can print the freshly-refitted model. Returns the best fitness ever seen.
+fn run_eda<M, F, R>(
+    model: M,
+    params: &EdaParams<M::Params>,
+    seed: u64,
+    gens: usize,
+    mut fitness: F,
+    mut report: R,
+) -> f32
+where
+    M: ProbabilityModel<B> + 'static,
+    F: FnMut(&[f32]) -> f32,
+    R: FnMut(usize, &M::State),
+{
+    let device: <B as BackendTypes>::Device = Default::default();
+    let strategy = EdaStrategy::<B, M>::new(model);
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut state = strategy.init(params, &mut rng, &device);
+
+    for generation in 0..gens {
+        let (population, carried) = strategy.ask(params, &state, &mut rng, &device);
+        let fit = eval_population(&population, &device, &mut fitness);
+        let (next, _metrics) = strategy.tell(params, population, fit, carried, &mut rng);
+        state = next;
+        report(generation, &state.model_state);
+    }
+
+    strategy.best(&state).map_or(f32::INFINITY, |(_, f)| f)
+}
+
+fn mean(xs: &[f32]) -> f32 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let n = xs.len() as f32;
+    xs.iter().sum::<f32>() / n
+}
+
+fn median(values: &mut [f32]) -> f32 {
+    values.sort_by(f32::total_cmp);
+    values[values.len() / 2]
+}
+
+/// Log schedule for the verbose single-seed traces: print at generations
+/// 1, 2, 5, 10, 25, 50, 100, 250, 500. A converging EDA does most of its
+/// model-shaping early — and MIMIC only captures significant correlations
+/// while the selected set is still spread out — so the early generations
+/// are exactly the ones worth seeing. Uniform spacing buries them.
+fn logged(generation: usize) -> bool {
+    matches!(generation + 1, 1 | 2 | 5 | 10 | 25 | 50 | 100 | 250 | 500)
+}
+
+// ── Demo 1 — continuous: UMDA vs MIMIC on Rosenbrock ──────────────────────────
+
+const ROSEN_DIM: usize = 10;
+const ROSEN_POP: usize = 50;
+const ROSEN_GENS: usize = 500;
+const ROSEN_RATIO: f32 = 0.3;
+const ROSEN_INIT_MEAN: f32 = 0.5;
+const ROSEN_INIT_STD: f32 = 0.5;
+const ROSEN_MIN_VAR: f32 = 1e-3;
+const ROSEN_BOUNDS: Option<(f32, f32)> = Some((-2.048, 2.048));
+const ROSEN_SEEDS: [u64; 9] = [101, 202, 303, 404, 505, 606, 707, 808, 909];
+
+fn umda_params() -> UnivariateGaussianParams {
+    let mut p = UnivariateGaussianParams::default_for(ROSEN_DIM);
+    p.init_mean = ROSEN_INIT_MEAN;
+    p.init_std = ROSEN_INIT_STD;
+    p.min_variance = ROSEN_MIN_VAR;
+    p
+}
+
+fn mimic_params() -> DependencyChainParams {
+    let mut p = DependencyChainParams::default_for(ROSEN_DIM);
+    p.init_mean = ROSEN_INIT_MEAN;
+    p.init_std = ROSEN_INIT_STD;
+    p.min_variance = ROSEN_MIN_VAR;
+    p
+}
+
+fn eda_params<MP>(model: MP) -> EdaParams<MP> {
+    EdaParams {
+        pop_size: ROSEN_POP,
+        selection_ratio: ROSEN_RATIO,
+        bounds: ROSEN_BOUNDS,
+        model,
+    }
+}
+
+fn rosenbrock_demo() {
+    println!("══ Demo 1: UMDA vs MIMIC on Rosenbrock-D{ROSEN_DIM} ══");
+    println!(
+        "Rosenbrock couples adjacent variables (x_{{i+1}} ≈ x_i²). UMDA models each\n\
+         dimension independently; MIMIC fits a dependency chain. Watch MIMIC's\n\
+         strongest captured link correlation grow while UMDA has no such notion.\n"
+    );
+
+    let landscape = Rosenbrock::new(ROSEN_DIM);
+    let trace_seed = ROSEN_SEEDS[0];
+
+    // Verbose single-seed run: UMDA. Print mean position magnitude + mean σ.
+    println!("UMDA (seed {trace_seed}) — independent per-dimension Gaussian:");
+    println!("  {:>4} {:>12} {:>10}", "gen", "mean|μ|", "mean σ");
+    let umda_best = run_eda(
+        UnivariateGaussian,
+        &eda_params(umda_params()),
+        trace_seed,
+        ROSEN_GENS,
+        |row| rosenbrock_fitness(landscape, row),
+        |g, st: &UnivariateGaussianState| {
+            if logged(g) {
+                let mean_abs_mu = mean(&st.mean.iter().map(|m| m.abs()).collect::<Vec<_>>());
+                let mean_sigma = mean(&st.variance.iter().map(|v| v.sqrt()).collect::<Vec<_>>());
+                println!("  {:>4} {mean_abs_mu:>12.5} {mean_sigma:>10.5}", g + 1);
+            }
+        },
+    );
+    println!("  → best fitness: {umda_best:.5}\n");
+
+    // Verbose single-seed run: MIMIC. Print the strongest surviving link per
+    // snapshot, and track the peak captured dependency across the whole run —
+    // the chain regularizes its links to zero once the elite set tightens, so
+    // the snapshot value alone understates how much structure it exploited.
+    println!("MIMIC (seed {trace_seed}) — first-order dependency chain:");
+    println!(
+        "  {:>4} {:>12} {:>10} {:>10}  strongest surviving link",
+        "gen", "mean|μ|", "mean σ", "max|r|"
+    );
+    let mut peak_corr = 0.0_f32;
+    let mut peak_link: (usize, usize) = (0, 0);
+    let mut link_gens = 0_usize;
+    let mimic_best = run_eda(
+        DependencyChain,
+        &eda_params(mimic_params()),
+        trace_seed,
+        ROSEN_GENS,
+        |row| rosenbrock_fitness(landscape, row),
+        |g, st: &DependencyChainState| {
+            // Strongest captured dependency this generation: the chain position
+            // whose link correlation has the largest magnitude, and the (parent
+            // → child) dims it ties. Position 0 is the root (no parent).
+            let (pos, corr) = st
+                .link_corr
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.abs().total_cmp(&b.1.abs()))
+                .map_or((0, 0.0), |(p, &c)| (p, c.abs()));
+            let link = if pos >= 1 && st.chain.len() >= 2 {
+                Some((st.chain[pos - 1], st.chain[pos]))
+            } else {
+                None
+            };
+            // Peak tracking runs every generation, not just on logged ones.
+            if corr > 0.0 {
+                link_gens += 1;
+            }
+            if corr > peak_corr {
+                peak_corr = corr;
+                if let Some(l) = link {
+                    peak_link = l;
+                }
+            }
+            if logged(g) {
+                let mean_abs_mu = mean(&st.mean.iter().map(|m| m.abs()).collect::<Vec<_>>());
+                let mean_sigma = mean(&st.std);
+                let label = link.map_or_else(
+                    || "(all filtered out)".to_string(),
+                    |(parent, child)| format!("dim {parent} → dim {child}"),
+                );
+                println!("  {:>4} {mean_abs_mu:>12.5} {mean_sigma:>10.5} {corr:>10.4}  {label}", g + 1);
+            }
+        },
+    );
+    println!(
+        "  peak |r| = {peak_corr:.3} (dim {} → dim {}); {link_gens}/{ROSEN_GENS} \
+         generations captured ≥1 significant link",
+        peak_link.0, peak_link.1
+    );
+    println!("  → best fitness: {mimic_best:.5}\n");
+
+    rosenbrock_medians(landscape);
+}
+
+/// Robustness check: median final fitness over all nine seeds (the
+/// acceptance-gate configuration), so the MIMIC win reads as structural rather
+/// than a single lucky seed.
+fn rosenbrock_medians(landscape: Rosenbrock) {
+    let mut umda: Vec<f32> = ROSEN_SEEDS
+        .iter()
+        .map(|&seed| {
+            run_eda(
+                UnivariateGaussian,
+                &eda_params(umda_params()),
+                seed,
+                ROSEN_GENS,
+                |row| rosenbrock_fitness(landscape, row),
+                |_gen, _st: &UnivariateGaussianState| {},
+            )
+        })
+        .collect();
+    let mut mimic: Vec<f32> = ROSEN_SEEDS
+        .iter()
+        .map(|&seed| {
+            run_eda(
+                DependencyChain,
+                &eda_params(mimic_params()),
+                seed,
+                ROSEN_GENS,
+                |row| rosenbrock_fitness(landscape, row),
+                |_gen, _st: &DependencyChainState| {},
+            )
+        })
+        .collect();
+    let umda_med = median(&mut umda);
+    let mimic_med = median(&mut mimic);
+    println!("Median final fitness over {} seeds:", ROSEN_SEEDS.len());
+    println!("  UMDA  : {umda_med:.4}");
+    println!("  MIMIC : {mimic_med:.4}");
+    let verdict = if mimic_med < umda_med {
+        "MIMIC wins — modelling the coupling pays off"
+    } else {
+        "UMDA matched MIMIC this run"
+    };
+    println!("  → {verdict}\n");
+}
+
+// ── Demo 2 — binary: PBIL vs cGA on OneMax ────────────────────────────────────
+
+const ONEMAX_DIM: usize = 20;
+const ONEMAX_POP: usize = 50;
+const ONEMAX_GENS: usize = 120;
+const ONEMAX_RATIO: f32 = 0.5;
+const ONEMAX_SEED: u64 = 7;
+
+/// `OneMax` under the minimization convention: fitness is the number of `0`
+/// genes, so the all-ones optimum scores `0.0`. Genes arrive as raw `{0, 1}`
+/// `f32`; treat `>= 0.5` as a 1-bit.
+fn onemax_zeros(row: &[f32]) -> f32 {
+    #[allow(clippy::cast_precision_loss)]
+    let zeros = row.iter().filter(|&&g| g < 0.5).count() as f32;
+    zeros
+}
+
+/// Render a probability vector as one glyph per gene (`0`–`9` ≈ ⌊10·p⌋, `#` for
+/// p ≈ 1) so convergence reads without relying on colour.
+fn prob_bar(prob: &[f32]) -> String {
+    prob.iter()
+        .map(|&p| {
+            if p >= 0.99 {
+                '#'
+            } else {
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let d = (p * 10.0) as u8;
+                char::from(b'0' + d.min(9))
+            }
+        })
+        .collect()
+}
+
+fn onemax_demo() {
+    println!("══ Demo 2: PBIL vs cGA on OneMax-D{ONEMAX_DIM} ══");
+    println!(
+        "Both keep a per-gene probability vector and sample raw {{0,1}} genes — no\n\
+         crossover, no mutation. Watch the vector march to all-ones ('#'). OneMax is\n\
+         separable, so a univariate model is already optimal; the deceptive binary\n\
+         case that needs a multivariate model (BOA) is deferred to issue #37.\n"
+    );
+
+    println!("PBIL (seed {ONEMAX_SEED}):");
+    println!("  {:>4} {:>9}  probability vector (0–9, '#'≈1)", "gen", "mean p");
+    let pbil_best = run_eda(
+        UnivariateBernoulli,
+        &EdaParams {
+            pop_size: ONEMAX_POP,
+            selection_ratio: ONEMAX_RATIO,
+            bounds: None,
+            model: UnivariateBernoulliParams::default_for(ONEMAX_DIM),
+        },
+        ONEMAX_SEED,
+        ONEMAX_GENS,
+        onemax_zeros,
+        |g, st: &UnivariateBernoulliState| {
+            println!("  {:>4} {:>9.4}  {}", g + 1, mean(&st.prob), prob_bar(&st.prob));
+        },
+    );
+    println!("  → best fitness (0 = all-ones found): {pbil_best:.1}\n");
+
+    println!("cGA (seed {ONEMAX_SEED}):");
+    println!("  {:>4} {:>9}  probability vector (0–9, '#'≈1)", "gen", "mean p");
+    let cga_best = run_eda(
+        CompactGenetic,
+        &EdaParams {
+            pop_size: ONEMAX_POP,
+            selection_ratio: ONEMAX_RATIO,
+            bounds: None,
+            model: CompactGeneticParams::default_for(ONEMAX_DIM),
+        },
+        ONEMAX_SEED,
+        ONEMAX_GENS,
+        onemax_zeros,
+        |g, st: &CompactGeneticState| {
+            println!("  {:>4} {:>9.4}  {}", g + 1, mean(&st.prob), prob_bar(&st.prob));
+        },
+    );
+    println!("  → best fitness (0 = all-ones found): {cga_best:.1}\n");
+}
+
+fn main() {
+    println!(
+        "Estimation-of-Distribution Algorithms: replace crossover/mutation with a\n\
+         fit → sample loop over an explicit probability model.\n"
+    );
+    rosenbrock_demo();
+    onemax_demo();
+}

--- a/crates/rlevo/tests/determinism.rs
+++ b/crates/rlevo/tests/determinism.rs
@@ -1,0 +1,138 @@
+//! Bit-exact determinism for the EDA strategies (cross-crate).
+//!
+//! Runs each of the four `ProbabilityModel` implementations twice from
+//! the same seed on the real [`Sphere`] landscape from
+//! `rlevo-environments` and asserts the per-generation best-fitness
+//! trajectories are bit-identical. EDA sampling draws exclusively from
+//! host-side [`SeedPurpose::EdaSampling`] streams, so equal seeds must
+//! produce equal trajectories on any backend.
+//!
+//! [`SeedPurpose::EdaSampling`]: rlevo_evolution::rng::SeedPurpose::EdaSampling
+
+use burn::backend::Flex;
+
+use rlevo_environments::landscapes::sphere::Sphere;
+use rlevo_evolution::algorithms::eda::{
+    CompactGeneticParams, DependencyChainParams, UnivariateBernoulliParams,
+    UnivariateGaussianParams,
+};
+use rlevo_evolution::fitness::FromLandscape;
+use rlevo_evolution::strategy::EvolutionaryHarness;
+use rlevo_evolution::{
+    CompactGenetic, DependencyChain, EdaParams, EdaStrategy, ProbabilityModel,
+    UnivariateBernoulli, UnivariateGaussian,
+};
+
+type B = Flex;
+
+const DIM: usize = 10;
+const SEED: u64 = 1_234_567;
+const GENS: usize = 30;
+const BOUNDS: Option<(f32, f32)> = Some((-5.12, 5.12));
+
+/// Drives one EDA model through `GENS` generations on Sphere-D10 and
+/// collects the per-generation best-fitness trajectory.
+fn run<M>(model: M, model_params: M::Params, bounds: Option<(f32, f32)>) -> Vec<f32>
+where
+    M: ProbabilityModel<B> + 'static,
+{
+    let device = Default::default();
+    let params = EdaParams {
+        pop_size: 32,
+        selection_ratio: 0.5,
+        bounds,
+        model: model_params,
+    };
+    let mut harness = EvolutionaryHarness::<B, EdaStrategy<B, M>, _>::new(
+        EdaStrategy::new(model),
+        params,
+        FromLandscape::new(Sphere::new(DIM)),
+        SEED,
+        device,
+        GENS,
+    );
+    harness.reset();
+    let mut trajectory = Vec::with_capacity(GENS);
+    loop {
+        let step = harness.step(());
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        if step.done {
+            break;
+        }
+    }
+    trajectory
+}
+
+/// Single test function on purpose: determinism assertions must not
+/// interleave with other tests that could perturb shared backend state
+/// (same convention as `rlevo-evolution/tests/determinism.rs`).
+#[test]
+fn eda_same_seed_same_trajectories() {
+    // UMDA — univariate Gaussian.
+    let a = run(
+        UnivariateGaussian,
+        UnivariateGaussianParams::default_for(DIM),
+        BOUNDS,
+    );
+    let b = run(
+        UnivariateGaussian,
+        UnivariateGaussianParams::default_for(DIM),
+        BOUNDS,
+    );
+    assert!(a.iter().all(|f| f.is_finite()));
+    assert_eq!(
+        a, b,
+        "UnivariateGaussian (UMDA) trajectories diverge under the same seed"
+    );
+
+    // PBIL — univariate Bernoulli; raw {0,1} genes, bounds unused.
+    let a = run(
+        UnivariateBernoulli,
+        UnivariateBernoulliParams::default_for(DIM),
+        None,
+    );
+    let b = run(
+        UnivariateBernoulli,
+        UnivariateBernoulliParams::default_for(DIM),
+        None,
+    );
+    assert!(a.iter().all(|f| f.is_finite()));
+    assert_eq!(
+        a, b,
+        "UnivariateBernoulli (PBIL) trajectories diverge under the same seed"
+    );
+
+    // cGA — compact genetic algorithm; raw {0,1} genes, bounds unused.
+    let a = run(
+        CompactGenetic,
+        CompactGeneticParams::default_for(DIM),
+        None,
+    );
+    let b = run(
+        CompactGenetic,
+        CompactGeneticParams::default_for(DIM),
+        None,
+    );
+    assert!(a.iter().all(|f| f.is_finite()));
+    assert_eq!(
+        a, b,
+        "CompactGenetic (cGA) trajectories diverge under the same seed"
+    );
+
+    // MIMIC — Gaussian dependency chain.
+    let a = run(
+        DependencyChain,
+        DependencyChainParams::default_for(DIM),
+        BOUNDS,
+    );
+    let b = run(
+        DependencyChain,
+        DependencyChainParams::default_for(DIM),
+        BOUNDS,
+    );
+    assert!(a.iter().all(|f| f.is_finite()));
+    assert_eq!(
+        a, b,
+        "DependencyChain (MIMIC) trajectories diverge under the same seed"
+    );
+}

--- a/crates/rlevo/tests/eda_convergence.rs
+++ b/crates/rlevo/tests/eda_convergence.rs
@@ -1,0 +1,213 @@
+//! EDA convergence gates (cross-crate).
+//!
+//! Two acceptance criteria from the Phase 3b spec (issue #31):
+//!
+//! 1. Every `ProbabilityModel` implementation drives `best_fitness_ever`
+//!    to `<= 0.01` on Sphere-D10 within 500 generations
+//!    (`pop_size = 50`, `selection_ratio = 0.5`).
+//! 2. MIMIC ([`DependencyChain`]) achieves a strictly lower *median*
+//!    final fitness than UMDA ([`UnivariateGaussian`]) on Rosenbrock-D10
+//!    over nine fixed seeds — the dependency-chain model must exploit
+//!    Rosenbrock's adjacent-variable coupling that a univariate model
+//!    cannot represent.
+//!
+//! Runs are bit-deterministic per seed (host-RNG sampling only), so
+//! these gates cannot flake run-to-run on a given platform.
+
+use burn::backend::Flex;
+
+use rlevo_core::fitness::Landscape;
+use rlevo_environments::landscapes::rosenbrock::Rosenbrock;
+use rlevo_environments::landscapes::sphere::Sphere;
+use rlevo_evolution::algorithms::eda::{
+    CompactGeneticParams, DependencyChainParams, UnivariateBernoulliParams,
+    UnivariateGaussianParams,
+};
+use rlevo_evolution::fitness::FromLandscape;
+use rlevo_evolution::strategy::EvolutionaryHarness;
+use rlevo_evolution::{
+    CompactGenetic, DependencyChain, EdaParams, EdaStrategy, ProbabilityModel,
+    UnivariateBernoulli, UnivariateGaussian,
+};
+
+type B = Flex;
+
+const DIM: usize = 10;
+const POP_SIZE: usize = 50;
+const SELECTION_RATIO: f32 = 0.5;
+const GENS: usize = 500;
+
+/// Drives one EDA model for `GENS` generations and returns the final
+/// `best_fitness_ever`.
+fn run<M, L>(
+    model: M,
+    model_params: M::Params,
+    selection_ratio: f32,
+    bounds: Option<(f32, f32)>,
+    landscape: L,
+    seed: u64,
+) -> f32
+where
+    M: ProbabilityModel<B> + 'static,
+    L: Landscape + 'static,
+{
+    let device = Default::default();
+    let params = EdaParams {
+        pop_size: POP_SIZE,
+        selection_ratio,
+        bounds,
+        model: model_params,
+    };
+    let mut harness = EvolutionaryHarness::<B, EdaStrategy<B, M>, _>::new(
+        EdaStrategy::new(model),
+        params,
+        FromLandscape::new(landscape),
+        seed,
+        device,
+        GENS,
+    );
+    harness.reset();
+    loop {
+        if harness.step(()).done {
+            break;
+        }
+    }
+    harness.latest_metrics().unwrap().best_fitness_ever
+}
+
+/// Median of a small sample; NaN-free by construction (fitness is
+/// sanitized inside `EdaStrategy::tell`).
+fn median(values: &mut [f32]) -> f32 {
+    values.sort_by(f32::total_cmp);
+    values[values.len() / 2]
+}
+
+#[test]
+fn all_four_models_reach_sphere_threshold() {
+    const SEED: u64 = 42;
+    const TARGET: f32 = 0.01;
+    let bounds = Some((-5.12, 5.12));
+
+    let umda = run(
+        UnivariateGaussian,
+        UnivariateGaussianParams::default_for(DIM),
+        SELECTION_RATIO,
+        bounds,
+        Sphere::new(DIM),
+        SEED,
+    );
+    assert!(
+        umda <= TARGET,
+        "UMDA best_fitness_ever on Sphere-D10 after {GENS} gens = {umda}"
+    );
+
+    // PBIL and cGA emit raw {0,1} genes; the all-zeros genome scores
+    // exactly 0.0 on Sphere, so the gate stays meaningful without bounds.
+    let pbil = run(
+        UnivariateBernoulli,
+        UnivariateBernoulliParams::default_for(DIM),
+        SELECTION_RATIO,
+        None,
+        Sphere::new(DIM),
+        SEED,
+    );
+    assert!(
+        pbil <= TARGET,
+        "PBIL best_fitness_ever on Sphere-D10 after {GENS} gens = {pbil}"
+    );
+
+    let cga = run(
+        CompactGenetic,
+        CompactGeneticParams::default_for(DIM),
+        SELECTION_RATIO,
+        None,
+        Sphere::new(DIM),
+        SEED,
+    );
+    assert!(
+        cga <= TARGET,
+        "cGA best_fitness_ever on Sphere-D10 after {GENS} gens = {cga}"
+    );
+
+    let mimic = run(
+        DependencyChain,
+        DependencyChainParams::default_for(DIM),
+        SELECTION_RATIO,
+        bounds,
+        Sphere::new(DIM),
+        SEED,
+    );
+    assert!(
+        mimic <= TARGET,
+        "MIMIC best_fitness_ever on Sphere-D10 after {GENS} gens = {mimic}"
+    );
+}
+
+#[test]
+fn mimic_beats_umda_median_on_rosenbrock() {
+    const SEEDS: [u64; 9] = [101, 202, 303, 404, 505, 606, 707, 808, 909];
+    // Calibrated configuration (identical for both models). Rationale:
+    //
+    // - De Jong domain ±2.048 rather than Rosenbrock's native ±30: the
+    //   narrower box keeps early generations out of the 1e8 plateau so
+    //   the model-quality difference, not the initial spread, drives the
+    //   gap.
+    // - `init_mean = 0.5`, `init_std = 0.5`: starts the prior on the limb
+    //   of Rosenbrock's `x_{i+1} ≈ x_i²` valley, where the coupling is
+    //   locally *linear*. Centered at the origin the parabola's tangent is
+    //   flat, Pearson correlation vanishes, and a Gaussian chain has
+    //   nothing to model — the comparison would measure noise.
+    // - `min_variance = 1e-3` keeps both models exploring instead of
+    //   collapsing onto the valley floor before traversing it.
+    // - `selection_ratio = 0.3` sharpens selection so the elite set lies
+    //   inside the valley, where the chain correlations are real.
+    const RATIO: f32 = 0.3;
+    const INIT_MEAN: f32 = 0.5;
+    const INIT_STD: f32 = 0.5;
+    const MIN_VARIANCE: f32 = 1e-3;
+    let bounds = Some((-2.048, 2.048));
+
+    let mut umda: Vec<f32> = SEEDS
+        .iter()
+        .map(|&seed| {
+            let mut p = UnivariateGaussianParams::default_for(DIM);
+            p.init_mean = INIT_MEAN;
+            p.init_std = INIT_STD;
+            p.min_variance = MIN_VARIANCE;
+            run(
+                UnivariateGaussian,
+                p,
+                RATIO,
+                bounds,
+                Rosenbrock::new(DIM),
+                seed,
+            )
+        })
+        .collect();
+    let mut mimic: Vec<f32> = SEEDS
+        .iter()
+        .map(|&seed| {
+            let mut p = DependencyChainParams::default_for(DIM);
+            p.init_mean = INIT_MEAN;
+            p.init_std = INIT_STD;
+            p.min_variance = MIN_VARIANCE;
+            run(
+                DependencyChain,
+                p,
+                RATIO,
+                bounds,
+                Rosenbrock::new(DIM),
+                seed,
+            )
+        })
+        .collect();
+
+    let umda_median = median(&mut umda);
+    let mimic_median = median(&mut mimic);
+    assert!(
+        mimic_median < umda_median,
+        "MIMIC median final fitness ({mimic_median}) must be strictly below \
+         UMDA's ({umda_median}) on Rosenbrock-D10; per-seed UMDA {umda:?}, \
+         MIMIC {mimic:?}"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -120,6 +120,11 @@ pendulum-random:
 harness-ga-rastrigin:
     cargo run -p rlevo-examples --example ga_rastrigin
 
+# EDAs: UMDA vs MIMIC on Rosenbrock (dependency capture) + PBIL vs cGA on OneMax
+# (probability-vector convergence). Prints model internals each generation.
+eda-showcase:
+    cargo run --release -p rlevo-examples --example eda_showcase
+
 harness-tabular-bandit:
     cargo run -p rlevo-examples --example tabular_bandit
 
@@ -183,6 +188,11 @@ test-memetic:
 # Memetic calibration explorer [ignored: multi-seed sweep for re-pinning the margin].
 test-memetic-calibration:
     cargo test -p rlevo --test memetic_rastrigin --release -- calibration_explorer --ignored --nocapture
+
+# EDA convergence: all four ProbabilityModels reach the Sphere-D10 gate, and
+# MIMIC beats UMDA's median on Rosenbrock-D10 across 9 fixed seeds.
+test-eda:
+    cargo test -p rlevo --test eda_convergence
 
 # Post-run record → report pipeline smoke [requires viz-report feature].
 test-report-smoke:


### PR DESCRIPTION
- **feat(eda): Add ProbabilityModel trait and EDAs**
- **docs(rlevo-examples): add EDA model showcase**

## Summary

Implements ADR-0017 (phase 3b): adds the `ProbabilityModel<B>` trait and a
generic `EdaStrategy<B, M>` driver to `rlevo-evolution`, along with four
reference models — `UnivariateGaussian` (UMDA), `UnivariateBernoulli` (PBIL),
`CompactGenetic` (cGA), and `DependencyChain` (MIMIC with a `|r| < 2/√k`
correlation significance filter). The change is purely additive; `Strategy`,
the harness, and all existing manifests are unchanged.

## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — New evolutionary algorithms and trait (additive, pre-approved in ADR-0017 / issue #31)

## Linked Issue

Closes #31

## What Was Changed

- `crates/rlevo-evolution/src/probability_model.rs` — new `ProbabilityModel<B>` trait (`fit`/`sample`; `fit` accepts `prev: Option<&State>` incremental seam for PBIL/cGA/CMA-ES path reuse)
- `crates/rlevo-evolution/src/algorithms/eda/mod.rs` — generic `EdaStrategy<B, M>` driver: truncation selection, `SeedPurpose::EdaSampling` host-RNG stream, NaN-sanitize chokepoint reuse, `EdaParams`/`EdaState` types
- `crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs` — `UnivariateGaussian` (UMDA): per-dimension Gaussian MLE, `min_variance` floor
- `crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs` — `UnivariateBernoulli` (PBIL): per-bit probability vector with learning-rate update
- `crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs` — `CompactGenetic` (cGA): virtual-population probability vector, winner/loser from truncation subset
- `crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs` — `DependencyChain` (MIMIC): pairwise-correlation chain with `|r| < 2/√k` significance filter
- `crates/rlevo-evolution/src/rng.rs` — added `SeedPurpose::EdaSampling` variant
- `crates/rlevo-evolution/src/lib.rs` / `algorithms/mod.rs` — re-exports for new modules
- `crates/rlevo-evolution/tests/eda_smoke.rs` — smoke tests for all four models
- `crates/rlevo/tests/determinism.rs` — cross-crate determinism tests (seed → bit-identical run)
- `crates/rlevo/tests/eda_convergence.rs` — convergence tests on sphere/Rastrigin/binary landscapes
- `crates/rlevo-examples/examples/evolution/eda_showcase.rs` — self-contained showcase for all four EDA models
- `crates/rlevo-examples/Cargo.toml` — no new external deps; example entry added
- `justfile` — convenience aliases for EDA-related `cargo test`/`cargo run` invocations

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable 1.87.0 (aarch64-apple-darwin)
- Burn backend tested: `Flex` (ndarray fallback)
- OS: macOS Darwin 25.5.0

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Sonnet 4.6 (Claude Code). Scope: architecture design, implementation, tests, and documentation throughout.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. *(N/A — no bug fix)*
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

Binary models (`UnivariateBernoulli`, `CompactGenetic`) emit raw `{0, 1}` genes; the `EdaParams::bounds` clamp is a no-op for them. BOA (Bayesian Optimization Algorithm) is deferred per ADR-0017. The `prev: Option<&State>` seam in `ProbabilityModel::fit` is the incremental hook CMA-ES will reuse for path/rank-μ updates in a future phase.
