### PR TITLE
fix(rlevo-evolution): harden strategy/observer/shaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6438,6 +6438,7 @@ dependencies = [
  "rayon",
  "rlevo-core",
  "serde",
+ "thiserror 2.0.18",
  "tracing",
 ]
 

--- a/crates/rlevo-evolution/Cargo.toml
+++ b/crates/rlevo-evolution/Cargo.toml
@@ -23,6 +23,9 @@ parking_lot = { workspace = true }
 # Programming (3e-R1 §5). Pinned at the workspace version.
 rayon = { workspace = true }
 serde = { workspace = true }
+# Derives `ShapingError` (fallible fitness-shaping transforms). Workspace-pinned
+# at 2.x, same as `rlevo-core`.
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rlevo-evolution/src/lib.rs
+++ b/crates/rlevo-evolution/src/lib.rs
@@ -91,4 +91,5 @@ pub use local_search::{
     HillClimbing, LocalSearch, NelderMead, RandomRestart, SimulatedAnnealing,
 };
 pub use observer::{PopulationObserver, PopulationSnapshot, SharedPopulationObserver};
+pub use shaping::ShapingError;
 pub use strategy::{EvolutionaryHarness, Strategy, StrategyMetrics};

--- a/crates/rlevo-evolution/src/shaping.rs
+++ b/crates/rlevo-evolution/src/shaping.rs
@@ -9,6 +9,17 @@
 use burn::prelude::ElementConversion;
 use burn::tensor::{backend::Backend, Tensor};
 
+/// Error returned by fallible fitness-shaping transforms.
+#[derive(Debug, thiserror::Error)]
+pub enum ShapingError {
+    /// The input tensor's element data could not be read as `f32` — e.g. an
+    /// integer-typed backend tensor was passed to a transform that ranks host
+    /// values. This is a backend/dtype mismatch, surfaced as a recoverable error
+    /// rather than a panic.
+    #[error("shaping transform requires f32 tensor data")]
+    NonFloatData,
+}
+
 /// Returns `fitness - fitness.mean()` divided by the (population) std-dev,
 /// clamped to avoid divide-by-zero when all fitnesses are equal.
 ///
@@ -68,27 +79,26 @@ pub fn z_score<B: Backend>(fitness: Tensor<B, 1>) -> Tensor<B, 1> {
 ///
 /// let device = Default::default();
 /// let t = Tensor::<Flex, 1>::from_floats([10.0f32, 20.0, 30.0, 40.0], &device);
-/// let r = centered_rank(t, &device);
+/// let r = centered_rank(t, &device).unwrap();
 /// let values = r.into_data().into_vec::<f32>().unwrap();
 /// // Smallest value maps to -0.5, largest to +0.5.
 /// assert!((values[0] - (-0.5)).abs() < 1e-6);
 /// assert!((values[3] - 0.5).abs() < 1e-6);
 /// ```
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the tensor's element data cannot be converted to `f32` —
-/// for example, when using a backend that stores integer-typed tensors
-/// and `into_vec::<f32>()` returns an error.
-#[must_use]
-pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1> {
+/// Returns [`ShapingError::NonFloatData`] if the tensor's element data cannot be
+/// read as `f32` — for example, when using a backend that stores integer-typed
+/// tensors and `into_vec::<f32>()` fails.
+pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Result<Tensor<B, 1>, ShapingError> {
     let raw = fitness
         .into_data()
         .into_vec::<f32>()
-        .expect("centered_rank requires f32 tensor data");
+        .map_err(|_| ShapingError::NonFloatData)?;
     let n = raw.len();
     if n == 0 {
-        return Tensor::<B, 1>::from_floats([0.0f32; 0], device);
+        return Ok(Tensor::<B, 1>::from_floats([0.0f32; 0], device));
     }
     // Sanitize NaN → −inf (worst under maximise) so a NaN fitness ranks lowest
     // rather than corrupting the ascending order.
@@ -107,7 +117,7 @@ pub fn centered_rank<B: Backend>(fitness: Tensor<B, 1>, device: &<B as burn::ten
         let r = rank as f32 / n_f - 0.5;
         ranks[idx] = r;
     }
-    Tensor::<B, 1>::from_floats(ranks.as_slice(), device)
+    Ok(Tensor::<B, 1>::from_floats(ranks.as_slice(), device))
 }
 
 #[cfg(test)]
@@ -131,7 +141,7 @@ mod tests {
     fn centered_rank_spans_half_interval() {
         let device = Default::default();
         let t = Tensor::<TestBackend, 1>::from_floats([10.0f32, 20.0, 30.0, 40.0], &device);
-        let r = centered_rank(t, &device);
+        let r = centered_rank(t, &device).unwrap();
         let values = r.into_data().into_vec::<f32>().unwrap();
         // smallest → -0.5, largest → +0.5
         approx::assert_relative_eq!(values[0], -0.5, epsilon = 1e-6);
@@ -142,12 +152,20 @@ mod tests {
     fn centered_rank_preserves_order() {
         let device = Default::default();
         let t = Tensor::<TestBackend, 1>::from_floats([3.0f32, 1.0, 2.0], &device);
-        let r = centered_rank(t, &device);
+        let r = centered_rank(t, &device).unwrap();
         let values = r.into_data().into_vec::<f32>().unwrap();
         // original: 3, 1, 2 → ranks sorted ascending: [1, 2, 3] at indices [1, 2, 0]
         // rank-positions centered: index 1 → -0.5, index 2 → 0.0, index 0 → 0.5
         approx::assert_relative_eq!(values[1], -0.5, epsilon = 1e-6);
         approx::assert_relative_eq!(values[2], 0.0, epsilon = 1e-6);
         approx::assert_relative_eq!(values[0], 0.5, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn centered_rank_empty_is_ok() {
+        let device = Default::default();
+        let t = Tensor::<TestBackend, 1>::from_floats([0.0f32; 0], &device);
+        let r = centered_rank(t, &device).expect("empty input is not an error");
+        assert_eq!(r.dims()[0], 0);
     }
 }

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -213,17 +213,33 @@ pub struct StrategyMetrics {
 impl StrategyMetrics {
     /// Computes population statistics from a host-side fitness slice.
     ///
+    /// Each value is passed through the crate's NaN-hygiene primitive
+    /// [`sanitize_fitness`](crate::fitness::sanitize_fitness) before folding, so
+    /// a `NaN` is treated as `f32::NEG_INFINITY` (the worst value under the
+    /// maximise convention, ADR 0023) *consistently* across every statistic. A
+    /// generation containing any `NaN` therefore yields `worst_fitness = −∞` and
+    /// `mean_fitness = −∞` while `best_fitness` remains the largest finite value —
+    /// degenerate but well-defined, rather than the old silent asymmetry where
+    /// `best`/`worst` ignored the `NaN` (comparisons against `NaN` are false) yet
+    /// `mean` propagated it.
+    ///
     /// # Panics
     ///
-    /// Panics if `fitnesses` is empty.
+    /// Panics if `fitnesses` is empty. Callers hold a non-empty population by
+    /// construction — `pop_size` is validated non-zero at the harness
+    /// constructor (ADR 0026).
     #[must_use]
     pub fn from_host_fitness(generation: usize, fitnesses: &[f32], best_fitness_ever: f32) -> Self {
         assert!(!fitnesses.is_empty(), "fitness slice must be non-empty");
         let population_size = fitnesses.len();
         // Canonical (maximise) space: best is the largest value, worst the
-        // smallest, and best-ever a rolling maximum.
+        // smallest, and best-ever a rolling maximum. Each value is sanitized
+        // (NaN → −∞) up front so all three statistics agree on the crate-wide
+        // NaN convention instead of best/worst silently dropping NaN while the
+        // sum propagates it.
         let (mut best, mut worst, mut sum) = (f32::NEG_INFINITY, f32::INFINITY, 0.0_f32);
         for &f in fitnesses {
+            let f = crate::fitness::sanitize_fitness(f);
             if f > best {
                 best = f;
             }
@@ -243,6 +259,43 @@ impl StrategyMetrics {
             best_fitness_ever: best_fitness_ever.max(best),
         }
     }
+}
+
+/// Builds a per-generation [`PopulationSnapshot`] from a host-side fitness
+/// vector, or `None` when the vector is empty.
+///
+/// `fitnesses` is in **natural (user-sense)** space: the best individual is the
+/// smallest value for a [`Minimize`](ObjectiveSense::Minimize) objective and the
+/// largest for [`Maximize`](ObjectiveSense::Maximize). Returning `None` on an
+/// empty vector guards against emitting an out-of-range `best_index` (the fold
+/// would otherwise default to `0`, indexing into a zero-length slice).
+fn build_population_snapshot(
+    generation: u32,
+    fitnesses: Vec<f32>,
+    sense: ObjectiveSense,
+) -> Option<PopulationSnapshot> {
+    if fitnesses.is_empty() {
+        return None;
+    }
+    let best_index = fitnesses
+        .iter()
+        .enumerate()
+        .reduce(|best, cur| {
+            let better = match sense {
+                ObjectiveSense::Minimize => cur.1 < best.1,
+                ObjectiveSense::Maximize => cur.1 > best.1,
+            };
+            if better { cur } else { best }
+        })
+        .map_or(0, |(i, _)| u32::try_from(i).unwrap_or(0));
+    Some(PopulationSnapshot {
+        generation,
+        fitnesses,
+        diversity: None,
+        best_index,
+        best_genome_digest: None,
+        parents_of_best: Vec::new(),
+    })
 }
 
 /// Wraps a [`Strategy`] into a [`BenchEnv`] so the benchmark harness can
@@ -534,28 +587,36 @@ where
             "evolution generation",
         );
         if let (Some(observer), Some(fitnesses)) = (self.observer.as_ref(), snapshot_fitness) {
-            // `fitnesses` is in natural space; the best individual is the
-            // smallest for a `Minimize` objective, the largest for `Maximize`.
-            let best_index = fitnesses
-                .iter()
-                .enumerate()
-                .reduce(|best, cur| {
-                    let better = match sense {
-                        ObjectiveSense::Minimize => cur.1 < best.1,
-                        ObjectiveSense::Maximize => cur.1 > best.1,
-                    };
-                    if better { cur } else { best }
-                })
-                .map_or(0, |(i, _)| u32::try_from(i).unwrap_or(0));
-            let snapshot = PopulationSnapshot {
-                generation: u32::try_from(metrics.generation).unwrap_or(u32::MAX),
-                fitnesses,
-                diversity: None,
-                best_index,
-                best_genome_digest: None,
-                parents_of_best: Vec::new(),
-            };
-            observer.lock().on_population(snapshot);
+            let generation = u32::try_from(metrics.generation).unwrap_or(u32::MAX);
+            match build_population_snapshot(generation, fitnesses, sense) {
+                Some(snapshot) => {
+                    // Isolate the observer: a panicking third-party sink drops
+                    // this snapshot but must not abort an otherwise-healthy
+                    // optimization run. `SharedPopulationObserver` is backed by a
+                    // `parking_lot::Mutex` (no poisoning), so the guard drops
+                    // during unwind and the next generation re-locks cleanly.
+                    let dispatched = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        observer.lock().on_population(snapshot);
+                    }));
+                    if dispatched.is_err() {
+                        tracing::warn!(
+                            generation,
+                            "population observer panicked; dropping snapshot and continuing",
+                        );
+                    }
+                }
+                None => {
+                    // An empty fitness vector means the device→host transfer at
+                    // `snapshot_fitness` yielded nothing (a masked conversion
+                    // failure). Surface it rather than emitting an out-of-range
+                    // `best_index` into a zero-length vector.
+                    tracing::warn!(
+                        generation,
+                        "empty population fitness vector; skipping observer snapshot \
+                         (device→host transfer likely failed)",
+                    );
+                }
+            }
         }
         self.latest_metrics = Some(metrics);
         let done = self.generation >= self.max_generations;
@@ -747,6 +808,36 @@ mod tests {
         approx::assert_relative_eq!(m.best_fitness_ever, 5.0, epsilon = 1e-6);
     }
 
+    #[test]
+    fn from_host_fitness_sanitizes_nan() {
+        // A NaN is sanitized to −∞ (worst under maximise) *consistently*: it
+        // never becomes best, and it drags worst and mean to −∞ rather than the
+        // old asymmetry where best/worst ignored it but mean turned NaN.
+        let m = StrategyMetrics::from_host_fitness(0, &[1.0, f32::NAN, 3.0, 2.0], 0.0);
+        approx::assert_relative_eq!(m.best_fitness, 3.0, epsilon = 1e-6);
+        assert!(m.worst_fitness.is_infinite() && m.worst_fitness.is_sign_negative());
+        assert!(m.mean_fitness.is_infinite() && m.mean_fitness.is_sign_negative());
+        approx::assert_relative_eq!(m.best_fitness_ever, 3.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn build_population_snapshot_empty_returns_none() {
+        assert!(build_population_snapshot(0, Vec::new(), ObjectiveSense::Minimize).is_none());
+    }
+
+    #[test]
+    fn build_population_snapshot_picks_best_for_sense() {
+        // Values: [0.3, 0.1, 0.9]. Minimize → best is the smallest (index 1);
+        // Maximize → best is the largest (index 2).
+        let min = build_population_snapshot(7, vec![0.3, 0.1, 0.9], ObjectiveSense::Minimize)
+            .expect("non-empty");
+        assert_eq!(min.best_index, 1);
+        assert_eq!(min.generation, 7);
+        let max = build_population_snapshot(7, vec![0.3, 0.1, 0.9], ObjectiveSense::Maximize)
+            .expect("non-empty");
+        assert_eq!(max.best_index, 2);
+    }
+
     /// Per-individual fitness = `1.0 / (i + 1)` so the best (smallest)
     /// is always at index `pop_size - 1` — a deterministic shape the
     /// observer test can pin against.
@@ -816,6 +907,45 @@ mod tests {
         assert!(guard.snapshots[0].diversity.is_none());
         assert!(guard.snapshots[0].best_genome_digest.is_none());
         assert!(guard.snapshots[0].parents_of_best.is_empty());
+    }
+
+    /// Observer whose callback always panics — used to prove the harness
+    /// isolates a misbehaving sink instead of aborting the run.
+    #[derive(Debug, Default)]
+    struct PanicObserver;
+
+    impl crate::observer::PopulationObserver for PanicObserver {
+        fn on_population(&mut self, _snapshot: PopulationSnapshot) {
+            panic!("observer intentionally panics");
+        }
+    }
+
+    #[test]
+    fn harness_survives_panicking_observer() {
+        use std::sync::Arc;
+
+        use parking_lot::Mutex;
+        let device = Default::default();
+        let observer = Arc::new(Mutex::new(PanicObserver));
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            Constant,
+            Params {
+                pop_size: 4,
+                dim: 2,
+            },
+            RankedFitness,
+            1,
+            device,
+            2,
+        )
+        .expect("valid params")
+        .with_observer(observer.clone() as SharedPopulationObserver);
+        harness.reset();
+        // Each step's observer dispatch panics; the harness must swallow it and
+        // keep advancing generations to completion.
+        assert!(!harness.step(()).done);
+        assert!(harness.step(()).done);
+        assert_eq!(harness.generation(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens three failure-prone seams in `rlevo-evolution` flagged in #159: `centered_rank` now returns a `Result` instead of panicking on non-`f32` tensor data, `StrategyMetrics::from_host_fitness` sanitizes `NaN` consistently across `best`/`worst`/`mean` instead of silently diverging, and the harness's population-observer dispatch is isolated behind `catch_unwind` so a panicking third-party sink can't abort an otherwise-healthy run.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #159

## What Was Changed

- `crates/rlevo-evolution/src/shaping.rs`: added `ShapingError` (`thiserror`-derived); `centered_rank` returns `Result<Tensor<B, 1>, ShapingError>` instead of `.expect()`-panicking on non-`f32` tensor data; doc comment updated from `# Panics` to `# Errors`; added `centered_rank_empty_is_ok` regression test.
- `crates/rlevo-evolution/src/strategy.rs`:
  - `StrategyMetrics::from_host_fitness` now folds each fitness through `crate::fitness::sanitize_fitness` (NaN → `f32::NEG_INFINITY`) before the best/worst/sum reduction, so a `NaN` in the population degrades `worst`/`mean` to `-∞` symmetrically instead of silently skipping `NaN` in `best`/`worst` while `mean` picked it up.
  - Extracted `build_population_snapshot` (returns `Option<PopulationSnapshot>`, `None` on an empty fitness vector) out of `EvolutionaryHarness::step`, replacing the prior fold that would default `best_index` to `0` and index into a zero-length slice.
  - Wrapped the observer dispatch (`observer.lock().on_population(snapshot)`) in `std::panic::catch_unwind`; a panicking observer is logged via `tracing::warn!` and the snapshot is dropped, but the harness keeps advancing generations. Relies on `parking_lot::Mutex` having no poisoning, so the lock guard drops cleanly during unwind.
  - Added `from_host_fitness_sanitizes_nan`, `build_population_snapshot_empty_returns_none`, `build_population_snapshot_picks_best_for_sense`, and `harness_survives_panicking_observer` (via a `PanicObserver` test double) regression tests.
- `crates/rlevo-evolution/src/lib.rs`: re-exported `ShapingError`.
- `crates/rlevo-evolution/Cargo.toml`, `Cargo.lock`: added `thiserror` (workspace-pinned 2.x, matching `rlevo-core`) as a dependency of `rlevo-evolution`.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable (per `rust-toolchain`/workspace default)
- Burn backend tested: ndarray (`TestBackend`)
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Sonnet 5). Scope: implementation of the `ShapingError` type, `centered_rank` signature change, `StrategyMetrics` NaN-sanitization, `build_population_snapshot` extraction, and the panic-isolation wrapper around observer dispatch, plus their regression tests.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).