### PR TITLE
refactor(evolution): Consolidate selection helpers into ops

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/de.rs
+++ b/crates/rlevo-evolution/src/algorithms/de.rs
@@ -37,6 +37,7 @@ use rand::{Rng, RngExt};
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -473,7 +474,7 @@ where
         // First `tell`: stash fitness for the initial population.
         if state.fitness.is_empty() {
             state.fitness.clone_from(&fitness_host);
-            state.best_index = argmax(&fitness_host);
+            state.best_index = argmax_host(&fitness_host);
             state.generation += 1;
             update_best(&mut state, &trial, &fitness_host);
             let m = StrategyMetrics::from_host_fitness(
@@ -513,7 +514,7 @@ where
 
         state.population = next_pop;
         state.fitness.clone_from(&new_fit);
-        state.best_index = argmax(&new_fit);
+        state.best_index = argmax_host(&new_fit);
         state.generation += 1;
         update_best(&mut state, &trial, &fitness_host);
         let m = StrategyMetrics::from_host_fitness(state.generation, &new_fit, state.best_fitness);
@@ -533,23 +534,11 @@ where
     }
 }
 
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
-}
-
 fn update_best<B: Backend>(state: &mut DeState<B>, pop: &Tensor<B, 2>, fitness: &[f32]) {
     if fitness.is_empty() {
         return;
     }
-    let best_idx = argmax(fitness);
+    let best_idx = argmax_host(fitness);
     let best_f = fitness[best_idx];
     if best_f > state.best_fitness {
         let device = pop.device();

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -32,6 +32,7 @@ use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
 use crate::ops::mutation::gaussian_mutation_per_row;
 use crate::ops::replacement::{mu_comma_lambda, mu_plus_lambda};
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -437,7 +438,7 @@ where
             }
             EsKind::OnePlusLambda { .. } => {
                 // Best of (parent, offspring pool).
-                let best_off_idx = argmax(&fitness_host);
+                let best_off_idx = argmax_host(&fitness_host);
                 let best_off_fit = fitness_host[best_off_idx];
                 if best_off_fit > state.parent_fitness[0] {
                     #[allow(clippy::single_range_in_vec_init)]
@@ -513,23 +514,11 @@ where
     }
 }
 
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
-}
-
 fn update_best<B: Backend>(state: &mut EsState<B>, pop: &Tensor<B, 2>, fitness: &[f32]) {
     if fitness.is_empty() {
         return;
     }
-    let best_idx = argmax(fitness);
+    let best_idx = argmax_host(fitness);
     let best_f = fitness[best_idx];
     if best_f > state.best_fitness {
         let device = pop.device();

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
@@ -42,6 +42,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use crate::ops::selection::{argmax_host, tournament_indices_host};
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -60,7 +61,8 @@ pub struct AbcConfig {
     pub limit: usize,
     /// Tournament size for onlooker selection. Canonical ABC uses
     /// roulette (fitness-proportionate); tournament is a GPU-friendly
-    /// equivalent that reuses [`crate::ops::selection::tournament_select`].
+    /// equivalent that reuses
+    /// [`crate::ops::selection::tournament_indices_host`].
     pub tournament_size: usize,
 }
 
@@ -261,17 +263,13 @@ where
         for i in 0..pop {
             targets.push(i);
         }
-        // Onlooker phase — tournament selection, fitness-biased.
-        for _ in 0..pop {
-            let mut best = stream.random_range(0..pop);
-            for _ in 1..params.tournament_size {
-                let c = stream.random_range(0..pop);
-                if state.fitness[c] < state.fitness[best] {
-                    best = c;
-                }
-            }
-            targets.push(best);
-        }
+        // Onlooker phase — tournament selection biased toward the
+        // fittest (canonical maximise) sources.
+        targets.extend(
+            tournament_indices_host(&state.fitness, params.tournament_size, pop, &mut stream)
+                .into_iter()
+                .map(|w| usize::try_from(w).expect("winner index is non-negative")),
+        );
         // Neighbour + dim + φ for every candidate.
         for &t in &targets {
             let mut k = stream.random_range(0..pop);
@@ -319,7 +317,7 @@ where
         // First tell: population is the initial colony being scored.
         if state.fitness.is_empty() {
             state.fitness.clone_from(&fitness_host);
-            let best_idx = argmax(&fitness_host);
+            let best_idx = argmax_host(&fitness_host);
             state.best_fitness = fitness_host[best_idx];
             #[allow(clippy::cast_possible_wrap)]
             let idx = Tensor::<B, 1, Int>::from_data(
@@ -424,7 +422,7 @@ where
 
         // Update best-so-far from the refreshed colony's fitness cache
         // (excluding INF-tagged scouts, which next `ask` evaluates).
-        let best_idx = argmax(&state.fitness);
+        let best_idx = argmax_host(&state.fitness);
         if state.fitness[best_idx].is_finite() && state.fitness[best_idx] > state.best_fitness {
             state.best_fitness = state.fitness[best_idx];
             #[allow(clippy::cast_possible_wrap)]
@@ -450,24 +448,14 @@ where
     }
 }
 
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
     use burn::backend::Flex;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
@@ -492,6 +480,34 @@ mod tests {
         fn evaluate(&self, x: &Self::Individual, _: &Self::Landscape) -> f64 {
             x.iter().map(|v| v * v).sum()
         }
+    }
+
+    // Regression for the inverted onlooker sense (issue #150): under the
+    // canonical maximise convention onlookers must concentrate on the
+    // *fittest* source, not the worst.
+    #[test]
+    fn onlooker_targets_prefer_best_source() {
+        let device = Default::default();
+        let strategy = ArtificialBeeColony::<TestBackend>::new();
+        let mut params = AbcConfig::default_for(16, 4);
+        params.tournament_size = 8;
+        let mut rng = StdRng::seed_from_u64(11);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        // Simulate a scored colony where bee 3 dominates.
+        state.fitness = vec![0.0; 16];
+        state.fitness[3] = 100.0;
+        let (_candidates, next) = strategy.ask(&params, &state, &mut rng, &device);
+        // Rows 0..pop are the employed phase; rows pop.. are onlookers.
+        let onlooker_hits = next.target_of_candidate[16..]
+            .iter()
+            .filter(|&&t| t == 3)
+            .count();
+        // P(best wins an 8-ary tournament over pop 16) ≈ 0.40, so ~6 of
+        // 16 onlookers in expectation; the inverted sense yields ~0.
+        assert!(
+            onlooker_hits >= 3,
+            "onlooker hits on the best bee = {onlooker_hits} (expected ~6)",
+        );
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -34,6 +34,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -347,7 +348,7 @@ where
 
         if state.fitness.is_empty() {
             state.fitness.clone_from(&fitness_host);
-            let best_idx = argmax(&fitness_host);
+            let best_idx = argmax_host(&fitness_host);
             state.best_fitness = fitness_host[best_idx];
             #[allow(clippy::cast_possible_wrap)]
             let idx = Tensor::<B, 1, Int>::from_data(
@@ -392,7 +393,7 @@ where
         state.fitness = new_fitness;
 
         // Refresh global best.
-        let best_idx = argmax(&state.fitness);
+        let best_idx = argmax_host(&state.fitness);
         if state.fitness[best_idx] > state.best_fitness {
             state.best_fitness = state.fitness[best_idx];
             #[allow(clippy::cast_possible_wrap)]
@@ -419,18 +420,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 #[cfg(test)]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -38,6 +38,7 @@ use rand_distr::{Distribution as RandDistDist, Normal};
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -294,7 +295,7 @@ where
 
         if state.fitness.is_empty() {
             state.fitness.clone_from(&fitness_host);
-            let best_idx = argmax(&fitness_host);
+            let best_idx = argmax_host(&fitness_host);
             state.best_fitness = fitness_host[best_idx];
             #[allow(clippy::cast_possible_wrap)]
             let idx = Tensor::<B, 1, Int>::from_data(
@@ -374,7 +375,7 @@ where
         }
 
         // Best-so-far from finite-fitness slots.
-        let best_idx = argmax(&state.fitness);
+        let best_idx = argmax_host(&state.fitness);
         if state.fitness[best_idx].is_finite() && state.fitness[best_idx] > state.best_fitness {
             state.best_fitness = state.fitness[best_idx];
             #[allow(clippy::cast_possible_wrap)]
@@ -400,18 +401,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 #[cfg(test)]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -31,6 +31,7 @@ use rand::SeedableRng;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -329,7 +330,7 @@ where
         state.fitness.clone_from(&fitness_host);
         state.positions.clone_from(&population);
 
-        let best_idx = argmax(&fitness_host);
+        let best_idx = argmax_host(&fitness_host);
         if fitness_host[best_idx] > state.best_fitness {
             state.best_fitness = fitness_host[best_idx];
             #[allow(clippy::cast_possible_wrap)]
@@ -354,18 +355,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 #[cfg(test)]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -39,6 +39,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -268,7 +269,7 @@ where
         let fitness_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
         state.fitness.clone_from(&fitness_host);
         state.pack.clone_from(&population);
-        let best_idx = argmax(&fitness_host);
+        let best_idx = argmax_host(&fitness_host);
         if fitness_host[best_idx] > state.best_fitness {
             state.best_fitness = fitness_host[best_idx];
             let device = population.device();
@@ -294,18 +295,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 /// Indices of the three largest values in `xs`. Panics if `xs.len() < 3`.

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
@@ -55,6 +55,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -330,7 +331,7 @@ where
         if state.personal_best_fitness.is_empty() {
             state.personal_best.clone_from(&population);
             state.personal_best_fitness.clone_from(&fitness_host);
-            let best_idx = argmax(&fitness_host);
+            let best_idx = argmax_host(&fitness_host);
             state.global_best_fitness = fitness_host[best_idx];
             #[allow(clippy::cast_possible_wrap)]
             let idx = Tensor::<B, 1, Int>::from_data(
@@ -375,7 +376,7 @@ where
         state.personal_best_fitness.clone_from(&new_pbest_fit);
 
         // Update global best from the new personal bests.
-        let best_idx = argmax(&new_pbest_fit);
+        let best_idx = argmax_host(&new_pbest_fit);
         if new_pbest_fit[best_idx] > state.global_best_fitness {
             state.global_best_fitness = new_pbest_fit[best_idx];
             #[allow(clippy::cast_possible_wrap)]
@@ -403,18 +404,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.global_best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 #[cfg(test)]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
@@ -40,6 +40,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -279,7 +280,7 @@ where
         let fitness_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
         state.fitness.clone_from(&fitness_host);
         state.positions.clone_from(&population);
-        let best_idx = argmax(&fitness_host);
+        let best_idx = argmax_host(&fitness_host);
         if fitness_host[best_idx] > state.best_fitness {
             state.best_fitness = fitness_host[best_idx];
             let device = population.device();
@@ -305,18 +306,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 #[cfg(test)]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -39,6 +39,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
@@ -313,7 +314,7 @@ where
         let fitness_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
         state.fitness.clone_from(&fitness_host);
         state.positions.clone_from(&population);
-        let best_idx = argmax(&fitness_host);
+        let best_idx = argmax_host(&fitness_host);
         if fitness_host[best_idx] > state.best_fitness {
             state.best_fitness = fitness_host[best_idx];
             let device = population.device();
@@ -339,18 +340,6 @@ where
             .as_ref()
             .map(|g| (g.clone(), state.best_fitness))
     }
-}
-
-fn argmax(xs: &[f32]) -> usize {
-    let mut best_idx = 0usize;
-    let mut best = f32::NEG_INFINITY;
-    for (i, &v) in xs.iter().enumerate() {
-        if v > best {
-            best = v;
-            best_idx = i;
-        }
-    }
-    best_idx
 }
 
 #[cfg(test)]

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
@@ -51,12 +51,12 @@ use std::marker::PhantomData;
 
 use burn::module::Module;
 use burn::tensor::{Tensor, TensorData, backend::Backend};
-use rand::rngs::StdRng;
 use rand::{Rng, RngExt};
 use rand_distr::{Distribution as _, Normal};
 
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use crate::ops::selection::{argmax_host, tournament_indices_host, truncation_indices_host};
 use crate::param_reshaper::{ModuleReshaper, ParamReshaper};
 use crate::rng::{SeedPurpose, seed_stream};
 
@@ -571,15 +571,12 @@ impl<B: Backend> ArchNasStrategy<B> {
         let resident_arch = &state.population.arch_ids;
 
         // Elitism: indices sorted by descending (better, canonical maximise)
-        // fitness — highest first.
-        let mut order: Vec<usize> = (0..pop).collect();
-        // Sanitize NaN → −inf (worst) so it can never rank as best; descending.
-        let sane: Vec<f32> = state
-            .fitness
-            .iter()
-            .map(|&f| crate::fitness::sanitize_fitness(f))
+        // fitness — highest first; NaN sanitised to −inf so it never ranks
+        // as best.
+        let order: Vec<usize> = truncation_indices_host(&state.fitness, pop)
+            .into_iter()
+            .map(|i| usize::try_from(i).expect("winner index is non-negative"))
             .collect();
-        order.sort_by(|&a, &b| sane[b].total_cmp(&sane[a]));
         let elite_count = params.elite_count.min(pop);
         let tournament_size = params.tournament_size.max(1);
 
@@ -592,10 +589,19 @@ impl<B: Backend> ArchNasStrategy<B> {
             child_arch.push(resident_arch[ei]);
         }
 
-        // Fill the rest with offspring.
+        // Fill the rest with offspring. All parent tournaments draw from
+        // the dedicated `sel_rng` stream, so batching the draws up front
+        // preserves the exact per-child draw order.
+        let parents = tournament_indices_host(
+            &state.fitness,
+            tournament_size,
+            2 * (pop - elite_count),
+            &mut sel_rng,
+        );
         for ci in elite_count..pop {
-            let pa = tournament(&state.fitness, tournament_size, &mut sel_rng);
-            let pb = tournament(&state.fitness, tournament_size, &mut sel_rng);
+            let pair = 2 * (ci - elite_count);
+            let pa = usize::try_from(parents[pair]).expect("winner index is non-negative");
+            let pb = usize::try_from(parents[pair + 1]).expect("winner index is non-negative");
             let arch = resident_arch[pa];
             let n = params.per_variant_params[arch];
             let base = ci * max;
@@ -675,21 +681,6 @@ impl<B: Backend> ArchNasStrategy<B> {
     }
 }
 
-/// k-tournament selection over a host fitness slice (canonical maximise):
-/// returns the index of the best (highest-fitness) of `size` uniformly-drawn
-/// competitors.
-fn tournament(fitness: &[f32], size: usize, rng: &mut StdRng) -> usize {
-    let pop = fitness.len();
-    let mut best = rng.random_range(0..pop);
-    for _ in 1..size {
-        let challenger = rng.random_range(0..pop);
-        if fitness[challenger] > fitness[best] {
-            best = challenger;
-        }
-    }
-    best
-}
-
 /// Update best-ever tracking from a freshly-evaluated population.
 fn update_best<B: Backend>(
     state: &mut NasState<B>,
@@ -700,14 +691,8 @@ fn update_best<B: Backend>(
     if fitness.is_empty() {
         return;
     }
-    let mut best_idx = 0_usize;
-    let mut best_f = fitness[0];
-    for (i, &f) in fitness.iter().enumerate().skip(1) {
-        if f > best_f {
-            best_f = f;
-            best_idx = i;
-        }
-    }
+    let best_idx = argmax_host(fitness);
+    let best_f = fitness[best_idx];
     if best_f > state.best_fitness {
         #[allow(clippy::single_range_in_vec_init)]
         let row: Tensor<B, 1> = pop
@@ -727,6 +712,7 @@ mod tests {
     use burn::backend::Flex;
     use burn::nn::{Linear, LinearConfig};
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     type TestBackend = Flex;
 

--- a/crates/rlevo-evolution/src/ops/selection.rs
+++ b/crates/rlevo-evolution/src/ops/selection.rs
@@ -16,10 +16,48 @@
 //! Fitness values are **canonical (maximise)**: *higher is better*.
 //! Tournament selection retains the *largest* fitness seen across all
 //! candidates in a single draw; truncation selection returns the `top_k`
-//! entries with the largest fitnesses.
+//! entries with the largest fitnesses; [`argmax_host`] reduces a fitness
+//! slice to the index of its single largest entry.
 
 use burn::tensor::{backend::Backend, Int, Tensor, TensorData};
 use rand::{Rng, RngExt};
+
+/// Returns the index of the largest fitness value.
+///
+/// `fitness` is canonical (maximise): *higher is better*. The scan keeps
+/// the running best under a strict `>` seeded from `NEG_INFINITY`, so:
+///
+/// - ties resolve to the lowest index,
+/// - `NaN` and `−inf` entries never displace the running best (every
+///   comparison against them or the seed is strict), and
+/// - a slice with no entry above `−inf` (e.g. all-`NaN`) falls back to
+///   index `0`.
+///
+/// # Examples
+///
+/// ```
+/// use rlevo_evolution::ops::selection::argmax_host;
+///
+/// let fitness = [1.0_f32, 5.0, 3.0];
+/// assert_eq!(argmax_host(&fitness), 1);
+/// ```
+///
+/// # Panics
+///
+/// Panics if `fitness.is_empty()`.
+#[must_use]
+pub fn argmax_host(fitness: &[f32]) -> usize {
+    assert!(!fitness.is_empty(), "fitness must be non-empty");
+    let mut best_idx = 0usize;
+    let mut best = f32::NEG_INFINITY;
+    for (i, &v) in fitness.iter().enumerate() {
+        if v > best {
+            best = v;
+            best_idx = i;
+        }
+    }
+    best_idx
+}
 
 /// K-ary tournament selection over a fitness slice.
 ///
@@ -32,7 +70,8 @@ use rand::{Rng, RngExt};
 /// `fitness` is a flat slice where index `i` is the canonical fitness of
 /// population member `i` (higher is better). `tournament_size` controls
 /// selection pressure: larger values yield stronger pressure toward
-/// higher-fitness members.
+/// higher-fitness members. A `tournament_size` of 1 degenerates to
+/// pressure-free uniform-random selection.
 ///
 /// # Examples
 ///
@@ -53,7 +92,7 @@ use rand::{Rng, RngExt};
 ///
 /// # Panics
 ///
-/// Panics if `fitness.is_empty()` or if `tournament_size < 2`.
+/// Panics if `fitness.is_empty()` or if `tournament_size == 0`.
 #[must_use]
 pub fn tournament_indices_host(
     fitness: &[f32],
@@ -62,7 +101,7 @@ pub fn tournament_indices_host(
     rng: &mut dyn Rng,
 ) -> Vec<i32> {
     assert!(!fitness.is_empty(), "fitness must be non-empty");
-    assert!(tournament_size >= 2, "tournament size must be >= 2");
+    assert!(tournament_size >= 1, "tournament size must be >= 1");
     let pop_size = fitness.len();
     let mut winners = Vec::with_capacity(n_winners);
     for _ in 0..n_winners {
@@ -94,7 +133,7 @@ pub fn tournament_indices_host(
 /// # Panics
 ///
 /// Inherits the panic conditions of [`tournament_indices_host`]:
-/// `fitness.is_empty()` or `tournament_size < 2`.
+/// `fitness.is_empty()` or `tournament_size == 0`.
 #[must_use]
 pub fn tournament_select<B: Backend>(
     population: &Tensor<B, 2>,
@@ -222,6 +261,53 @@ mod tests {
         assert!(idx.contains(&2));
     }
     // ANCHOR_END: truncation_ordering_test
+
+    #[test]
+    fn argmax_returns_index_of_largest() {
+        assert_eq!(argmax_host(&[1.0, 5.0, 3.0]), 1);
+        assert_eq!(argmax_host(&[-3.0, -1.0, -2.0]), 1);
+        assert_eq!(argmax_host(&[7.0]), 0);
+    }
+
+    #[test]
+    fn argmax_tie_resolves_to_lowest_index() {
+        assert_eq!(argmax_host(&[2.0, 5.0, 5.0, 5.0]), 1);
+    }
+
+    #[test]
+    fn argmax_nan_never_wins() {
+        assert_eq!(argmax_host(&[1.0, f32::NAN, 3.0]), 2);
+        assert_eq!(argmax_host(&[f32::NAN, 1.0]), 1);
+    }
+
+    #[test]
+    fn argmax_degenerate_slice_falls_back_to_zero() {
+        // No entry strictly exceeds the NEG_INFINITY seed, so the scan
+        // keeps the initial index 0.
+        assert_eq!(argmax_host(&[f32::NAN, f32::NAN]), 0);
+        assert_eq!(argmax_host(&[f32::NAN, f32::NEG_INFINITY]), 0);
+        assert_eq!(argmax_host(&[f32::NEG_INFINITY, f32::NEG_INFINITY]), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "fitness must be non-empty")]
+    fn argmax_empty_panics() {
+        let _ = argmax_host(&[]);
+    }
+
+    #[test]
+    fn tournament_size_one_is_uniform_random() {
+        // A 1-ary "tournament" is a single uniform draw: the dominant
+        // member wins ~1/4 of the time, not most of the time.
+        let mut rng = StdRng::seed_from_u64(3);
+        let fitness = [0.0f32, 100.0, 0.0, 0.0];
+        let winners = tournament_indices_host(&fitness, 1, 1000, &mut rng);
+        let wins_for_best = winners.iter().filter(|&&w| w == 1).count();
+        assert!(
+            (150..=350).contains(&wins_for_best),
+            "wins_for_best={wins_for_best} (expected ~250)",
+        );
+    }
 
     #[test]
     fn truncation_sorts_nan_fitness_last() {


### PR DESCRIPTION
## Summary

Ten byte-identical private `argmax` helpers (across eight metaheuristics plus DE and classical ES) and three hand-rolled variants in arch-NAS duplicated logic that `ops::selection` already owned, each with its own NaN and empty-slice semantics. This consolidates them behind a single tested `argmax_host`, relaxes `tournament_indices_host` to accept size-1 (pressure-free uniform) tournaments, and delegates every call site to the shared `ops` module. Along the way it fixes a real correctness bug: ABC's onlooker-phase tournament had survived the ADR 0023 maximise flip with its minimise-era `<` comparison, silently biasing onlookers toward the *worst* food sources instead of concentrating effort on the best.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — internal refactor consolidating duplicated selection helpers behind `rlevo_evolution::ops::selection`; touches only algorithm-internal call sites, no public API change beyond the new `argmax_host` export.

## Linked Issue

Closes #143
Closes #150

## What Was Changed

- `crates/rlevo-evolution/src/ops/selection.rs` — added `argmax_host` (strict `>` scan seeded from `NEG_INFINITY`: ties resolve low, NaN/−inf never win, empty slice panics); relaxed `tournament_indices_host`'s panic bound from `tournament_size >= 2` to `>= 1` so pressure-free uniform selection stays expressible.
- `crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs` — deleted the local `argmax` and the hand-rolled onlooker tournament; onlooker phase now delegates to `tournament_indices_host` (fixes the inverted `<` comparison from #150); added a regression test (`onlooker_targets_prefer_best_source`) pinning the corrected sense via `target_of_candidate`.
- `crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs` — replaced the hand-rolled parent `tournament` fn and inline elitism sort with `tournament_indices_host` / `truncation_indices_host`; `update_best` now uses `argmax_host`. Parent tournaments are batched up front from the dedicated `sel_rng` substream ahead of the offspring loop, preserving the exact per-child draw order.
- `crates/rlevo-evolution/src/algorithms/de.rs`, `es_classical.rs`, `metaheuristic/{bat,cuckoo,firefly,gwo,pso,salp,woa}.rs` — removed each file's duplicated local `argmax` and delegated to `argmax_host`.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

New/updated coverage:
- `argmax_returns_index_of_largest`, `argmax_tie_resolves_to_lowest_index`, `argmax_nan_never_wins`, `argmax_degenerate_slice_falls_back_to_zero`, `argmax_empty_panics` (`ops/selection.rs`)
- `tournament_size_one_is_uniform_random` (`ops/selection.rs`) — pins the relaxed `tournament_size >= 1` bound to genuinely pressure-free behavior
- `onlooker_targets_prefer_best_source` (`abc.rs`) — regression for issue #150, asserts onlookers concentrate on the dominant bee rather than the worst

- Rust toolchain: stable (per `rust-toolchain`/`rustup show`)
- Burn backend tested: Flex (CPU)
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Claude Sonnet 5 / Claude Fable 5). Scope: implementation of the `ops::selection` consolidation and the ABC onlooker sense fix, under maintainer review and direction.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [ ] This PR addresses a single concern. (It bundles the planned refactor (#143) with a bug fix (#150) discovered while doing it — see Notes.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

This PR bundles two closely related issues: the planned helper consolidation (#143) and a correctness bug in ABC's onlooker selection (#150) that the consolidation directly surfaced and fixed — splitting them would have meant re-deriving the same delegation twice. **CRITICAL:** seeded ABC trajectories change with this commit (the onlooker sense flip is a real behavior change, not just a refactor) — any recorded ABC benchmark fixture must be regenerated. Arch-NAS seeded runs remain bit-for-bit reproducible; only the internal draw batching changed, not the per-winner draw pattern.

## Commits

- **refactor(evolution): Consolidate argmax into ops**
- **fix(evolution): Flip ABC onlooker to maximise**
