### PR TITLE
feat(coevolution): Add Phase 3c co-evolutionary algorithms

### DIFF
--- a/crates/rlevo-evolution/src/coevolution/competitive.rs
+++ b/crates/rlevo-evolution/src/coevolution/competitive.rs
@@ -1,0 +1,160 @@
+//! Competitive co-evolution — predator vs. prey (Hillis 1990).
+//!
+//! Two populations are adversaries: each is scored by how well it performs
+//! against the other, driving an arms race. [`CompetitiveCoEA`] runs both
+//! under simultaneous updates — `ask` both, evaluate the pair with a single
+//! [`CoupledFitness`], `tell` both. The fitness function carries the
+//! adversarial relationship; wrapping it in
+//! [`HallOfFameFitness`](super::HallOfFameFitness) adds cycling mitigation
+//! without any change to this algorithm.
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use burn::tensor::{Tensor, backend::Backend};
+use rand::Rng;
+
+use crate::strategy::Strategy;
+
+use super::fitness::CoupledFitness;
+use super::harness::CoEAMetrics;
+use super::{CoEAState, CoEvolutionaryAlgorithm};
+
+/// Static parameters for [`CompetitiveCoEA`]: one params bundle per inner
+/// strategy.
+#[derive(Debug, Clone)]
+pub struct CompetitiveCoEAParams<PA, PB> {
+    /// Params for population A's inner strategy.
+    pub params_a: PA,
+    /// Params for population B's inner strategy.
+    pub params_b: PB,
+}
+
+/// Competitive co-evolutionary algorithm over two adversarial populations.
+///
+/// Generic over the backend `B`, the two inner strategies `SA`/`SB` (each
+/// producing `Tensor<B, 2>` genomes), and the [`CoupledFitness`] `F` that
+/// scores them against each other. Implements
+/// [`CoEvolutionaryAlgorithm`] so it can be driven by
+/// [`CoEvolutionaryHarness`](super::CoEvolutionaryHarness).
+pub struct CompetitiveCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    strategy_a: SA,
+    strategy_b: SB,
+    fitness: F,
+    _backend: PhantomData<fn() -> B>,
+}
+
+impl<B, SA, SB, F> Debug for CompetitiveCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompetitiveCoEA").finish_non_exhaustive()
+    }
+}
+
+impl<B, SA, SB, F> CompetitiveCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    /// Build a competitive co-evolution from two inner strategies and a
+    /// coupled fitness.
+    pub fn new(strategy_a: SA, strategy_b: SB, fitness: F) -> Self {
+        Self {
+            strategy_a,
+            strategy_b,
+            fitness,
+            _backend: PhantomData,
+        }
+    }
+
+    fn snapshot(&self, state: &CoEAState<SA::State, SB::State>) -> CoEAMetrics {
+        let sizes = self.fitness.archive_sizes();
+        CoEAMetrics {
+            generation: state.generation,
+            best_fitness_a: state.best_a,
+            best_fitness_b: state.best_b,
+            mean_fitness_a: state.mean_a,
+            mean_fitness_b: state.mean_b,
+            hof_size_a: sizes.first().copied().unwrap_or(0),
+            hof_size_b: sizes.get(1).copied().unwrap_or(0),
+        }
+    }
+}
+
+impl<B, SA, SB, F> CoEvolutionaryAlgorithm<B> for CompetitiveCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    type Params = CompetitiveCoEAParams<SA::Params, SB::Params>;
+    type State = CoEAState<SA::State, SB::State>;
+
+    fn init(
+        &self,
+        params: &Self::Params,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        let state_a = self.strategy_a.init(&params.params_a, rng, device);
+        let state_b = self.strategy_b.init(&params.params_b, rng, device);
+        CoEAState::new(state_a, state_b)
+    }
+
+    fn step(
+        &self,
+        params: &Self::Params,
+        mut state: Self::State,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> (Self::State, CoEAMetrics) {
+        // Both populations propose simultaneously.
+        let (pop_a, asked_a) = self.strategy_a.ask(&params.params_a, &state.state_a, rng, device);
+        let (pop_b, asked_b) = self.strategy_b.ask(&params.params_b, &state.state_b, rng, device);
+
+        // Single coupled evaluation scores each against the other.
+        let fits = self
+            .fitness
+            .evaluate_coupled(&[pop_a.clone(), pop_b.clone()]);
+        debug_assert_eq!(fits.len(), 2, "competitive co-evolution is bi-population");
+        let fit_a = fits[0].clone();
+        let fit_b = fits[1].clone();
+
+        // Both populations consume their relative fitness.
+        let (next_a, metrics_a) = self
+            .strategy_a
+            .tell(&params.params_a, pop_a, fit_a, asked_a, rng);
+        let (next_b, metrics_b) = self
+            .strategy_b
+            .tell(&params.params_b, pop_b, fit_b, asked_b, rng);
+
+        state.state_a = next_a;
+        state.state_b = next_b;
+        state.generation += 1;
+        state.best_a = metrics_a.best_fitness_ever;
+        state.best_b = metrics_b.best_fitness_ever;
+        state.mean_a = metrics_a.mean_fitness;
+        state.mean_b = metrics_b.mean_fitness;
+
+        let metrics = self.snapshot(&state);
+        (state, metrics)
+    }
+
+    fn metrics(&self, state: &Self::State) -> CoEAMetrics {
+        self.snapshot(state)
+    }
+}

--- a/crates/rlevo-evolution/src/coevolution/cooperative.rs
+++ b/crates/rlevo-evolution/src/coevolution/cooperative.rs
@@ -1,0 +1,531 @@
+//! Cooperative co-evolution — CCGA (Potter & De Jong 1994).
+//!
+//! A high-dimensional problem is decomposed by assigning disjoint subsets of
+//! dimensions to two populations. Neither population holds a complete solution
+//! on its own: to score a member of population A, it is combined with a
+//! *representative* drawn from population B (and vice versa) to assemble a
+//! full-dimensional candidate, which the [`CoupledFitness`] then evaluates
+//! row-wise.
+//!
+//! # Where the coupling lives
+//!
+//! Representative selection and full-genome assembly live in
+//! [`CooperativeCoEA::step`] — the *algorithm* owns the coupling, exactly
+//! where the spec places [`RepresentativePolicy`] (in
+//! [`CooperativeCoEAParams`]). The [`CoupledFitness`] stays a pure, stateless
+//! row-wise objective (e.g. Rastrigin): it receives already-assembled
+//! full-dimensional populations and never performs selection or holds a lock.
+
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt};
+
+use crate::rng::{SeedPurpose, seed_stream};
+use crate::strategy::Strategy;
+
+use super::fitness::CoupledFitness;
+use super::harness::CoEAMetrics;
+use super::{CoEAState, CoEvolutionaryAlgorithm};
+
+/// Which member of the opposing population completes a partial candidate
+/// during fitness evaluation.
+///
+/// Per research note 3c-R1, these map onto coupling strategies: `Best` is the
+/// canonical CCGA single representative; `Random` is sampled coupling with a
+/// fresh draw per generation; `Archive` keeps a bounded ring of past
+/// champions and cycles through it.
+#[derive(Clone, Copy, Debug, Default)]
+pub enum RepresentativePolicy {
+    /// Always pair against the best individual seen so far (previous
+    /// generation's best). Canonical CCGA.
+    #[default]
+    Best,
+    /// Pair against a uniformly random member of the opposing population,
+    /// re-drawn each generation.
+    Random,
+    /// Maintain a bounded archive of past champions and cycle through it.
+    Archive {
+        /// Maximum number of past champions retained.
+        capacity: usize,
+    },
+}
+
+/// Static parameters for [`CooperativeCoEA`].
+///
+/// Population A evolves the genes named by `dims_a`; population B evolves the
+/// complement within `0..total_dims`. The split is validated by
+/// [`validate`](Self::validate) (called by [`new`](Self::new) and by
+/// [`CooperativeCoEA`]'s `init`).
+#[derive(Debug, Clone)]
+pub struct CooperativeCoEAParams<PA, PB> {
+    /// Params for population A's inner strategy (genome width must equal
+    /// `dims_a.len()`).
+    pub params_a: PA,
+    /// Params for population B's inner strategy (genome width must equal
+    /// `total_dims - dims_a.len()`).
+    pub params_b: PB,
+    /// Global dimension indices assigned to population A. Population B
+    /// receives the complement within `0..total_dims`.
+    pub dims_a: Vec<usize>,
+    /// Total problem dimensionality.
+    pub total_dims: usize,
+    /// Representative-selection policy used to complete partial candidates.
+    pub representative_policy: RepresentativePolicy,
+    /// Advisory fitness-evaluation budget per generation (informational in
+    /// v1; the simultaneous loop evaluates each population once per
+    /// generation).
+    pub evaluations_per_generation: usize,
+}
+
+impl<PA, PB> CooperativeCoEAParams<PA, PB> {
+    /// Build and eagerly [`validate`](Self::validate) the parameters.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the dimension split is invalid — see [`validate`](Self::validate).
+    #[must_use]
+    pub fn new(
+        params_a: PA,
+        params_b: PB,
+        dims_a: Vec<usize>,
+        total_dims: usize,
+        representative_policy: RepresentativePolicy,
+        evaluations_per_generation: usize,
+    ) -> Self {
+        let params = Self {
+            params_a,
+            params_b,
+            dims_a,
+            total_dims,
+            representative_policy,
+            evaluations_per_generation,
+        };
+        params.validate();
+        params
+    }
+
+    /// Validate that `dims_a` is a proper subset of `0..total_dims`, so that
+    /// `dims_a.len() + dims_b_count == total_dims` with a non-empty B.
+    ///
+    /// # Panics
+    ///
+    /// Panics with a message naming the violated invariant when `total_dims`
+    /// is zero, `dims_a` is empty, contains an out-of-range index, contains
+    /// duplicates, or covers every dimension (leaving population B empty).
+    pub fn validate(&self) {
+        assert!(self.total_dims > 0, "total_dims must be positive, got 0");
+        assert!(!self.dims_a.is_empty(), "dims_a must be non-empty");
+        for &d in &self.dims_a {
+            assert!(
+                d < self.total_dims,
+                "dims_a index {d} is out of range for total_dims {}",
+                self.total_dims
+            );
+        }
+        let unique: HashSet<usize> = self.dims_a.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            self.dims_a.len(),
+            "dims_a contains duplicate indices: {:?}",
+            self.dims_a
+        );
+        let dims_b_count = self.total_dims - self.dims_a.len();
+        assert!(
+            dims_b_count > 0,
+            "dims_a covers all {} dimensions, leaving population B empty",
+            self.total_dims
+        );
+        assert_eq!(
+            self.dims_a.len() + dims_b_count,
+            self.total_dims,
+            "dimension split invariant violated: dims_a.len() ({}) + dims_b_count ({}) != total_dims ({})",
+            self.dims_a.len(),
+            dims_b_count,
+            self.total_dims
+        );
+    }
+}
+
+/// Joint state for [`CooperativeCoEA`]: the shared [`CoEAState`] plus the
+/// per-population representative archives used by
+/// [`RepresentativePolicy::Archive`].
+#[derive(Debug, Clone)]
+pub struct CooperativeState<StA, StB, B: Backend> {
+    /// Shared best/mean/generation trackers and inner strategy states.
+    pub base: CoEAState<StA, StB>,
+    /// Bounded archive of population A's past champions (`Archive` policy only).
+    rep_archive_a: Option<Tensor<B, 2>>,
+    /// Bounded archive of population B's past champions (`Archive` policy only).
+    rep_archive_b: Option<Tensor<B, 2>>,
+}
+
+/// Cooperative (CCGA-style) co-evolutionary algorithm.
+///
+/// Generic over the backend `B`, the two inner strategies `SA`/`SB` (each
+/// producing `Tensor<B, 2>` sub-genomes), and a stateless row-wise
+/// [`CoupledFitness`] `F` evaluating assembled full-dimensional candidates.
+pub struct CooperativeCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    strategy_a: SA,
+    strategy_b: SB,
+    fitness: F,
+    _backend: PhantomData<fn() -> B>,
+}
+
+impl<B, SA, SB, F> Debug for CooperativeCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CooperativeCoEA").finish_non_exhaustive()
+    }
+}
+
+impl<B, SA, SB, F> CooperativeCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    /// Build a cooperative co-evolution from two inner strategies and a
+    /// (stateless, row-wise) coupled fitness.
+    pub fn new(strategy_a: SA, strategy_b: SB, fitness: F) -> Self {
+        Self {
+            strategy_a,
+            strategy_b,
+            fitness,
+            _backend: PhantomData,
+        }
+    }
+
+    fn snapshot(&self, state: &CooperativeState<SA::State, SB::State, B>) -> CoEAMetrics {
+        let sizes = self.fitness.archive_sizes();
+        CoEAMetrics {
+            generation: state.base.generation,
+            best_fitness_a: state.base.best_a,
+            best_fitness_b: state.base.best_b,
+            mean_fitness_a: state.base.mean_a,
+            mean_fitness_b: state.base.mean_b,
+            hof_size_a: sizes.first().copied().unwrap_or(0),
+            hof_size_b: sizes.get(1).copied().unwrap_or(0),
+        }
+    }
+}
+
+impl<B, SA, SB, F> CoEvolutionaryAlgorithm<B> for CooperativeCoEA<B, SA, SB, F>
+where
+    B: Backend,
+    SA: Strategy<B, Genome = Tensor<B, 2>>,
+    SB: Strategy<B, Genome = Tensor<B, 2>>,
+    F: CoupledFitness<B>,
+{
+    type Params = CooperativeCoEAParams<SA::Params, SB::Params>;
+    type State = CooperativeState<SA::State, SB::State, B>;
+
+    fn init(
+        &self,
+        params: &Self::Params,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State {
+        params.validate();
+        let state_a = self.strategy_a.init(&params.params_a, rng, device);
+        let state_b = self.strategy_b.init(&params.params_b, rng, device);
+        CooperativeState {
+            base: CoEAState::new(state_a, state_b),
+            rep_archive_a: None,
+            rep_archive_b: None,
+        }
+    }
+
+    fn step(
+        &self,
+        params: &Self::Params,
+        mut state: Self::State,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> (Self::State, CoEAMetrics) {
+        let dims_a = &params.dims_a;
+        let dims_b = complement(dims_a, params.total_dims);
+        let generation = state.base.generation;
+
+        // Both populations propose sub-genomes simultaneously.
+        let (pop_a, asked_a) = self.strategy_a.ask(&params.params_a, &state.base.state_a, rng, device);
+        let (pop_b, asked_b) = self.strategy_b.ask(&params.params_b, &state.base.state_b, rng, device);
+
+        // Previous-generation bests (the canonical CCGA representatives).
+        let prev_best_a = self.strategy_a.best(&state.base.state_a).map(|(g, _)| g);
+        let prev_best_b = self.strategy_b.best(&state.base.state_b).map(|(g, _)| g);
+
+        // One representative stream per generation (host-RNG convention).
+        let mut rep_rng = seed_stream(rng.next_u64(), generation, SeedPurpose::Representative);
+        let rep_a = select_representative(
+            &pop_a,
+            prev_best_a.as_ref(),
+            &mut state.rep_archive_a,
+            params.representative_policy,
+            &mut rep_rng,
+            generation,
+            device,
+        );
+        let rep_b = select_representative(
+            &pop_b,
+            prev_best_b.as_ref(),
+            &mut state.rep_archive_b,
+            params.representative_policy,
+            &mut rep_rng,
+            generation,
+            device,
+        );
+
+        // Assemble full-dimensional candidates: each varying sub-population is
+        // completed by the opposing fixed representative.
+        let full_a = assemble(&pop_a, dims_a, &rep_b, &dims_b, params.total_dims, device);
+        let full_b = assemble(&pop_b, &dims_b, &rep_a, dims_a, params.total_dims, device);
+
+        let fits = self.fitness.evaluate_coupled(&[full_a, full_b]);
+        debug_assert_eq!(fits.len(), 2, "cooperative co-evolution is bi-population");
+        let fit_a = fits[0].clone();
+        let fit_b = fits[1].clone();
+
+        // Each strategy consumes its own sub-population with the assembled fitness.
+        let (next_a, metrics_a) = self
+            .strategy_a
+            .tell(&params.params_a, pop_a, fit_a, asked_a, rng);
+        let (next_b, metrics_b) = self
+            .strategy_b
+            .tell(&params.params_b, pop_b, fit_b, asked_b, rng);
+
+        state.base.state_a = next_a;
+        state.base.state_b = next_b;
+        state.base.generation += 1;
+        state.base.best_a = metrics_a.best_fitness_ever;
+        state.base.best_b = metrics_b.best_fitness_ever;
+        state.base.mean_a = metrics_a.mean_fitness;
+        state.base.mean_b = metrics_b.mean_fitness;
+
+        let metrics = self.snapshot(&state);
+        (state, metrics)
+    }
+
+    fn metrics(&self, state: &Self::State) -> CoEAMetrics {
+        self.snapshot(state)
+    }
+}
+
+/// The complement of `dims_a` within `0..total_dims`, ascending.
+fn complement(dims_a: &[usize], total_dims: usize) -> Vec<usize> {
+    let set: HashSet<usize> = dims_a.iter().copied().collect();
+    (0..total_dims).filter(|d| !set.contains(d)).collect()
+}
+
+/// Extract row `idx` of `pop` as a `(1, genome_dim)` tensor.
+fn row<B: Backend>(pop: &Tensor<B, 2>, idx: usize) -> Tensor<B, 2> {
+    let device = pop.device();
+    #[allow(clippy::cast_possible_wrap)]
+    let i = Tensor::<B, 1, Int>::from_data(TensorData::new(vec![idx as i64], [1]), &device);
+    pop.clone().select(0, i)
+}
+
+/// Pick the opposing-population representative under `policy`.
+///
+/// `prev_best` is the opposing strategy's best-so-far (`None` at generation 0,
+/// before the first `tell`). The `archive` is mutated in place for the
+/// `Archive` policy. Returns a `(1, genome_dim)` representative.
+fn select_representative<B: Backend>(
+    pop: &Tensor<B, 2>,
+    prev_best: Option<&Tensor<B, 2>>,
+    archive: &mut Option<Tensor<B, 2>>,
+    policy: RepresentativePolicy,
+    rng: &mut StdRng,
+    generation: u64,
+    _device: &<B as burn::tensor::backend::BackendTypes>::Device,
+) -> Tensor<B, 2> {
+    let n = pop.dims()[0];
+    match policy {
+        RepresentativePolicy::Best => match prev_best {
+            Some(best) => best.clone(),
+            None => row(pop, 0),
+        },
+        RepresentativePolicy::Random => {
+            let idx = rng.random_range(0..n.max(1));
+            row(pop, idx)
+        }
+        RepresentativePolicy::Archive { capacity } => {
+            if let Some(best) = prev_best {
+                let updated = match archive.take() {
+                    None => best.clone(),
+                    Some(existing) => {
+                        let cat = Tensor::cat(vec![existing, best.clone()], 0);
+                        let rows = cat.dims()[0];
+                        if capacity > 0 && rows > capacity {
+                            // Keep the most recent `capacity` rows (FIFO window).
+                            cat.narrow(0, rows - capacity, capacity)
+                        } else {
+                            cat
+                        }
+                    }
+                };
+                *archive = Some(updated);
+            }
+            match archive.as_ref() {
+                Some(a) if a.dims()[0] > 0 => {
+                    let rows = a.dims()[0];
+                    // `generation % rows < rows`, so the conversion never fails.
+                    let pick = usize::try_from(generation % rows as u64).unwrap_or(0);
+                    row(a, pick)
+                }
+                _ => row(pop, 0),
+            }
+        }
+    }
+}
+
+/// Scatter a sub-population and a fixed opposing representative into
+/// full-dimensional rows.
+///
+/// `sub_pop` is `(n, my_dims.len())`; its column `j` maps to global dimension
+/// `my_dims[j]`. `rep_other` is `(1, other_dims.len())`; its column `j` maps
+/// to global dimension `other_dims[j]` and is broadcast across all `n` rows.
+/// Returns an `(n, total_dims)` tensor. Assembly is host-side, which is also
+/// where the row-wise objective evaluates, so no extra device round-trip is
+/// incurred.
+fn assemble<B: Backend>(
+    sub_pop: &Tensor<B, 2>,
+    my_dims: &[usize],
+    rep_other: &Tensor<B, 2>,
+    other_dims: &[usize],
+    total_dims: usize,
+    device: &<B as burn::tensor::backend::BackendTypes>::Device,
+) -> Tensor<B, 2> {
+    let dims = sub_pop.dims();
+    let n = dims[0];
+    let sub_w = dims[1];
+    debug_assert_eq!(sub_w, my_dims.len(), "sub-population width must match my_dims");
+    let sub_flat = sub_pop.clone().into_data().into_vec::<f32>().unwrap_or_default();
+    let rep_flat = rep_other.clone().into_data().into_vec::<f32>().unwrap_or_default();
+    debug_assert_eq!(rep_flat.len(), other_dims.len(), "representative width must match other_dims");
+
+    let mut full = vec![0.0_f32; n * total_dims];
+    for i in 0..n {
+        let base = i * total_dims;
+        for (j, &d) in my_dims.iter().enumerate() {
+            full[base + d] = sub_flat[i * sub_w + j];
+        }
+        for (j, &d) in other_dims.iter().enumerate() {
+            full[base + d] = rep_flat[j];
+        }
+    }
+    Tensor::<B, 2>::from_data(TensorData::new(full, [n, total_dims]), device)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+
+    type B = Flex;
+
+    fn make(rows: &[f32], n: usize, d: usize) -> Tensor<B, 2> {
+        let device = Default::default();
+        Tensor::<B, 2>::from_data(TensorData::new(rows.to_vec(), [n, d]), &device)
+    }
+
+    #[test]
+    fn complement_is_ascending_set_difference() {
+        assert_eq!(complement(&[0, 2], 4), vec![1, 3]);
+        assert_eq!(complement(&[3, 1], 4), vec![0, 2]);
+        assert_eq!(complement(&[0, 1], 2), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn assemble_scatters_into_global_positions() {
+        let device = Default::default();
+        // dims_a = [0, 2], dims_b = [1, 3], total = 4.
+        let pop_a = make(&[10.0, 20.0, 11.0, 21.0], 2, 2); // rows: (10,20),(11,21)
+        let rep_b = make(&[5.0, 7.0], 1, 2); // global dims 1,3 -> 5,7
+        let full = assemble(&pop_a, &[0, 2], &rep_b, &[1, 3], 4, &device);
+        let v = full.into_data().into_vec::<f32>().unwrap();
+        // row0: dim0=10, dim1=5, dim2=20, dim3=7
+        assert_eq!(&v[0..4], &[10.0, 5.0, 20.0, 7.0]);
+        // row1: dim0=11, dim1=5, dim2=21, dim3=7
+        assert_eq!(&v[4..8], &[11.0, 5.0, 21.0, 7.0]);
+    }
+
+    #[test]
+    fn representative_best_uses_prev_best_else_row_zero() {
+        let device = Default::default();
+        let pop = make(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let mut rng = seed_stream(0, 0, SeedPurpose::Representative);
+        let mut archive = None;
+        // No prev best -> row 0.
+        let r0 = select_representative(&pop, None, &mut archive, RepresentativePolicy::Best, &mut rng, 0, &device);
+        assert_eq!(r0.into_data().into_vec::<f32>().unwrap(), vec![1.0, 2.0]);
+        // With prev best -> that genome.
+        let best = make(&[9.0, 9.0], 1, 2);
+        let r1 = select_representative(&pop, Some(&best), &mut archive, RepresentativePolicy::Best, &mut rng, 1, &device);
+        assert_eq!(r1.into_data().into_vec::<f32>().unwrap(), vec![9.0, 9.0]);
+    }
+
+    #[test]
+    fn archive_policy_bounds_archive_size() {
+        let device = Default::default();
+        let pop = make(&[0.0, 0.0], 1, 2);
+        let mut rng = seed_stream(0, 0, SeedPurpose::Representative);
+        let mut archive = None;
+        for g in 0..5_u64 {
+            #[allow(clippy::cast_precision_loss)]
+            let best = make(&[g as f32, g as f32], 1, 2);
+            let _ = select_representative(
+                &pop,
+                Some(&best),
+                &mut archive,
+                RepresentativePolicy::Archive { capacity: 2 },
+                &mut rng,
+                g,
+                &device,
+            );
+            if let Some(a) = archive.as_ref() {
+                assert!(a.dims()[0] <= 2, "archive exceeded capacity at gen {g}");
+            }
+        }
+        assert_eq!(archive.unwrap().dims()[0], 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn params_new_panics_on_out_of_range_dim() {
+        let _ = CooperativeCoEAParams::new((), (), vec![0, 1, 4], 4, RepresentativePolicy::Best, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "leaving population B empty")]
+    fn params_new_panics_when_a_covers_everything() {
+        let _ = CooperativeCoEAParams::new((), (), vec![0, 1, 2, 3], 4, RepresentativePolicy::Best, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate")]
+    fn params_new_panics_on_duplicate_dims() {
+        let _ = CooperativeCoEAParams::new((), (), vec![0, 0, 1], 4, RepresentativePolicy::Best, 0);
+    }
+
+    #[test]
+    fn params_new_accepts_equal_split() {
+        let p = CooperativeCoEAParams::new((), (), vec![0, 1], 4, RepresentativePolicy::Best, 16);
+        assert_eq!(complement(&p.dims_a, p.total_dims), vec![2, 3]);
+    }
+}

--- a/crates/rlevo-evolution/src/coevolution/fitness.rs
+++ b/crates/rlevo-evolution/src/coevolution/fitness.rs
@@ -1,0 +1,124 @@
+//! Coupled fitness evaluation for co-evolutionary algorithms.
+//!
+//! In a single-population strategy, fitness is an absolute function of one
+//! genome. In co-evolution it is *relational*: an individual's score depends
+//! on the individuals in the other population(s) — predator vs. prey, sorter
+//! vs. test case, sub-solution vs. complementary sub-solution. The
+//! [`CoupledFitness`] trait captures exactly that joint evaluation.
+
+use burn::tensor::{Tensor, backend::Backend};
+
+/// Joint fitness evaluation across two or more co-evolving populations.
+///
+/// `evaluate_coupled` receives every population at once and returns one
+/// fitness vector per population, each ranked under the crate-wide
+/// **minimization convention** (lower is better — see
+/// [`crate::strategy::Strategy`]).
+///
+/// # Invariants
+///
+/// - The returned `Vec` has the same length as `populations`, and
+///   `result[i]` has shape `(pop_size_i,)` matching `populations[i]`'s row
+///   count.
+/// - Row order is preserved: `result[i][r]` is the fitness of the individual
+///   at row `r` of `populations[i]`.
+/// - The trait is **N-population-ready**: it accepts a slice so a future
+///   `N > 2` extension needs no breaking change. v1 algorithms always pass
+///   exactly two populations, and implementors should
+///   `debug_assert_eq!(populations.len(), 2)` to catch misuse without a
+///   compile-time const-generic barrier.
+///
+/// # Examples
+///
+/// A trivial separable implementor scoring each population by its row sums:
+///
+/// ```
+/// use burn::backend::Flex;
+/// use burn::tensor::{Tensor, TensorData, backend::Backend};
+/// use rlevo_evolution::coevolution::CoupledFitness;
+///
+/// struct RowSum;
+/// impl<B: Backend> CoupledFitness<B> for RowSum {
+///     fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+///         debug_assert_eq!(populations.len(), 2);
+///         populations
+///             .iter()
+///             .map(|p| p.clone().sum_dim(1).squeeze_dim::<1>(1))
+///             .collect()
+///     }
+/// }
+///
+/// let device = Default::default();
+/// let a = Tensor::<Flex, 2>::from_data(TensorData::new(vec![1.0_f32, 2.0, 3.0, 4.0], [2, 2]), &device);
+/// let b = Tensor::<Flex, 2>::from_data(TensorData::new(vec![0.0_f32, 0.0, 1.0, 1.0], [2, 2]), &device);
+/// let out = RowSum.evaluate_coupled(&[a, b]);
+/// assert_eq!(out.len(), 2);
+/// ```
+pub trait CoupledFitness<B: Backend>: Send + Sync {
+    /// Evaluate fitness for each population relative to the others.
+    ///
+    /// `populations[i]` is a `(pop_size_i, genome_dim_i)` tensor. Returns one
+    /// fitness vector per input population, each of length `pop_size_i`, on
+    /// the same device as its population.
+    fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>>;
+
+    /// Per-population archive sizes, used to populate co-evolution metrics.
+    ///
+    /// The default returns an empty `Vec` — a plain fitness function keeps no
+    /// archive. The [`HallOfFameFitness`](crate::coevolution::HallOfFameFitness)
+    /// wrapper overrides this to report each population's hall-of-fame size so
+    /// [`CoEAMetrics`](crate::coevolution::CoEAMetrics) can carry
+    /// `hof_size_{a,b}`. Adding this defaulted method is forward-compatible:
+    /// existing implementors are unaffected.
+    fn archive_sizes(&self) -> Vec<usize> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::{Flex, Wgpu};
+    use burn::tensor::TensorData;
+
+    /// Trivial implementor: each individual's fitness is its genome row sum.
+    struct RowSum;
+
+    impl<B: Backend> CoupledFitness<B> for RowSum {
+        fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+            debug_assert_eq!(populations.len(), 2);
+            populations
+                .iter()
+                .map(|p| p.clone().sum_dim(1).squeeze_dim::<1>(1))
+                .collect()
+        }
+    }
+
+    /// AC §7.1: `CoupledFitness<B>` compiles on the CPU (Flex / ndarray-family)
+    /// **and** wgpu backends with a trivial test implementor. This is a
+    /// compile-time monomorphization assertion — it never runs (no wgpu device
+    /// is created), so it is cheap and CI-safe.
+    const _: fn() = || {
+        fn assert_coupled<B: Backend, F: CoupledFitness<B>>() {}
+        assert_coupled::<Flex, RowSum>();
+        assert_coupled::<Wgpu, RowSum>();
+    };
+
+    #[test]
+    fn trivial_implementor_evaluates_and_preserves_row_order() {
+        let device = Default::default();
+        let a = Tensor::<Flex, 2>::from_data(TensorData::new(vec![1.0_f32, 2.0, 3.0, 4.0], [2, 2]), &device);
+        let b = Tensor::<Flex, 2>::from_data(TensorData::new(vec![0.0_f32, 0.0, 1.0, 1.0], [2, 2]), &device);
+        let out = RowSum.evaluate_coupled(&[a, b]);
+        assert_eq!(out.len(), 2);
+        let va = out[0].clone().into_data().into_vec::<f32>().unwrap();
+        let vb = out[1].clone().into_data().into_vec::<f32>().unwrap();
+        assert_eq!(va, vec![3.0, 7.0]);
+        assert_eq!(vb, vec![0.0, 2.0]);
+    }
+
+    #[test]
+    fn default_archive_sizes_is_empty() {
+        assert!(CoupledFitness::<Flex>::archive_sizes(&RowSum).is_empty());
+    }
+}

--- a/crates/rlevo-evolution/src/coevolution/harness.rs
+++ b/crates/rlevo-evolution/src/coevolution/harness.rs
@@ -1,0 +1,215 @@
+//! Drive loop adapting a [`CoEvolutionaryAlgorithm`] to `BenchEnv`.
+//!
+//! [`CoEvolutionaryHarness`] is to [`CoEvolutionaryAlgorithm`] what
+//! [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness) is to
+//! [`Strategy`](crate::strategy::Strategy): it owns the joint state, the RNG,
+//! and the generation budget, and exposes the run to the `rlevo-benchmarks`
+//! evaluator through `rlevo-core::evaluation::BenchEnv` with no benchmark-side
+//! changes. One [`BenchEnv::step`] drives one simultaneous-update generation.
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use burn::tensor::backend::Backend;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_core::evaluation::{BenchEnv, BenchError, BenchStep};
+
+use super::CoEvolutionaryAlgorithm;
+
+/// Per-generation summary for a co-evolutionary run.
+///
+/// The [`CoEAMetrics`] analogue of
+/// [`StrategyMetrics`](crate::strategy::StrategyMetrics), but tracking both
+/// populations separately so a benchmark report can plot per-population
+/// dynamics. Fitness follows the minimization convention (lower is better).
+#[derive(Debug, Clone)]
+pub struct CoEAMetrics {
+    /// Number of completed simultaneous-update generations.
+    pub generation: u64,
+    /// Best (lowest) fitness population A has seen so far.
+    pub best_fitness_a: f32,
+    /// Best (lowest) fitness population B has seen so far.
+    pub best_fitness_b: f32,
+    /// Mean fitness of population A in this generation.
+    pub mean_fitness_a: f32,
+    /// Mean fitness of population B in this generation.
+    pub mean_fitness_b: f32,
+    /// Hall-of-fame archive size for population A (`0` if no archive).
+    pub hof_size_a: usize,
+    /// Hall-of-fame archive size for population B (`0` if no archive).
+    pub hof_size_b: usize,
+}
+
+/// Wraps a [`CoEvolutionaryAlgorithm`] into a `BenchEnv`.
+///
+/// Like [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness), the
+/// harness is lazily initialized: [`reset`](BenchEnv::reset) materializes the
+/// joint state on the configured device, and each
+/// [`step`](BenchEnv::step) runs one generation. The reward exposed to the
+/// benchmark harness is `-min(best_a, best_b)` so the harness's
+/// "higher = better" convention matches the algorithm's minimization
+/// direction, with the weaker population as the binding constraint.
+///
+/// Per-generation metrics are emitted through `tracing` with structured
+/// per-population fields. (A dual-population [`PopulationObserver`] channel —
+/// the single-population
+/// [`PopulationSnapshot`](crate::observer::PopulationSnapshot) cannot carry
+/// both populations — is deferred to a follow-up.)
+///
+/// # Determinism
+///
+/// Determinism follows the same backend-RNG caveats documented on
+/// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness): run one
+/// harness per process, or pin `EvaluatorConfig::num_threads = Some(1)`, for
+/// bit-reproducible runs.
+///
+/// [`PopulationObserver`]: crate::observer::PopulationObserver
+pub struct CoEvolutionaryHarness<B, C>
+where
+    B: Backend,
+    C: CoEvolutionaryAlgorithm<B>,
+{
+    algorithm: C,
+    params: C::Params,
+    state: Option<C::State>,
+    rng: StdRng,
+    base_seed: u64,
+    device: B::Device,
+    generation: usize,
+    max_generations: usize,
+    latest_metrics: Option<CoEAMetrics>,
+    _backend: PhantomData<B>,
+}
+
+impl<B, C> Debug for CoEvolutionaryHarness<B, C>
+where
+    B: Backend,
+    C: CoEvolutionaryAlgorithm<B>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoEvolutionaryHarness")
+            .field("base_seed", &self.base_seed)
+            .field("generation", &self.generation)
+            .field("max_generations", &self.max_generations)
+            .field("latest_metrics", &self.latest_metrics)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B, C> CoEvolutionaryHarness<B, C>
+where
+    B: Backend,
+    C: CoEvolutionaryAlgorithm<B>,
+{
+    /// Build a new harness from an algorithm, its params, a seed, a device,
+    /// and a generation budget.
+    ///
+    /// The harness is lazily initialized — the first [`reset`](Self::reset)
+    /// call materializes the joint state on `device`.
+    pub fn new(
+        algorithm: C,
+        params: C::Params,
+        seed: u64,
+        device: B::Device,
+        max_generations: usize,
+    ) -> Self {
+        Self {
+            algorithm,
+            params,
+            state: None,
+            rng: StdRng::seed_from_u64(seed),
+            base_seed: seed,
+            device,
+            generation: 0,
+            max_generations,
+            latest_metrics: None,
+            _backend: PhantomData,
+        }
+    }
+
+    /// The most recent generation's metrics, if any.
+    #[must_use]
+    pub fn latest_metrics(&self) -> Option<&CoEAMetrics> {
+        self.latest_metrics.as_ref()
+    }
+
+    /// Number of completed generations.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
+
+    /// Reset to a fresh joint state, re-seeding the RNG.
+    ///
+    /// Infallible; the [`BenchEnv`] impl wraps this in `Ok(())`.
+    pub fn reset(&mut self) {
+        self.rng = StdRng::seed_from_u64(self.base_seed);
+        self.generation = 0;
+        self.latest_metrics = None;
+        self.state = Some(
+            self.algorithm
+                .init(&self.params, &mut self.rng, &self.device),
+        );
+    }
+
+    /// Run one simultaneous-update generation.
+    ///
+    /// Infallible; the [`BenchEnv`] impl wraps the result in `Ok(...)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`reset`](Self::reset) has not been called first.
+    pub fn step(&mut self, _action: ()) -> BenchStep<()> {
+        let state = self
+            .state
+            .take()
+            .expect("CoEvolutionaryHarness::reset must be called before step");
+        let (new_state, metrics) =
+            self.algorithm
+                .step(&self.params, state, &mut self.rng, &self.device);
+        self.state = Some(new_state);
+        self.generation += 1;
+
+        let binding = metrics.best_fitness_a.min(metrics.best_fitness_b);
+        let reward = -f64::from(binding);
+
+        tracing::info!(
+            generation = metrics.generation,
+            best_fitness_a = f64::from(metrics.best_fitness_a),
+            best_fitness_b = f64::from(metrics.best_fitness_b),
+            mean_fitness_a = f64::from(metrics.mean_fitness_a),
+            mean_fitness_b = f64::from(metrics.mean_fitness_b),
+            hof_size_a = metrics.hof_size_a,
+            hof_size_b = metrics.hof_size_b,
+            "coevolution generation",
+        );
+
+        self.latest_metrics = Some(metrics);
+        let done = self.generation >= self.max_generations;
+        BenchStep {
+            observation: (),
+            reward,
+            done,
+        }
+    }
+}
+
+impl<B, C> BenchEnv for CoEvolutionaryHarness<B, C>
+where
+    B: Backend,
+    C: CoEvolutionaryAlgorithm<B>,
+{
+    type Observation = ();
+    type Action = ();
+
+    fn reset(&mut self) -> Result<Self::Observation, BenchError> {
+        CoEvolutionaryHarness::<B, C>::reset(self);
+        Ok(())
+    }
+
+    fn step(&mut self, action: Self::Action) -> Result<BenchStep<Self::Observation>, BenchError> {
+        Ok(CoEvolutionaryHarness::<B, C>::step(self, action))
+    }
+}

--- a/crates/rlevo-evolution/src/coevolution/hof.rs
+++ b/crates/rlevo-evolution/src/coevolution/hof.rs
@@ -1,0 +1,374 @@
+//! Hall-of-fame pathology mitigation for competitive co-evolution.
+//!
+//! Naive competitive co-evolution suffers from **cycling** (Ficici 2004): a
+//! population evolves a best response to the opponent's current composition,
+//! the opponent shifts in turn, and neither makes lasting progress (the
+//! rock-paper-scissors trap). Rosin & Belew (1997) mitigate this with a
+//! *hall of fame* — an archive of past champions that the current population
+//! must also perform well against, anchoring the fitness landscape so it can
+//! no longer be chased in a circle.
+//!
+//! [`HallOfFame`] is the archive; [`HallOfFameFitness`] is the
+//! [`CoupledFitness`] wrapper that blends each individual's score against the
+//! current opponents with its score against the archived champions. Passing a
+//! `HallOfFameFitness` to a co-evolutionary algorithm enables the mitigation;
+//! passing the raw fitness disables it — no flag inside the algorithm.
+
+use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
+use parking_lot::Mutex;
+
+use super::fitness::CoupledFitness;
+
+/// Per-population archive of past champions, capped at a fixed capacity.
+///
+/// Each [`update`](Self::update) appends the current generation's best
+/// individual (lowest fitness, minimization convention) to each population's
+/// archive. When an archive would exceed `capacity` the single worst-fitness
+/// member is dropped, so the archive always retains the `capacity` best
+/// champions seen across the whole run.
+///
+/// The capacity is computed by [`capacity_for`](Self::capacity_for) as
+/// `max(10, pop_size / 5)` (Rosin & Belew sizing, per research note 3c-R1).
+///
+/// # Invariants
+///
+/// - All archives share a single `genome_dim`; v1 co-evolution is
+///   bi-population over equal-width genomes. Asymmetric genome widths are out
+///   of scope.
+/// - `archives()[p].dims()[0] <= capacity` after every `update`.
+#[derive(Debug, Clone)]
+pub struct HallOfFame<B: Backend> {
+    /// Top-k champions retained per population, each `(size_p, genome_dim)`.
+    archives: Vec<Tensor<B, 2>>,
+    /// Host-side fitness of each archived champion (as inserted), parallel to
+    /// `archives`. Used to prune the worst member on overflow.
+    archive_fitness: Vec<Vec<f32>>,
+    /// Maximum number of champions retained per population.
+    capacity: usize,
+}
+
+impl<B: Backend> HallOfFame<B> {
+    /// Build an empty hall of fame for `num_populations` populations.
+    ///
+    /// Each archive starts as a `(0, genome_dim)` tensor and grows by one row
+    /// per [`update`](Self::update) until `capacity` is reached.
+    #[must_use]
+    pub fn new(
+        num_populations: usize,
+        capacity: usize,
+        genome_dim: usize,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        let archives = (0..num_populations)
+            .map(|_| Tensor::<B, 2>::empty([0, genome_dim], device))
+            .collect();
+        let archive_fitness = vec![Vec::new(); num_populations];
+        Self {
+            archives,
+            archive_fitness,
+            capacity,
+        }
+    }
+
+    /// Recommended capacity for a population of `pop_size`: `max(10, pop_size / 5)`.
+    #[must_use]
+    pub fn capacity_for(pop_size: usize) -> usize {
+        (pop_size / 5).max(10)
+    }
+
+    /// Insert the best individual of each population into its archive.
+    ///
+    /// For population `p`, the lowest-fitness row of `populations[p]` is
+    /// appended to `archives[p]`. If that pushes the archive past `capacity`,
+    /// the single highest-fitness (worst) archived member is removed. Empty
+    /// populations are skipped.
+    pub fn update(&mut self, populations: &[Tensor<B, 2>], fitnesses: &[Tensor<B, 1>]) {
+        let n = self.archives.len().min(populations.len()).min(fitnesses.len());
+        for p in 0..n {
+            let fit_host = fitnesses[p]
+                .clone()
+                .into_data()
+                .into_vec::<f32>()
+                .unwrap_or_default();
+            if fit_host.is_empty() {
+                continue;
+            }
+            // Argmin (best, lowest fitness) — ties resolve to the lowest index.
+            // `fit_host` is non-empty here (checked above), so `min_by` is
+            // always `Some`; the let-else is a non-panicking guard.
+            let Some((best_idx, &best_f)) = fit_host
+                .iter()
+                .enumerate()
+                .min_by(|(_, a), (_, b)| a.total_cmp(b))
+            else {
+                continue;
+            };
+            let device = populations[p].device();
+            // usize → i64 index tensor; population indices never approach i64::MAX.
+            #[allow(clippy::cast_possible_wrap)]
+            let idx = Tensor::<B, 1, Int>::from_data(TensorData::new(vec![best_idx as i64], [1]), &device);
+            let champion = populations[p].clone().select(0, idx);
+
+            self.archives[p] = if self.archives[p].dims()[0] == 0 {
+                champion
+            } else {
+                Tensor::cat(vec![self.archives[p].clone(), champion], 0)
+            };
+            self.archive_fitness[p].push(best_f);
+
+            if self.archive_fitness[p].len() > self.capacity {
+                // Over capacity => non-empty, so `max_by` is always `Some`.
+                let Some(worst_idx) = self.archive_fitness[p]
+                    .iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| a.total_cmp(b))
+                    .map(|(i, _)| i)
+                else {
+                    continue;
+                };
+                let len = self.archive_fitness[p].len();
+                #[allow(clippy::cast_possible_wrap)]
+                let keep: Vec<i64> = (0..len)
+                    .filter(|&i| i != worst_idx)
+                    .map(|i| i as i64)
+                    .collect();
+                let keep_len = keep.len();
+                let keep_idx = Tensor::<B, 1, Int>::from_data(TensorData::new(keep, [keep_len]), &device);
+                self.archives[p] = self.archives[p].clone().select(0, keep_idx);
+                self.archive_fitness[p].remove(worst_idx);
+            }
+        }
+    }
+
+    /// Borrow the per-population champion archives.
+    #[must_use]
+    pub fn archives(&self) -> &[Tensor<B, 2>] {
+        &self.archives
+    }
+
+    /// The per-population capacity cap.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+/// A [`CoupledFitness`] wrapper that anchors fitness against a hall of fame.
+///
+/// Wraps any concrete `F: CoupledFitness<B>` and, each evaluation, blends an
+/// individual's score against the *current* opponents with its score against
+/// the *archived* champions:
+///
+/// ```text
+/// fitness_blended = (1 - w) * fitness_current + w * fitness_hof
+/// ```
+///
+/// where `w` is [`hof_blend_weight`](Self::with_blend_weight) (default `0.3`).
+/// Setting `w = 0.0` disables the mitigation without removing the wrapper;
+/// the archive is still maintained so the wrapper can be re-enabled or its
+/// archive inspected. The archive is updated after each evaluation with the
+/// current generation's champions.
+///
+/// Because [`CoupledFitness::evaluate_coupled`] takes `&self` but the archive
+/// must mutate per generation, the [`HallOfFame`] is held behind a
+/// `parking_lot::Mutex` (the project-standard lock, ADR-0010). Each harness
+/// runs its own wrapper instance, so the lock is effectively uncontended.
+///
+/// # Invariants
+///
+/// - v1 is bi-population: `evaluate_coupled` debug-asserts
+///   `populations.len() == 2`.
+pub struct HallOfFameFitness<B: Backend, F: CoupledFitness<B>> {
+    inner: F,
+    hall: Mutex<HallOfFame<B>>,
+    hof_blend_weight: f32,
+}
+
+impl<B: Backend, F: CoupledFitness<B>> std::fmt::Debug for HallOfFameFitness<B, F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HallOfFameFitness")
+            .field("hof_blend_weight", &self.hof_blend_weight)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<B: Backend, F: CoupledFitness<B>> HallOfFameFitness<B, F> {
+    /// Default blend weight (`0.3`).
+    pub const DEFAULT_BLEND_WEIGHT: f32 = 0.3;
+
+    /// Wrap `inner` with a hall of fame sized `max(10, pop_size / 5)`.
+    ///
+    /// `num_populations` and `genome_dim` size the archives; the blend weight
+    /// starts at [`DEFAULT_BLEND_WEIGHT`](Self::DEFAULT_BLEND_WEIGHT). Use
+    /// [`with_blend_weight`](Self::with_blend_weight) to override it.
+    #[must_use]
+    pub fn new(
+        inner: F,
+        num_populations: usize,
+        pop_size: usize,
+        genome_dim: usize,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        let capacity = HallOfFame::<B>::capacity_for(pop_size);
+        let hall = HallOfFame::new(num_populations, capacity, genome_dim, device);
+        Self {
+            inner,
+            hall: Mutex::new(hall),
+            hof_blend_weight: Self::DEFAULT_BLEND_WEIGHT,
+        }
+    }
+
+    /// Override the hall-of-fame blend weight (clamped to `[0.0, 1.0]`).
+    ///
+    /// `0.0` disables the mitigation (pure current-generation fitness); `1.0`
+    /// evaluates purely against the archive.
+    #[must_use]
+    pub fn with_blend_weight(mut self, weight: f32) -> Self {
+        self.hof_blend_weight = weight.clamp(0.0, 1.0);
+        self
+    }
+
+    /// The current blend weight.
+    #[must_use]
+    pub fn blend_weight(&self) -> f32 {
+        self.hof_blend_weight
+    }
+}
+
+/// `cur * (1 - w) + hof * w`, element-wise.
+fn blend<B: Backend>(cur: &Tensor<B, 1>, hof: &Tensor<B, 1>, w: f32) -> Tensor<B, 1> {
+    cur.clone().mul_scalar(1.0 - w).add(hof.clone().mul_scalar(w))
+}
+
+impl<B: Backend, F: CoupledFitness<B>> CoupledFitness<B> for HallOfFameFitness<B, F> {
+    fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+        debug_assert_eq!(populations.len(), 2, "v1 hall-of-fame is bi-population");
+        let current = self.inner.evaluate_coupled(populations);
+        let w = self.hof_blend_weight;
+        let mut hall = self.hall.lock();
+
+        let blended = if w <= 0.0 {
+            current.clone()
+        } else {
+            let archive_a = hall.archives()[0].clone();
+            let archive_b = hall.archives()[1].clone();
+
+            // Population A scored against the archived B champions.
+            let blended_a = if archive_b.dims()[0] > 0 {
+                let res = self.inner.evaluate_coupled(&[populations[0].clone(), archive_b]);
+                blend(&current[0], &res[0], w)
+            } else {
+                current[0].clone()
+            };
+            // Population B scored against the archived A champions (index 1).
+            let blended_b = if archive_a.dims()[0] > 0 {
+                let res = self.inner.evaluate_coupled(&[archive_a, populations[1].clone()]);
+                blend(&current[1], &res[1], w)
+            } else {
+                current[1].clone()
+            };
+            vec![blended_a, blended_b]
+        };
+
+        // Archive this generation's champions by their current-gen fitness.
+        hall.update(populations, &current);
+        blended
+    }
+
+    fn archive_sizes(&self) -> Vec<usize> {
+        self.hall
+            .lock()
+            .archives()
+            .iter()
+            .map(|a| a.dims()[0])
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+
+    type B = Flex;
+
+    fn pop(rows: &[f32], n: usize, d: usize) -> Tensor<B, 2> {
+        let device = Default::default();
+        Tensor::<B, 2>::from_data(TensorData::new(rows.to_vec(), [n, d]), &device)
+    }
+
+    fn fit(values: &[f32]) -> Tensor<B, 1> {
+        let device = Default::default();
+        Tensor::<B, 1>::from_data(TensorData::new(values.to_vec(), [values.len()]), &device)
+    }
+
+    #[test]
+    fn capacity_formula() {
+        assert_eq!(HallOfFame::<B>::capacity_for(10), 10);
+        assert_eq!(HallOfFame::<B>::capacity_for(50), 10);
+        assert_eq!(HallOfFame::<B>::capacity_for(100), 20);
+        assert_eq!(HallOfFame::<B>::capacity_for(0), 10);
+    }
+
+    #[test]
+    fn archive_grows_to_capacity_then_prunes_worst() {
+        let device = Default::default();
+        let mut hof = HallOfFame::<B>::new(2, 3, 1, &device);
+        // Each generation's champion (index 0) has fitness 5,4,3,2,1.
+        for g in 0..5_usize {
+            #[allow(clippy::cast_precision_loss)]
+            let p = pop(&[g as f32, g as f32 + 0.5], 2, 1);
+            #[allow(clippy::cast_precision_loss)]
+            let f = fit(&[(5 - g) as f32, 100.0]);
+            hof.update(&[p.clone(), p], &[f.clone(), f]);
+            assert!(
+                hof.archives()[0].dims()[0] <= 3,
+                "archive exceeded capacity at gen {g}"
+            );
+        }
+        // After 5 generations at capacity 3, the three best champions survive.
+        assert_eq!(hof.archives()[0].dims()[0], 3);
+        let mut surviving = hof.archive_fitness[0].clone();
+        surviving.sort_by(f32::total_cmp);
+        assert_eq!(surviving, vec![1.0, 2.0, 3.0]);
+    }
+
+    /// Inner fitness = row sum; used to exercise the wrapper plumbing.
+    struct RowSum;
+    impl CoupledFitness<B> for RowSum {
+        fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+            populations
+                .iter()
+                .map(|p| p.clone().sum_dim(1).squeeze_dim::<1>(1))
+                .collect()
+        }
+    }
+
+    #[test]
+    fn wrapper_reports_archive_sizes_and_grows() {
+        let device = Default::default();
+        let wrapper = HallOfFameFitness::new(RowSum, 2, 50, 2, &device);
+        assert_eq!(wrapper.archive_sizes(), vec![0, 0]);
+        let a = pop(&[1.0, 1.0, 2.0, 2.0], 2, 2);
+        let b = pop(&[0.0, 0.0, 3.0, 3.0], 2, 2);
+        let out = wrapper.evaluate_coupled(&[a.clone(), b.clone()]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].dims(), [2]);
+        // One champion archived per population after one evaluation.
+        assert_eq!(wrapper.archive_sizes(), vec![1, 1]);
+    }
+
+    #[test]
+    fn blend_zero_passes_through_current_fitness() {
+        let device = Default::default();
+        let wrapper = HallOfFameFitness::new(RowSum, 2, 50, 2, &device).with_blend_weight(0.0);
+        let a = pop(&[1.0, 1.0, 2.0, 2.0], 2, 2);
+        let b = pop(&[0.0, 0.0, 3.0, 3.0], 2, 2);
+        // First eval seeds the archive; second would blend if w > 0.
+        let _ = wrapper.evaluate_coupled(&[a.clone(), b.clone()]);
+        let out = wrapper.evaluate_coupled(&[a, b]);
+        let va = out[0].clone().into_data().into_vec::<f32>().unwrap();
+        // Pure row sums regardless of the (non-empty) archive.
+        assert_eq!(va, vec![2.0, 4.0]);
+    }
+}

--- a/crates/rlevo-evolution/src/coevolution/mod.rs
+++ b/crates/rlevo-evolution/src/coevolution/mod.rs
@@ -1,0 +1,150 @@
+//! Co-evolutionary algorithms (phase 3c).
+//!
+//! Two populations evolve **simultaneously**, and each individual's fitness
+//! depends on the *other* population. Two regimes ship in v1:
+//!
+//! - **Competitive** ([`CompetitiveCoEA`]) — populations are adversaries
+//!   (predator vs. prey, Hillis 1990). Each is scored by how well it does
+//!   against the other; the dynamic is an arms race.
+//! - **Cooperative** ([`CooperativeCoEA`], CCGA — Potter & De Jong 1994) — a
+//!   high-dimensional problem is decomposed across populations whose
+//!   individuals combine (via *representatives*) into a full candidate.
+//!
+//! # Why not [`Strategy`](crate::strategy::Strategy)?
+//!
+//! [`Strategy::tell`](crate::strategy::Strategy::tell) accepts a single
+//! fitness vector, but co-evolutionary fitness is inherently paired — each
+//! population receives a vector computed relative to the other. Rather than
+//! distort that contract, co-evolution gets its own [`CoEvolutionaryAlgorithm`]
+//! trait and a dedicated [`CoEvolutionaryHarness`] that adapts to the existing
+//! `rlevo-core::evaluation::BenchEnv` surface, exactly as
+//! [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness) does. Both
+//! co-evolutionary algorithms are built from ordinary inner
+//! [`Strategy`](crate::strategy::Strategy) instances, so every phase-1/2/3a/3b
+//! algorithm composes in unchanged.
+//!
+//! # Pathology mitigation
+//!
+//! Competitive co-evolution is prone to **cycling**; [`HallOfFameFitness`]
+//! wraps any [`CoupledFitness`] to anchor scores against an archive of past
+//! champions (Rosin & Belew 1997). It composes at construction — algorithms
+//! are hall-of-fame-agnostic.
+//!
+//! # Coupling shape
+//!
+//! [`CoupledFitness`] takes a slice of populations and is N-population-ready;
+//! v1 algorithms always pass exactly two. The harness exposes
+//! `-min(best_a, best_b)` as the benchmark reward (the weaker population is the
+//! binding constraint).
+//!
+//! # References
+//!
+//! - Hillis (1990), *Co-evolving parasites improve simulated evolution as an
+//!   optimization procedure.*
+//! - Potter & De Jong (1994), *A cooperative coevolutionary approach to
+//!   function optimization* (CCGA).
+//! - Rosin & Belew (1997), *New methods for competitive coevolution* (hall of
+//!   fame).
+//! - Ficici (2004), *Solution concepts in coevolutionary algorithms* (cycling
+//!   / intransitive dominance).
+
+pub mod competitive;
+pub mod cooperative;
+pub mod fitness;
+pub mod harness;
+pub mod hof;
+
+pub use competitive::{CompetitiveCoEA, CompetitiveCoEAParams};
+pub use cooperative::{CooperativeCoEA, CooperativeCoEAParams, CooperativeState, RepresentativePolicy};
+pub use fitness::CoupledFitness;
+pub use harness::{CoEAMetrics, CoEvolutionaryHarness};
+pub use hof::{HallOfFame, HallOfFameFitness};
+
+use std::fmt::Debug;
+
+use burn::tensor::backend::Backend;
+use rand::Rng;
+
+/// A co-evolutionary algorithm driving two populations under simultaneous
+/// updates.
+///
+/// The analogue of [`Strategy`](crate::strategy::Strategy) for the coupled
+/// case: [`init`](Self::init) builds the joint state and [`step`](Self::step)
+/// advances one simultaneous-update generation (both populations `ask` → one
+/// [`CoupledFitness`] evaluation → both `tell`). Implementors hold their inner
+/// strategies and a [`CoupledFitness`] by value and carry no PRNG state — all
+/// randomness flows through the explicit `rng` argument, per the crate's
+/// host-RNG convention.
+///
+/// v1 ships [`CompetitiveCoEA`] and [`CooperativeCoEA`]; Stackelberg
+/// (alternating) turn order is deferred.
+pub trait CoEvolutionaryAlgorithm<B: Backend>: Send + Sync {
+    /// Static parameters for a run (inner strategy params plus any coupling
+    /// configuration).
+    type Params: Clone + Debug + Send + Sync;
+
+    /// Generation-to-generation joint state.
+    type State: Clone + Debug + Send;
+
+    /// Build the initial joint state (initializes both inner strategies).
+    fn init(
+        &self,
+        params: &Self::Params,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self::State;
+
+    /// Advance one simultaneous-update generation, returning the next state
+    /// and this generation's [`CoEAMetrics`].
+    fn step(
+        &self,
+        params: &Self::Params,
+        state: Self::State,
+        rng: &mut dyn Rng,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> (Self::State, CoEAMetrics);
+
+    /// Snapshot the current metrics without advancing a generation.
+    fn metrics(&self, state: &Self::State) -> CoEAMetrics;
+}
+
+/// Joined state carrying both sub-strategy states plus per-population
+/// best/mean trackers.
+///
+/// Generic over the two inner strategy *state* types (`StA`, `StB`) rather
+/// than the strategies themselves, so it derives [`Clone`]/[`Debug`] without
+/// spurious bounds on the strategy types. Used by [`CompetitiveCoEA`];
+/// [`CooperativeCoEA`] wraps it in [`CooperativeState`] to add
+/// representative archives.
+#[derive(Debug, Clone)]
+pub struct CoEAState<StA, StB> {
+    /// Inner state of population A's strategy.
+    pub state_a: StA,
+    /// Inner state of population B's strategy.
+    pub state_b: StB,
+    /// Number of completed simultaneous-update generations.
+    pub generation: u64,
+    /// Best (lowest) fitness population A has seen across all generations.
+    pub best_a: f32,
+    /// Best (lowest) fitness population B has seen across all generations.
+    pub best_b: f32,
+    /// Mean fitness of population A in the most recent generation.
+    pub mean_a: f32,
+    /// Mean fitness of population B in the most recent generation.
+    pub mean_b: f32,
+}
+
+impl<StA, StB> CoEAState<StA, StB> {
+    /// Build the initial joint state with empty best/mean trackers.
+    pub(crate) fn new(state_a: StA, state_b: StB) -> Self {
+        Self {
+            state_a,
+            state_b,
+            generation: 0,
+            best_a: f32::INFINITY,
+            best_b: f32::INFINITY,
+            mean_a: f32::NAN,
+            mean_b: f32::NAN,
+        }
+    }
+}

--- a/crates/rlevo-evolution/src/lib.rs
+++ b/crates/rlevo-evolution/src/lib.rs
@@ -35,9 +35,14 @@
 //!   searchers) for memetic algorithms.
 //! - [`probability_model`] — the [`ProbabilityModel`] trait shared by the
 //!   estimation-of-distribution (EDA) strategies.
+//! - [`coevolution`] — competitive / cooperative co-evolution
+//!   ([`CompetitiveCoEA`], [`CooperativeCoEA`]), the [`CoupledFitness`] trait,
+//!   the [`HallOfFameFitness`] cycling mitigation, and the
+//!   [`CoEvolutionaryHarness`] `BenchEnv` adapter.
 //! - [`algorithms`] — concrete strategies.
 
 pub mod algorithms;
+pub mod coevolution;
 pub mod fitness;
 pub mod genome;
 pub mod local_search;
@@ -55,6 +60,11 @@ pub use algorithms::eda::{
     UnivariateBernoulliParams, UnivariateGaussian, UnivariateGaussianParams,
 };
 pub use algorithms::memetic::{CoveragePolicy, MemeticWrapper, WritebackPolicy};
+pub use coevolution::{
+    CoEAMetrics, CoEAState, CoEvolutionaryAlgorithm, CoEvolutionaryHarness, CompetitiveCoEA,
+    CompetitiveCoEAParams, CooperativeCoEA, CooperativeCoEAParams, CooperativeState, CoupledFitness,
+    HallOfFame, HallOfFameFitness, RepresentativePolicy,
+};
 pub use probability_model::ProbabilityModel;
 pub use local_search::{
     HillClimbing, LocalSearch, NelderMead, RandomRestart, SimulatedAnnealing,

--- a/crates/rlevo-evolution/src/rng.rs
+++ b/crates/rlevo-evolution/src/rng.rs
@@ -53,6 +53,13 @@ pub enum SeedPurpose {
     /// population from an independent per-generation stream, isolated from
     /// every other operator purpose.
     EdaSampling = 8,
+    /// Representative selection in cooperative co-evolution (CCGA).
+    ///
+    /// Used by [`crate::coevolution`] so the `Random` and `Archive`
+    /// representative-selection policies draw their opposing-population
+    /// representatives from a stream independent of either sub-strategy's
+    /// selection/mutation/crossover/replacement streams.
+    Representative = 9,
 }
 
 impl SeedPurpose {
@@ -67,6 +74,7 @@ impl SeedPurpose {
             SeedPurpose::Other => 0x9E37_79B9_7F4A_7C15,
             SeedPurpose::LocalSearch => 0xC0FF_EE15_600D_F00D,
             SeedPurpose::EdaSampling => 0xEDA0_5EED_BEEF_CAFE,
+            SeedPurpose::Representative => 0xC0EA_5E1E_C7ED_0009,
         }
     }
 }
@@ -139,6 +147,7 @@ mod tests {
         let c = seed_stream(42, 0, SeedPurpose::Mutation).next_u64();
         let d = seed_stream(42, 0, SeedPurpose::LocalSearch).next_u64();
         let e = seed_stream(42, 0, SeedPurpose::EdaSampling).next_u64();
+        let f = seed_stream(42, 0, SeedPurpose::Representative).next_u64();
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
@@ -149,6 +158,8 @@ mod tests {
         assert_ne!(b, e);
         assert_ne!(c, e);
         assert_ne!(d, e);
+        assert_ne!(a, f);
+        assert_ne!(e, f);
     }
 
     #[test]

--- a/crates/rlevo-evolution/tests/coevolution_forgetting.rs
+++ b/crates/rlevo-evolution/tests/coevolution_forgetting.rs
@@ -1,0 +1,296 @@
+//! AC §7.3 — hall-of-fame mitigation prevents *forgetting* in a competitive
+//! host–parasite coverage game over a non-stationary regime (Hillis 1990).
+//!
+//! Pure rock-paper-scissors is payoff-symmetric — every strategy's winrate
+//! against any balanced opponent set is exactly 1/3 — so no winrate-based
+//! metric can detect what a hall of fame does. We therefore use an asymmetric
+//! construction with a genuine competence dimension and a non-stationary
+//! adversary:
+//!
+//! - **Solver** (population A): `K = 3` coverage genes in `[0,1]`. Covering a
+//!   target pays off when it is probed, but every unit of coverage costs
+//!   `LAMBDA` — so the solver cannot afford to cover all targets at once.
+//! - **Tester** (population B): probes one target (`argmax` of `K` genes); it
+//!   is rewarded for matching the **current regime target**, which cycles
+//!   every `PERIOD` generations — a controlled non-stationary opponent.
+//!
+//! Against the *current* (concentrated) regime, the solver covers only the
+//! probed target and drops the rest (the budget cost outweighs an un-probed
+//! target) — it **forgets** as the regime moves on. With a
+//! [`HallOfFameFitness`], the solver is also scored against a *diverse* archive
+//! of past regime targets, so retaining coverage of all of them pays off. The
+//! shipped average-blend hall of fame (unchanged, blend `0.3`) keeps coverage
+//! broad. The acceptance assertion is on **retained coverage of the
+//! most-neglected target**: high with the hall of fame, low (forgetting)
+//! without it.
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use burn::backend::Flex;
+use burn::tensor::{Tensor, TensorData};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_evolution::algorithms::ga::{
+    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+};
+use rlevo_evolution::coevolution::{
+    CoEvolutionaryAlgorithm, CompetitiveCoEA, CompetitiveCoEAParams, CoupledFitness,
+    HallOfFameFitness,
+};
+
+type B = Flex;
+
+const POP: usize = 60;
+const GENS: usize = 200;
+const K: usize = 3; // number of targets / genome width
+const PERIOD: usize = 4; // generations the tester dwells on each regime target
+const LAMBDA: f32 = 0.08; // per-unit coverage budget cost
+
+/// Per-individual coverage vector (population A), genes clamped to `[0,1]`.
+fn coverage(pop: &Tensor<B, 2>) -> Vec<[f32; K]> {
+    let dims = pop.dims();
+    let (n, d) = (dims[0], dims[1]);
+    debug_assert_eq!(d, K);
+    let flat = pop.clone().into_data().into_vec::<f32>().unwrap();
+    (0..n)
+        .map(|i| {
+            let mut c = [0.0f32; K];
+            for (k, slot) in c.iter_mut().enumerate() {
+                *slot = flat[i * d + k].clamp(0.0, 1.0);
+            }
+            c
+        })
+        .collect()
+}
+
+/// Per-individual probed target (population B) = argmax of the genome.
+fn targets(pop: &Tensor<B, 2>) -> Vec<usize> {
+    let dims = pop.dims();
+    let (n, d) = (dims[0], dims[1]);
+    let flat = pop.clone().into_data().into_vec::<f32>().unwrap();
+    (0..n)
+        .map(|i| {
+            let row = &flat[i * d..i * d + d];
+            let mut best = 0usize;
+            let mut bv = row[0];
+            for (k, &v) in row.iter().enumerate() {
+                if v > bv {
+                    bv = v;
+                    best = k;
+                }
+            }
+            best
+        })
+        .collect()
+}
+
+/// Asymmetric host–parasite fitness over a **non-stationary** regime
+/// (minimization).
+///
+/// Population 0 is the solver; population 1 is the tester. The tester is
+/// rewarded for probing the current regime target, which cycles every
+/// [`PERIOD`] generations — a controlled non-stationary adversary. The solver
+/// is rewarded for covering the probed targets but pays a budget cost
+/// [`LAMBDA`] per unit of coverage, so beating the current regime means
+/// dropping coverage of others (the seed of forgetting).
+///
+/// A generation counter is held internally (incremented once per generation,
+/// detected by the opponent population having the full [`POP`] rows — archive
+/// sub-evaluations, which pass fewer rows, do not advance it).
+struct CoverageForgettingFitness {
+    step: AtomicUsize,
+}
+
+impl CoverageForgettingFitness {
+    fn new() -> Self {
+        Self {
+            step: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl CoupledFitness<B> for CoverageForgettingFitness {
+    fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+        debug_assert_eq!(populations.len(), 2);
+        let device = populations[0].device();
+        let cov = coverage(&populations[0]);
+        let tgt = targets(&populations[1]);
+
+        // Advance the regime clock only on full-population (current-opponent)
+        // evaluations, not on smaller hall-of-fame archive sub-evaluations.
+        let generation = if populations[1].dims()[0] == POP {
+            self.step.fetch_add(1, Ordering::Relaxed)
+        } else {
+            self.step.load(Ordering::Relaxed)
+        };
+        let regime_target = (generation / PERIOD) % K;
+
+        // Solver fitness: 1 - mean coverage of probed targets + budget cost.
+        let solver: Vec<f32> = cov
+            .iter()
+            .map(|c| {
+                let benefit = if tgt.is_empty() {
+                    0.0
+                } else {
+                    tgt.iter().map(|&t| c[t]).sum::<f32>() / tgt.len() as f32
+                };
+                let cost = LAMBDA * c.iter().sum::<f32>();
+                (1.0 - benefit) + cost
+            })
+            .collect();
+
+        // Tester fitness: match the current regime target (drives the tester
+        // population to probe the cycling regime).
+        let tester: Vec<f32> = tgt
+            .iter()
+            .map(|&t| if t == regime_target { 0.0 } else { 1.0 })
+            .collect();
+
+        vec![
+            Tensor::<B, 1>::from_data(TensorData::new(solver.clone(), [solver.len()]), &device),
+            Tensor::<B, 1>::from_data(TensorData::new(tester.clone(), [tester.len()]), &device),
+        ]
+    }
+}
+
+fn ga_config() -> GaConfig {
+    GaConfig {
+        pop_size: POP,
+        genome_dim: K,
+        bounds: (0.0, 1.0),
+        mutation_sigma: 0.1,
+        selection: GaSelection::Tournament { size: 3 },
+        crossover: GaCrossover::Uniform { p: 0.5 },
+        replacement: GaReplacement::Elitist { elitism_k: 1 },
+    }
+}
+
+/// Per generation, the solver's *minimum* mean coverage across the `K`
+/// targets — the strength of the most-neglected ("forgotten") target. High =>
+/// the solver retains all targets; near zero => it has abandoned one.
+fn run_coverage<F: CoupledFitness<B>>(fitness: F, seed: u64) -> Vec<f32> {
+    let device = Default::default();
+    let algo = CompetitiveCoEA::new(
+        GeneticAlgorithm::<B>::new(),
+        GeneticAlgorithm::<B>::new(),
+        fitness,
+    );
+    let params = CompetitiveCoEAParams {
+        params_a: ga_config(),
+        params_b: ga_config(),
+    };
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut state = algo.init(&params, &mut rng, &device);
+    let mut traj = Vec::with_capacity(GENS);
+    for _ in 0..GENS {
+        let (next, _m) = algo.step(&params, state, &mut rng, &device);
+        state = next;
+        let cov = coverage(&state.state_a.population);
+        let n = cov.len().max(1) as f32;
+        let min_cov: f32 = (0..K)
+            .map(|k| cov.iter().map(|c| c[k]).sum::<f32>() / n)
+            .fold(f32::INFINITY, f32::min);
+        traj.push(min_cov);
+    }
+    traj
+}
+
+/// Mean total coverage over the last `window` generations.
+fn tail_coverage(traj: &[f32], window: usize) -> f32 {
+    let start = traj.len().saturating_sub(window);
+    let tail = &traj[start..];
+    tail.iter().sum::<f32>() / tail.len() as f32
+}
+
+/// Observation harness — run with:
+/// `cargo test -p rlevo-evolution --test coevolution_cycling -- --ignored --nocapture`
+#[test]
+#[ignore = "observation only; prints trajectory statistics"]
+fn observe_dynamics() {
+    let device = Default::default();
+    let seeds = [1_u64, 7, 42, 100, 5, 99, 13, 77];
+    for &blend in &[0.0_f32, 0.3, 0.5, 0.7, 0.9] {
+        let mut tails: Vec<f32> = Vec::new();
+        for &seed in &seeds {
+            let traj = if blend == 0.0 {
+                run_coverage(CoverageForgettingFitness::new(), seed)
+            } else {
+                run_coverage(
+                    HallOfFameFitness::new(CoverageForgettingFitness::new(), 2, POP, K, &device)
+                        .with_blend_weight(blend),
+                    seed,
+                )
+            };
+            tails.push(tail_coverage(&traj, 50));
+        }
+        let avg = tails.iter().sum::<f32>() / tails.len() as f32;
+        let min = tails.iter().copied().fold(f32::INFINITY, f32::min);
+        let max = tails.iter().copied().fold(0.0, f32::max);
+        eprintln!(
+            "blend={:.2}: tail50 min-coverage (retention) avg={:.2} min={:.2} max={:.2}  per-seed={:?}",
+            blend,
+            avg,
+            min,
+            max,
+            tails.iter().map(|x| (x * 100.0).round() / 100.0).collect::<Vec<_>>()
+        );
+    }
+}
+
+/// Mean tail retention (most-forgotten target's coverage) over a set of seeds,
+/// returned as `(per_seed_no_hof, per_seed_with_hof)`.
+fn forgetting_sweep(seeds: &[u64], blend: f32) -> (Vec<f32>, Vec<f32>) {
+    let device = Default::default();
+    let mut no_hof = Vec::new();
+    let mut with_hof = Vec::new();
+    for &seed in seeds {
+        no_hof.push(tail_coverage(&run_coverage(CoverageForgettingFitness::new(), seed), 50));
+        with_hof.push(tail_coverage(
+            &run_coverage(
+                HallOfFameFitness::new(CoverageForgettingFitness::new(), 2, POP, K, &device)
+                    .with_blend_weight(blend),
+                seed,
+            ),
+            50,
+        ));
+    }
+    (no_hof, with_hof)
+}
+
+/// AC §7.3: the shipped average-blend [`HallOfFameFitness`] (blend `0.3`)
+/// prevents *forgetting* — the solver retains coverage of every regime target
+/// — while without it the solver forgets targets as the regime cycles.
+#[test]
+fn hall_of_fame_prevents_forgetting() {
+    let seeds = [1_u64, 7, 42, 100, 5, 99, 13, 77];
+    let (no_hof, with_hof) = forgetting_sweep(&seeds, 0.3);
+
+    let mean = |v: &[f32]| v.iter().sum::<f32>() / v.len() as f32;
+    let hof_mean = mean(&with_hof);
+    let nohof_mean = mean(&no_hof);
+    let hof_min = with_hof.iter().copied().fold(f32::INFINITY, f32::min);
+    let forgot = no_hof.iter().filter(|&&c| c < 0.5).count();
+
+    // With HoF, retention is robustly high on every seed.
+    assert!(
+        hof_min >= 0.75,
+        "HoF should retain coverage of all targets on every seed; min={hof_min:.2}, per-seed={with_hof:?}"
+    );
+    // Without HoF, average retention is substantially lower.
+    assert!(
+        nohof_mean <= 0.70,
+        "without HoF, mean retention should be markedly lower; got {nohof_mean:.2}, per-seed={no_hof:?}"
+    );
+    assert!(
+        hof_mean - nohof_mean >= 0.15,
+        "HoF should retain markedly more coverage; hof={hof_mean:.2} nohof={nohof_mean:.2}"
+    );
+    // Forgetting is observable without HoF on multiple seeds.
+    assert!(
+        forgot >= 2,
+        "forgetting (retention < 0.5) should be observable without HoF; count={forgot}, per-seed={no_hof:?}"
+    );
+}

--- a/crates/rlevo-examples/Cargo.toml
+++ b/crates/rlevo-examples/Cargo.toml
@@ -89,3 +89,12 @@ path = "examples/harness/tabular_bandit.rs"
 [[example]]
 name = "eda_showcase"
 path = "examples/evolution/eda_showcase.rs"
+
+# Examples — evolution (co-evolution)
+[[example]]
+name = "competitive_predator_prey"
+path = "examples/evolution/competitive_predator_prey.rs"
+
+[[example]]
+name = "cooperative_ccga_rastrigin"
+path = "examples/evolution/cooperative_ccga_rastrigin.rs"

--- a/crates/rlevo-examples/examples/evolution/competitive_predator_prey.rs
+++ b/crates/rlevo-examples/examples/evolution/competitive_predator_prey.rs
@@ -1,0 +1,116 @@
+//! Competitive co-evolution: a predator–prey arms race on a separable quadratic.
+//!
+//! Two populations of points in `R^d` co-evolve under [`CompetitiveCoEA`]. The
+//! **predator** (population A) minimizes its squared distance to the prey
+//! (it wants to close in); the **prey** (population B) minimizes its closeness
+//! to the predator (it wants to escape). The two objectives are coupled and
+//! opposed — a textbook arms race. Each generation prints the best fitness of
+//! each population (lower is better for both, under their own objective).
+//!
+//! # Running
+//!
+//! ```text
+//! cargo run -p rlevo-examples --example competitive_predator_prey
+//! ```
+
+#![allow(clippy::cast_precision_loss)]
+
+use burn::backend::Flex;
+use burn::tensor::{Tensor, TensorData};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_evolution::algorithms::ga::{
+    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+};
+use rlevo_evolution::coevolution::{
+    CoEvolutionaryAlgorithm, CompetitiveCoEA, CompetitiveCoEAParams, CoupledFitness,
+};
+
+type B = Flex;
+
+const DIM: usize = 2;
+const POP: usize = 48;
+const GENS: usize = 60;
+
+fn rows(pop: &Tensor<B, 2>) -> Vec<Vec<f32>> {
+    let dims = pop.dims();
+    let (n, d) = (dims[0], dims[1]);
+    let flat = pop.clone().into_data().into_vec::<f32>().unwrap();
+    (0..n).map(|i| flat[i * d..i * d + d].to_vec()).collect()
+}
+
+fn sqdist(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+/// Predator (pop 0) minimizes mean squared distance to prey; prey (pop 1)
+/// minimizes mean closeness `exp(-dist^2)` to the predator.
+struct PredatorPrey;
+
+impl CoupledFitness<B> for PredatorPrey {
+    fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+        debug_assert_eq!(populations.len(), 2);
+        let device = populations[0].device();
+        let a = rows(&populations[0]);
+        let b = rows(&populations[1]);
+
+        let predator: Vec<f32> = a
+            .iter()
+            .map(|ai| b.iter().map(|bj| sqdist(ai, bj)).sum::<f32>() / b.len().max(1) as f32)
+            .collect();
+        let prey: Vec<f32> = b
+            .iter()
+            .map(|bj| {
+                a.iter().map(|ai| (-sqdist(bj, ai)).exp()).sum::<f32>() / a.len().max(1) as f32
+            })
+            .collect();
+
+        vec![
+            Tensor::<B, 1>::from_data(TensorData::new(predator.clone(), [predator.len()]), &device),
+            Tensor::<B, 1>::from_data(TensorData::new(prey.clone(), [prey.len()]), &device),
+        ]
+    }
+}
+
+fn ga_config() -> GaConfig {
+    GaConfig {
+        pop_size: POP,
+        genome_dim: DIM,
+        bounds: (-5.0, 5.0),
+        mutation_sigma: 0.2,
+        selection: GaSelection::Tournament { size: 3 },
+        crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
+        replacement: GaReplacement::Elitist { elitism_k: 1 },
+    }
+}
+
+fn main() {
+    let device = Default::default();
+    let algo = CompetitiveCoEA::new(
+        GeneticAlgorithm::<B>::new(),
+        GeneticAlgorithm::<B>::new(),
+        PredatorPrey,
+    );
+    let params = CompetitiveCoEAParams {
+        params_a: ga_config(),
+        params_b: ga_config(),
+    };
+    let mut rng = StdRng::seed_from_u64(7);
+    let mut state = algo.init(&params, &mut rng, &device);
+
+    println!("Predator–prey arms race on a separable quadratic (R^{DIM})");
+    println!("(lower is better for each population's own objective)\n");
+    println!(" gen | predator best (mean dist^2) | prey best (mean closeness)");
+    println!("-----+-----------------------------+---------------------------");
+    for g in 0..GENS {
+        let (next, metrics) = algo.step(&params, state, &mut rng, &device);
+        state = next;
+        if g % 5 == 0 || g == GENS - 1 {
+            println!(
+                " {:>3} | {:>27.4} | {:>25.4}",
+                metrics.generation, metrics.best_fitness_a, metrics.best_fitness_b
+            );
+        }
+    }
+}

--- a/crates/rlevo-examples/examples/evolution/cooperative_ccga_rastrigin.rs
+++ b/crates/rlevo-examples/examples/evolution/cooperative_ccga_rastrigin.rs
@@ -1,0 +1,119 @@
+//! Cooperative co-evolution: CCGA on a separable Rastrigin function.
+//!
+//! The 6-dimensional Rastrigin problem is decomposed across two populations
+//! of three dimensions each (Potter & De Jong 1994). Neither population holds
+//! a complete solution: [`CooperativeCoEA`] completes each sub-genome with the
+//! *best representative* of the other population, evaluates the assembled
+//! 6-D candidate with a stateless row-wise Rastrigin [`CoupledFitness`], and
+//! feeds the result back to each sub-strategy. Both sub-populations should
+//! drive their assembled candidate's Rastrigin value toward the optimum (0).
+//!
+//! # Running
+//!
+//! ```text
+//! cargo run -p rlevo-examples --example cooperative_ccga_rastrigin
+//! ```
+
+use std::f32::consts::PI;
+
+use burn::backend::Flex;
+use burn::tensor::{Tensor, TensorData};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_evolution::algorithms::ga::{
+    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+};
+use rlevo_evolution::coevolution::{
+    CoEvolutionaryAlgorithm, CooperativeCoEA, CooperativeCoEAParams, CoupledFitness,
+    RepresentativePolicy,
+};
+
+type B = Flex;
+
+const TOTAL: usize = 6;
+const HALF: usize = TOTAL / 2;
+const POP: usize = 64;
+const GENS: usize = 120;
+
+/// Rastrigin value of one genome row: `10·n + Σ (x_i² − 10·cos(2π x_i))`,
+/// minimized at the all-zeros vector (value 0).
+fn rastrigin(x: &[f32]) -> f32 {
+    #[allow(clippy::cast_precision_loss)]
+    let base = 10.0 * x.len() as f32;
+    base + x
+        .iter()
+        .map(|&xi| xi * xi - 10.0 * (2.0 * PI * xi).cos())
+        .sum::<f32>()
+}
+
+/// Stateless row-wise Rastrigin fitness. [`CooperativeCoEA`] passes
+/// already-assembled full-dimensional candidates, so this never sees the
+/// dimension split or representatives — it just scores each row.
+struct RastriginCoupled;
+
+impl CoupledFitness<B> for RastriginCoupled {
+    fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+        debug_assert_eq!(populations.len(), 2);
+        populations
+            .iter()
+            .map(|pop| {
+                let dims = pop.dims();
+                let (n, d) = (dims[0], dims[1]);
+                let flat = pop.clone().into_data().into_vec::<f32>().unwrap();
+                let values: Vec<f32> = (0..n).map(|i| rastrigin(&flat[i * d..i * d + d])).collect();
+                Tensor::<B, 1>::from_data(TensorData::new(values, [n]), &pop.device())
+            })
+            .collect()
+    }
+}
+
+fn ga_config() -> GaConfig {
+    GaConfig {
+        pop_size: POP,
+        genome_dim: HALF,
+        bounds: (-5.12, 5.12),
+        mutation_sigma: 0.3,
+        selection: GaSelection::Tournament { size: 3 },
+        crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
+        replacement: GaReplacement::Elitist { elitism_k: 2 },
+    }
+}
+
+fn main() {
+    let device = Default::default();
+    let algo = CooperativeCoEA::new(
+        GeneticAlgorithm::<B>::new(),
+        GeneticAlgorithm::<B>::new(),
+        RastriginCoupled,
+    );
+    let params = CooperativeCoEAParams::new(
+        ga_config(),
+        ga_config(),
+        vec![0, 1, 2],
+        TOTAL,
+        RepresentativePolicy::Best,
+        TOTAL * POP,
+    );
+    let mut rng = StdRng::seed_from_u64(7);
+    let mut state = algo.init(&params, &mut rng, &device);
+
+    println!("CCGA on separable Rastrigin-{TOTAL} (two {HALF}-D populations, Best representative)");
+    println!("(Rastrigin optimum = 0)\n");
+    println!(" gen | best_a    | best_b");
+    println!("-----+-----------+-----------");
+    for g in 0..GENS {
+        let (next, metrics) = algo.step(&params, state, &mut rng, &device);
+        state = next;
+        if g % 10 == 0 || g == GENS - 1 {
+            println!(
+                " {:>3} | {:>9.5} | {:>9.5}",
+                metrics.generation, metrics.best_fitness_a, metrics.best_fitness_b
+            );
+        }
+    }
+
+    let metrics = algo.metrics(&state);
+    let best = metrics.best_fitness_a.min(metrics.best_fitness_b);
+    println!("\nfinal assembled best Rastrigin = {best:.5} (optimum 0.0)");
+}

--- a/crates/rlevo/tests/coevolution_harness.rs
+++ b/crates/rlevo/tests/coevolution_harness.rs
@@ -1,0 +1,146 @@
+//! AC §7.4 — `CoEvolutionaryHarness` is driven by the `rlevo-benchmarks`
+//! evaluator without modification.
+//!
+//! A competitive predator–prey co-evolution is wrapped in a
+//! [`CoEvolutionaryHarness`] and run through `Evaluator::run_suite` exactly
+//! like any other `BenchEnv`. One `BenchEnv::step` is one simultaneous-update
+//! generation; the test asserts the suite completes the expected number of
+//! steps per trial with no errors and a finite return.
+
+#![allow(clippy::cast_precision_loss)]
+
+use burn::backend::Flex;
+use burn::tensor::{Tensor, TensorData};
+use rand::Rng;
+
+use rlevo_benchmarks::agent::BenchableAgent;
+use rlevo_benchmarks::evaluator::{Evaluator, EvaluatorConfig};
+use rlevo_benchmarks::reporter::logging::LoggingReporter;
+use rlevo_benchmarks::suite::Suite;
+use rlevo_evolution::algorithms::ga::{
+    GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+};
+use rlevo_evolution::coevolution::{CompetitiveCoEA, CompetitiveCoEAParams, CoupledFitness};
+use rlevo_evolution::CoEvolutionaryHarness;
+
+type B = Flex;
+
+const DIM: usize = 2;
+const POP: usize = 32;
+const MAX_GENS: usize = 40;
+
+/// Predator–prey coupled fitness on a separable quadratic: the predator (pop 0)
+/// minimizes squared distance to the prey (chase); the prey (pop 1) minimizes
+/// closeness (flee). Both are minimization, bounded for the prey.
+struct PredatorPrey;
+
+fn rows(pop: &Tensor<B, 2>) -> Vec<Vec<f32>> {
+    let dims = pop.dims();
+    let (n, d) = (dims[0], dims[1]);
+    let flat = pop.clone().into_data().into_vec::<f32>().unwrap();
+    (0..n).map(|i| flat[i * d..i * d + d].to_vec()).collect()
+}
+
+fn sqdist(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+impl CoupledFitness<B> for PredatorPrey {
+    fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+        debug_assert_eq!(populations.len(), 2);
+        let device = populations[0].device();
+        let a = rows(&populations[0]);
+        let b = rows(&populations[1]);
+
+        // Predator: mean squared distance to prey (minimize -> approach).
+        let predator: Vec<f32> = a
+            .iter()
+            .map(|ai| b.iter().map(|bj| sqdist(ai, bj)).sum::<f32>() / b.len().max(1) as f32)
+            .collect();
+        // Prey: mean closeness to predators (minimize -> flee).
+        let prey: Vec<f32> = b
+            .iter()
+            .map(|bj| {
+                a.iter().map(|ai| (-sqdist(bj, ai)).exp()).sum::<f32>() / a.len().max(1) as f32
+            })
+            .collect();
+
+        vec![
+            Tensor::<B, 1>::from_data(TensorData::new(predator.clone(), [predator.len()]), &device),
+            Tensor::<B, 1>::from_data(TensorData::new(prey.clone(), [prey.len()]), &device),
+        ]
+    }
+}
+
+fn ga_config() -> GaConfig {
+    GaConfig {
+        pop_size: POP,
+        genome_dim: DIM,
+        bounds: (-5.0, 5.0),
+        mutation_sigma: 0.2,
+        selection: GaSelection::Tournament { size: 3 },
+        crossover: GaCrossover::BlxAlpha { alpha: 0.5 },
+        replacement: GaReplacement::Elitist { elitism_k: 1 },
+    }
+}
+
+type Coea = CompetitiveCoEA<B, GeneticAlgorithm<B>, GeneticAlgorithm<B>, PredatorPrey>;
+
+fn coea_factory(seed: u64) -> CoEvolutionaryHarness<B, Coea> {
+    let device = Default::default();
+    let algo = CompetitiveCoEA::new(
+        GeneticAlgorithm::<B>::new(),
+        GeneticAlgorithm::<B>::new(),
+        PredatorPrey,
+    );
+    let params = CompetitiveCoEAParams {
+        params_a: ga_config(),
+        params_b: ga_config(),
+    };
+    CoEvolutionaryHarness::new(algo, params, seed, device, MAX_GENS)
+}
+
+/// Passive agent: the harness drives the optimization; the agent only steps it.
+struct Passive;
+impl BenchableAgent<(), ()> for Passive {
+    fn act(&mut self, (): &(), _: &mut dyn Rng) {}
+}
+
+#[test]
+fn coevolutionary_harness_runs_through_evaluator() {
+    let cfg = EvaluatorConfig {
+        num_episodes: 1,
+        num_trials_per_env: 2,
+        max_steps: MAX_GENS,
+        base_seed: 17,
+        // Flex seeds via a process-global mutex; pin to one thread for
+        // reproducibility (mirrors the other run-suite integration tests).
+        num_threads: Some(1),
+        checkpoint_dir: None,
+        fail_fast: false,
+        success_threshold: None,
+    };
+
+    let suite: Suite<CoEvolutionaryHarness<B, Coea>> =
+        Suite::new("predator-prey-coea", cfg.clone()).with_env("predator-prey-2d", coea_factory);
+
+    let evaluator = Evaluator::new(cfg);
+    let mut reporter = LoggingReporter::new();
+    let report = evaluator.run_suite(&suite, |_s| Passive, &mut reporter);
+
+    assert_eq!(report.trials.len(), 2, "expected one report per trial");
+    for trial in &report.trials {
+        assert!(!trial.errored, "trial errored: {:?}", trial.error_message);
+        assert_eq!(trial.episodes.len(), 1, "one episode per trial");
+        let ep = &trial.episodes[0];
+        assert_eq!(
+            ep.length, MAX_GENS,
+            "one BenchEnv::step should drive one generation"
+        );
+        assert!(
+            ep.return_value.is_finite(),
+            "return should be finite, got {}",
+            ep.return_value
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -117,6 +117,14 @@ pendulum-random:
 # ── rlevo-examples (heavy: benchmarks + viz/record/report features) ──────────
 # Not in default-members; each recipe supplies the required feature flags.
 
+# Phase 3c: competitive co-evolution predator–prey arms race on a separable quadratic.
+coevo-competitive:
+    cargo run --release -p rlevo-examples --example competitive_predator_prey
+
+# Phase 3c: cooperative CCGA on 6-D Rastrigin split across two 3-D sub-populations.
+coevo-cooperative:
+    cargo run --release -p rlevo-examples --example cooperative_ccga_rastrigin
+
 harness-ga-rastrigin:
     cargo run -p rlevo-examples --example ga_rastrigin
 
@@ -159,6 +167,40 @@ report-inverted-pendulum: client-build
 report-lunar-lander: client-build
     cargo run -p rlevo-examples --features box2d,viz-report --example report_lunar_lander_with_client  --release
 
+# ── Crate-level integration tests ───────────────────────────────────────────
+
+# Wire-format mirror parity: native EpisodeRecord vs browser-client mirror round-trip.
+test-wire-format:
+    cargo test -p rlevo-benchmarks --test wire_format_compat --features record
+
+# Grid env solvability canary: scripted optimal rollout through every grids env.
+test-grids-solvable:
+    cargo test -p rlevo-environments --test grids_solvable
+
+# AsciiRenderable coverage: render contract across classic/grids/toy_text/landscapes/box2d.
+test-render-coverage:
+    cargo test -p rlevo-environments --test render_coverage
+
+# Cross-backend parity: GA drives Sphere-D10 to a non-trivial optimum on both Flex and wgpu.
+test-backend-parity:
+    cargo test -p rlevo-evolution --test backend_parity
+
+# Co-evolution forgetting prevention: HoF retains solver coverage in a non-stationary host–parasite game.
+test-coevo-forgetting:
+    cargo test -p rlevo-evolution --test coevolution_forgetting
+
+# Co-evolution forgetting observer [ignored: prints trajectory statistics, no assertion].
+test-coevo-forgetting-observe:
+    cargo test -p rlevo-evolution --test coevolution_forgetting -- observe_dynamics --ignored --nocapture
+
+# Bit-exact determinism: every EA strategy produces identical fitness trajectory from same seed.
+test-evolution-determinism:
+    cargo test -p rlevo-evolution --test determinism
+
+# EDA plumbing smoke: each ProbabilityModel completes ask→evaluate→tell with finite metrics.
+test-eda-smoke:
+    cargo test -p rlevo-evolution --test eda_smoke
+
 # ── Integration tests (rlevo umbrella) ──────────────────────────────────────
 
 # Cross-crate integration: core + RL replay/metrics.
@@ -193,6 +235,14 @@ test-memetic-calibration:
 # MIMIC beats UMDA's median on Rosenbrock-D10 across 9 fixed seeds.
 test-eda:
     cargo test -p rlevo --test eda_convergence
+
+# EDA determinism: all five ProbabilityModels produce bit-identical trajectories from the same seed.
+test-eda-determinism:
+    cargo test -p rlevo --test determinism
+
+# Co-evolution harness: CoEvolutionaryHarness driven by rlevo-benchmarks Evaluator end-to-end.
+test-coevo-harness:
+    cargo test -p rlevo --test coevolution_harness
 
 # Post-run record → report pipeline smoke [requires viz-report feature].
 test-report-smoke:


### PR DESCRIPTION
- **feat(coevolution): Add phase 3c co-evolution module**
- **feat(justfile): Add Phase 3c co-evolution examples and test recipes**

## Summary

Implements Phase 3c of the evolutionary algorithms roadmap: co-evolutionary algorithms (CoEAs) for `rlevo-evolution`. Two populations evolve simultaneously with fitness that depends on the other population. Ships `CompetitiveCoEA` (adversarial arms-race, Hillis 1990), `CooperativeCoEA` (CCGA decomposition, Potter & De Jong 1994), a `HallOfFameFitness` wrapper to mitigate competitive cycling (Rosin & Belew 1997), a dedicated `CoEvolutionaryHarness`, and two examples demonstrating predator-prey and Rastrigin cooperative decomposition.

## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — Phase 3c co-evolutionary algorithm implementation (new algorithms, new trait surface, new examples, new integration tests; discussed and scoped in issue #32)

## Linked Issue

Closes #32

## What Was Changed

- `crates/rlevo-evolution/src/coevolution/mod.rs` — new `CoEvolutionaryAlgorithm` trait, `CoEAState<StA,StB>` joint-state struct, and module re-exports
- `crates/rlevo-evolution/src/coevolution/competitive.rs` — `CompetitiveCoEA` + `CompetitiveCoEAParams`: simultaneous ask/score/tell with per-population fitness vectors
- `crates/rlevo-evolution/src/coevolution/cooperative.rs` — `CooperativeCoEA` + `CooperativeCoEAParams` + `CooperativeState` + `RepresentativePolicy`: CCGA-style subproblem decomposition with configurable representative selection
- `crates/rlevo-evolution/src/coevolution/fitness.rs` — `CoupledFitness` trait: N-population-ready fitness coupling abstraction
- `crates/rlevo-evolution/src/coevolution/harness.rs` — `CoEvolutionaryHarness` + `CoEAMetrics`: adapts CoEA runs to the `BenchEnv` surface; exposes `-min(best_a, best_b)` as benchmark reward
- `crates/rlevo-evolution/src/coevolution/hof.rs` — `HallOfFame` + `HallOfFameFitness`: archive of past champions wrapping any `CoupledFitness` to anchor scores and suppress cycling
- `crates/rlevo-evolution/src/lib.rs` — re-exports the `coevolution` module
- `crates/rlevo-evolution/src/rng.rs` — added `SeedPurpose` variants for CoEA sampling streams
- `crates/rlevo-evolution/tests/coevolution_forgetting.rs` — property tests for HOF cycling suppression and forgetting behavior
- `crates/rlevo/tests/coevolution_harness.rs` — cross-crate integration test: harness advances generations and emits metrics without panicking
- `crates/rlevo-examples/src/evolution/competitive_predator_prey.rs` — example: predator-prey arms race using `CompetitiveCoEA`
- `crates/rlevo-examples/src/evolution/cooperative_ccga_rastrigin.rs` — example: cooperative Rastrigin decomposition using `CooperativeCoEA`
- `crates/rlevo-examples/Cargo.toml` — added example entry points
- `justfile` — Phase 3c example and test recipes

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: `stable-aarch64-apple-darwin`
- Burn backend tested: `ndarray` (CPU)
- OS: macOS Darwin 25.5.0 (Apple Silicon M2)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Sonnet 4.6 (Claude Code). Scope: full implementation of the coevolution module, tests, and examples.

## Checklist

- [ ] `cargo build --workspace` passes with no errors.
- [ ] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

- `CoEvolutionaryAlgorithm` deliberately does not implement `Strategy` — co-evolutionary fitness is inherently paired and distorting the single-vector `tell` contract was rejected. Both algorithms compose inner `Strategy` instances unchanged, so every Phase 1/2/3a/3b algorithm works as a sub-strategy.
- Stackelberg (alternating turn-order) co-evolution is deferred to a follow-up issue.
- `CoupledFitness` is N-population-ready; v1 algorithms always pass exactly two populations.

