### PR TITLE
feat(rlevo-core): add Observable projection trait for modality-changing POMDPs

### DIFF
--- a/crates/rlevo-core/src/lib.rs
+++ b/crates/rlevo-core/src/lib.rs
@@ -11,7 +11,7 @@
 //! |---|---|
 //! | [`base`] | [`Reward`], [`Observation`], [`State`], [`Action`], [`TensorConvertible`], [`UpdateFunction`] — the primitive trait vocabulary |
 //! | [`action`] | [`DiscreteAction`], [`MultiDiscreteAction`], [`ContinuousAction`] — layered action-space extensions |
-//! | [`state`] | [`MarkovState`], [`BeliefState`], [`HiddenState`], [`LatentState`], [`StateAggregation`] — POMDP and latent-space extensions |
+//! | [`state`] | [`MarkovState`], [`BeliefState`], [`HiddenState`], [`LatentState`], [`StateAggregation`], [`Observable`] — POMDP and latent-space extensions |
 //! | [`environment`] | [`Environment`], [`Snapshot`], [`SnapshotBase`], [`EpisodeStatus`], [`EnvironmentError`] — the agent/environment protocol |
 //! | [`reward`] | [`ScalarReward`] — the standard single-value reward concrete type |
 //! | [`evaluation`] | [`BenchEnv`], [`BenchStep`], [`BenchError`] — object-safe environment interface for harnesses |
@@ -66,6 +66,7 @@
 //! [`HiddenState`]: crate::state::HiddenState
 //! [`LatentState`]: crate::state::LatentState
 //! [`StateAggregation`]: crate::state::StateAggregation
+//! [`Observable`]: crate::state::Observable
 //! [`Environment`]: crate::environment::Environment
 //! [`Snapshot`]: crate::environment::Snapshot
 //! [`SnapshotBase`]: crate::environment::SnapshotBase
@@ -171,7 +172,8 @@ pub mod reward;
 /// Advanced state abstractions for POMDPs and latent representations.
 ///
 /// Extends [`base::State`] with [`MarkovState`], [`BeliefState`],
-/// [`HiddenState`], [`LatentState`], and [`StateAggregation`].
+/// [`HiddenState`], [`LatentState`], [`StateAggregation`], and [`Observable`]
+/// (the modality-changing state→observation projection for `OR != SR`).
 ///
 /// [`base::State`]: crate::base::State
 /// [`MarkovState`]: crate::state::MarkovState
@@ -179,6 +181,7 @@ pub mod reward;
 /// [`HiddenState`]: crate::state::HiddenState
 /// [`LatentState`]: crate::state::LatentState
 /// [`StateAggregation`]: crate::state::StateAggregation
+/// [`Observable`]: crate::state::Observable
 pub mod state;
 
 /// Shared utility helpers used across `rlevo-core` modules.

--- a/crates/rlevo-core/src/state.rs
+++ b/crates/rlevo-core/src/state.rs
@@ -7,6 +7,7 @@
 //! - [`HiddenState`] — recurrent agent memory (e.g., RNN hidden state)
 //! - [`LatentState`] — learned compact representation with encode/predict/decode
 //! - [`StateAggregation`] — maps concrete states to abstract representatives
+//! - [`Observable`] — modality-changing state→observation projection (`OR != SR`)
 //!
 //! [`State`]: crate::base::State
 
@@ -168,5 +169,218 @@ pub trait StateAggregation<const SR: usize, S: State<SR>> {
     /// Returns `true` when `state1` and `state2` map to the same abstract state.
     fn same_aggregate(&self, state1: &S, state2: &S) -> bool {
         self.aggregate(state1) == self.aggregate(state2)
+    }
+}
+
+/// Projects a state into an observation whose tensor order may differ from the
+/// state's own.
+///
+/// [`State::observe`] welds its observation to the state's tensor order
+/// (`type Observation: Observation<SR>`), so it can never change rank. That is
+/// the right model for *information*-reducing partial observability (e.g.
+/// dropping velocities from CartPole: a smaller-`shape`, same-order
+/// observation). It cannot express a **modality change** — a compact, low-order
+/// latent state observed through a higher-order sensor, such as an
+/// emulator-RAM byte vector (rank 1) presented to the agent as a pixel image
+/// (rank 2 or 3).
+///
+/// `Observable` is the typed home for that rank-changing projection. It is a
+/// **standalone** trait (not a supertrait of [`State`]): a modality-changing
+/// environment's state implements [`State<SR>`](State) for its full
+/// representation *and* `Observable<OR>` for the projected observation, then
+/// builds its snapshots from [`project`](Observable::project) instead of
+/// [`observe`](State::observe). [`crate::environment::Environment`] already
+/// permits `R != SR` (its observation and state types are independent), so no
+/// change to the environment contract is required.
+///
+/// # Type Parameters
+///
+/// - `OR`: Tensor order (rank) of the projected observation. Named `OR` rather
+///   than `R` — as on the sibling [`HiddenState`]/[`LatentState`] seams — to
+///   make the state→observation rank decoupling explicit at every impl site
+///   (`impl Observable<2> for Ram`) and to distinguish it from the state order
+///   `SR`. This naming is deliberate; do not normalise it to `R`.
+///
+/// # Invariants
+///
+/// - **Total over valid states.** `project` is infallible: for any state the
+///   environment considers valid, it returns a well-formed observation. The
+///   output shape is the compile-time constant `Self::Observation::shape()`,
+///   and the projection performs no I/O, so there is no runtime failure mode.
+///   (A future emulator that can fail to read a framebuffer models that failure
+///   at the [`Environment::step`](crate::environment::Environment::step)
+///   boundary via [`EnvironmentError`](crate::environment::EnvironmentError),
+///   not here.)
+/// - **`OR` is independent of any `State<SR>` order** the type also implements;
+///   `OR == SR`, `OR < SR`, and `OR > SR` are all permitted.
+///
+/// # Examples
+///
+/// A compact rank-1 state projected into a rank-2 pixel observation:
+///
+/// ```
+/// use rlevo_core::base::Observation;
+/// use rlevo_core::state::Observable;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, Clone)]
+/// struct Ram {
+///     byte: u8,
+/// }
+///
+/// #[derive(Debug, Clone, Serialize, Deserialize)]
+/// struct Pixels([[u8; 2]; 2]);
+///
+/// impl Observation<2> for Pixels {
+///     fn shape() -> [usize; 2] {
+///         [2, 2]
+///     }
+/// }
+///
+/// impl Observable<2> for Ram {
+///     type Observation = Pixels;
+///
+///     fn project(&self) -> Pixels {
+///         let b = self.byte;
+///         Pixels([[b & 1, (b >> 1) & 1], [(b >> 2) & 1, (b >> 3) & 1]])
+///     }
+/// }
+///
+/// let obs = Ram { byte: 0b1011 }.project();
+/// assert_eq!(Pixels::shape(), [2, 2]);
+/// assert_eq!(<Pixels as Observation<2>>::RANK, 2);
+/// assert_eq!(obs.0, [[1, 1], [0, 1]]);
+/// ```
+pub trait Observable<const OR: usize> {
+    /// The observation produced by this projection, at tensor order `OR`.
+    type Observation: Observation<OR>;
+
+    /// Projects `self` into an observation whose order `OR` may differ from any
+    /// [`State<SR>`](State) order the type also implements.
+    ///
+    /// This is the rank-changing analogue of [`State::observe`]: where `observe`
+    /// reads out a same-order perception, `project` maps the state into a
+    /// possibly different-order observation modality. It is total over valid
+    /// states (see the trait [Invariants](Observable#invariants)).
+    fn project(&self) -> Self::Observation;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    /// A rank-2 pixel observation: a 2x2 grid of bits.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct MockRamObservation {
+        pixels: [[u8; 2]; 2],
+    }
+
+    impl Observation<2> for MockRamObservation {
+        fn shape() -> [usize; 2] {
+            [2, 2]
+        }
+    }
+
+    /// A trivial rank-1 observation: the raw RAM byte, fully observable.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct MockRamByte {
+        byte: u8,
+    }
+
+    impl Observation<1> for MockRamByte {
+        fn shape() -> [usize; 1] {
+            [1]
+        }
+    }
+
+    /// A compact rank-1 state (one byte of emulator RAM) that is observed two
+    /// ways: fully via [`State::observe`] (rank 1), and as a pixel image via
+    /// [`Observable::project`] (rank 2) — the modality change `OR != SR`.
+    #[derive(Debug, Clone)]
+    struct MockRamState {
+        byte: u8,
+    }
+
+    impl State<1> for MockRamState {
+        type Observation = MockRamByte;
+
+        fn shape() -> [usize; 1] {
+            [1]
+        }
+
+        fn observe(&self) -> Self::Observation {
+            MockRamByte { byte: self.byte }
+        }
+
+        fn is_valid(&self) -> bool {
+            true
+        }
+
+        fn numel(&self) -> usize {
+            1
+        }
+    }
+
+    impl Observable<2> for MockRamState {
+        type Observation = MockRamObservation;
+
+        fn project(&self) -> Self::Observation {
+            let b = self.byte;
+            MockRamObservation {
+                pixels: [[b & 1, (b >> 1) & 1], [(b >> 2) & 1, (b >> 3) & 1]],
+            }
+        }
+    }
+
+    /// The projected observation is a strictly higher tensor order than the
+    /// state — the whole point of the trait.
+    #[test]
+    fn test_observable_changes_tensor_order() {
+        assert_eq!(
+            <MockRamState as State<1>>::shape().len(),
+            1,
+            "state is rank 1"
+        );
+        assert_eq!(
+            <MockRamState as Observable<2>>::Observation::RANK,
+            2,
+            "projected observation is rank 2"
+        );
+        assert_ne!(
+            <MockRamState as State<1>>::shape().len(),
+            <MockRamState as Observable<2>>::Observation::shape().len(),
+            "modality change: observation order differs from state order"
+        );
+    }
+
+    /// `observe()` and `project()` coexist on one type and produce different
+    /// modalities from the same state.
+    #[test]
+    fn test_observable_coexists_with_observe() {
+        let state = MockRamState { byte: 0b1011 };
+
+        let full: MockRamByte = state.observe();
+        assert_eq!(full, MockRamByte { byte: 0b1011 }, "observe is identity here");
+
+        let pixels = state.project();
+        assert_eq!(
+            pixels.pixels,
+            [[1, 1], [0, 1]],
+            "project unpacks the byte into a 2x2 pixel grid"
+        );
+    }
+
+    /// The projected observation's declared shape matches its rank-2 contents.
+    #[test]
+    fn test_observable_projection_shape() {
+        assert_eq!(
+            MockRamObservation::shape(),
+            [2, 2],
+            "projected observation has shape [2, 2]"
+        );
+        let pixels = MockRamState { byte: 0 }.project();
+        assert_eq!(pixels.pixels.len(), 2, "outer axis matches shape[0]");
+        assert_eq!(pixels.pixels[0].len(), 2, "inner axis matches shape[1]");
     }
 }

--- a/crates/rlevo/tests/observable_modality_change.rs
+++ b/crates/rlevo/tests/observable_modality_change.rs
@@ -1,0 +1,217 @@
+//! Cross-crate proof that an [`Environment`] can expose an observation whose
+//! tensor order differs from its state's order (`R != SR`), driven by the
+//! [`Observable`] projection trait (issue #62, ADR 0019).
+//!
+//! The environment holds a compact rank-1 `MockRamState` and builds every
+//! snapshot from `state.project()` — the rank-2 pixel projection — rather than
+//! `state.observe()`. This is the modality-changing POMDP shape (RAM behind
+//! pixels) that `State::observe()` structurally cannot express. The whole point
+//! is that this compiles and round-trips end-to-end with **no** change to the
+//! `Environment`/`Snapshot` contract.
+
+use rlevo_core::base::{Action, Observation, State};
+use rlevo_core::environment::{
+    Environment, EnvironmentError, EpisodeStatus, Snapshot, SnapshotBase,
+};
+use rlevo_core::reward::ScalarReward;
+use rlevo_core::state::Observable;
+
+use serde::{Deserialize, Serialize};
+
+/// Rank-2 pixel observation: a 2x2 grid of bits (the projected modality).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct MockRamObservation {
+    pixels: [[u8; 2]; 2],
+}
+
+impl Observation<2> for MockRamObservation {
+    fn shape() -> [usize; 2] {
+        [2, 2]
+    }
+}
+
+/// Rank-1 "full" observation: the raw RAM byte. Required because `State<1>`
+/// pins its own `observe()` output to rank 1; the modality change lives on the
+/// separate `Observable<2>` impl.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct MockRamByte {
+    byte: u8,
+}
+
+impl Observation<1> for MockRamByte {
+    fn shape() -> [usize; 1] {
+        [1]
+    }
+}
+
+/// Compact rank-1 state: one byte of emulator RAM.
+#[derive(Debug, Clone)]
+struct MockRamState {
+    byte: u8,
+}
+
+impl State<1> for MockRamState {
+    type Observation = MockRamByte;
+
+    fn shape() -> [usize; 1] {
+        [1]
+    }
+
+    fn observe(&self) -> Self::Observation {
+        MockRamByte { byte: self.byte }
+    }
+
+    fn is_valid(&self) -> bool {
+        true
+    }
+
+    fn numel(&self) -> usize {
+        1
+    }
+}
+
+impl Observable<2> for MockRamState {
+    type Observation = MockRamObservation;
+
+    fn project(&self) -> Self::Observation {
+        let b = self.byte;
+        MockRamObservation {
+            pixels: [[b & 1, (b >> 1) & 1], [(b >> 2) & 1, (b >> 3) & 1]],
+        }
+    }
+}
+
+/// Minimal rank-1 action: increment or decrement the RAM byte. Core ships only
+/// the `Action`/`DiscreteAction` *traits*, so a concrete action mock is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MockAction {
+    Inc,
+    Dec,
+}
+
+impl Action<1> for MockAction {
+    fn shape() -> [usize; 1] {
+        [1]
+    }
+
+    fn is_valid(&self) -> bool {
+        true
+    }
+}
+
+/// A modality-changing environment: rank-1 state, rank-2 observation, rank-1
+/// action — i.e. `Environment<2, 1, 1>`, with `R(2) != SR(1)`.
+#[derive(Debug)]
+struct ModalityEnv {
+    state: MockRamState,
+    steps: usize,
+}
+
+impl ModalityEnv {
+    fn new() -> Self {
+        Self {
+            state: MockRamState { byte: 0 },
+            steps: 0,
+        }
+    }
+}
+
+impl Environment<2, 1, 1> for ModalityEnv {
+    type StateType = MockRamState;
+    type ObservationType = MockRamObservation;
+    type ActionType = MockAction;
+    type RewardType = ScalarReward;
+    type SnapshotType = SnapshotBase<2, MockRamObservation, ScalarReward>;
+
+    fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.state = MockRamState { byte: 0b0000 };
+        self.steps = 0;
+        // Build the snapshot from the rank-2 projection, NOT `observe()`.
+        Ok(SnapshotBase::running(self.state.project(), ScalarReward(0.0)))
+    }
+
+    fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.state.byte = match action {
+            MockAction::Inc => self.state.byte.wrapping_add(1),
+            MockAction::Dec => self.state.byte.wrapping_sub(1),
+        };
+        self.steps += 1;
+
+        let obs = self.state.project();
+        let reward = ScalarReward(1.0);
+        let snap = if self.steps >= 4 {
+            SnapshotBase::terminated(obs, reward)
+        } else {
+            SnapshotBase::running(obs, reward)
+        };
+        Ok(snap)
+    }
+}
+
+/// The environment's observation is rank 2 while its state is rank 1 — the
+/// modality change is visible through the snapshot the agent receives.
+#[test]
+fn test_modality_env_reset_yields_rank2_observation() {
+    let mut env = ModalityEnv::new();
+    let snap = env.reset().expect("reset succeeds");
+
+    assert_eq!(snap.status(), EpisodeStatus::Running, "reset is Running");
+    assert_eq!(
+        MockRamObservation::shape(),
+        [2, 2],
+        "observation is rank 2, shape [2, 2]"
+    );
+    assert_eq!(
+        <MockRamState as State<1>>::shape(),
+        [1],
+        "underlying state is rank 1"
+    );
+    assert_eq!(
+        snap.observation().pixels,
+        [[0, 0], [0, 0]],
+        "byte 0 projects to an all-zero pixel grid"
+    );
+}
+
+/// A full reset -> step loop round-trips through `project()` and terminates,
+/// proving `R != SR` works end-to-end against the unchanged `Environment` API.
+#[test]
+fn test_modality_env_step_loop_terminates() {
+    let mut env = ModalityEnv::new();
+    env.reset().expect("reset succeeds");
+
+    // Four increments: byte 0 -> 1 -> 2 -> 3 -> 4.
+    let mut last = None;
+    for _ in 0..4 {
+        last = Some(env.step(MockAction::Inc).expect("step succeeds"));
+    }
+    let snap = last.expect("at least one step ran");
+
+    assert!(snap.is_done(), "episode terminates after 4 steps");
+    assert_eq!(snap.status(), EpisodeStatus::Terminated, "intrinsic termination");
+    assert_eq!(
+        snap.observation().pixels,
+        // byte == 4 == 0b0100 -> bit2 set
+        [[0, 0], [1, 0]],
+        "byte 4 projects to bit-2 set in the 2x2 grid"
+    );
+    let reward: f32 = (*snap.reward()).into();
+    assert!((reward - 1.0).abs() < 1e-6, "terminal step reward is 1.0");
+}
+
+/// A `Dec` from byte 0 wraps to 255, projecting to an all-ones pixel grid —
+/// exercises the decrement action and confirms the projection sees the wrap.
+#[test]
+fn test_modality_env_decrement_wraps() {
+    let mut env = ModalityEnv::new();
+    env.reset().expect("reset succeeds");
+
+    let snap = env.step(MockAction::Dec).expect("step succeeds");
+
+    assert_eq!(
+        snap.observation().pixels,
+        // byte 0 -> wrapping_sub(1) -> 255 == 0b11111111 -> low 4 bits all set
+        [[1, 1], [1, 1]],
+        "decrement wraps to 255, all low-nibble pixels set"
+    );
+}

--- a/docs/user-book/src/SUMMARY.md
+++ b/docs/user-book/src/SUMMARY.md
@@ -37,5 +37,6 @@
 - [Hybrid Algorithms](appendix-c-hybrid-algorithms/index.md)
 - [Supplementary Material](appendix-d-suppl/index.md)
   - [Fitness Landscapes](appendix-d-suppl/fitness-landscape.md)
+  - [Tensor Rank vs. Matrix Rank vs. Dimensionality](appendix-d-suppl/tensor-rank-vs-matrix-rank.md)
 - [Notation](notation.md)
 - [Bibliography](bibliography.md)

--- a/docs/user-book/src/appendix-d-suppl/tensor-rank-vs-matrix-rank.md
+++ b/docs/user-book/src/appendix-d-suppl/tensor-rank-vs-matrix-rank.md
@@ -1,0 +1,138 @@
+# Tensor Rank vs. Matrix Rank vs. Dimensionality
+
+The word **rank** is overloaded. In `rlevo` it appears as the const generic on
+`State<R>`, `Observation<R>`, and `Action<AR>` — and it means something very
+specific there. But the same word means something *different* in linear algebra,
+and something different again in everyday "how big is this space?" talk. Three of
+those senses collide precisely in the discussion of partially-observable
+environments ([issue #62](https://github.com/anthonytorlucci/rlevo/issues/62)),
+where it is easy to conclude that an observation space has a "lower rank" than its
+state space and reach for the wrong tool. This page pulls the three senses apart.
+
+## Three senses of "rank"
+
+### 1. Tensor order (ndim) — the one `rlevo` tracks
+
+The `const R` in `State<R>` / `Observation<R>` is the **number of axes** a tensor
+has — what NumPy calls `ndim` and Burn writes as the `R` in `Tensor<B, R>`. It is
+the count of indices you need to address a single element, *not* the size of any
+axis:
+
+- a scalar is order $0$;
+- a flat vector $v \in \mathbb{R}^{n}$ is order $1$ — one index, $v[i]$;
+- a matrix / greyscale image $M \in \mathbb{R}^{h \times w}$ is order $2$ — two
+  indices, $M[i][j]$;
+- an RGB image is order $3$ — $\text{img}[c][i][j]$.
+
+Crucially, the *size* of each axis is irrelevant to the order. A length-$1000$
+vector and a length-$2$ vector are **both order 1**. This is the only "rank" the
+type system reasons about: it stops you from feeding a rank-2 observation where a
+rank-1 one is expected, but it says nothing about how many values live along each
+axis. (See also the [tensor conventions](index.md#tensor-conventions-in-rlevo)
+note.)
+
+### 2. Matrix rank — a property of the *values*, invisible to the types
+
+In linear algebra, the **rank** of a matrix $A \in \mathbb{R}^{m \times n}$ is the
+dimension of its column space — the number of linearly independent columns,
+$\operatorname{rank}(A) \le \min(m, n)$. This is a fact about the *numbers inside*
+the matrix, not about its shape. The matrix
+
+```math
+A = \begin{bmatrix} 1 & 2 \\ 2 & 4 \end{bmatrix}
+```
+
+is order-2 and shape $2 \times 2$, yet has **matrix rank 1** (the second column is
+twice the first). A linear map $y = Ax$ with $\operatorname{rank}(A) = r$ collapses
+its input onto an $r$-dimensional subspace, losing information along the null
+space. The type system cannot see this at all: $A$ is just a `Tensor<B, 2>`
+whatever its column space looks like.
+
+### 3. Cardinality / dimensionality — the size of an axis
+
+The third sense is the everyday one: "how big is the space?" — the number of values
+an axis (or the whole space) can take. In `rlevo` this is the content of
+`shape()`: a rank-1 observation with `shape() == [16]` has $16$ slots along its
+single axis. Critically, **`Observation::shape()` is independent of
+`State::shape()`** — a rank-1 state of shape $[n]$ can already produce a rank-1
+observation of shape $[m]$ with $m < n$. Shrinking an axis is a *dimensionality*
+reduction at **constant tensor order**.
+
+### Side by side
+
+| Sense | Means | A property of… | Where it lives in `rlevo` |
+| --- | --- | --- | --- |
+| **Tensor order (ndim)** | number of axes / indices | the container's shape | the `const R`/`SR`/`AR` on `State`/`Observation`/`Action` — the **only** "rank" the types track |
+| **Matrix rank** | dimension of a linear map's column space | the *values* of a matrix | nowhere in the types; a numerical fact about a `Tensor<B, 2>` |
+| **Cardinality / dimensionality** | size of an axis (count of values) | the container's shape | `shape()` entries (and `numel()`) — independent between state and observation |
+
+A clean way to keep them straight: **tensor order** counts the axes,
+**dimensionality** counts the values *along* an axis, and **matrix rank** counts
+the independent directions *inside* the numbers. Reducing one says nothing about
+the others.
+
+## Why this matters for partial observability
+
+A POMDP is defined by an *information* deficit: the observation does not pin down
+the state. Newcomers often translate "the observation carries less information" into
+"the observation has lower rank" — but which rank? Almost always the reduction is in
+**dimensionality** (a smaller axis) or in **matrix rank** (a lossy linear/stochastic
+projection), both at **constant tensor order**. Genuinely changing the *tensor
+order* — the `const R` — is a much rarer thing, and it has a different name:
+a **modality change**.
+
+The canonical POMDP benchmarks make the distinction concrete. Reading the "rank"
+column carefully shows that nearly all of them keep the tensor order fixed:
+
+| Example | State (order / shape) | Obs (order / shape) | Reduction mechanism | Tensor-order change? |
+| --- | --- | --- | --- | --- |
+| **Tiger** | 1 / $[2]$ | 1 / $[2]$ | stochastic aliasing (noisy emission) | no |
+| **PO grid world** | 1 / $[N\cdot M]$ | 1 / $[16]$ | combinatorial compression (local percept) | no |
+| **RockSample** | 1 / $[\text{pos}\cdot 2^k]$ | 1 / $[3]$ | exponential collapse + distance-decayed sensor | no |
+| **LQG** | 1 / $[n]$ | 1 / $[m]$, $m<n$ | **matrix**-rank-$m$ linear projection $y = Cx + \varepsilon$ | **no** |
+| **Contact manipulation** | 1 / $[n]$ | 1 / $[m]$, $m\ll n$ | nonlinear proprioceptive projection $y = h(x)+\varepsilon$ | no |
+| **Atari** | 1 / $[\text{ram}]$ | **2–3** / $[H, W, C]$ | **modality** change (RAM → pixels) | **yes** |
+
+The instructive trap is **LQG** — the example most often cited as the "cleanest"
+statement of a rank-deficient observation. Its emission matrix $C \in
+\mathbb{R}^{m \times n}$ with $m < n$ genuinely *is* rank-deficient — but that is
+**matrix rank**. Both $x \in \mathbb{R}^{n}$ and $y \in \mathbb{R}^{m}$ are
+**order-1 tensors**; the Kalman filter and the separation principle live entirely
+in that constant-order, dimensionality-reducing regime. Nothing about LQG changes
+`ndim`.
+
+Only the last row — **Atari**, a compact emulator-RAM state (order 1) observed as a
+pixel image (order 2 or 3) — actually changes the tensor order. That, and only
+that, is a case the const generics must be allowed to differ for.
+
+## How `rlevo` handles each case
+
+The three senses map onto three different mechanisms:
+
+- **Dimensionality / stochastic reduction** (Tiger, grid worlds, RockSample, LQG,
+  contact manipulation) is handled by **`State::observe()`** returning a
+  smaller-`shape`, same-order observation. Because `Observation::shape()` is
+  independent of `State::shape()`, no special machinery is needed — this is the
+  flavour of partial observability `rlevo` models directly, and `R == SR` still
+  holds.
+- **Matrix-rank reduction** is just a *kind* of dimensionality/information loss; it
+  too is expressed inside `observe()` (or inside a learned encoder). It never forces
+  a tensor-order change.
+- **Modality change** (Atari) is the one case `observe()` cannot express, because
+  `State<SR>` welds its observation to the state's *own* order
+  (`type Observation: Observation<SR>`). That is exactly what the
+  [`Observable<OR>`](https://docs.rs/rlevo-core/latest/rlevo_core/state/trait.Observable.html)
+  projection trait is for: it lets a state `project()` into an observation of a
+  *different* tensor order $OR \neq SR$. The
+  [Environments chapter](../part-1-foundations/34-environment.md) walks through how
+  an environment wires this up.
+
+The one-line takeaway: **partial observability is almost always a dimensionality or
+matrix-rank reduction at constant tensor order — handled by `observe()`. Only a
+modality change alters the tensor order, and that is the niche `Observable<OR>`
+exists to fill.**
+
+---
+
+*Co-Authored-By: Anthropic Claude Opus 4.8*\
+*Reviewed-By: (Human) Anthony Torlucci*

--- a/docs/user-book/src/part-1-foundations/34-environment.md
+++ b/docs/user-book/src/part-1-foundations/34-environment.md
@@ -68,17 +68,23 @@ equality — it never binds `ObservationType = StateType::Observation`. Those ar
 independent associated types, which leaves a deliberate seam: a *modality-changing*
 POMDP, where the observation is a different rank from the state. The textbook
 case is Atari — a low-rank emulator-RAM state behind a rank-2 pixel observation.
-Expressing that in `rlevo` means declaring an `ObservationType` unrelated to the
-state's and projecting the state into it *inside `step`/`reset`*, deliberately
-routing around `State::observe()` (which the `State` trait would otherwise pin to
-the state's rank). No environment does this today, but the separate `R`/`SR`
-parameters are what make it reachable.
+`State::observe()` cannot express that, because the `State` trait pins its
+observation to the state's *own* rank.
 
-There is a mild design tension here, captured in
-[issue #62](https://github.com/anthonytorlucci/rlevo/issues/62): `State` *couples*
-observation rank to state rank, while `Environment` *leaves them independent*. For
-now, the practical rule is simple — **`R == SR` for any environment that observes
-via `State::observe()`, which is all of them.** The parameter that genuinely
+That is exactly what the [`Observable`](https://docs.rs/rlevo-core/latest/rlevo_core/state/trait.Observable.html)
+trait is for. `Observable<OR>` is a standalone projection trait
+(`fn project(&self) -> Self::Observation`, where `Self::Observation: Observation<OR>`)
+that lets a state map into an observation of a *different* rank `OR`. A
+modality-changing environment's state implements `State<SR>` for its full
+representation **and** `Observable<OR>` for the projected modality, then builds its
+snapshots from `state.project()` instead of `state.observe()`. Because `Environment`
+already permits `R != SR`, no change to the environment contract is needed — this is
+the typed home for the rank change, resolving
+[issue #62](https://github.com/anthonytorlucci/rlevo/issues/62).
+
+So the practical rule is precise: **`R == SR` for any environment that observes via
+`State::observe()` (all of them today); an environment that observes via
+`Observable::project()` may have `R != SR`.** The other parameter that genuinely
 varies is **`AR`**: in `Environment<3, 3, 1>` the state and observation are rank-3
 while the action is a single rank-1 discrete choice.
 
@@ -282,8 +288,9 @@ the crate as a vocabulary anchor more than a workhorse.
   (state, observation, action, reward, snapshot) welded into a consistent unit,
   plus `reset` and `step`.
 - `R == SR` for every environment that observes via `State::observe()` (all of
-  them); `AR` is the rank that genuinely varies. The separate `R`/`SR`
-  parameters leave room for modality-changing POMDPs ([issue #62](https://github.com/anthonytorlucci/rlevo/issues/62)),
+  them today); `AR` is the rank that genuinely varies. A modality-changing POMDP
+  can break that equality by observing through `Observable::project()` instead —
+  the typed home for a state→observation rank change ([issue #62](https://github.com/anthonytorlucci/rlevo/issues/62)) —
   and the `SnapshotType` bound forces the noun-set to agree.
 - `reset`/`step` return `Result<Snapshot, EnvironmentError>` — fallibility is
   part of the contract.


### PR DESCRIPTION
## Summary

Adds a standalone `Observable<OR>` trait to `rlevo-core::state` that gives
environments a typed home for **modality-changing** partial observability —
where the observation tensor order (`OR`) differs from the state tensor order
(`SR`). The canonical example is an Atari-style agent whose state is a compact
rank-1 RAM byte vector but whose agent perception is a rank-2 (or rank-3)
pixel grid. `State::observe()` is rank-locked to `SR`, so it structurally
cannot express this; `Observable<OR>` fills that gap. The trait is standalone
(not a supertrait of `State`), infallible, and requires zero changes to the
`Environment`/`Snapshot` contract. ADR 0019 documents the design rationale.

## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — purely additive new trait in `rlevo-core::state`; no existing API changed.

## Linked Issue

Closes #62

## What Was Changed

- `crates/rlevo-core/src/state.rs` — added `Observable<OR>` trait with full
  doc block (rationale, invariants, worked example), and an in-module unit test
  suite covering the rank-changing round-trip, `OR > SR`, `OR < SR`, and the
  identity case.
- `crates/rlevo-core/src/lib.rs` — registered `Observable` in the crate-level
  module table and `pub mod state` doc block.
- `crates/rlevo/tests/observable_modality_change.rs` — new cross-crate
  integration test proving that a complete `Environment` built on
  `state.project()` compiles and round-trips end-to-end with no `Environment`
  contract change.
- `docs/user-book/src/part-1-foundations/34-environment.md` — updated the
  POMDP observation section to mention `Observable` and the modality-change use
  case.
- `docs/user-book/src/appendix-d-suppl/tensor-rank-vs-matrix-rank.md` — new
  supplementary appendix explaining tensor rank vs. matrix rank, included in
  `SUMMARY.md`.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable
- Burn backend tested: ndarray (CPU)
- OS: macOS 15 (Darwin 25.5.0)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Sonnet 4.6 (Claude Code). Scope: trait definition, doc comments, test scaffolding, and ADR 0019 text. All code reviewed and accepted by the author.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fix — not applicable.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

`Observable` is **not** needed for information-reducing POMDPs (Tiger,
RockSample, LQG, contact-manipulation) that reduce cardinality or matrix rank
at constant tensor order — those continue to use `State::observe()`. Only
Atari-style modality changes (RAM→pixels) require `Observable`. This is
documented in ADR 0019.
