### PR TITLE
feat(eda): Add BOA (BayesianNetwork) model and ConcatenatedTrap benchmark

### DIFF
--- a/crates/rlevo-environments/src/bench/landscape.rs
+++ b/crates/rlevo-environments/src/bench/landscape.rs
@@ -13,8 +13,9 @@
 use rlevo_core::fitness::Landscape;
 
 use crate::landscapes::{
-    ackley::Ackley, alpine1::Alpine1, branin::Branin, bukin6::Bukin6, cross_in_tray::CrossInTray,
-    deb1::Deb1, easom::Easom, eggholder::Eggholder, goldstein_price::GoldsteinPrice,
+    ackley::Ackley, alpine1::Alpine1, branin::Branin, bukin6::Bukin6,
+    concatenated_trap::ConcatenatedTrap, cross_in_tray::CrossInTray, deb1::Deb1, easom::Easom,
+    eggholder::Eggholder, goldstein_price::GoldsteinPrice,
     griewank::Griewank, himmelblau::Himmelblau, lunacek_bi_rastrigin::LunacekBiRastrigin,
     michalewicz::Michalewicz, needle_eye::Needle, penalized1::Penalized1, rastrigin::Rastrigin,
     rosenbrock::Rosenbrock, rosenbrock_flat::RosenbrockFlat, schwefel::Schwefel,
@@ -28,6 +29,12 @@ use crate::landscapes::{
 impl Landscape for Sphere {
     fn evaluate(&self, x: &[f64]) -> f64 {
         Sphere::evaluate(self, x)
+    }
+}
+
+impl Landscape for ConcatenatedTrap {
+    fn evaluate(&self, x: &[f64]) -> f64 {
+        ConcatenatedTrap::evaluate(self, x)
     }
 }
 

--- a/crates/rlevo-environments/src/landscapes/concatenated_trap.rs
+++ b/crates/rlevo-environments/src/landscapes/concatenated_trap.rs
@@ -1,0 +1,315 @@
+//! Concatenated trap — a deceptive, additively decomposable binary landscape.
+//!
+//! The genome is `num_blocks · block_size` binary genes, partitioned into
+//! contiguous, non-overlapping blocks of `k = block_size` bits each. Genes
+//! are interpreted as bits via a `>= 0.5` threshold. Each block contributes a
+//! cost that depends only on its *unitation* `u` (the number of 1-bits in the
+//! block), and the total objective is the sum across blocks:
+//!
+//! ```text
+//!   cost(u) = 0        if u == k        (all-ones block)
+//!   cost(u) = u + 1    otherwise
+//! ```
+//!
+//! For a trap of order `k = 5`, the per-block cost table is:
+//!
+//! | unitation `u` | 0 | 1 | 2 | 3 | 4 | 5 |
+//! |---------------|---|---|---|---|---|---|
+//! | `cost(u)`     | 1 | 2 | 3 | 4 | 5 | 0 |
+//!
+//! This is a *minimisation* problem (lower is better), consistent with the
+//! convention used throughout `rlevo-evolution`. The **global optimum** is the
+//! all-ones genome with total cost `0`. There is a strong **deceptive local
+//! optimum** at the all-zeros genome with total cost `num_blocks`: from
+//! all-zeros, flipping any single bit to `1` lifts that block from `cost(0) = 1`
+//! to `cost(1) = 2`, so every Hamming-1 neighbour is strictly worse. The cost
+//! gradient over a block therefore points *away* from the all-ones optimum for
+//! every unitation below `k`.
+//!
+//! # Deception and EDAs
+//!
+//! Univariate estimation-of-distribution algorithms (UMDA, PBIL, cGA) model
+//! each gene's marginal `P(x_i = 1)` independently. Because the trap rewards
+//! the all-zeros block at every unitation except the very last, the marginal
+//! statistics of selected individuals push each bit toward `0` — the univariate
+//! model cannot represent the higher-order dependency that "all `k` bits must
+//! flip together" to reach the optimum. Such algorithms reliably converge to
+//! the all-zeros deceptive optimum. Models that capture inter-gene structure
+//! (MIMIC's dependency chain, the Bayesian Optimization Algorithm) are required
+//! to solve order-`k` traps, which is precisely why concatenated traps are the
+//! canonical benchmark for multivariate EDAs.
+//!
+//! # References
+//!
+//! - Deb, K. & Goldberg, D. E. (1992). "Analyzing deception in trap functions."
+//!   *Foundations of Genetic Algorithms 2*, 93–108.
+//! - Pelikan, M., Goldberg, D. E. & Cantú-Paz, E. (1999). "BOA: The Bayesian
+//!   Optimization Algorithm." *Proceedings of GECCO-99*, 525–532.
+
+/// Concatenated trap evaluator: `num_blocks` order-`block_size` traps.
+#[derive(Debug, Clone, Copy)]
+pub struct ConcatenatedTrap {
+    /// Number of contiguous, non-overlapping trap blocks.
+    pub num_blocks: usize,
+    /// Trap order `k` — the number of bits in each block.
+    pub block_size: usize,
+}
+
+impl ConcatenatedTrap {
+    /// Creates a concatenated trap of `num_blocks` blocks, each an order-`block_size` trap.
+    #[must_use]
+    pub const fn new(num_blocks: usize, block_size: usize) -> Self {
+        Self {
+            num_blocks,
+            block_size,
+        }
+    }
+
+    /// Total genome dimension: `num_blocks · block_size`.
+    #[must_use]
+    pub const fn dim(&self) -> usize {
+        self.num_blocks * self.block_size
+    }
+
+    /// Evaluate the concatenated trap at `x`.
+    ///
+    /// Genes are thresholded to bits via `>= 0.5`, partitioned into contiguous
+    /// blocks of `block_size`, and each block's trap cost (`0` if the block is
+    /// all-ones, else `u + 1` for unitation `u`) is summed. Lower is better;
+    /// the all-ones genome scores `0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x.len() != self.dim()`.
+    #[must_use]
+    pub fn evaluate(&self, x: &[f64]) -> f64 {
+        assert_eq!(x.len(), self.dim(), "input dimension mismatch");
+        let total: usize = x
+            .chunks_exact(self.block_size)
+            .map(|block| {
+                let u = block.iter().filter(|&&gene| gene >= 0.5).count();
+                Self::block_cost(self.block_size, u)
+            })
+            .sum();
+        // The total is bounded by num_blocks · (k + 1), well within the exact
+        // integer range of f64 (2^53), so the cast is exact, not lossy.
+        #[allow(clippy::cast_precision_loss)]
+        let cost = total as f64;
+        cost
+    }
+
+    /// Recommended search domain for each coordinate: the binary box `[0, 1]`.
+    #[must_use]
+    pub const fn bounds(&self) -> (f64, f64) {
+        (0.0, 1.0)
+    }
+
+    /// Per-block trap cost for a block of unitation `u` (count of 1-bits).
+    ///
+    /// Returns `0` when the block is all-ones (`u == block_size`), otherwise
+    /// `u + 1`. This is the deceptive trap: cost rises with unitation right up
+    /// until the final, rewarding all-ones configuration.
+    const fn block_cost(block_size: usize, u: usize) -> usize {
+        if u == block_size {
+            0
+        } else {
+            u + 1
+        }
+    }
+
+    /// 2D projection of [`evaluate`](Self::evaluate) for visualisation.
+    ///
+    /// `x` and `y` drive the fill fractions of the first two blocks; every
+    /// remaining block is held at all-ones (zero cost), so the rendered slice
+    /// passes through the global optimum at the `(1, 1)` corner. Each driven
+    /// block uses a continuous relaxation of the trap cost:
+    ///
+    /// ```text
+    ///   cost(p) = 1 + (k − 1)·p   for p < 1   (deceptive ramp away from 1)
+    ///   cost(p) = 0               for p >= 1  (the rewarding all-ones state)
+    /// ```
+    ///
+    /// `x`/`y` are clamped to `[0, 1]`. When `num_blocks == 1` only `x` drives
+    /// the surface; `y` is ignored.
+    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        let k = self.block_size;
+        // Continuous relaxation of the per-block trap cost over a fill fraction.
+        #[allow(clippy::cast_precision_loss)]
+        let relaxed = |p: f64| -> f64 {
+            let p = p.clamp(0.0, 1.0);
+            if p >= 1.0 {
+                0.0
+            } else {
+                1.0 + (k.saturating_sub(1)) as f64 * p
+            }
+        };
+        let mut cost = relaxed(x);
+        if self.num_blocks >= 2 {
+            cost += relaxed(y);
+        }
+        cost
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASCII renderer
+// ---------------------------------------------------------------------------
+
+impl crate::render::AsciiRenderable for ConcatenatedTrap {
+    fn render_ascii(&self) -> String {
+        super::render::render_landscape_ascii(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "ConcatenatedTrap",
+        )
+    }
+
+    fn render_styled(&self) -> crate::render::StyledFrame {
+        super::render::render_landscape_styled(
+            |x, y| self.evaluate_2d(x, y),
+            self.bounds(),
+            "ConcatenatedTrap",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn dim_is_blocks_times_block_size() {
+        let t = ConcatenatedTrap::new(4, 5);
+        assert_eq!(t.dim(), 20, "4 blocks of 5 bits must yield dim 20");
+    }
+
+    #[test]
+    fn global_minimum_all_ones() {
+        let t = ConcatenatedTrap::new(4, 5);
+        assert_relative_eq!(t.evaluate(&[1.0; 20]), 0.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn deceptive_optimum_all_zeros_costs_num_blocks() {
+        let t = ConcatenatedTrap::new(4, 5);
+        // Each all-zeros block costs cost(0) = 1, so 4 blocks cost 4.
+        assert_relative_eq!(t.evaluate(&[0.0; 20]), 4.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn single_flip_from_all_zeros_is_strictly_worse() {
+        let t = ConcatenatedTrap::new(4, 5);
+        let baseline = t.evaluate(&[0.0; 20]);
+        for i in 0..t.dim() {
+            let mut x = [0.0_f64; 20];
+            x[i] = 1.0;
+            let flipped = t.evaluate(&x);
+            assert!(
+                flipped > baseline,
+                "flipping bit {i} alone must be strictly worse than all-zeros"
+            );
+            // The affected block moves from cost(0)=1 to cost(1)=2, lifting the
+            // total from 4 to exactly 5.
+            assert_relative_eq!(flipped, 5.0, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn per_block_cost_curve_matches_trap() {
+        let t = ConcatenatedTrap::new(1, 5);
+        let expected = [1.0, 2.0, 3.0, 4.0, 5.0, 0.0];
+        for (u, &want) in expected.iter().enumerate() {
+            let mut x = [0.0_f64; 5];
+            for bit in x.iter_mut().take(u) {
+                *bit = 1.0;
+            }
+            assert_relative_eq!(t.evaluate(&x), want, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn additively_decomposable_across_blocks() {
+        let block = ConcatenatedTrap::new(1, 5);
+        let two = ConcatenatedTrap::new(2, 5);
+        // Two distinct blocks: one with u=2 leading ones, one with u=3.
+        let a = [1.0, 1.0, 0.0, 0.0, 0.0];
+        let b = [1.0, 1.0, 1.0, 0.0, 0.0];
+        let mut joined = [0.0_f64; 10];
+        joined[..5].copy_from_slice(&a);
+        joined[5..].copy_from_slice(&b);
+        assert_relative_eq!(
+            two.evaluate(&joined),
+            block.evaluate(&a) + block.evaluate(&b),
+            epsilon = 1e-6,
+        );
+    }
+
+    #[test]
+    fn threshold_rounds_genes_to_bits() {
+        let t = ConcatenatedTrap::new(1, 5);
+        // 0.49 -> 0, 0.5 -> 1, 0.51 -> 1, 1.0 -> 1, 0.99 -> 1 ⇒ u = 4 ⇒ cost 5.
+        assert_relative_eq!(
+            t.evaluate(&[0.5, 0.49, 0.51, 1.0, 0.99]),
+            5.0,
+            epsilon = 1e-6,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "input dimension mismatch")]
+    fn evaluate_panics_on_dimension_mismatch() {
+        let t = ConcatenatedTrap::new(4, 5);
+        let _ = t.evaluate(&[0.0; 19]);
+    }
+
+    #[test]
+    fn render_styled_matches_ascii() {
+        use crate::render::AsciiRenderable;
+
+        let t = ConcatenatedTrap::new(4, 5);
+        let plain_no_trailing: String = t.render_ascii().lines().collect::<Vec<_>>().join("\n");
+        assert_eq!(
+            t.render_styled().plain_text(),
+            plain_no_trailing,
+            "styled glyphs must match the plain ASCII render",
+        );
+    }
+
+    #[test]
+    fn render_styled_uses_best_palette() {
+        use crate::render::AsciiRenderable;
+        use crate::render::palette::{BEST_FG, BEST_MODIFIER};
+
+        let t = ConcatenatedTrap::new(4, 5);
+        let styled = t.render_styled();
+        let label = styled.lines[0]
+            .spans
+            .iter()
+            .find(|s| s.text == "ConcatenatedTrap")
+            .expect("ConcatenatedTrap label span present");
+        assert_eq!(
+            label.style.fg,
+            Some(BEST_FG),
+            "label must carry the best-marker foreground colour",
+        );
+        assert!(
+            label.style.modifier.contains(BEST_MODIFIER),
+            "label must carry the best-marker modifier",
+        );
+    }
+
+    #[test]
+    fn render_ascii_within_width_budget() {
+        use crate::render::AsciiRenderable;
+
+        let t = ConcatenatedTrap::new(4, 5);
+        for line in t.render_ascii().lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds 80 cols: {line:?} ({} chars)",
+                line.chars().count()
+            );
+        }
+    }
+}

--- a/crates/rlevo-environments/src/lib.rs
+++ b/crates/rlevo-environments/src/lib.rs
@@ -38,6 +38,7 @@ pub mod landscapes {
     pub mod sphere;
 
     // Tier 1 — scalable n-D landscapes.
+    pub mod concatenated_trap;
     pub mod griewank;
     pub mod michalewicz;
     pub mod penalized1;

--- a/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
@@ -1,0 +1,835 @@
+//! Bayesian-network model (BOA — Bayesian Optimization Algorithm) for binary
+//! search spaces.
+//!
+//! Unlike the univariate binary models ([`super::univariate_bernoulli`],
+//! [`super::compact_genetic`]) and the first-order chain of
+//! [`super::dependency_chain`], this model learns an arbitrary-topology directed
+//! acyclic graph (DAG) over the binary genes, bounded to at most
+//! [`BayesianNetworkParams::max_parents`] parents per node. [`fit`] greedily
+//! constructs the network by adding the single edge with the highest score gain
+//! each round; [`sample`] performs ancestral sampling along a topological order,
+//! drawing each gene from its conditional probability table (CPT) given the
+//! already-sampled parent configuration.
+//!
+//! The chain is built à la BOA (Pelikan, Goldberg & Cantú-Paz, 1999): starting
+//! from an edgeless network, the algorithm repeatedly scores every candidate
+//! edge `u → v` and commits the one with the largest strictly-positive gain,
+//! subject to the `max_parents` cap and an acyclicity check, until no profitable
+//! edge remains.
+//!
+//! The `fitness` tensor is accepted by the [`ProbabilityModel`] interface but
+//! always ignored; the fit is unweighted (the MIMIC precedent).
+//!
+//! # Non-incremental fit
+//!
+//! `prev` is consumed only as the *not-bootstrap* signal: when `prev = Some(_)`
+//! the whole network — structure and CPTs — is relearned from scratch from the
+//! current generation's selected rows. Canonical BOA carries no cross-generation
+//! state, so the previous [`BayesianNetworkState`] is never read. The `Some`
+//! arm exists purely to distinguish the learning path from the
+//! [`params`](BayesianNetworkParams)-only prior path.
+//!
+//! # Structure score: BIC
+//!
+//! Edges are scored with the Bayesian Information Criterion (BIC). For a node
+//! `v` with sorted parent set `Pa` (`q = |Pa|`), let `N(c, x)` be the number of
+//! selected rows in which the parents take packed configuration `c` and gene `v`
+//! takes bit `x ∈ {0, 1}`, and `N(c) = N(c, 0) + N(c, 1)`:
+//!
+//! ```text
+//! score(v, Pa) = Σ_c Σ_x  N(c, x) · ln( N(c, x) / N(c) )  −  (ln(n) / 2) · 2^q
+//! ```
+//!
+//! The log-likelihood term rewards parents that make `v` more predictable; the
+//! `−½·ln(n)·2^q` complexity term penalises CPT size (`2^q` cells), which grows
+//! exponentially in the parent count. This penalty is the structural analogue
+//! of [`super::dependency_chain`]'s `|r| < 2/√k` significance filter: both
+//! suppress spurious dependencies that a univariate model would never pay for,
+//! here by requiring an edge's likelihood improvement to outweigh the cost of
+//! doubling the child's CPT. The score is computed on **raw maximum-likelihood
+//! counts** — never the Laplace-smoothed counts used for CPT estimation — so the
+//! penalty is the sole overfitting guard. Terms with `N(c, x) = 0` contribute
+//! exactly `0` (the `p·ln p → 0` limit), and configurations with `N(c) = 0`
+//! contribute `0` likelihood while still counting toward the `2^q` penalty. All
+//! scoring arithmetic is performed in `f64`.
+//!
+//! # Parent-configuration bit-packing
+//!
+//! For a node `v` with `parents[v]` sorted ascending, a row's parent
+//! configuration is packed as `config = Σ_j bit(gene[parents[v][j]]) << j`:
+//! parent `j` (in sorted order) contributes bit `j`. [`fit`] and [`sample`] use
+//! the identical packing, so the CPT index computed at sampling time matches the
+//! one used during estimation. See the [`cpt`](BayesianNetworkState::cpt) field.
+//!
+//! # Complexity
+//!
+//! [`fit`] is `O(D² · N · κ)` per generation with gain caching: the first sweep
+//! scores all `D²` candidate edges (each an `O(N·κ)` counting pass), and after
+//! each accepted edge only the `D` entries sharing the affected child are
+//! rescored. It is fully host-side and sequential. [`sample`] is `O(D)` per
+//! drawn individual: one conditional Bernoulli draw per gene.
+//!
+//! # Binary gene convention
+//!
+//! Genes are emitted as raw `{0, 1}` `f32` values, so
+//! [`EdaParams::bounds`](crate::algorithms::eda::EdaParams::bounds) clamps are a
+//! documented no-op (the PBIL / cGA precedent).
+//!
+//! # References
+//!
+//! - Pelikan, Goldberg & Cantú-Paz (1999), *BOA: The Bayesian optimization
+//!   algorithm*.
+//!
+//! [`fit`]: crate::ProbabilityModel::fit
+//! [`sample`]: crate::ProbabilityModel::sample
+
+use burn::tensor::{Tensor, TensorData, backend::Backend};
+use rand::{Rng, RngExt};
+
+use crate::probability_model::ProbabilityModel;
+
+/// Per-run configuration for the [`BayesianNetwork`] model.
+///
+/// Held inside [`EdaParams::model`](crate::algorithms::eda::EdaParams::model)
+/// for the lifetime of a run. Use [`BayesianNetworkParams::default_for`] for
+/// typical binary-optimisation defaults.
+#[derive(Debug, Clone)]
+pub struct BayesianNetworkParams {
+    /// Number of bits per genome; the number of nodes `D` in the network and
+    /// the length of [`BayesianNetworkState::order`] and
+    /// [`BayesianNetworkState::parents`].
+    pub genome_dim: usize,
+    /// Maximum number of parents per node (`κ`); bounds each node's CPT to
+    /// `2^κ` cells and caps the greedy edge-addition search.
+    pub max_parents: usize,
+    /// Prior marginal probability of a `1` gene, used to seed every edgeless
+    /// CPT on the prior path (`prev = None`).
+    pub init_prob: f32,
+    /// Laplace pseudo-count `s` added per CPT cell during estimation; `s ≥ 1`
+    /// keeps every probability strictly inside `(0, 1)`. Applies only to CPT
+    /// estimation for sampling, never to the BIC structure score.
+    pub smoothing_count: usize,
+}
+
+impl BayesianNetworkParams {
+    /// Sensible BOA defaults for a `genome_dim`-bit problem.
+    #[must_use]
+    pub fn default_for(genome_dim: usize) -> Self {
+        Self {
+            genome_dim,
+            max_parents: 3,
+            init_prob: 0.5,
+            smoothing_count: 1,
+        }
+    }
+}
+
+/// Fitted state for the [`BayesianNetwork`] model after one call to
+/// [`ProbabilityModel::fit`].
+///
+/// On the prior path (`prev = None`) the network is edgeless: `order` is the
+/// natural order `[0, 1, …, D-1]`, every `parents[v]` is empty, and every
+/// `cpt[v]` is the single-entry vector `[init_prob]`.
+#[derive(Debug, Clone)]
+pub struct BayesianNetworkState {
+    /// Topological sampling order: a permutation of `0..D` such that every
+    /// node appears after all of its parents. Ancestral sampling walks this
+    /// order so each gene's parents are already drawn.
+    pub order: Vec<usize>,
+    /// `parents[node]` is the node's parent index set, kept sorted ascending.
+    /// The sort defines the bit positions used by the CPT packing (see the
+    /// [module docs](self)).
+    pub parents: Vec<Vec<usize>>,
+    /// Conditional probability tables: `cpt[node][config]` is
+    /// `P(node = 1 | parents = config)`, where `config` is the bit-packed
+    /// parent configuration `Σ_j bit(parent_j) << j` over `parents[node]` in
+    /// sorted order. Each inner vector has length `2^|parents[node]|`.
+    pub cpt: Vec<Vec<f32>>,
+}
+
+/// Bayesian-network model for binary spaces (BOA).
+///
+/// Implements [`ProbabilityModel`] by greedily learning a bounded-in-degree DAG
+/// over the binary genes with a BIC structure score, then ancestral-sampling
+/// from the fitted CPTs (see the [module docs](self) for the algorithm, the BIC
+/// rationale, bit-packing, and references). Fitness is accepted but ignored; the
+/// fit is always unweighted and non-incremental.
+///
+/// [`fit`](ProbabilityModel::fit) is `O(D² · N · κ)`;
+/// [`sample`](ProbabilityModel::sample) is `O(D)` per individual.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BayesianNetwork;
+
+/// Build the edgeless prior state: natural order, no parents, single-cell CPTs
+/// initialised to `init_prob`.
+fn prior_state(d: usize, init_prob: f32) -> BayesianNetworkState {
+    BayesianNetworkState {
+        order: (0..d).collect(),
+        parents: vec![Vec::new(); d],
+        cpt: vec![vec![init_prob]; d],
+    }
+}
+
+/// Pack the parent configuration for node `v` from a single row's bits.
+///
+/// `parents` is `parents[v]` (sorted ascending); parent `j` contributes bit `j`.
+fn pack_config(bits: &[u8], row_base: usize, parents: &[usize]) -> usize {
+    let mut config = 0usize;
+    for (j, &p) in parents.iter().enumerate() {
+        if bits[row_base + p] == 1 {
+            config |= 1 << j;
+        }
+    }
+    config
+}
+
+/// BIC score of node `v` given the (sorted) candidate parent set `parents`.
+///
+/// Single pass over the `n` rows: pack each row's parent config and increment
+/// `counts[config * 2 + bit_v]`. The likelihood term sums
+/// `N(c, x) · ln(N(c, x) / N(c))` over occupied cells (zero counts skipped), and
+/// the `½·ln(n)·2^q` complexity penalty applies regardless of which configs were
+/// observed. All arithmetic is `f64`; scores use raw MLE counts.
+//
+// Single-char math names (n, d, v, q, c, x) mirror the BIC formula and the
+// sibling EDA models; spelling them out would obscure the algebra.
+#[allow(clippy::many_single_char_names)]
+fn bic_score(bits: &[u8], n: usize, d: usize, v: usize, parents: &[usize]) -> f64 {
+    let q = parents.len();
+    let num_configs = 1usize << q;
+    // counts[config * 2 + x] = N(config, x).
+    let mut counts = vec![0u32; num_configs * 2];
+    for i in 0..n {
+        let base = i * d;
+        let x = usize::from(bits[base + v]);
+        let config = pack_config(bits, base, parents);
+        counts[config * 2 + x] += 1;
+    }
+
+    let mut log_likelihood = 0.0_f64;
+    for c in 0..num_configs {
+        let count_0 = counts[c * 2];
+        let count_1 = counts[c * 2 + 1];
+        let count_total = count_0 + count_1;
+        if count_total == 0 {
+            // N(c) == 0: zero likelihood, but the config still counts toward the
+            // 2^q penalty below (that is the pressure keeping q small).
+            continue;
+        }
+        // f64::from(u32) is a lossless widening, not a lossy cast.
+        let total_f = f64::from(count_total);
+        for &count_x in &[count_0, count_1] {
+            if count_x == 0 {
+                // N(c, x) == 0 contributes exactly 0 (the p·ln p → 0 limit); no
+                // ln(0) path is ever reached.
+                continue;
+            }
+            let count_x_f = f64::from(count_x);
+            log_likelihood += count_x_f * (count_x_f / total_f).ln();
+        }
+    }
+
+    // Complexity penalty: ½·ln(n)·2^q over all 2^q configs.
+    #[allow(clippy::cast_precision_loss)]
+    let nf = n as f64;
+    #[allow(clippy::cast_precision_loss)]
+    let penalty = 0.5 * nf.ln() * (num_configs as f64);
+    log_likelihood - penalty
+}
+
+/// Insert `value` into the ascending-sorted vector `parents`, keeping it sorted.
+fn insert_sorted(parents: &mut Vec<usize>, value: usize) {
+    let pos = parents.partition_point(|&p| p < value);
+    parents.insert(pos, value);
+}
+
+/// Does adding edge `u → v` create a cycle?
+///
+/// A cycle appears iff `v` is already an ancestor of `u`. Iterative DFS upward
+/// from `u` through `parents[]`, looking for `v`. `O(D·κ)` per check.
+fn creates_cycle(parents: &[Vec<usize>], u: usize, v: usize) -> bool {
+    let d = parents.len();
+    let mut visited = vec![false; d];
+    let mut stack = vec![u];
+    while let Some(node) = stack.pop() {
+        if node == v {
+            return true;
+        }
+        if visited[node] {
+            continue;
+        }
+        visited[node] = true;
+        for &p in &parents[node] {
+            if !visited[p] {
+                stack.push(p);
+            }
+        }
+    }
+    false
+}
+
+/// Kahn's algorithm with deterministic minimum-index selection.
+///
+/// Repeatedly emits the smallest-index node whose remaining (unemitted) parent
+/// count is zero. The greedy loop guarantees the graph is a DAG.
+fn topological_order(parents: &[Vec<usize>]) -> Vec<usize> {
+    let d = parents.len();
+    let mut indegree: Vec<usize> = parents.iter().map(Vec::len).collect();
+    let mut emitted = vec![false; d];
+    let mut order = Vec::with_capacity(d);
+    while order.len() < d {
+        // Smallest-index node with indegree 0 not yet emitted.
+        let mut next = None;
+        for v in 0..d {
+            if !emitted[v] && indegree[v] == 0 {
+                next = Some(v);
+                break;
+            }
+        }
+        let Some(node) = next else { break };
+        emitted[node] = true;
+        order.push(node);
+        // Decrement indegree of every node that has `node` as a parent.
+        for (child, ps) in parents.iter().enumerate() {
+            if !emitted[child] && ps.contains(&node) {
+                indegree[child] -= 1;
+            }
+        }
+    }
+    order
+}
+
+impl<B: Backend> ProbabilityModel<B> for BayesianNetwork {
+    type Params = BayesianNetworkParams;
+    type State = BayesianNetworkState;
+
+    /// Fit the Bayesian network to the selected population.
+    ///
+    /// When `prev = None` returns the edgeless prior (natural order, empty
+    /// parent lists, single-cell CPTs at `init_prob`); `population` and
+    /// `fitness` are ignored. Otherwise the whole network is relearned from
+    /// scratch (the fit is non-incremental — `prev` is the not-bootstrap signal
+    /// only):
+    ///
+    /// 1. Bitizes the selected rows to `{0, 1}` via `>= 0.5`.
+    /// 2. Greedily adds the highest-BIC-gain edge each round (subject to the
+    ///    `max_parents` cap and acyclicity) until no strictly-positive gain
+    ///    remains, using a `D × D` gain cache.
+    /// 3. Estimates Laplace-smoothed CPTs from the final structure.
+    /// 4. Computes a deterministic topological order (Kahn, min-index).
+    ///
+    /// The `fitness` argument is accepted but always ignored.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic; the closing `debug_assert_eq!` checks the topological
+    /// order covers all `D` nodes (guaranteed by the DAG invariant).
+    // The counting passes, gain-cached greedy search, CPT estimation, and
+    // topological ordering form one coherent fit; splitting them would scatter
+    // the shared `bits`/`parents` buffers without aiding readability.
+    // Single-char math names (n, d, v, q, s, u) mirror the BIC/CPT formulae and
+    // the sibling EDA models; spelling them out would obscure the algebra.
+    #[allow(clippy::too_many_lines, clippy::many_single_char_names)]
+    fn fit(
+        &self,
+        params: &Self::Params,
+        prev: Option<&Self::State>,
+        population: Tensor<B, 2>,
+        fitness: Tensor<B, 1>,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let _ = device;
+        // Fitness is accepted but ignored: the fit is unweighted.
+        let _ = fitness;
+        let Some(_prev) = prev else {
+            // Prior path: edgeless network in natural order; population and
+            // fitness ignored. `prev` is consumed only as the bootstrap signal.
+            return prior_state(params.genome_dim, params.init_prob);
+        };
+
+        // Host extraction and bitization. The population's column count is the
+        // row stride for every counting pass below, so it — not
+        // `params.genome_dim` — is the authoritative `d` (mirrors
+        // `DependencyChain::fit`); the two must agree.
+        let [n, d] = population.dims();
+        debug_assert_eq!(
+            d, params.genome_dim,
+            "population column count must match params.genome_dim"
+        );
+        // CPT sizes are 2^q with q <= max_parents; a cap at or above the
+        // word width would overflow the `1usize << q` table sizing.
+        debug_assert!(
+            params.max_parents < usize::BITS as usize,
+            "max_parents must be below usize::BITS"
+        );
+        let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
+        if n == 0 {
+            // Degenerate input: nothing to learn, return the prior-shaped
+            // state (params-shaped, since a 0×0 tensor carries no width).
+            return prior_state(params.genome_dim, params.init_prob);
+        }
+        let bits: Vec<u8> = rows.iter().map(|&v| u8::from(v >= 0.5)).collect();
+
+        // Greedy structure learning with a D×D gain cache.
+        let mut parents: Vec<Vec<usize>> = vec![Vec::new(); d];
+        let mut base_score: Vec<f64> = (0..d).map(|v| bic_score(&bits, n, d, v, &[])).collect();
+
+        // gain_cache[u * d + v] = score(v, parents[v] ∪ {u}) − base_score[v],
+        // an exact recomputation. Entries are recomputed for child v* after each
+        // accepted edge; eligibility (cycle / cap / already-present) is checked
+        // live at selection time, so the cache holds only the score gain.
+        let mut gain_cache = vec![f64::NEG_INFINITY; d * d];
+        // Helper closure would need to borrow `bits`/`parents`/`base_score`
+        // mutably and immutably; an inline recompute keeps borrows simple.
+        // Initial full sweep.
+        for u in 0..d {
+            for v in 0..d {
+                if u == v {
+                    continue;
+                }
+                let mut cand = parents[v].clone();
+                insert_sorted(&mut cand, u);
+                gain_cache[u * d + v] = bic_score(&bits, n, d, v, &cand) - base_score[v];
+            }
+        }
+
+        loop {
+            // Select the eligible (u, v) with the maximal cached gain.
+            // Lexicographic (u, v) scan with strict '>' ⇒ first pair wins ties.
+            let mut best: Option<(f64, usize, usize)> = None;
+            for u in 0..d {
+                for v in 0..d {
+                    if u == v
+                        || parents[v].len() >= params.max_parents
+                        || parents[v].contains(&u)
+                        || creates_cycle(&parents, u, v)
+                    {
+                        continue;
+                    }
+                    let g = gain_cache[u * d + v];
+                    if best.is_none_or(|(bg, _, _)| g > bg) {
+                        best = Some((g, u, v));
+                    }
+                }
+            }
+
+            let Some((gain, u, v)) = best else { break };
+            if gain <= 0.0 {
+                // Strictly-positive gain required to add an edge.
+                break;
+            }
+            insert_sorted(&mut parents[v], u);
+            base_score[v] += gain;
+
+            // Only entries with child == v are now stale; recompute just those.
+            for uu in 0..d {
+                if uu == v {
+                    continue;
+                }
+                let mut cand = parents[v].clone();
+                if !cand.contains(&uu) {
+                    insert_sorted(&mut cand, uu);
+                }
+                gain_cache[uu * d + v] = bic_score(&bits, n, d, v, &cand) - base_score[v];
+            }
+        }
+
+        // CPT estimation from the final structure: one counting pass per node.
+        let s = params.smoothing_count;
+        let mut cpt: Vec<Vec<f32>> = Vec::with_capacity(d);
+        // Laplace pseudo-count as f64; `s` is a tiny smoothing constant, far
+        // below f64's exact-integer range, so the cast is lossless.
+        #[allow(clippy::cast_precision_loss)]
+        let s_f = s as f64;
+        for v in 0..d {
+            let q = parents[v].len();
+            let num_configs = 1usize << q;
+            let mut counts = vec![0u32; num_configs * 2];
+            for i in 0..n {
+                let base = i * d;
+                let x = usize::from(bits[base + v]);
+                let config = pack_config(&bits, base, &parents[v]);
+                counts[config * 2 + x] += 1;
+            }
+            let mut table = Vec::with_capacity(num_configs);
+            for c in 0..num_configs {
+                let count_1 = counts[c * 2 + 1];
+                let count_total = counts[c * 2] + count_1;
+                let prob = if s == 0 && count_total == 0 {
+                    // Guard 0/0: unseen config with no smoothing ⇒ prior marginal.
+                    params.init_prob
+                } else {
+                    // (N(c,1) + s) / (N(c) + 2s); f64::from(u32) is lossless.
+                    let num = f64::from(count_1) + s_f;
+                    let den = f64::from(count_total) + 2.0 * s_f;
+                    // Probability in (0, 1) for s ≥ 1; the f64→f32 narrowing of a
+                    // value in [0, 1] cannot truncate meaningfully.
+                    #[allow(clippy::cast_possible_truncation)]
+                    let prob_f32 = (num / den) as f32;
+                    prob_f32
+                };
+                table.push(prob);
+            }
+            cpt.push(table);
+        }
+
+        let order = topological_order(&parents);
+        debug_assert_eq!(order.len(), d, "topological order must cover all nodes");
+
+        BayesianNetworkState {
+            order,
+            parents,
+            cpt,
+        }
+    }
+
+    /// Draw `n` binary genomes by ancestral sampling along the topological order.
+    ///
+    /// Each gene `v` is sampled from `P(v = 1 | parents)` read out of its CPT at
+    /// the bit-packed parent configuration (parents already sampled, since the
+    /// traversal follows the topological order). Exactly one `rng.random::<f32>()`
+    /// call is consumed per gene regardless of structure, keeping RNG
+    /// consumption stable. Host RNG only (never `Tensor::random` / `B::seed`).
+    /// The returned tensor has shape `(n, D)` and contains only `0.0` and `1.0`.
+    fn sample(
+        &self,
+        state: &Self::State,
+        n: usize,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Tensor<B, 2> {
+        let d = state.parents.len();
+        let mut rows = vec![0.0_f32; n * d];
+        for i in 0..n {
+            let base = i * d;
+            for &v in &state.order {
+                let mut config = 0usize;
+                for (j, &p) in state.parents[v].iter().enumerate() {
+                    if rows[base + p] >= 0.5 {
+                        config |= 1 << j;
+                    }
+                }
+                let p1 = state.cpt[v][config];
+                rows[base + v] = if rng.random::<f32>() < p1 { 1.0 } else { 0.0 };
+            }
+        }
+        Tensor::<B, 2>::from_data(TensorData::new(rows, [n, d]), device)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestBackend = Flex;
+
+    fn pop(rows: Vec<f32>, n: usize, d: usize) -> Tensor<TestBackend, 2> {
+        let device = Default::default();
+        Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [n, d]), &device)
+    }
+
+    fn fitness(values: Vec<f32>) -> Tensor<TestBackend, 1> {
+        let device = Default::default();
+        let n = values.len();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(values, [n]), &device)
+    }
+
+    fn fit_prior(p: &BayesianNetworkParams) -> BayesianNetworkState {
+        let device = Default::default();
+        <BayesianNetwork as ProbabilityModel<TestBackend>>::fit(
+            &BayesianNetwork,
+            p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        )
+    }
+
+    fn refit(p: &BayesianNetworkParams, rows: Vec<f32>, n: usize, d: usize) -> BayesianNetworkState {
+        let device = Default::default();
+        let prior = fit_prior(p);
+        // Test row counts are tiny; the cast is lossless.
+        #[allow(clippy::cast_precision_loss)]
+        let fit_values: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        <BayesianNetwork as ProbabilityModel<TestBackend>>::fit(
+            &BayesianNetwork,
+            p,
+            Some(&prior),
+            pop(rows, n, d),
+            fitness(fit_values),
+            &device,
+        )
+    }
+
+    #[test]
+    fn prior_is_edgeless_with_init_prob() {
+        let p = BayesianNetworkParams::default_for(3);
+        let state = fit_prior(&p);
+        assert_eq!(state.order, vec![0, 1, 2], "prior order is natural");
+        for ps in &state.parents {
+            assert!(ps.is_empty(), "prior parent lists must be empty");
+        }
+        for table in &state.cpt {
+            assert_eq!(table, &vec![0.5], "prior CPT is single-cell init_prob");
+        }
+    }
+
+    #[test]
+    fn two_fits_same_data_identical_state() {
+        let p = BayesianNetworkParams::default_for(3);
+        // gene1 = copy of gene0; gene2 a balanced, decorrelated pattern.
+        let rows = vec![
+            0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, //
+            0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, //
+            0.0, 0.0, 0.0, //
+            1.0, 1.0, 1.0, //
+            1.0, 1.0, 0.0, //
+            1.0, 1.0, 1.0, //
+            1.0, 1.0, 0.0, //
+            1.0, 1.0, 1.0, //
+        ];
+        let a = refit(&p, rows.clone(), 10, 3);
+        let b = refit(&p, rows, 10, 3);
+        assert_eq!(a.order, b.order, "order must be bit-deterministic");
+        assert_eq!(a.parents, b.parents, "parents must be bit-deterministic");
+        assert_eq!(a.cpt, b.cpt, "CPTs must be bit-deterministic");
+    }
+
+    #[test]
+    fn cpt_probabilities_strictly_interior() {
+        let p = BayesianNetworkParams::default_for(3);
+        // gene1 is constant 1 (constant column); Laplace smoothing must keep
+        // every CPT entry strictly inside (0, 1).
+        let rows = vec![
+            0.0, 1.0, 0.0, //
+            0.0, 1.0, 1.0, //
+            1.0, 1.0, 0.0, //
+            1.0, 1.0, 1.0, //
+            0.0, 1.0, 1.0, //
+            1.0, 1.0, 0.0, //
+        ];
+        let state = refit(&p, rows, 6, 3);
+        for (v, table) in state.cpt.iter().enumerate() {
+            for (c, &prob) in table.iter().enumerate() {
+                assert!(
+                    prob > 0.0 && prob < 1.0,
+                    "cpt[{v}][{c}] = {prob} not strictly interior"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn samples_are_binary_and_finite() {
+        let p = BayesianNetworkParams::default_for(4);
+        let rows = vec![
+            0.0, 0.0, 1.0, 1.0, //
+            1.0, 1.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 1.0, //
+            1.0, 0.0, 1.0, 0.0, //
+        ];
+        let state = refit(&p, rows, 4, 4);
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(7);
+        let samples = <BayesianNetwork as ProbabilityModel<TestBackend>>::sample(
+            &BayesianNetwork,
+            &state,
+            1000,
+            &mut rng,
+            &device,
+        );
+        let data = samples.into_data().into_vec::<f32>().unwrap();
+        for v in data {
+            assert!(v.is_finite(), "sampled gene must be finite, got {v}");
+            // Exact float compare is correct: sample() writes literal 0.0/1.0.
+            #[allow(clippy::float_cmp)]
+            let is_binary = v == 0.0 || v == 1.0;
+            assert!(is_binary, "non-binary gene {v}");
+        }
+    }
+
+    #[test]
+    fn recovers_pairwise_dependency() {
+        // d=3, n=20: gene0 balanced (10 zeros then 10 ones), gene1 = copy of
+        // gene0, gene2 alternating within each half (zero correlation to gene0).
+        // BIC: dependence gain ≈ n·ln2 ≈ 13.9 vs penalty increment ½·ln20 ≈ 1.5
+        // ⇒ exactly one edge between 0 and 1; gene2 isolated.
+        let p = BayesianNetworkParams::default_for(3);
+        let mut rows = Vec::with_capacity(20 * 3);
+        for i in 0..20 {
+            let g0 = if i < 10 { 0.0 } else { 1.0 };
+            let g1 = g0; // exact copy
+            let g2 = if i % 2 == 0 { 0.0 } else { 1.0 }; // alternating, decorrelated
+            rows.push(g0);
+            rows.push(g1);
+            rows.push(g2);
+        }
+        let state = refit(&p, rows, 20, 3);
+        // Direction-agnostic single edge between 0 and 1.
+        let edge_0_to_1 = state.parents[1] == vec![0];
+        let edge_1_to_0 = state.parents[0] == vec![1];
+        assert!(
+            edge_0_to_1 ^ edge_1_to_0,
+            "expected exactly one 0↔1 edge, parents = {:?}",
+            state.parents
+        );
+        // gene2 has no parents and appears in nobody's parent list.
+        assert!(state.parents[2].is_empty(), "gene2 must have no parents");
+        for ps in &state.parents {
+            assert!(!ps.contains(&2), "gene2 must not be a parent: {ps:?}");
+        }
+        // The child's 2-entry CPT is ≈ [<0.2, >0.8] after smoothing.
+        let child = usize::from(edge_0_to_1);
+        assert_eq!(state.cpt[child].len(), 2, "child CPT has 2 cells");
+        assert!(
+            state.cpt[child][0] < 0.2,
+            "P(child=1 | parent=0) too high: {}",
+            state.cpt[child][0]
+        );
+        assert!(
+            state.cpt[child][1] > 0.8,
+            "P(child=1 | parent=1) too low: {}",
+            state.cpt[child][1]
+        );
+    }
+
+    #[test]
+    fn recovers_two_parent_dependency() {
+        // gene2 = gene0 AND gene1 over the four balanced combos repeated 8×.
+        let p = BayesianNetworkParams::default_for(3);
+        let mut rows = Vec::with_capacity(32 * 3);
+        for _ in 0..8 {
+            for &(a, b) in &[(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)] {
+                let c = if a >= 0.5 && b >= 0.5 { 1.0 } else { 0.0 };
+                rows.push(a);
+                rows.push(b);
+                rows.push(c);
+            }
+        }
+        let state = refit(&p, rows, 32, 3);
+        // Assert specifically on gene2's parents (a 0↔1 edge, if added, is fine).
+        assert_eq!(
+            state.parents[2],
+            vec![0, 1],
+            "gene2 must depend on both 0 and 1, got {:?}",
+            state.parents[2]
+        );
+    }
+
+    #[test]
+    fn independent_data_yields_no_edges() {
+        // d=2, all four combinations equally → no detectable dependency.
+        let p = BayesianNetworkParams::default_for(2);
+        let rows = vec![
+            0.0, 0.0, //
+            0.0, 1.0, //
+            1.0, 0.0, //
+            1.0, 1.0, //
+        ];
+        let state = refit(&p, rows, 4, 2);
+        for ps in &state.parents {
+            assert!(ps.is_empty(), "independent data must yield no edges: {ps:?}");
+        }
+    }
+
+    #[test]
+    fn max_parents_cap_respected() {
+        // AND dataset with max_parents = 1: must complete and respect the cap.
+        let mut p = BayesianNetworkParams::default_for(3);
+        p.max_parents = 1;
+        let mut rows = Vec::with_capacity(32 * 3);
+        for _ in 0..8 {
+            for &(a, b) in &[(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)] {
+                let c = if a >= 0.5 && b >= 0.5 { 1.0 } else { 0.0 };
+                rows.push(a);
+                rows.push(b);
+                rows.push(c);
+            }
+        }
+        let state = refit(&p, rows, 32, 3);
+        for ps in &state.parents {
+            assert!(ps.len() <= 1, "max_parents=1 violated: {ps:?}");
+        }
+    }
+
+    #[test]
+    fn order_is_topological() {
+        // After a structure-learning fit, order is a permutation of 0..d with
+        // every parent preceding its child.
+        let p = BayesianNetworkParams::default_for(3);
+        let mut rows = Vec::with_capacity(32 * 3);
+        for _ in 0..8 {
+            for &(a, b) in &[(0.0, 0.0), (0.0, 1.0), (1.0, 0.0), (1.0, 1.0)] {
+                let c = if a >= 0.5 && b >= 0.5 { 1.0 } else { 0.0 };
+                rows.push(a);
+                rows.push(b);
+                rows.push(c);
+            }
+        }
+        let state = refit(&p, rows, 32, 3);
+        // Permutation check.
+        let mut seen = state.order.clone();
+        seen.sort_unstable();
+        assert_eq!(seen, vec![0, 1, 2], "order must be a permutation of 0..d");
+        // Parent precedes child.
+        let position: Vec<usize> = {
+            let mut pos = vec![0usize; state.order.len()];
+            for (idx, &node) in state.order.iter().enumerate() {
+                pos[node] = idx;
+            }
+            pos
+        };
+        for (child, ps) in state.parents.iter().enumerate() {
+            for &parent in ps {
+                assert!(
+                    position[parent] < position[child],
+                    "parent {parent} must precede child {child} in {:?}",
+                    state.order
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sampling_respects_learned_dependency() {
+        // Fit the copy dataset, sample 5000, columns 0 and 1 agree on > 90%.
+        let p = BayesianNetworkParams::default_for(2);
+        let mut rows = Vec::with_capacity(20 * 2);
+        for i in 0..20 {
+            let g0 = if i < 10 { 0.0 } else { 1.0 };
+            rows.push(g0);
+            rows.push(g0); // gene1 = copy of gene0
+        }
+        let state = refit(&p, rows, 20, 2);
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(123);
+        let n = 5000;
+        let samples = <BayesianNetwork as ProbabilityModel<TestBackend>>::sample(
+            &BayesianNetwork,
+            &state,
+            n,
+            &mut rng,
+            &device,
+        );
+        let data = samples.into_data().into_vec::<f32>().unwrap();
+        let mut agree = 0usize;
+        for i in 0..n {
+            if (data[i * 2] - data[i * 2 + 1]).abs() < 0.5 {
+                agree += 1;
+            }
+        }
+        // Tiny counts vs f64 exact range; lossless.
+        #[allow(clippy::cast_precision_loss)]
+        let frac = agree as f64 / n as f64;
+        assert!(
+            frac > 0.9,
+            "sampled columns 0 and 1 should agree on > 90% of rows, got {frac}"
+        );
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/eda/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/mod.rs
@@ -10,7 +10,7 @@
 //! 4. [`sample`](crate::ProbabilityModel::sample) a fresh population.
 //!
 //! The model is supplied as a [`ProbabilityModel`]; the generic
-//! [`EdaStrategy`] driver is model-agnostic. Four reference models ship here:
+//! [`EdaStrategy`] driver is model-agnostic. Five reference models ship here:
 //!
 //! - [`UnivariateGaussian`] — UMDA, a per-dimension Gaussian (unweighted MLE,
 //!   `÷k` variance, `min_variance` floor; fitness is accepted but ignored).
@@ -22,10 +22,13 @@
 //!   pairwise draw as in classic cGA).
 //! - [`DependencyChain`] — a continuous-Gaussian MIMIC chain capturing
 //!   pairwise dependencies (fitness accepted but ignored).
+//! - [`BayesianNetwork`] — BOA, a BIC-scored Bayesian network (bounded-in-degree
+//!   DAG over binary genes; non-incremental, unweighted fit; Pelikan, Goldberg
+//!   & Cantú-Paz 1999).
 //!
-//! Both binary models ([`UnivariateBernoulli`] and [`CompactGenetic`]) emit
-//! raw `{0, 1}` genes; the [`EdaParams::bounds`] clamp is therefore a no-op
-//! for them.
+//! The three binary models ([`UnivariateBernoulli`], [`CompactGenetic`], and
+//! [`BayesianNetwork`]) emit raw `{0, 1}` genes; the [`EdaParams::bounds`] clamp
+//! is therefore a no-op for them.
 //!
 //! # References
 //!
@@ -37,12 +40,16 @@
 //! - Harik, Lobo & Goldberg (1999), *The compact genetic algorithm*.
 //! - De Bonet, Isbell & Viola (1997), *MIMIC: Finding optima by estimating
 //!   probability densities*.
+//! - Pelikan, Goldberg & Cantú-Paz (1999), *BOA: The Bayesian optimization
+//!   algorithm*.
 
+pub mod bayesian_network;
 pub mod compact_genetic;
 pub mod dependency_chain;
 pub mod univariate_bernoulli;
 pub mod univariate_gaussian;
 
+pub use bayesian_network::{BayesianNetwork, BayesianNetworkParams, BayesianNetworkState};
 pub use compact_genetic::{CompactGenetic, CompactGeneticParams, CompactGeneticState};
 pub use dependency_chain::{DependencyChain, DependencyChainParams, DependencyChainState};
 pub use univariate_bernoulli::{
@@ -110,7 +117,7 @@ pub struct EdaState<B: Backend, MS> {
 ///
 /// Type parameter `M` must implement [`ProbabilityModel<B>`]; in practice
 /// this is one of [`UnivariateGaussian`], [`UnivariateBernoulli`],
-/// [`CompactGenetic`], or [`DependencyChain`].
+/// [`CompactGenetic`], [`DependencyChain`], or [`BayesianNetwork`].
 ///
 /// # Example
 ///
@@ -229,10 +236,10 @@ impl<B: Backend, M: ProbabilityModel<B>> Strategy<B> for EdaStrategy<B, M> {
     /// and refits the model to them (passing `prev = Some(model_state)`).
     ///
     /// The `fitness` tensor is forwarded to [`ProbabilityModel::fit`]; models
-    /// that weight or rank their selected individuals can use it. The four
+    /// that weight or rank their selected individuals can use it. The five
     /// built-in models ([`UnivariateGaussian`], [`UnivariateBernoulli`],
-    /// [`CompactGenetic`], [`DependencyChain`]) all perform an unweighted fit
-    /// and ignore it.
+    /// [`CompactGenetic`], [`DependencyChain`], [`BayesianNetwork`]) all perform
+    /// an unweighted fit and ignore it.
     fn tell(
         &self,
         params: &Self::Params,

--- a/crates/rlevo-evolution/src/lib.rs
+++ b/crates/rlevo-evolution/src/lib.rs
@@ -50,9 +50,9 @@ pub mod shaping;
 pub mod strategy;
 
 pub use algorithms::eda::{
-    CompactGenetic, CompactGeneticParams, DependencyChain, DependencyChainParams, EdaParams,
-    EdaState, EdaStrategy, UnivariateBernoulli, UnivariateBernoulliParams, UnivariateGaussian,
-    UnivariateGaussianParams,
+    BayesianNetwork, BayesianNetworkParams, CompactGenetic, CompactGeneticParams, DependencyChain,
+    DependencyChainParams, EdaParams, EdaState, EdaStrategy, UnivariateBernoulli,
+    UnivariateBernoulliParams, UnivariateGaussian, UnivariateGaussianParams,
 };
 pub use algorithms::memetic::{CoveragePolicy, MemeticWrapper, WritebackPolicy};
 pub use probability_model::ProbabilityModel;

--- a/crates/rlevo-examples/examples/evolution/eda_showcase.rs
+++ b/crates/rlevo-examples/examples/evolution/eda_showcase.rs
@@ -9,7 +9,7 @@
 //! hiding them behind the [`EvolutionaryHarness`]. It drives the
 //! [`Strategy`] `ask` → evaluate → `tell` loop by hand for exactly that reason.
 //!
-//! Two demos, each paired with the problem that actually exercises its models:
+//! Three demos, each paired with the problem that actually exercises its models:
 //!
 //! ## Demo 1 — continuous, Rosenbrock-D10: why dependencies matter
 //!
@@ -31,7 +31,28 @@
 //! per-gene probability vector; watch it march to all-ones. `OneMax` is fully
 //! *separable*, so a univariate model is already optimal here — the binary
 //! analogue of "dependencies matter" needs a deceptive problem **and** a
-//! multivariate binary model (BOA), which is deferred to issue #37.
+//! multivariate binary model (BOA) — see Demo 3.
+//!
+//! ## Demo 3 — binary deception, `ConcatenatedTrap` trap-5 × 4: linkage matters
+//!
+//! Runs [`UnivariateGaussian`] (UMDA), [`DependencyChain`] (MIMIC), and
+//! [`BayesianNetwork`] (BOA) on a deceptive order-5 trap of four blocks
+//! (dim 20). Each block costs `cost(u) = 0` if `u == k` else `u + 1`, where `u`
+//! is the block's unitation (1-bit count) and `k = 5` — so the all-ones optimum
+//! costs `0` but the all-zeros deceptive basin costs `num_blocks = 4`. In a
+//! random population, blocks with *fewer* ones are cheaper on average, so every
+//! per-gene average marches the model toward all-zeros: UMDA's means collapse,
+//! and MIMIC's first-order chain — which can tie at most one neighbour per gene
+//! — still cannot capture the order-5 intra-block linkage. Only BOA, learning a
+//! bounded-in-degree DAG, discovers the within-block edges and samples whole
+//! solved blocks; watch its intra-block edge count climb while UMDA/MIMIC are
+//! deceived. Verdict: BOA median cost `0.0`, UMDA/MIMIC medians ≈ `3`.
+//!
+//! Demo 3 deliberately omits the *incremental* binary models. At this large
+//! population the damped PBIL/cGA updates resist the deceptive average gradient
+//! and partially escape the trap (cGA solved 9/10 calibration seeds), so they
+//! muddy the structural story. The three full-refit models compared here make
+//! the linkage punchline clean.
 //!
 //! # Running
 //!
@@ -39,8 +60,9 @@
 //! cargo run --release -p rlevo-examples --example eda_showcase
 //! ```
 //!
-//! No feature flags are required. Release is recommended — the run drives a few
-//! thousand generations of Burn tensor ops.
+//! No feature flags are required. Release is strongly recommended — the run
+//! drives a few thousand generations of Burn tensor ops, and Demo 3 alone adds
+//! ~11 runs at population 2000 × 60 generations.
 
 use burn::backend::Flex;
 use burn::tensor::backend::BackendTypes;
@@ -48,14 +70,16 @@ use burn::tensor::{Tensor, TensorData};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
+use rlevo_environments::landscapes::concatenated_trap::ConcatenatedTrap;
 use rlevo_environments::landscapes::rosenbrock::Rosenbrock;
 use rlevo_evolution::algorithms::eda::{
-    CompactGeneticState, DependencyChainState, UnivariateBernoulliState, UnivariateGaussianState,
+    BayesianNetworkState, CompactGeneticState, DependencyChainState, UnivariateBernoulliState,
+    UnivariateGaussianState,
 };
 use rlevo_evolution::{
-    CompactGenetic, CompactGeneticParams, DependencyChain, DependencyChainParams, EdaParams,
-    EdaStrategy, ProbabilityModel, Strategy, UnivariateBernoulli, UnivariateBernoulliParams,
-    UnivariateGaussian, UnivariateGaussianParams,
+    BayesianNetwork, BayesianNetworkParams, CompactGenetic, CompactGeneticParams, DependencyChain,
+    DependencyChainParams, EdaParams, EdaStrategy, ProbabilityModel, Strategy, UnivariateBernoulli,
+    UnivariateBernoulliParams, UnivariateGaussian, UnivariateGaussianParams,
 };
 
 type B = Flex;
@@ -399,6 +423,267 @@ fn onemax_demo() {
     println!("  → best fitness (0 = all-ones found): {cga_best:.1}\n");
 }
 
+// ── Demo 3 — binary deception: UMDA vs MIMIC vs BOA on ConcatenatedTrap ────────
+
+/// Number of order-`TRAP_K` trap blocks; total dim is `TRAP_BLOCKS · TRAP_K`.
+const TRAP_BLOCKS: usize = 4;
+/// Trap order `k`: bits per block. Reaching the per-block optimum requires
+/// flipping all `k` bits together — the order-`k` linkage UMDA/MIMIC miss.
+const TRAP_K: usize = 5;
+/// Genome dimension: `TRAP_BLOCKS · TRAP_K = 20`.
+const TRAP_DIM: usize = TRAP_BLOCKS * TRAP_K;
+/// Selected-row count is load-bearing: the BIC edge gain grows with `N` while
+/// the complexity penalty grows like `ln N`, so the intra-block edges clear the
+/// penalty only when thousands of rows are selected (ADR 0018 calibration).
+const TRAP_POP: usize = 2000;
+/// Truncation ratio; `0.3` enriches solved-block carriers fast enough that BOA
+/// learns the structure before the deceptive per-gene gradient collapses.
+const TRAP_RATIO: f32 = 0.3;
+/// Generation budget for the trap (short by design — the structure, if any, is
+/// learned early or never).
+const TRAP_GENS: usize = 60;
+/// Verbose single-seed trace seed for Demo 3.
+const TRAP_TRACE_SEED: u64 = 11;
+/// Median seeds for Demo 3 (the ADR 0018 convergence-gate set).
+const TRAP_SEEDS: [u64; 5] = [11, 22, 33, 44, 55];
+/// Symmetric prior over the binary box `[0, 1]` shared by the continuous models.
+const TRAP_INIT_MEAN: f32 = 0.5;
+const TRAP_INIT_STD: f32 = 0.5;
+
+/// `ConcatenatedTrap` under the EDA minimization convention. The host genome row
+/// is `f32`; widen to `f64` for the landscape, then narrow the scalar back.
+#[allow(clippy::cast_possible_truncation)]
+fn trap_fitness(trap: ConcatenatedTrap, row: &[f32]) -> f32 {
+    let point: Vec<f64> = row.iter().map(|&g| f64::from(g)).collect();
+    trap.evaluate(&point) as f32
+}
+
+/// UMDA prior for the trap: symmetric over the binary box.
+fn trap_umda_params() -> UnivariateGaussianParams {
+    let mut p = UnivariateGaussianParams::default_for(TRAP_DIM);
+    p.init_mean = TRAP_INIT_MEAN;
+    p.init_std = TRAP_INIT_STD;
+    p
+}
+
+/// MIMIC prior for the trap: same symmetric box prior as UMDA.
+fn trap_mimic_params() -> DependencyChainParams {
+    let mut p = DependencyChainParams::default_for(TRAP_DIM);
+    p.init_mean = TRAP_INIT_MEAN;
+    p.init_std = TRAP_INIT_STD;
+    p
+}
+
+/// `EdaParams` for the continuous trap models (UMDA, MIMIC): clamp to `[0, 1]`.
+fn trap_continuous_params<MP>(model: MP) -> EdaParams<MP> {
+    EdaParams {
+        pop_size: TRAP_POP,
+        selection_ratio: TRAP_RATIO,
+        bounds: Some((0.0, 1.0)),
+        model,
+    }
+}
+
+/// `EdaParams` for BOA: emits raw `{0, 1}` genes, so bounds are a no-op.
+fn trap_boa_params() -> EdaParams<BayesianNetworkParams> {
+    EdaParams {
+        pop_size: TRAP_POP,
+        selection_ratio: TRAP_RATIO,
+        bounds: None,
+        model: BayesianNetworkParams::default_for(TRAP_DIM),
+    }
+}
+
+/// Is the directed edge `parent → child` inside a single trap block? Both
+/// endpoints share a block iff they map to the same `TRAP_K`-wide bucket.
+fn intra_block(parent: usize, child: usize) -> bool {
+    parent / TRAP_K == child / TRAP_K
+}
+
+/// Count total edges and intra-block edges in a fitted Bayesian network, plus a
+/// per-block tally of intra-block edges (`blocks[b]` = intra edges in block `b`).
+fn edge_stats(state: &BayesianNetworkState) -> (usize, usize, [usize; TRAP_BLOCKS]) {
+    let mut total = 0usize;
+    let mut intra = 0usize;
+    let mut blocks = [0usize; TRAP_BLOCKS];
+    for (child, parents) in state.parents.iter().enumerate() {
+        for &parent in parents {
+            total += 1;
+            if intra_block(parent, child) {
+                intra += 1;
+                blocks[parent / TRAP_K] += 1;
+            }
+        }
+    }
+    (total, intra, blocks)
+}
+
+/// Render the per-block intra-edge tally as `[b0: 3 intra-edges] [b1: 4] …`,
+/// spelling "intra-edges" only on the first block to keep the line compact.
+fn block_map(blocks: &[usize; TRAP_BLOCKS]) -> String {
+    blocks
+        .iter()
+        .enumerate()
+        .map(|(b, &count)| {
+            if b == 0 {
+                format!("[b0: {count} intra-edges]")
+            } else {
+                format!("[b{b}: {count}]")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn trap_demo() {
+    println!(
+        "══ Demo 3: UMDA vs MIMIC vs BOA on ConcatenatedTrap trap-{TRAP_K} × {TRAP_BLOCKS} \
+         (dim {TRAP_DIM}) ══"
+    );
+    println!(
+        "Each block costs cost(u) = 0 if u == k else u + 1, with k = {TRAP_K} bits per\n\
+         block and u the block's 1-count. The all-ones optimum costs 0; the all-zeros\n\
+         basin costs {TRAP_BLOCKS}. In a random population, blocks with FEWER ones are\n\
+         cheaper on average, so per-gene statistics march everything to all-zeros\n\
+         (cost {TRAP_BLOCKS}). The all-ones optimum (cost 0) is reachable only by a model\n\
+         that captures the order-{TRAP_K} intra-block linkage. Note: the incremental\n\
+         binary models (PBIL/cGA) partially escape this trap at pop {TRAP_POP} — their\n\
+         damped updates resist the deceptive gradient — so this demo compares the\n\
+         full-refit models, where the structural story is clean.\n"
+    );
+
+    let trap = ConcatenatedTrap::new(TRAP_BLOCKS, TRAP_K);
+
+    // UMDA trace: per-gene Gaussian means collapse toward 0 (deceived).
+    println!("UMDA (seed {TRAP_TRACE_SEED}) — independent per-dimension Gaussian:");
+    println!("  {:>4} {:>10}", "gen", "mean μ");
+    let umda_best = run_eda(
+        UnivariateGaussian,
+        &trap_continuous_params(trap_umda_params()),
+        TRAP_TRACE_SEED,
+        TRAP_GENS,
+        |row| trap_fitness(trap, row),
+        |g, st: &UnivariateGaussianState| {
+            if logged(g) {
+                println!("  {:>4} {:>10.5}", g + 1, mean(&st.mean));
+            }
+        },
+    );
+    println!("  → best fitness (0 = all-ones found): {umda_best:.1}\n");
+
+    // MIMIC trace: means + strongest captured link. A first-order chain ties at
+    // most one neighbour per gene, so it cannot represent order-5 linkage and is
+    // deceived just like UMDA.
+    println!("MIMIC (seed {TRAP_TRACE_SEED}) — first-order dependency chain:");
+    println!("  {:>4} {:>10} {:>10}", "gen", "mean μ", "max|r|");
+    let mimic_best = run_eda(
+        DependencyChain,
+        &trap_continuous_params(trap_mimic_params()),
+        TRAP_TRACE_SEED,
+        TRAP_GENS,
+        |row| trap_fitness(trap, row),
+        |g, st: &DependencyChainState| {
+            if logged(g) {
+                let max_corr = st
+                    .link_corr
+                    .iter()
+                    .map(|c| c.abs())
+                    .fold(0.0_f32, f32::max);
+                println!("  {:>4} {:>10.5} {max_corr:>10.4}", g + 1, mean(&st.mean));
+            }
+        },
+    );
+    println!("  → best fitness (0 = all-ones found): {mimic_best:.1}\n");
+
+    // BOA trace: total/intra-block edge counts + a compact per-block parent map.
+    // Track the peak intra-block edge count across the WHOLE run (every
+    // generation, not just logged ones) — the structure is transient, so the
+    // logged snapshots alone understate the linkage BOA exploited.
+    println!("BOA (seed {TRAP_TRACE_SEED}) — bounded-in-degree Bayesian network:");
+    println!("  per-gen edge structure (an edge u→v is intra-block when u/{TRAP_K} == v/{TRAP_K}):");
+    let mut peak_intra = 0usize;
+    let boa_best = run_eda(
+        BayesianNetwork,
+        &trap_boa_params(),
+        TRAP_TRACE_SEED,
+        TRAP_GENS,
+        |row| trap_fitness(trap, row),
+        |g, st: &BayesianNetworkState| {
+            let (total, intra, blocks) = edge_stats(st);
+            // Peak tracking runs every generation, not just on logged ones.
+            peak_intra = peak_intra.max(intra);
+            if logged(g) {
+                println!(
+                    "  gen {:>2}: edges {total} (intra-block {intra}) | blocks: {}",
+                    g + 1,
+                    block_map(&blocks)
+                );
+            }
+        },
+    );
+    println!("  peak intra-block edges over all {TRAP_GENS} generations: {peak_intra}");
+    println!("  → best fitness (0 = all-ones found): {boa_best:.1}\n");
+
+    trap_medians(trap);
+}
+
+/// Robustness check: median final cost over the five ADR 0018 seeds for all
+/// three models, so BOA's win reads as structural rather than one lucky seed.
+fn trap_medians(trap: ConcatenatedTrap) {
+    let mut umda: Vec<f32> = TRAP_SEEDS
+        .iter()
+        .map(|&seed| {
+            run_eda(
+                UnivariateGaussian,
+                &trap_continuous_params(trap_umda_params()),
+                seed,
+                TRAP_GENS,
+                |row| trap_fitness(trap, row),
+                |_g, _st: &UnivariateGaussianState| {},
+            )
+        })
+        .collect();
+    let mut mimic: Vec<f32> = TRAP_SEEDS
+        .iter()
+        .map(|&seed| {
+            run_eda(
+                DependencyChain,
+                &trap_continuous_params(trap_mimic_params()),
+                seed,
+                TRAP_GENS,
+                |row| trap_fitness(trap, row),
+                |_g, _st: &DependencyChainState| {},
+            )
+        })
+        .collect();
+    let mut boa: Vec<f32> = TRAP_SEEDS
+        .iter()
+        .map(|&seed| {
+            run_eda(
+                BayesianNetwork,
+                &trap_boa_params(),
+                seed,
+                TRAP_GENS,
+                |row| trap_fitness(trap, row),
+                |_g, _st: &BayesianNetworkState| {},
+            )
+        })
+        .collect();
+    let umda_med = median(&mut umda);
+    let mimic_med = median(&mut mimic);
+    let boa_med = median(&mut boa);
+    println!("Median final cost over {} seeds:", TRAP_SEEDS.len());
+    println!("  UMDA  : {umda_med:.1}  (deceived — stalls near the all-zeros basin)");
+    println!("  MIMIC : {mimic_med:.1}  (deceived — first-order chain misses order-5 linkage)");
+    println!("  BOA   : {boa_med:.1}  (solves — captures the intra-block linkage)");
+    let verdict = if boa_med < umda_med && boa_med < mimic_med {
+        "BOA wins — only the multivariate model escapes the deceptive trap"
+    } else {
+        "BOA did not separate from UMDA/MIMIC this run"
+    };
+    println!("  → {verdict}\n");
+}
+
 fn main() {
     println!(
         "Estimation-of-Distribution Algorithms: replace crossover/mutation with a\n\
@@ -406,4 +691,5 @@ fn main() {
     );
     rosenbrock_demo();
     onemax_demo();
+    trap_demo();
 }

--- a/crates/rlevo/tests/determinism.rs
+++ b/crates/rlevo/tests/determinism.rs
@@ -1,6 +1,6 @@
 //! Bit-exact determinism for the EDA strategies (cross-crate).
 //!
-//! Runs each of the four `ProbabilityModel` implementations twice from
+//! Runs each of the five `ProbabilityModel` implementations twice from
 //! the same seed on the real [`Sphere`] landscape from
 //! `rlevo-environments` and asserts the per-generation best-fitness
 //! trajectories are bit-identical. EDA sampling draws exclusively from
@@ -13,14 +13,14 @@ use burn::backend::Flex;
 
 use rlevo_environments::landscapes::sphere::Sphere;
 use rlevo_evolution::algorithms::eda::{
-    CompactGeneticParams, DependencyChainParams, UnivariateBernoulliParams,
-    UnivariateGaussianParams,
+    BayesianNetworkParams, CompactGeneticParams, DependencyChainParams,
+    UnivariateBernoulliParams, UnivariateGaussianParams,
 };
 use rlevo_evolution::fitness::FromLandscape;
 use rlevo_evolution::strategy::EvolutionaryHarness;
 use rlevo_evolution::{
-    CompactGenetic, DependencyChain, EdaParams, EdaStrategy, ProbabilityModel,
-    UnivariateBernoulli, UnivariateGaussian,
+    BayesianNetwork, CompactGenetic, DependencyChain, EdaParams, EdaStrategy,
+    ProbabilityModel, UnivariateBernoulli, UnivariateGaussian,
 };
 
 type B = Flex;
@@ -134,5 +134,22 @@ fn eda_same_seed_same_trajectories() {
     assert_eq!(
         a, b,
         "DependencyChain (MIMIC) trajectories diverge under the same seed"
+    );
+
+    // BOA — Bayesian network; raw {0,1} genes, bounds unused.
+    let a = run(
+        BayesianNetwork,
+        BayesianNetworkParams::default_for(DIM),
+        None,
+    );
+    let b = run(
+        BayesianNetwork,
+        BayesianNetworkParams::default_for(DIM),
+        None,
+    );
+    assert!(a.iter().all(|f| f.is_finite()));
+    assert_eq!(
+        a, b,
+        "BayesianNetwork (BOA) trajectories diverge under the same seed"
     );
 }

--- a/crates/rlevo/tests/eda_convergence.rs
+++ b/crates/rlevo/tests/eda_convergence.rs
@@ -1,6 +1,7 @@
 //! EDA convergence gates (cross-crate).
 //!
-//! Two acceptance criteria from the Phase 3b spec (issue #31):
+//! Two acceptance criteria from the Phase 3b spec (issue #31), plus the
+//! Phase 3b follow-up gate (issue #37):
 //!
 //! 1. Every `ProbabilityModel` implementation drives `best_fitness_ever`
 //!    to `<= 0.01` on Sphere-D10 within 500 generations
@@ -10,6 +11,11 @@
 //!    over nine fixed seeds — the dependency-chain model must exploit
 //!    Rosenbrock's adjacent-variable coupling that a univariate model
 //!    cannot represent.
+//! 3. BOA ([`BayesianNetwork`]) solves the deceptive
+//!    [`ConcatenatedTrap`] trap-5 × 4 (cost 0, all-ones) while UMDA and
+//!    MIMIC stall near the all-zeros deceptive basin (cost ≈ 4) — only a
+//!    model capturing the order-5 intra-block linkage can sample and
+//!    keep solved blocks.
 //!
 //! Runs are bit-deterministic per seed (host-RNG sampling only), so
 //! these gates cannot flake run-to-run on a given platform.
@@ -17,17 +23,18 @@
 use burn::backend::Flex;
 
 use rlevo_core::fitness::Landscape;
+use rlevo_environments::landscapes::concatenated_trap::ConcatenatedTrap;
 use rlevo_environments::landscapes::rosenbrock::Rosenbrock;
 use rlevo_environments::landscapes::sphere::Sphere;
 use rlevo_evolution::algorithms::eda::{
-    CompactGeneticParams, DependencyChainParams, UnivariateBernoulliParams,
-    UnivariateGaussianParams,
+    BayesianNetworkParams, CompactGeneticParams, DependencyChainParams,
+    UnivariateBernoulliParams, UnivariateGaussianParams,
 };
 use rlevo_evolution::fitness::FromLandscape;
 use rlevo_evolution::strategy::EvolutionaryHarness;
 use rlevo_evolution::{
-    CompactGenetic, DependencyChain, EdaParams, EdaStrategy, ProbabilityModel,
-    UnivariateBernoulli, UnivariateGaussian,
+    BayesianNetwork, CompactGenetic, DependencyChain, EdaParams, EdaStrategy,
+    ProbabilityModel, UnivariateBernoulli, UnivariateGaussian,
 };
 
 type B = Flex;
@@ -51,9 +58,38 @@ where
     M: ProbabilityModel<B> + 'static,
     L: Landscape + 'static,
 {
+    run_config(
+        model,
+        model_params,
+        POP_SIZE,
+        selection_ratio,
+        bounds,
+        landscape,
+        GENS,
+        seed,
+    )
+}
+
+/// Fully-parameterised runner: the trap gate needs a larger population
+/// and a shorter budget than the file-level Sphere/Rosenbrock constants.
+#[allow(clippy::too_many_arguments)] // mirrors the EdaParams + harness knobs 1:1
+fn run_config<M, L>(
+    model: M,
+    model_params: M::Params,
+    pop_size: usize,
+    selection_ratio: f32,
+    bounds: Option<(f32, f32)>,
+    landscape: L,
+    gens: usize,
+    seed: u64,
+) -> f32
+where
+    M: ProbabilityModel<B> + 'static,
+    L: Landscape + 'static,
+{
     let device = Default::default();
     let params = EdaParams {
-        pop_size: POP_SIZE,
+        pop_size,
         selection_ratio,
         bounds,
         model: model_params,
@@ -64,7 +100,7 @@ where
         FromLandscape::new(landscape),
         seed,
         device,
-        GENS,
+        gens,
     );
     harness.reset();
     loop {
@@ -83,7 +119,7 @@ fn median(values: &mut [f32]) -> f32 {
 }
 
 #[test]
-fn all_four_models_reach_sphere_threshold() {
+fn all_five_models_reach_sphere_threshold() {
     const SEED: u64 = 42;
     const TARGET: f32 = 0.01;
     let bounds = Some((-5.12, 5.12));
@@ -140,6 +176,132 @@ fn all_four_models_reach_sphere_threshold() {
     assert!(
         mimic <= TARGET,
         "MIMIC best_fitness_ever on Sphere-D10 after {GENS} gens = {mimic}"
+    );
+
+    // BOA also emits raw {0,1} genes; the all-zeros genome scores
+    // exactly 0.0 on Sphere (degenerate but NaN-free sanity gate).
+    let boa = run(
+        BayesianNetwork,
+        BayesianNetworkParams::default_for(DIM),
+        SELECTION_RATIO,
+        None,
+        Sphere::new(DIM),
+        SEED,
+    );
+    assert!(
+        boa <= TARGET,
+        "BOA best_fitness_ever on Sphere-D10 after {GENS} gens = {boa}"
+    );
+}
+
+/// Issue #37 discriminating gate: BOA solves the deceptive trap-5 × 4
+/// (`dim = 20`) to cost 0 (all-ones) while UMDA and MIMIC stall at/near
+/// the all-zeros basin (cost ≈ 4 = `num_blocks`).
+///
+/// Configuration pinned by the calibration sweep recorded in ADR 0018:
+///
+/// - `pop_size = 2000`, `selection_ratio = 0.3`, 60 generations,
+///   `max_parents = 3` (the `BayesianNetworkParams` default).
+/// - Both knobs are load-bearing for BOA. The BIC edge gain grows with
+///   the selected-row count `N` while the penalty grows like `ln N`, so
+///   the intra-block edges only clear the penalty when thousands of rows
+///   are selected; and `0.3` truncation enriches solved-block carriers
+///   fast enough that the structure is learned before the deceptive
+///   per-gene gradient collapses the population onto all-zeros. At
+///   `pop = 600` (any ratio) or `ratio = 0.5` (any pop ≤ 4000) BOA
+///   solved 0–4 of 10 calibration seeds; at this config it solved 10/10.
+/// - UMDA/MIMIC run the *same* budget with a symmetric prior over the
+///   binary box (`init_mean = 0.5`, `init_std = 0.5`, bounds `(0, 1)`);
+///   their failure is structural — a univariate (or first-order-chain)
+///   model cannot represent the order-5 intra-block linkage — not a
+///   budget artifact. Calibration medians: UMDA 3.0, MIMIC 3.0.
+#[test]
+fn boa_solves_trap_where_umda_and_mimic_stall() {
+    const SEEDS: [u64; 5] = [11, 22, 33, 44, 55];
+    const TRAP_POP: usize = 2000;
+    const TRAP_RATIO: f32 = 0.3;
+    const TRAP_GENS: usize = 60;
+    let trap = ConcatenatedTrap::new(4, 5); // trap-5 × 4 blocks, dim 20
+
+    let mut boa: Vec<f32> = SEEDS
+        .iter()
+        .map(|&seed| {
+            run_config(
+                BayesianNetwork,
+                BayesianNetworkParams::default_for(trap.dim()),
+                TRAP_POP,
+                TRAP_RATIO,
+                None,
+                trap,
+                TRAP_GENS,
+                seed,
+            )
+        })
+        .collect();
+    let mut umda: Vec<f32> = SEEDS
+        .iter()
+        .map(|&seed| {
+            let mut p = UnivariateGaussianParams::default_for(trap.dim());
+            p.init_mean = 0.5;
+            p.init_std = 0.5;
+            run_config(
+                UnivariateGaussian,
+                p,
+                TRAP_POP,
+                TRAP_RATIO,
+                Some((0.0, 1.0)),
+                trap,
+                TRAP_GENS,
+                seed,
+            )
+        })
+        .collect();
+    let mut mimic: Vec<f32> = SEEDS
+        .iter()
+        .map(|&seed| {
+            let mut p = DependencyChainParams::default_for(trap.dim());
+            p.init_mean = 0.5;
+            p.init_std = 0.5;
+            run_config(
+                DependencyChain,
+                p,
+                TRAP_POP,
+                TRAP_RATIO,
+                Some((0.0, 1.0)),
+                trap,
+                TRAP_GENS,
+                seed,
+            )
+        })
+        .collect();
+
+    let boa_median = median(&mut boa);
+    let umda_median = median(&mut umda);
+    let mimic_median = median(&mut mimic);
+
+    // Trap cost is integer-valued, so 0.0 is exact in f32.
+    assert!(
+        boa_median == 0.0,
+        "BOA must reach the all-ones optimum (median cost 0) on trap-5×4; \
+         got median {boa_median}, per-seed {boa:?}"
+    );
+    // ">= 2.0" rather than "== 4.0": a lucky block may be solved, but the
+    // univariate/pairwise models must remain deceived on most blocks.
+    assert!(
+        umda_median >= 2.0,
+        "UMDA is expected to stall near the all-zeros basin (cost ≈ 4) on \
+         trap-5×4; got median {umda_median}, per-seed {umda:?}"
+    );
+    assert!(
+        mimic_median >= 2.0,
+        "MIMIC's first-order chain cannot capture order-5 linkage and must \
+         stall near cost 4 on trap-5×4; got median {mimic_median}, per-seed \
+         {mimic:?}"
+    );
+    assert!(
+        boa_median < umda_median && boa_median < mimic_median,
+        "BOA (median {boa_median}) must beat both UMDA ({umda_median}) and \
+         MIMIC ({mimic_median}) on trap-5×4"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds `BayesianNetwork` (BOA — Pelikan 1999) as the fifth `ProbabilityModel` in the EDA suite, and `ConcatenatedTrap` as the discriminating deceptive benchmark that validates it. The frozen `ProbabilityModel` trait needed no changes (ADR 0018): the learned DAG lives entirely in `State`. BOA learns a bounded-in-degree DAG per generation via greedy BIC structure search over raw MLE counts (K2 rejected — see ADR 0018 for rationale); CPTs are Laplace-smoothed for sampling only. The cross-crate convergence gate confirms BOA reaches cost 0 on trap-5×4 at the empirically pinned budget (pop 2000, ratio 0.3, 60 gens) while UMDA and MIMIC stall in the all-zeros basin at identical budget.

## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — _new `ProbabilityModel` impl and benchmark landscape; purely additive, no existing API changed_

## Linked Issue

Closes #37

## What Was Changed

- `crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs` — new `BayesianNetwork` struct implementing `ProbabilityModel<B>`; greedy BIC DAG learning with `max_parents = 3` cap; Laplace `smoothing_count = 1` in CPT (never scoring); deterministic Kahn-order ancestral sampling; d×d gain cache invalidated only on modified node.
- `crates/rlevo-evolution/src/algorithms/eda/mod.rs` — export `BayesianNetwork` and `BayesianNetworkConfig`.
- `crates/rlevo-evolution/src/lib.rs` — re-export `BayesianNetwork`/`BayesianNetworkConfig` at crate root.
- `crates/rlevo-environments/src/landscapes/concatenated_trap.rs` — new `ConcatenatedTrap` deceptive landscape: trap-5, `cost(u) = 0` if `u == k` else `u + 1`; implements `BenchEnv` and `Landscape`.
- `crates/rlevo-environments/src/bench/landscape.rs` — minor extension to accommodate new landscape.
- `crates/rlevo-environments/src/lib.rs` — export `ConcatenatedTrap`.
- `crates/rlevo-examples/examples/evolution/eda_showcase.rs` — extend showcase with BOA on `ConcatenatedTrap`; empirical population/ratio/generation observations documented inline.
- `crates/rlevo/tests/eda_convergence.rs` — cross-crate convergence gate: BOA must hit cost 0; UMDA/MIMIC expected to stall.
- `crates/rlevo/tests/determinism.rs` — extend determinism suite to cover `BayesianNetwork`.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable
- Burn backend tested: ndarray (CPU)
- OS: macOS Darwin 25.5.0

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Fable 5 / Claude Sonnet 4.6. Scope: implementation of `BayesianNetwork` model, `ConcatenatedTrap` landscape, and associated tests and examples.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- BOA convergence is population-sensitive by design: BIC edge-gain grows with N while the penalty grows with ln N, making `pop_size` the load-bearing knob. The pinned gate values (2000 / 0.3 / 60) are empirical; looser budgets may require adjustment on slower hardware.
- `cGA` partially escapes the trap at this scale — documented as a recorded surprise in ADR 0018.
- The d×d gain cache in `fit()` recomputes only entries whose child matches the just-modified node; edge eligibility (cycle / parent cap / already-present) is re-checked live at selection time, so a cached score cannot resurrect a now-illegal edge.
