### PR TITLE
fix(evolution,environments): NaN-safe total_cmp everywhere

### DIFF
--- a/crates/rlevo-benchmarks-report-client/src/charts.rs
+++ b/crates/rlevo-benchmarks-report-client/src/charts.rs
@@ -225,7 +225,7 @@ pub fn convergence_panel_view(records: &[EpisodeRecord], _family: EnvFamily) -> 
         // `interactive_line_view`'s hover lookup (nearest_by_x) requires x-sorted
         // input. Step counters are monotone in practice, but sort here so the
         // contract holds regardless of emission order.
-        raw_full.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        raw_full.sort_by(|a, b| a.0.total_cmp(&b.0));
         let dec_xy: Vec<(f64, f64)> =
             decimated.iter().map(|&(x, y)| (f64::from(x), y)).collect();
         let title = title_for(&name).to_string();

--- a/crates/rlevo-benchmarks-report-client/src/series.rs
+++ b/crates/rlevo-benchmarks-report-client/src/series.rs
@@ -308,7 +308,7 @@ pub fn low_diversity_threshold(diversity: &[(u32, f64)]) -> Option<f64> {
     if firsts.is_empty() {
         return None;
     }
-    firsts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    firsts.sort_by(f64::total_cmp);
     Some(quantile(&firsts, 0.05))
 }
 
@@ -525,7 +525,7 @@ pub fn population_box_data(samples: &[PopulationSample]) -> Vec<BoxStats> {
 /// the raw min/max so the box still renders.
 fn box_stats_for(generation: u32, fitnesses: &[f32]) -> BoxStats {
     let mut sorted: Vec<f64> = fitnesses.iter().map(|f| f64::from(*f)).collect();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(f64::total_cmp);
     let q1 = quantile(&sorted, 0.25);
     let median = quantile(&sorted, 0.5);
     let q3 = quantile(&sorted, 0.75);
@@ -611,7 +611,11 @@ pub fn diversity_series(samples: &[PopulationSample]) -> Vec<(u32, f64)> {
 
 /// Selection-pressure indicator: `best / median` per generation. Skips
 /// generations whose median is zero (degenerate, all-zero fitness) and
-/// generations with empty fitness vectors.
+/// generations with no finite fitness values.
+///
+/// Non-finite fitnesses (`NaN`, `±inf`) are dropped before ordering: a positive
+/// `NaN` sorts as the maximum under `total_cmp` and would otherwise be reported
+/// as the "best" value under [`ObjectiveSense::Maximize`].
 ///
 /// `sense` orients which end of the sorted fitness vector counts as "best":
 /// for [`ObjectiveSense::Maximize`] the best is the largest value, for
@@ -625,12 +629,16 @@ pub fn selection_pressure_series(
     samples
         .iter()
         .filter_map(|s| {
-            if s.fitnesses.is_empty() {
+            let mut sorted: Vec<f64> = s
+                .fitnesses
+                .iter()
+                .map(|f| f64::from(*f))
+                .filter(|v| v.is_finite())
+                .collect();
+            if sorted.is_empty() {
                 return None;
             }
-            let mut sorted: Vec<f64> = s.fitnesses.iter().map(|f| f64::from(*f)).collect();
-            sorted
-                .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            sorted.sort_by(f64::total_cmp);
             let median = quantile(&sorted, 0.5);
             if median.abs() < f64::EPSILON {
                 return None;
@@ -646,7 +654,11 @@ pub fn selection_pressure_series(
 
 /// `(best, median, worst)` overlay traces for the box-plot reference
 /// lines. One tuple of three series, all sharing the same x-axis
-/// (generation). Empty samples produce three empty vectors.
+/// (generation). Samples with no finite fitness produce no point.
+///
+/// Non-finite fitnesses (`NaN`, `±inf`) are dropped before ordering: a positive
+/// `NaN` sorts as the maximum under `total_cmp` and would otherwise be reported
+/// as the "best" value under [`ObjectiveSense::Maximize`].
 ///
 /// `sense` orients which end of the sorted fitness vector is "best": for
 /// [`ObjectiveSense::Maximize`] best is the largest value and worst the
@@ -661,11 +673,16 @@ pub fn fitness_range_series(
     let mut median = Vec::new();
     let mut worst = Vec::new();
     for s in samples {
-        if s.fitnesses.is_empty() {
+        let mut sorted: Vec<f64> = s
+            .fitnesses
+            .iter()
+            .map(|f| f64::from(*f))
+            .filter(|v| v.is_finite())
+            .collect();
+        if sorted.is_empty() {
             continue;
         }
-        let mut sorted: Vec<f64> = s.fitnesses.iter().map(|f| f64::from(*f)).collect();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.sort_by(f64::total_cmp);
         let lo = sorted[0];
         let hi = *sorted.last().unwrap_or(&0.0);
         let (best_v, worst_v) = match sense {
@@ -1326,5 +1343,45 @@ mod tests {
         assert!(best.is_empty());
         assert!(median.is_empty());
         assert!(worst.is_empty());
+    }
+
+    #[test]
+    fn selection_pressure_drops_nan_from_best() {
+        // A positive NaN sorts as the maximum under `total_cmp`; without the
+        // finite filter it would be reported as the Maximize "best", yielding a
+        // NaN ratio. The filter drops it so best = 3.0, median = 2.0 → 1.5.
+        let samples = vec![pop_sample(0, vec![1.0, 2.0, 3.0, f32::NAN], None)];
+        let out = selection_pressure_series(&samples, ObjectiveSense::Maximize);
+        assert_eq!(out, vec![(0, 1.5)]);
+        assert!(out[0].1.is_finite());
+    }
+
+    #[test]
+    fn selection_pressure_skips_all_nan_generation() {
+        let samples = vec![pop_sample(0, vec![f32::NAN, f32::NAN], None)];
+        assert!(selection_pressure_series(&samples, ObjectiveSense::Maximize).is_empty());
+    }
+
+    #[test]
+    fn fitness_range_drops_nan_from_best_and_worst() {
+        // NaN must never surface as best (Maximize) or worst; the finite values
+        // are 1.0..=3.0 so best = 3.0, worst = 1.0, median = 2.0.
+        let samples = vec![pop_sample(0, vec![1.0, 2.0, 3.0, f32::NAN], None)];
+        let (best, median, worst) = fitness_range_series(&samples, ObjectiveSense::Maximize);
+        assert_eq!(best, vec![(0, 3.0)]);
+        assert_eq!(median, vec![(0, 2.0)]);
+        assert_eq!(worst, vec![(0, 1.0)]);
+        assert!(best[0].1.is_finite() && worst[0].1.is_finite());
+    }
+
+    #[test]
+    fn fitness_range_skips_all_nan_generation() {
+        let samples = vec![
+            pop_sample(0, vec![f32::NAN, f32::INFINITY], None),
+            pop_sample(1, vec![1.0, 2.0, 3.0], None),
+        ];
+        let (best, _, _) = fitness_range_series(&samples, ObjectiveSense::Maximize);
+        // Only the finite generation 1 produces a point.
+        assert_eq!(best, vec![(1, 3.0)]);
     }
 }

--- a/crates/rlevo-benchmarks/src/metrics/core.rs
+++ b/crates/rlevo-benchmarks/src/metrics/core.rs
@@ -85,7 +85,7 @@ pub fn median(xs: &[f64]) -> f64 {
         return 0.0;
     }
     let mut sorted: Vec<f64> = xs.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(f64::total_cmp);
     let n = sorted.len();
     if n.is_multiple_of(2) {
         f64::midpoint(sorted[n / 2 - 1], sorted[n / 2])

--- a/crates/rlevo-environments/src/classic/acrobot.rs
+++ b/crates/rlevo-environments/src/classic/acrobot.rs
@@ -830,12 +830,7 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for AcrobotActio
             .map_err(|e| TensorConversionError {
                 message: e.to_string(),
             })?;
-        let idx = v
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+        let idx = crate::tensor_decode::argmax(&v);
         Ok(Self::from_index(idx))
     }
 }
@@ -924,6 +919,19 @@ mod tests {
         assert_eq!(AcrobotAction::ACTION_COUNT, 3);
         assert_eq!(AcrobotAction::from_index(0), AcrobotAction::TorqueNeg);
         assert_eq!(AcrobotAction::from_index(2), AcrobotAction::TorquePos);
+    }
+
+    #[test]
+    fn action_from_tensor_is_nan_safe() {
+        use burn::tensor::{Tensor, TensorData as TD};
+        type TestBackend = burn::backend::Flex;
+        let device = Default::default();
+        // An all-NaN logit vector must not panic; falls back to index 0.
+        let data = TD::new(vec![f32::NAN, f32::NAN, f32::NAN], [3]);
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+        let back = <AcrobotAction as TensorConvertible<1, TestBackend>>::from_tensor(tensor)
+            .expect("all-NaN decodes to fallback");
+        assert_eq!(back, AcrobotAction::from_index(0));
     }
 
     #[test]

--- a/crates/rlevo-environments/src/classic/cartpole.rs
+++ b/crates/rlevo-environments/src/classic/cartpole.rs
@@ -803,12 +803,7 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for CartPoleActi
             .map_err(|e| TensorConversionError {
                 message: e.to_string(),
             })?;
-        let idx = v
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+        let idx = crate::tensor_decode::argmax(&v);
         Ok(Self::from_index(idx))
     }
 }
@@ -898,6 +893,19 @@ mod tests {
         assert_eq!(CartPoleAction::from_index(1), CartPoleAction::Right);
         assert_eq!(CartPoleAction::Left.to_index(), 0);
         assert_eq!(CartPoleAction::Right.to_index(), 1);
+    }
+
+    #[test]
+    fn action_from_tensor_is_nan_safe() {
+        use burn::tensor::{Tensor, TensorData as TD};
+        type TestBackend = burn::backend::Flex;
+        let device = Default::default();
+        // An all-NaN logit vector must not panic; falls back to index 0.
+        let data = TD::new(vec![f32::NAN, f32::NAN], [2]);
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+        let back = <CartPoleAction as TensorConvertible<1, TestBackend>>::from_tensor(tensor)
+            .expect("all-NaN decodes to fallback");
+        assert_eq!(back, CartPoleAction::from_index(0));
     }
 
     #[test]

--- a/crates/rlevo-environments/src/classic/mountain_car.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car.rs
@@ -518,12 +518,7 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for MountainCarA
             .map_err(|e| TensorConversionError {
                 message: e.to_string(),
             })?;
-        let idx = v
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+        let idx = crate::tensor_decode::argmax(&v);
         Ok(Self::from_index(idx))
     }
 }
@@ -584,6 +579,19 @@ mod tests {
         assert_eq!(MountainCarAction::ACTION_COUNT, 3);
         assert_eq!(MountainCarAction::from_index(0), MountainCarAction::Left);
         assert_eq!(MountainCarAction::from_index(2), MountainCarAction::Right);
+    }
+
+    #[test]
+    fn action_from_tensor_is_nan_safe() {
+        use burn::tensor::{Tensor, TensorData as TD};
+        type TestBackend = burn::backend::Flex;
+        let device = Default::default();
+        // An all-NaN logit vector must not panic; falls back to index 0.
+        let data = TD::new(vec![f32::NAN, f32::NAN, f32::NAN], [3]);
+        let tensor = Tensor::<TestBackend, 1>::from_data(data, &device);
+        let back = <MountainCarAction as TensorConvertible<1, TestBackend>>::from_tensor(tensor)
+            .expect("all-NaN decodes to fallback");
+        assert_eq!(back, MountainCarAction::from_index(0));
     }
 
     #[test]

--- a/crates/rlevo-environments/src/lib.rs
+++ b/crates/rlevo-environments/src/lib.rs
@@ -91,5 +91,8 @@ pub mod grids;
 pub mod locomotion;
 pub mod pixel_grid;
 pub mod render;
+/// Shared helpers for decoding tensors back into discrete environment types
+/// (e.g. `NaN`-safe argmax for action `from_tensor`).
+pub(crate) mod tensor_decode;
 pub mod toy_text;
 pub mod wrappers;

--- a/crates/rlevo-environments/src/tensor_decode.rs
+++ b/crates/rlevo-environments/src/tensor_decode.rs
@@ -1,0 +1,63 @@
+//! Shared helpers for decoding tensors back into discrete environment types.
+//!
+//! Action `from_tensor` implementations decode a one-hot (or logit) vector into
+//! a discrete action index by taking the argmax. Doing so with
+//! `partial_cmp(..).unwrap()` panics the moment any element is `NaN` (e.g. a
+//! diverged policy emitting non-finite logits). [`argmax`] instead uses a
+//! `NaN`-safe fold, matching the crate-wide `total_cmp`/`NaN`-safe comparison
+//! convention (see `docs/rules.md`).
+
+/// Returns the index of the largest element in `values`, `NaN`-safely.
+///
+/// Ties resolve to the **lowest** index. `NaN` elements never win: `NaN > x` is
+/// `false`, so the running best is only displaced by a strictly greater finite
+/// value. An all-`NaN` (or empty) slice therefore returns `0`, matching the
+/// historical `.map(..).unwrap_or(0)` fallback of the classic action decoders.
+///
+/// This is the discrete-action analog of the crate's `total_cmp` sort
+/// convention: it never panics on non-finite input.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(argmax(&[0.1, 0.9, 0.3]), 1);
+/// assert_eq!(argmax(&[f32::NAN, f32::NAN]), 0); // no panic
+/// assert_eq!(argmax(&[1.0, 1.0]), 0); // lowest index on ties
+/// ```
+pub(crate) fn argmax(values: &[f32]) -> usize {
+    values
+        .iter()
+        .enumerate()
+        .fold((0usize, f32::NEG_INFINITY), |best, (i, &x)| {
+            if x > best.1 { (i, x) } else { best }
+        })
+        .0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::argmax;
+
+    #[test]
+    fn argmax_picks_largest() {
+        assert_eq!(argmax(&[0.1, 0.9, 0.3]), 1);
+        assert_eq!(argmax(&[5.0, -2.0, 1.0]), 0);
+    }
+
+    #[test]
+    fn argmax_ties_resolve_to_lowest_index() {
+        assert_eq!(argmax(&[1.0, 1.0, 1.0]), 0);
+    }
+
+    #[test]
+    fn argmax_is_nan_safe() {
+        assert_eq!(argmax(&[f32::NAN, f32::NAN, f32::NAN]), 0);
+        // A finite value still beats surrounding NaNs.
+        assert_eq!(argmax(&[f32::NAN, 2.0, f32::NAN]), 1);
+    }
+
+    #[test]
+    fn argmax_empty_returns_zero() {
+        assert_eq!(argmax(&[]), 0);
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/cma_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cma_es.rs
@@ -417,11 +417,13 @@ where
         // feeds the engine `−cost`, so this descending canonical order
         // matches the `pycma` ascending-cost order point-for-point.
         let mut ranked: Vec<usize> = (0..lambda).collect();
-        ranked.sort_by(|&a, &b| {
-            fitness_host[b]
-                .partial_cmp(&fitness_host[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        // Sanitize NaN → −inf (worst) so it can never rank as best, then order
+        // by `total_cmp` (deterministic; sanitized NaN sorts last).
+        let sane: Vec<f32> = fitness_host
+            .iter()
+            .map(|&f| crate::fitness::sanitize_fitness(f))
+            .collect();
+        ranked.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
 
         let m_old: Vec<f32> = state.mean.clone();
         let sigma_old: f32 = state.sigma;

--- a/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
@@ -315,11 +315,13 @@ where
 
         // Rank descending (canonical maximise); take the μ best (highest).
         let mut ranked: Vec<usize> = (0..lambda).collect();
-        ranked.sort_by(|&a, &b| {
-            fitness_host[b]
-                .partial_cmp(&fitness_host[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        // Sanitize NaN → −inf (worst) so it can never rank as best, then order
+        // by `total_cmp` (deterministic; sanitized NaN sorts last).
+        let sane: Vec<f32> = fitness_host
+            .iter()
+            .map(|&f| crate::fitness::sanitize_fitness(f))
+            .collect();
+        ranked.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
 
         let m_old: Vec<f32> = state.mean.clone();
         #[allow(clippy::cast_precision_loss)]

--- a/crates/rlevo-evolution/src/algorithms/eda/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/mod.rs
@@ -268,7 +268,7 @@ impl<B: Backend, M: ProbabilityModel<B>> Strategy<B> for EdaStrategy<B, M> {
         let raw = fitness.into_data().into_vec::<f32>().unwrap_or_default();
         let sanitized: Vec<f32> = raw
             .iter()
-            .map(|&f| crate::local_search::sanitize_fitness(f))
+            .map(|&f| crate::fitness::sanitize_fitness(f))
             .collect();
         let n = sanitized.len();
         let device = population.device();

--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -355,14 +355,17 @@ where
             }
         }
 
-        // Sort by (win_count desc, fitness desc) and pick top μ.
+        // Sort by (win_count desc, fitness desc) and pick top μ. Sanitize the
+        // fitness tiebreak (NaN → −inf, worst) so a NaN can never rank as best.
         let mut indexed: Vec<usize> = (0..n).collect();
+        let sane: Vec<f32> = combined_fit
+            .iter()
+            .map(|&f| crate::fitness::sanitize_fitness(f))
+            .collect();
         indexed.sort_by(|&a, &b| {
-            win_counts[b].cmp(&win_counts[a]).then_with(|| {
-                combined_fit[b]
-                    .partial_cmp(&combined_fit[a])
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+            win_counts[b]
+                .cmp(&win_counts[a])
+                .then_with(|| sane[b].total_cmp(&sane[a]))
         });
         indexed.truncate(mu);
         #[allow(clippy::cast_possible_wrap)]

--- a/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
+++ b/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
@@ -451,10 +451,13 @@ where
         // (1+λ): parent survives only if NO offspring strictly beats it;
         // canonical CGP uses `>=` (under the maximise convention) to break
         // ties in favor of offspring (neutral mutations accumulate).
+        // Sanitize NaN → −inf (worst) so a NaN offspring can never be picked as
+        // best; the raw `best_off_fit >= parent` check below then rejects it.
         let best_off_idx = fitness_host
             .iter()
+            .map(|&f| crate::fitness::sanitize_fitness(f))
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
             .map_or(0, |(i, _)| i);
         let best_off_fit = fitness_host[best_off_idx];
         if best_off_fit >= state.parent_fitness {

--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -562,10 +562,15 @@ fn coverage_indices(policy: &CoveragePolicy, fitness: &[f32], pop_size: usize) -
         CoveragePolicy::TopK { k } => {
             let k: usize = k.min(pop_size);
             let mut ranked: Vec<usize> = (0..pop_size).collect();
-            // Stable sort by (fitness desc, index): `total_cmp` orders NaN
-            // deterministically, and `sort_by` is stable so equal fitnesses keep
-            // ascending-index order — making ties break by lower index.
-            ranked.sort_by(|&a, &b| fitness[b].total_cmp(&fitness[a]));
+            // Sanitize NaN → −inf (worst) so a NaN-fitness member can never be
+            // covered as a top-k member. Stable sort by (fitness desc, index):
+            // `sort_by` is stable so equal fitnesses keep ascending-index order,
+            // making ties break by lower index.
+            let sane: Vec<f32> = fitness
+                .iter()
+                .map(|&f| crate::fitness::sanitize_fitness(f))
+                .collect();
+            ranked.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
             ranked.truncate(k);
             ranked
         }
@@ -743,6 +748,21 @@ mod tests {
     #[test]
     fn coverage_policy_default_is_top_k_one() {
         assert_eq!(CoveragePolicy::default(), CoveragePolicy::TopK { k: 1 });
+    }
+
+    #[test]
+    fn coverage_indices_never_covers_nan_fitness() {
+        // NaN sanitises to −inf (worst), so a NaN-fitness member must never be
+        // selected as a top-k covered member ahead of a finite one.
+        let fitness = [3.0f32, f32::NAN, 5.0, 1.0];
+        let top3 = coverage_indices(&CoveragePolicy::TopK { k: 3 }, &fitness, 4);
+        // Best-first among finite fitnesses: 5.0 (idx 2), 3.0 (idx 0), 1.0 (idx 3);
+        // the NaN member (idx 1) is excluded.
+        assert_eq!(top3, vec![2, 0, 3]);
+        assert!(!top3.contains(&1));
+        // Covering all four ranks the NaN member last.
+        let all = coverage_indices(&CoveragePolicy::TopK { k: 4 }, &fitness, 4);
+        assert_eq!(all, vec![2, 0, 3, 1]);
     }
 
     // ---------------------------------------------------------------------

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -324,7 +324,12 @@ where
         if state.archive_fitness.is_empty() {
             // Sort archive by fitness, best (highest) first.
             let mut idx: Vec<usize> = (0..fitness_host.len()).collect();
-            idx.sort_by(|&a, &b| fitness_host[b].partial_cmp(&fitness_host[a]).unwrap());
+            // Sanitize NaN → −inf (worst) so it can never rank as best; descending.
+            let sane: Vec<f32> = fitness_host
+                .iter()
+                .map(|&f| crate::fitness::sanitize_fitness(f))
+                .collect();
+            idx.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
             #[allow(clippy::cast_possible_wrap)]
             let sorted_idx = Tensor::<B, 1, Int>::from_data(
                 TensorData::new(idx.iter().map(|&i| i as i64).collect::<Vec<_>>(), [k]),
@@ -351,7 +356,12 @@ where
         let mut combined_f: Vec<f32> = state.archive_fitness.clone();
         combined_f.extend_from_slice(&fitness_host);
         let mut idx: Vec<usize> = (0..combined_f.len()).collect();
-        idx.sort_by(|&a, &b| combined_f[b].partial_cmp(&combined_f[a]).unwrap());
+        // Sanitize NaN → −inf (worst) so it can never rank as best; descending.
+        let sane: Vec<f32> = combined_f
+            .iter()
+            .map(|&f| crate::fitness::sanitize_fitness(f))
+            .collect();
+        idx.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
         idx.truncate(k);
         #[allow(clippy::cast_possible_wrap)]
         let top_idx = Tensor::<B, 1, Int>::from_data(

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -338,8 +338,14 @@ where
         let n_abandon = (params.p_a * pop as f32) as usize;
         if n_abandon > 0 {
             let mut rank: Vec<usize> = (0..pop).collect();
-            // Ascending: lowest fitness (worst under maximise) first.
-            rank.sort_by(|&a, &b| state.fitness[a].partial_cmp(&state.fitness[b]).unwrap());
+            // Ascending: lowest fitness (worst under maximise) first. Sanitize
+            // NaN → −inf so a NaN-fitness nest is treated as worst (abandoned).
+            let sane: Vec<f32> = state
+                .fitness
+                .iter()
+                .map(|&f| crate::fitness::sanitize_fitness(f))
+                .collect();
+            rank.sort_by(|&a, &b| sane[a].total_cmp(&sane[b]));
             let worst: Vec<usize> = rank.into_iter().take(n_abandon).collect();
             let (lo, hi): (f32, f32) = params.bounds.into();
             // Host-sample abandoned-nest replacements from a deterministic

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
@@ -573,11 +573,13 @@ impl<B: Backend> ArchNasStrategy<B> {
         // Elitism: indices sorted by descending (better, canonical maximise)
         // fitness — highest first.
         let mut order: Vec<usize> = (0..pop).collect();
-        order.sort_by(|&a, &b| {
-            state.fitness[b]
-                .partial_cmp(&state.fitness[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        // Sanitize NaN → −inf (worst) so it can never rank as best; descending.
+        let sane: Vec<f32> = state
+            .fitness
+            .iter()
+            .map(|&f| crate::fitness::sanitize_fitness(f))
+            .collect();
+        order.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
         let elite_count = params.elite_count.min(pop);
         let tournament_size = params.tournament_size.max(1);
 

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/neat.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/neat.rs
@@ -347,11 +347,13 @@ impl<B: Backend> NeatStrategy<B> {
             &mut rep_rng,
         );
 
-        if let Some((idx, &best)) = state
+        // Sanitize NaN → −inf (worst) so a NaN fitness can never become best.
+        if let Some((idx, best)) = state
             .fitness
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, &f)| (i, crate::fitness::sanitize_fitness(f)))
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
             && best > state.best_fitness
         {
             state.best_fitness = best;
@@ -508,11 +510,13 @@ fn produce_offspring(
     }
     let sp = &ctx.species[species_idx];
     let mut members = sp.members.clone();
-    members.sort_by(|&a, &b| {
-        ctx.fitness[b]
-            .partial_cmp(&ctx.fitness[a])
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    // Sanitize NaN → −inf (worst) so it can never rank as best; descending.
+    let sane: Vec<f32> = ctx
+        .fitness
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .collect();
+    members.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
 
     let mut produced = 0usize;
     // Champion elitism: copy the best member unchanged (H5).

--- a/crates/rlevo-evolution/src/coevolution/hof.rs
+++ b/crates/rlevo-evolution/src/coevolution/hof.rs
@@ -18,6 +18,7 @@ use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
 use parking_lot::Mutex;
 
 use super::fitness::CoupledFitness;
+use crate::fitness::sanitize_fitness;
 
 /// Per-population archive of past champions, capped at a fixed capacity.
 ///
@@ -93,17 +94,21 @@ impl<B: Backend> HallOfFame<B> {
             if fit_host.is_empty() {
                 continue;
             }
+            // Sanitize NaN → −inf (worst) so a NaN-fitness member can never be
+            // crowned champion over a finite one; this also keeps `archive_fitness`
+            // NaN-free, which the eviction `min_by` below relies on.
+            let sane: Vec<f32> = fit_host.iter().map(|&f| sanitize_fitness(f)).collect();
             // Argmax (best, highest fitness — canonical maximise) — ties
             // resolve to the lowest index. Hand-rolled with a strict
             // `total_cmp == Greater` so equal-fitness ties keep the earliest
             // index (`Iterator::max_by` would instead keep the last).
             let mut best_idx = 0_usize;
-            for i in 1..fit_host.len() {
-                if fit_host[i].total_cmp(&fit_host[best_idx]) == std::cmp::Ordering::Greater {
+            for i in 1..sane.len() {
+                if sane[i].total_cmp(&sane[best_idx]) == std::cmp::Ordering::Greater {
                     best_idx = i;
                 }
             }
-            let best_f = fit_host[best_idx];
+            let best_f = sane[best_idx];
             let device = populations[p].device();
             // usize → i64 index tensor; population indices never approach i64::MAX.
             #[allow(clippy::cast_possible_wrap)]
@@ -119,6 +124,8 @@ impl<B: Backend> HallOfFame<B> {
 
             if self.archive_fitness[p].len() > self.capacity {
                 // Worst = lowest fitness under the maximise convention.
+                // `archive_fitness` is sanitised at push (no NaN), so a plain
+                // `total_cmp` correctly evicts the worst here.
                 // Over capacity => non-empty, so `min_by` is always `Some`.
                 let Some(worst_idx) = self.archive_fitness[p]
                     .iter()

--- a/crates/rlevo-evolution/src/fitness.rs
+++ b/crates/rlevo-evolution/src/fitness.rs
@@ -250,6 +250,30 @@ where
     }
 }
 
+/// Maps a `NaN` fitness to [`f32::NEG_INFINITY`], passing finite values through.
+///
+/// `−inf` is the worst value under the maximise convention, so a sanitized
+/// `NaN` can never seed or displace a finite best-so-far and thus never
+/// propagates to a returned fitness. This is the crate-wide fitness-hygiene
+/// primitive: it is applied by
+/// [`BudgetedEval::eval`](crate::local_search::BudgetedEval) (every probe,
+/// including the seeding eval), the searchers'
+/// [`refine_with_known_fitness`](crate::local_search::LocalSearch::refine_with_known_fitness)
+/// overrides (applied to the `known_fitness` hint, which does not flow through
+/// `BudgetedEval`), the EDA `tell` chokepoint
+/// ([`crate::algorithms::eda::EdaStrategy`]), and every NaN-safe fitness sort
+/// across the crate (selection, replacement, the ES/NEAT/ACO rankers) so a `NaN`
+/// can neither become the best-so-far nor corrupt an ordering. For the finite
+/// benchmark landscapes the searchers ship against this branch is never taken,
+/// so it costs only one `is_nan` check.
+pub(crate) fn sanitize_fitness(f: f32) -> f32 {
+    if f.is_nan() {
+        f32::NEG_INFINITY
+    } else {
+        f
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rlevo-evolution/src/local_search.rs
+++ b/crates/rlevo-evolution/src/local_search.rs
@@ -47,6 +47,10 @@ use rand::Rng;
 use rlevo_core::bounds::Bounds;
 
 use crate::fitness::FitnessFn;
+// `sanitize_fitness` is the crate-wide fitness-hygiene primitive; it now lives in
+// [`crate::fitness`]. Re-exported here so the searchers below (and existing
+// `crate::fitness::sanitize_fitness` callers) keep resolving it unchanged.
+pub(crate) use crate::fitness::sanitize_fitness;
 
 pub mod hill_climbing;
 pub mod nelder_mead;
@@ -259,28 +263,6 @@ impl<'a> BudgetedEval<'a> {
     }
 }
 
-/// Maps a `NaN` fitness to [`f32::NEG_INFINITY`], passing finite values through.
-///
-/// `−inf` is the worst value under the maximise convention, so a sanitized
-/// `NaN` can never seed or displace a finite best-so-far and thus never
-/// propagates to a returned fitness. This is the single rule shared by
-/// [`BudgetedEval::eval`] (applied to every probe, including the seeding eval),
-/// the searchers'
-/// [`refine_with_known_fitness`](LocalSearch::refine_with_known_fitness)
-/// overrides (applied to the `known_fitness` hint, which does not flow through
-/// `BudgetedEval`), and the EDA `tell` chokepoint
-/// ([`crate::algorithms::eda::EdaStrategy`]), which sanitizes the whole
-/// per-generation fitness vector before argmax/selection so a `NaN` can neither
-/// become the best-so-far nor corrupt the truncation ordering. For the finite
-/// benchmark landscapes the searchers ship
-/// against this branch is never taken, so it costs only one `is_nan` check.
-pub(crate) fn sanitize_fitness(f: f32) -> f32 {
-    if f.is_nan() {
-        f32::NEG_INFINITY
-    } else {
-        f
-    }
-}
 
 /// Clamps every coordinate of `genome` into the inclusive range `bounds`.
 ///

--- a/crates/rlevo-evolution/src/local_search/nelder_mead.rs
+++ b/crates/rlevo-evolution/src/local_search/nelder_mead.rs
@@ -248,12 +248,10 @@ impl NelderMead {
         let n: usize = simplex.len(); // == dim + 1
         loop {
             // Sort descending by fitness: index 0 is best (highest), last is
-            // worst (lowest).
-            simplex.sort_by(|a, b| {
-                b.fitness
-                    .partial_cmp(&a.fitness)
-                    .unwrap_or(core::cmp::Ordering::Equal)
-            });
+            // worst (lowest). Simplex fitnesses flow through `BudgetedEval`,
+            // which already sanitizes NaN → −inf, so `total_cmp` needs no extra
+            // guard here.
+            simplex.sort_by(|a, b| b.fitness.total_cmp(&a.fitness));
 
             let f_best: f32 = simplex[0].fitness;
             let f_worst: f32 = simplex[n - 1].fitness;

--- a/crates/rlevo-evolution/src/neuroevolution/species.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/species.rs
@@ -252,14 +252,14 @@ pub fn remove_stagnant(species: &mut Vec<Species>, generation: u64, stagnation_l
     if species.len() <= 1 {
         return;
     }
-    // Rank by best fitness (descending) to find the protected set.
+    // Rank by best fitness (descending) to find the protected set. Sanitize
+    // NaN → −inf (worst) so a NaN-fitness species can never be protected.
     let mut order: Vec<usize> = (0..species.len()).collect();
-    order.sort_by(|&a, &b| {
-        species[b]
-            .best_fitness
-            .partial_cmp(&species[a].best_fitness)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    let sane: Vec<f32> = species
+        .iter()
+        .map(|s| crate::fitness::sanitize_fitness(s.best_fitness))
+        .collect();
+    order.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
     let protected_count = STAGNATION_PROTECT_TOP_K.min(species.len());
     let mut keep = vec![false; species.len()];
     for &idx in order.iter().take(protected_count) {
@@ -330,15 +330,16 @@ pub fn allocate_offspring(species: &[Species], pop_size: usize) -> Vec<usize> {
         fracs.push((i, share - base));
     }
 
+    // Primary key: fractional remainder (finite by construction). Secondary
+    // tiebreak by best fitness, sanitizing NaN → −inf (worst).
     fracs.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| {
-                species[b.0]
-                    .best_fitness
-                    .partial_cmp(&species[a.0].best_fitness)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+        b.1.total_cmp(&a.1).then_with(|| {
+            let (fa, fb) = (
+                crate::fitness::sanitize_fitness(species[a.0].best_fitness),
+                crate::fitness::sanitize_fitness(species[b.0].best_fitness),
+            );
+            fb.total_cmp(&fa)
+        })
     });
     // Reconcile to an exact total: independently-floored f32 shares can under-
     // or (rarely) over-shoot `pop_size`. Award leftover seats to the largest

--- a/crates/rlevo-evolution/src/ops/linalg.rs
+++ b/crates/rlevo-evolution/src/ops/linalg.rs
@@ -211,7 +211,7 @@ mod tests {
         let a: Vec<f32> = vec![2.0, 1.0, 1.0, 2.0];
         let (vals, vecs) = jacobi_eigen(&a, 2);
         let mut sorted: Vec<f32> = vals.clone();
-        sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        sorted.sort_by(f32::total_cmp);
         approx::assert_relative_eq!(sorted[0], 1.0, epsilon = 1e-5);
         approx::assert_relative_eq!(sorted[1], 3.0, epsilon = 1e-5);
         let recon = reconstruct(&vals, &vecs, 2);

--- a/crates/rlevo-evolution/src/ops/replacement.rs
+++ b/crates/rlevo-evolution/src/ops/replacement.rs
@@ -237,7 +237,7 @@ mod tests {
         assert_eq!(rows.len(), 4);
         // fitness should be {50.0, 100.0}
         let mut f_sorted = f;
-        f_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        f_sorted.sort_by(f32::total_cmp);
         approx::assert_relative_eq!(f_sorted[0], 50.0, epsilon = 1e-6);
         approx::assert_relative_eq!(f_sorted[1], 100.0, epsilon = 1e-6);
     }
@@ -258,7 +258,7 @@ mod tests {
         assert_eq!(next.dims(), [2, 2]);
         // best two of offspring (highest fitness): 5.0 and 3.0
         let mut fs = f;
-        fs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        fs.sort_by(f32::total_cmp);
         approx::assert_relative_eq!(fs[0], 3.0, epsilon = 1e-6);
         approx::assert_relative_eq!(fs[1], 5.0, epsilon = 1e-6);
     }

--- a/crates/rlevo-evolution/src/ops/selection.rs
+++ b/crates/rlevo-evolution/src/ops/selection.rs
@@ -113,8 +113,9 @@ pub fn tournament_select<B: Backend>(
 ///
 /// Sorts the population by fitness (descending, i.e. highest first) and
 /// returns the first `top_k` indices. The returned `Vec` is ordered from
-/// best to worst among the selected members. Ties are broken by
-/// `f32::partial_cmp`, with `NaN` values sorted last.
+/// best to worst among the selected members. `NaN` fitnesses are sanitised to
+/// `−inf` (worst, per the maximise convention) and ordered with `f32::total_cmp`,
+/// so a `NaN`-fitness member always sorts last and can never be selected as best.
 ///
 /// This is the host-side building block; call [`truncation_select`] when
 /// you need the corresponding population rows as a tensor.
@@ -140,10 +141,15 @@ pub fn tournament_select<B: Backend>(
 pub fn truncation_indices_host(fitness: &[f32], top_k: usize) -> Vec<i32> {
     assert!(!fitness.is_empty(), "fitness must be non-empty");
     assert!(top_k <= fitness.len(), "top_k must be <= population size");
-    let mut indexed: Vec<(usize, f32)> = fitness.iter().copied().enumerate().collect();
-    // Descending: highest fitness first. NaN sorts last either way.
-    indexed
-        .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    // Sanitize NaN → −inf (worst under maximise) so a NaN-fitness member can
+    // never rank as best; `total_cmp` then gives a deterministic total order.
+    let mut indexed: Vec<(usize, f32)> = fitness
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .enumerate()
+        .collect();
+    // Descending: highest fitness first; sanitized NaN sorts last.
+    indexed.sort_by(|a, b| b.1.total_cmp(&a.1));
     #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
     indexed
         .into_iter()
@@ -216,6 +222,19 @@ mod tests {
         assert!(idx.contains(&2));
     }
     // ANCHOR_END: truncation_ordering_test
+
+    #[test]
+    fn truncation_sorts_nan_fitness_last() {
+        // `total_cmp` must place NaN-fitness members last (never panic), so a
+        // full-population truncation ranks the finite members ahead of the NaN.
+        let fitness = [3.0f32, f32::NAN, 5.0, 1.0];
+        let idx = truncation_indices_host(&fitness, fitness.len());
+        assert_eq!(idx.len(), 4);
+        // Best-first among finite fitnesses: 5.0 (idx 2), 3.0 (idx 0), 1.0 (idx 3).
+        assert_eq!(&idx[..3], &[2, 0, 3]);
+        // The NaN-fitness member (idx 1) sorts last.
+        assert_eq!(idx[3], 1);
+    }
 
     // ANCHOR: tournament_select_shape_test
     #[test]

--- a/crates/rlevo-evolution/src/shaping.rs
+++ b/crates/rlevo-evolution/src/shaping.rs
@@ -82,16 +82,22 @@ pub fn z_score<B: Backend>(fitness: Tensor<B, 1>) -> Tensor<B, 1> {
 /// and `into_vec::<f32>()` returns an error.
 #[must_use]
 pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
-    let data = fitness
+    let raw = fitness
         .into_data()
         .into_vec::<f32>()
         .expect("centered_rank requires f32 tensor data");
-    let n = data.len();
+    let n = raw.len();
     if n == 0 {
         return Tensor::<B, 1>::from_floats([0.0f32; 0], device);
     }
+    // Sanitize NaN → −inf (worst under maximise) so a NaN fitness ranks lowest
+    // rather than corrupting the ascending order.
+    let data: Vec<f32> = raw
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .collect();
     let mut indices: Vec<usize> = (0..n).collect();
-    indices.sort_by(|&i, &j| data[i].partial_cmp(&data[j]).unwrap_or(std::cmp::Ordering::Equal));
+    indices.sort_by(|&i, &j| data[i].total_cmp(&data[j]));
 
     #[allow(clippy::cast_precision_loss)]
     let n_f = (n - 1).max(1) as f32;

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -123,6 +123,25 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
   objective must declare `Maximize` explicitly so it cannot be optimised
   backwards by omission. Only `Landscape::sense()` defaults (to `Minimize`, since
   a landscape is a cost surface by definition).
+- **Compare floats with `total_cmp`, never `partial_cmp`.** `f32`/`f64`
+  comparisons in sorts, `max_by`/`min_by`, and argmax use `total_cmp` — a
+  deterministic total order. `partial_cmp(..).unwrap()` panics on any `NaN`
+  operand, and `partial_cmp(..).unwrap_or(Equal)` places `NaN` non-
+  deterministically. There is no clippy lint for this footgun
+  (`clippy::unwrap_used` is too broad to enable workspace-wide), so it is a
+  review-enforced convention.
+- **Sanitise fitness before comparing it.** `total_cmp` alone is *not* enough for
+  fitness ordering: Rust's `f32::NAN` is a *positive* NaN, so `total_cmp` ranks it
+  as the **maximum** — a raw `fit[b].total_cmp(&fit[a])` descending sort would put
+  a `NaN`-fitness member *first* (as the best). Under maximise-native `NaN` is the
+  **worst**, so map it to `−inf` first with `sanitize_fitness` (the single rule of
+  §Optimisation direction) and then `total_cmp`:
+  ```rust
+  let sane: Vec<f32> = fitness.iter().map(|&f| sanitize_fitness(f)).collect();
+  order.sort_by(|&a, &b| sane[b].total_cmp(&sane[a])); // best first; NaN last
+  ```
+  Non-fitness float comparisons (geometry, eigenvalues, argmax over logits) use
+  plain `total_cmp` — only *fitness* needs the sanitise step.
 
 ---
 


### PR DESCRIPTION
## Summary

Adopts a single NaN-safe `total_cmp` comparator idiom across `rlevo-environments` and `rlevo-evolution` in place of ad-hoc `partial_cmp(..).unwrap()`/`unwrap_or(Equal)`, which panics or nondeterministically ranks `NaN` (e.g. from a diverged policy or a broken fitness function). Since raw `f32::NAN.total_cmp` ranks as the *maximum*, fitness call sites additionally sanitise `NaN` to `f32::NEG_INFINITY` (worst, under the maximise-native convention) via a shared `sanitize_fitness` helper before sorting, so a `NaN`-fitness member can never be selected as best. The convention is now codified in `docs/rules.md`.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [ ] Other — _describe and justify scope below_

## Linked Issue

Closes #194
Closes #101
Closes #135

## What Was Changed

- `docs/rules.md`: codified the `total_cmp`-over-`partial_cmp` rule, plus the "sanitise fitness before comparing" corollary (NaN → −inf, then `total_cmp`).
- `crates/rlevo-environments/src/tensor_decode.rs`: new shared `argmax` helper — NaN-safe fold, ties resolve to lowest index, never panics.
- `crates/rlevo-environments/src/classic/{acrobot,cartpole,mountain_car}.rs`: `from_tensor` decoders now use the shared `argmax` instead of `partial_cmp(..).unwrap()`.
- `crates/rlevo-evolution/src/fitness.rs`: added `sanitize_fitness` (NaN → `NEG_INFINITY`) as the crate-wide fitness-hygiene primitive.
- `crates/rlevo-evolution/src/ops/selection.rs`, `ops/replacement.rs`: `truncation_indices_host` and related sorts sanitise fitness then use `f32::total_cmp` instead of `partial_cmp(..).unwrap_or(Equal)`.
- `crates/rlevo-evolution/src/coevolution/hof.rs`: `HallOfFame` champion/eviction logic sanitises fitness before `total_cmp`-based argmax/`min_by`.
- `crates/rlevo-evolution/src/local_search.rs`, `local_search/nelder_mead.rs`: moved `sanitize_fitness` into `crate::fitness` (re-exported for existing call sites) and applied it to `BudgetedEval`/`known_fitness` hints.
- `crates/rlevo-evolution/src/algorithms/{cma_es,cmsa_es,ep,gp_cgp,memetic}.rs`, `algorithms/eda/mod.rs`, `algorithms/metaheuristic/{aco_r,cuckoo}.rs`, `algorithms/neuroevolution/{arch_nas,neat}.rs`, `neuroevolution/species.rs`, `ops/linalg.rs`, `shaping.rs`: adopted sanitise-then-`total_cmp` (or plain `total_cmp` for non-fitness comparisons) at each remaining ranking/sort call site.
- `crates/rlevo-benchmarks/src/metrics/core.rs`, `rlevo-benchmarks-report-client/src/{charts,series}.rs`: viz-layer sorts adopted `total_cmp` for consistency (benchmark/viz consumes production ordering conventions, doesn't constrain them).

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

New regression tests added for `argmax` (NaN-safe, tie resolution, empty slice) in `tensor_decode.rs`, and for `truncation_indices_host` NaN ordering in `ops/selection.rs`.

- Rust toolchain: `rustc 1.94.1 (aarch64-apple-darwin)`
- Burn backend tested: ndarray (CPU)
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Sonnet). Scope: implementation of the `total_cmp`/`sanitize_fitness` idiom across all listed files, plus the `docs/rules.md` rule additions.

## Notes

`rlevo-reinforcement-learning`'s related non-finite-gradient guard is tracked separately in #173 and is out of scope here.

## Commits

- **docs(rules): Codify NaN-safe fitness comparison rule**
- **fix(environments): Adopt NaN-safe argmax in classic decoders**
- **refactor(evolution): Sanitise-then-total_cmp fitness ordering**
- **fix(evolution): Sanitise NaN in memetic/hof fitness ordering**
- **refactor(benchmarks): Adopt total_cmp in viz sorts**
