### PR TITLE
refactor(evolution): Encapsulate state/params/genome structs

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/cma_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cma_es.rs
@@ -265,21 +265,126 @@ impl Validate for CmaEsConfig {
 #[derive(Debug, Clone)]
 pub struct CmaEsState<B: Backend> {
     /// Distribution mean `m`, length `D`.
-    pub mean: Vec<f32>,
+    mean: Vec<f32>,
     /// Covariance matrix `C`, row-major `D × D`.
-    pub cov: Vec<f32>,
+    cov: Vec<f32>,
     /// Conjugate evolution path `p_σ`, length `D`.
-    pub p_sigma: Vec<f32>,
+    p_sigma: Vec<f32>,
     /// Anisotropic evolution path `p_c`, length `D`.
-    pub p_c: Vec<f32>,
+    p_c: Vec<f32>,
     /// Global step size `σ`.
-    pub sigma: f32,
+    sigma: f32,
     /// Completed-generation counter.
-    pub generation: usize,
+    generation: usize,
     /// Best-so-far genome, shape `(1, D)`.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness (canonical maximise convention).
-    pub best_fitness: f32,
+    best_fitness: f32,
+}
+
+impl<B: Backend> CmaEsState<B> {
+    /// Assembles a CMA-ES state, checking the distribution parameters are
+    /// dimensionally consistent.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `mean` is empty, if `cov` is not `D × D`
+    /// row-major (`D = mean.len()`), if `p_sigma` or `p_c` differs from `D`,
+    /// or if `sigma` is not strictly positive and finite.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        mean: Vec<f32>,
+        cov: Vec<f32>,
+        p_sigma: Vec<f32>,
+        p_c: Vec<f32>,
+        sigma: f32,
+        generation: usize,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+    ) -> Result<Self, ConfigError> {
+        let d = mean.len();
+        config::nonzero("CmaEsState", "mean", d)?;
+        if cov.len() != d * d {
+            return Err(ConfigError {
+                config: "CmaEsState",
+                field: "cov",
+                kind: ConstraintKind::Custom("covariance must be a row-major D × D matrix"),
+            });
+        }
+        if p_sigma.len() != d {
+            return Err(ConfigError {
+                config: "CmaEsState",
+                field: "p_sigma",
+                kind: ConstraintKind::Custom("evolution path length must equal D"),
+            });
+        }
+        if p_c.len() != d {
+            return Err(ConfigError {
+                config: "CmaEsState",
+                field: "p_c",
+                kind: ConstraintKind::Custom("evolution path length must equal D"),
+            });
+        }
+        config::positive("CmaEsState", "sigma", f64::from(sigma))?;
+        Ok(Self {
+            mean,
+            cov,
+            p_sigma,
+            p_c,
+            sigma,
+            generation,
+            best_genome,
+            best_fitness,
+        })
+    }
+
+    /// Distribution mean `m`, length `D`.
+    #[must_use]
+    pub fn mean(&self) -> &[f32] {
+        &self.mean
+    }
+
+    /// Covariance matrix `C`, row-major `D × D`.
+    #[must_use]
+    pub fn cov(&self) -> &[f32] {
+        &self.cov
+    }
+
+    /// Conjugate evolution path `p_σ`, length `D`.
+    #[must_use]
+    pub fn p_sigma(&self) -> &[f32] {
+        &self.p_sigma
+    }
+
+    /// Anisotropic evolution path `p_c`, length `D`.
+    #[must_use]
+    pub fn p_c(&self) -> &[f32] {
+        &self.p_c
+    }
+
+    /// Global step size `σ`.
+    #[must_use]
+    pub fn sigma(&self) -> f32 {
+        self.sigma
+    }
+
+    /// Completed-generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
+
+    /// Best-so-far genome (shape `(1, D)`), or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
 }
 
 /// Covariance Matrix Adaptation Evolution Strategy.
@@ -575,6 +680,53 @@ fn update_best<B: Backend>(state: &mut CmaEsState<B>, pop: &Tensor<B, 2>, fitnes
 #[cfg(test)]
 mod tests {
     use super::*;
+    use burn::backend::Flex;
+
+    #[test]
+    fn try_new_checks_dimensions() {
+        // D = 2: cov is 2×2 = 4 entries, both paths length 2, σ > 0.
+        assert!(
+            CmaEsState::<Flex>::try_new(
+                vec![0.0, 0.0],
+                vec![1.0, 0.0, 0.0, 1.0],
+                vec![0.0, 0.0],
+                vec![0.0, 0.0],
+                0.5,
+                0,
+                None,
+                f32::MIN,
+            )
+            .is_ok()
+        );
+        // cov length 3 ≠ D·D.
+        assert!(
+            CmaEsState::<Flex>::try_new(
+                vec![0.0, 0.0],
+                vec![1.0, 0.0, 0.0],
+                vec![0.0, 0.0],
+                vec![0.0, 0.0],
+                0.5,
+                0,
+                None,
+                f32::MIN,
+            )
+            .is_err()
+        );
+        // Non-positive σ.
+        assert!(
+            CmaEsState::<Flex>::try_new(
+                vec![0.0, 0.0],
+                vec![1.0, 0.0, 0.0, 1.0],
+                vec![0.0, 0.0],
+                vec![0.0, 0.0],
+                0.0,
+                0,
+                None,
+                f32::MIN,
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/cma_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cma_es.rs
@@ -630,7 +630,7 @@ where
             &fitness_host,
             state.best_fitness,
         );
-        state.best_fitness = metrics.best_fitness_ever;
+        state.best_fitness = metrics.best_fitness_ever();
 
         state.mean = mean_new;
         state.cov = cov_new;

--- a/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
@@ -369,7 +369,7 @@ where
             &fitness_host,
             state.best_fitness,
         );
-        state.best_fitness = metrics.best_fitness_ever;
+        state.best_fitness = metrics.best_fitness_ever();
 
         state.mean = mean_new;
         state.cov = cov_new;

--- a/crates/rlevo-evolution/src/algorithms/de.rs
+++ b/crates/rlevo-evolution/src/algorithms/de.rs
@@ -482,7 +482,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             state.population = trial;
             return (state, m);
         }
@@ -518,7 +518,7 @@ where
         state.generation += 1;
         update_best(&mut state, &trial, &fitness_host);
         let m = StrategyMetrics::from_host_fitness(state.generation, &new_fit, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -600,7 +600,7 @@ mod tests {
                 break;
             }
         }
-        harness.latest_metrics().unwrap().best_fitness_ever
+        harness.latest_metrics().unwrap().best_fitness_ever()
     }
 
     /// All five DE variants converge on Sphere-D10 within budget.

--- a/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
@@ -26,6 +26,7 @@
 
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rand::{Rng, RngExt};
+use rlevo_core::config::{self, ConfigError};
 
 use crate::probability_model::ProbabilityModel;
 
@@ -63,10 +64,37 @@ impl CompactGeneticParams {
 /// The vector has length `genome_dim`. On the prior path (`prev = None`) it
 /// is uniformly `0.5`; on subsequent calls entries are nudged by
 /// `±1 / virtual_pop_size` and clamped to `[0, 1]`.
+///
+/// The field is private so an out-of-range probability is unrepresentable
+/// from outside this module; build one with
+/// [`try_new`](CompactGeneticState::try_new) and read it via
+/// [`prob`](CompactGeneticState::prob).
 #[derive(Debug, Clone)]
 pub struct CompactGeneticState {
     /// Per-gene probability of sampling a `1.0` (always in `[0, 1]`).
-    pub prob: Vec<f32>,
+    prob: Vec<f32>,
+}
+
+impl CompactGeneticState {
+    /// Builds a cGA state from a per-gene probability vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `prob` is empty or if any entry is outside
+    /// the closed interval `[0, 1]` (or is non-finite).
+    pub fn try_new(prob: Vec<f32>) -> Result<Self, ConfigError> {
+        config::nonzero("CompactGeneticState", "prob", prob.len())?;
+        for &p in &prob {
+            config::in_range("CompactGeneticState", "prob", 0.0, 1.0, f64::from(p))?;
+        }
+        Ok(Self { prob })
+    }
+
+    /// Per-gene probabilities of sampling a `1.0`, each in `[0, 1]`.
+    #[must_use]
+    pub fn prob(&self) -> &[f32] {
+        &self.prob
+    }
 }
 
 /// Compact Genetic Algorithm for binary spaces (cGA).
@@ -215,6 +243,16 @@ mod tests {
     fn prior_is_half() {
         let p = CompactGeneticParams::default_for(3);
         assert_eq!(fit_prior(&p).prob, vec![0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn try_new_accepts_valid_and_rejects_out_of_range() {
+        let state = CompactGeneticState::try_new(vec![0.0, 0.5, 1.0]).unwrap();
+        assert_eq!(state.prob(), &[0.0, 0.5, 1.0]);
+        assert!(CompactGeneticState::try_new(vec![]).is_err());
+        assert!(CompactGeneticState::try_new(vec![0.5, 1.5]).is_err());
+        assert!(CompactGeneticState::try_new(vec![-0.1]).is_err());
+        assert!(CompactGeneticState::try_new(vec![f32::NAN]).is_err());
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/eda/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/mod.rs
@@ -330,7 +330,7 @@ impl<B: Backend, M: ProbabilityModel<B>> Strategy<B> for EdaStrategy<B, M> {
         state.generation += 1;
         let metrics =
             StrategyMetrics::from_host_fitness(state.generation, &sanitized, state.best_fitness_ever);
-        state.best_fitness_ever = metrics.best_fitness_ever;
+        state.best_fitness_ever = metrics.best_fitness_ever();
         (state, metrics)
     }
 
@@ -454,7 +454,7 @@ mod tests {
         let v = genome.into_data().into_vec::<f32>().unwrap();
         approx::assert_relative_eq!(v[0], 1.0, epsilon = 1e-6);
         approx::assert_relative_eq!(f, 9.0, epsilon = 1e-6);
-        assert!(m.best_fitness.is_finite());
+        assert!(m.best_fitness().is_finite());
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
@@ -29,6 +29,7 @@
 
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rand::{Rng, RngExt};
+use rlevo_core::config::{self, ConfigError};
 
 use crate::probability_model::ProbabilityModel;
 
@@ -71,10 +72,37 @@ impl UnivariateBernoulliParams {
 /// The vector has length `genome_dim`. On the prior path (`prev = None`) it
 /// is uniformly `0.5`; on subsequent calls the entries are nudged by the PBIL
 /// update rule (see [module docs](self)).
+///
+/// The field is private so an out-of-range probability is unrepresentable
+/// from outside this module; build one with
+/// [`try_new`](UnivariateBernoulliState::try_new) and read it via
+/// [`prob`](UnivariateBernoulliState::prob).
 #[derive(Debug, Clone)]
 pub struct UnivariateBernoulliState {
     /// Per-gene probability of sampling a `1.0` (always in `[0, 1]`).
-    pub prob: Vec<f32>,
+    prob: Vec<f32>,
+}
+
+impl UnivariateBernoulliState {
+    /// Builds a PBIL state from a per-gene probability vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `prob` is empty or if any entry is outside
+    /// the closed interval `[0, 1]` (or is non-finite).
+    pub fn try_new(prob: Vec<f32>) -> Result<Self, ConfigError> {
+        config::nonzero("UnivariateBernoulliState", "prob", prob.len())?;
+        for &p in &prob {
+            config::in_range("UnivariateBernoulliState", "prob", 0.0, 1.0, f64::from(p))?;
+        }
+        Ok(Self { prob })
+    }
+
+    /// Per-gene probabilities of sampling a `1.0`, each in `[0, 1]`.
+    #[must_use]
+    pub fn prob(&self) -> &[f32] {
+        &self.prob
+    }
 }
 
 /// Population-Based Incremental Learning model for binary spaces (PBIL).
@@ -222,6 +250,16 @@ mod tests {
         let p = UnivariateBernoulliParams::default_for(4);
         let state = fit_prior(&p);
         assert_eq!(state.prob, vec![0.5, 0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn try_new_accepts_valid_and_rejects_out_of_range() {
+        let state = UnivariateBernoulliState::try_new(vec![0.0, 0.5, 1.0]).unwrap();
+        assert_eq!(state.prob(), &[0.0, 0.5, 1.0]);
+        assert!(UnivariateBernoulliState::try_new(vec![]).is_err());
+        assert!(UnivariateBernoulliState::try_new(vec![1.2]).is_err());
+        assert!(UnivariateBernoulliState::try_new(vec![-0.5]).is_err());
+        assert!(UnivariateBernoulliState::try_new(vec![f32::NAN]).is_err());
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
@@ -24,6 +24,7 @@
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rand::Rng;
 use rand_distr::{Distribution as _, Normal};
+use rlevo_core::config::{self, ConfigError, ConstraintKind};
 
 use crate::probability_model::ProbabilityModel;
 
@@ -69,13 +70,59 @@ impl UnivariateGaussianParams {
 /// they are initialised from [`UnivariateGaussianParams::init_mean`] /
 /// `init_std²`; on subsequent calls they hold the unweighted MLE estimates
 /// computed from the truncation-selected population.
+///
+/// Fields are private so a mismatched `mean` / `variance` length (or a
+/// negative / non-finite variance) is unrepresentable from outside this
+/// module; use [`try_new`](UnivariateGaussianState::try_new) to build one and
+/// the [`mean`](UnivariateGaussianState::mean) /
+/// [`variance`](UnivariateGaussianState::variance) accessors to read it.
 #[derive(Debug, Clone)]
 pub struct UnivariateGaussianState {
     /// Per-dimension MLE mean.
-    pub mean: Vec<f32>,
+    mean: Vec<f32>,
     /// Per-dimension MLE variance, floored at
     /// [`UnivariateGaussianParams::min_variance`].
-    pub variance: Vec<f32>,
+    variance: Vec<f32>,
+}
+
+impl UnivariateGaussianState {
+    /// Builds a fitted Gaussian state from per-dimension `mean` and `variance`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `mean` is empty, if `mean` and `variance`
+    /// differ in length, or if any variance is negative or non-finite. A
+    /// variance is a squared deviation, so it must be `>= 0` and finite.
+    pub fn try_new(mean: Vec<f32>, variance: Vec<f32>) -> Result<Self, ConfigError> {
+        config::nonzero("UnivariateGaussianState", "mean", mean.len())?;
+        if mean.len() != variance.len() {
+            return Err(ConfigError {
+                config: "UnivariateGaussianState",
+                field: "variance",
+                kind: ConstraintKind::Custom("mean and variance must have equal length"),
+            });
+        }
+        if variance.iter().any(|v| !v.is_finite() || *v < 0.0) {
+            return Err(ConfigError {
+                config: "UnivariateGaussianState",
+                field: "variance",
+                kind: ConstraintKind::Custom("every variance must be finite and non-negative"),
+            });
+        }
+        Ok(Self { mean, variance })
+    }
+
+    /// Per-dimension MLE means, length `genome_dim`.
+    #[must_use]
+    pub fn mean(&self) -> &[f32] {
+        &self.mean
+    }
+
+    /// Per-dimension MLE variances, length `genome_dim`.
+    #[must_use]
+    pub fn variance(&self) -> &[f32] {
+        &self.variance
+    }
 }
 
 /// Univariate Marginal Distribution Algorithm for continuous spaces (UMDA).
@@ -321,6 +368,21 @@ mod tests {
         );
         assert_eq!(a.mean, b.mean);
         assert_eq!(a.variance, b.variance);
+    }
+
+    #[test]
+    fn try_new_accepts_valid_and_round_trips() {
+        let state = UnivariateGaussianState::try_new(vec![1.0, -2.0], vec![0.5, 4.0]).unwrap();
+        assert_eq!(state.mean(), &[1.0, -2.0]);
+        assert_eq!(state.variance(), &[0.5, 4.0]);
+    }
+
+    #[test]
+    fn try_new_rejects_length_mismatch_and_bad_variance() {
+        assert!(UnivariateGaussianState::try_new(vec![0.0, 0.0], vec![1.0]).is_err());
+        assert!(UnivariateGaussianState::try_new(vec![], vec![]).is_err());
+        assert!(UnivariateGaussianState::try_new(vec![0.0], vec![-1.0]).is_err());
+        assert!(UnivariateGaussianState::try_new(vec![0.0], vec![f32::NAN]).is_err());
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -316,7 +316,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             state.parents = offspring;
             state.sigmas = Tensor::<B, 1>::from_data(
                 TensorData::new(vec![params.initial_sigma; params.mu], [params.mu]),
@@ -390,7 +390,7 @@ where
         update_best(&mut state, &offspring, &fitness_host);
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -478,7 +478,7 @@ mod tests {
                 break;
             }
         }
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-2, "EP Sphere-D2 best={best}");
     }
 
@@ -501,7 +501,7 @@ mod tests {
                 break;
             }
         }
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-4, "EP Sphere-D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -137,26 +137,118 @@ impl Validate for EsConfig {
 pub struct EsState<B: Backend> {
     /// Parent population. `(μ, D)` for μ-parent variants; `(1, D)` for
     /// (1+1) and (1+λ).
-    pub parents: Tensor<B, 2>,
+    parents: Tensor<B, 2>,
     /// Per-parent σ values.
     ///
     /// Shape between generations is `(μ,)` for log-normal adaptation and
     /// `(1,)` for `(1+1)`/`(1+λ)` with shared σ. Between an `ask` and the
     /// matching `tell` the tensor is temporarily `(μ + λ,)`: parent σ
     /// followed by per-offspring σ. See `ask` for the rationale.
-    pub sigmas: Tensor<B, 1>,
+    sigmas: Tensor<B, 1>,
     /// Parent fitnesses.
-    pub parent_fitness: Vec<f32>,
+    parent_fitness: Vec<f32>,
     /// Best-so-far genome, shape `(1, D)`.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Completed-generation counter.
-    pub generation: usize,
+    generation: usize,
     /// (1+1) only: running success-rate counter for the 1/5th rule.
-    pub successes_in_window: u32,
+    successes_in_window: u32,
     /// (1+1) only: window length observed so far.
-    pub window_len: u32,
+    window_len: u32,
+}
+
+impl<B: Backend> EsState<B> {
+    /// Assembles an ES state, checking the parent fitness cache matches the
+    /// parent count.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `parents` has zero rows or if
+    /// `parent_fitness` is non-empty with a length other than the parent
+    /// count `μ` (`parents.dims()[0]`). The bootstrap state (empty
+    /// `parent_fitness`) is accepted.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        parents: Tensor<B, 2>,
+        sigmas: Tensor<B, 1>,
+        parent_fitness: Vec<f32>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+        successes_in_window: u32,
+        window_len: u32,
+    ) -> Result<Self, ConfigError> {
+        let mu = parents.dims()[0];
+        config::nonzero("EsState", "parents", mu)?;
+        if !parent_fitness.is_empty() && parent_fitness.len() != mu {
+            return Err(ConfigError {
+                config: "EsState",
+                field: "parent_fitness",
+                kind: ConstraintKind::Custom("length must equal the parent count μ"),
+            });
+        }
+        Ok(Self {
+            parents,
+            sigmas,
+            parent_fitness,
+            best_genome,
+            best_fitness,
+            generation,
+            successes_in_window,
+            window_len,
+        })
+    }
+
+    /// Parent population, shape `(μ, D)` (or `(1, D)` for `(1+1)`/`(1+λ)`).
+    #[must_use]
+    pub fn parents(&self) -> &Tensor<B, 2> {
+        &self.parents
+    }
+
+    /// Per-parent σ values (see the field docs for the transient `(μ + λ,)`
+    /// shape held between `ask` and `tell`).
+    #[must_use]
+    pub fn sigmas(&self) -> &Tensor<B, 1> {
+        &self.sigmas
+    }
+
+    /// Parent fitnesses (empty at bootstrap, else `μ` long).
+    #[must_use]
+    pub fn parent_fitness(&self) -> &[f32] {
+        &self.parent_fitness
+    }
+
+    /// Best-so-far genome (shape `(1, D)`), or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Completed-generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
+
+    /// `(1+1)` only: running success count for the 1/5th rule.
+    #[must_use]
+    pub fn successes_in_window(&self) -> u32 {
+        self.successes_in_window
+    }
+
+    /// `(1+1)` only: window length observed so far.
+    #[must_use]
+    pub fn window_len(&self) -> u32 {
+        self.window_len
+    }
 }
 
 /// Classical Evolution Strategy.
@@ -540,6 +632,35 @@ mod tests {
     use burn::backend::Flex;
     use rlevo_core::fitness::FitnessEvaluable;
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_parent_fitness_length() {
+        let device = Default::default();
+        let parents = Tensor::<TestBackend, 2>::zeros([4, 2], &device);
+        let sigmas = Tensor::<TestBackend, 1>::ones([4], &device);
+        // Bootstrap (empty) and fully-populated caches both accept.
+        assert!(
+            EsState::try_new(parents.clone(), sigmas.clone(), vec![], None, f32::MIN, 0, 0, 0)
+                .is_ok()
+        );
+        assert!(
+            EsState::try_new(
+                parents.clone(),
+                sigmas.clone(),
+                vec![1.0; 4],
+                None,
+                1.0,
+                1,
+                0,
+                0,
+            )
+            .is_ok()
+        );
+        // parent_fitness length 3 ≠ μ = 4.
+        assert!(
+            EsState::try_new(parents, sigmas, vec![1.0; 3], None, 1.0, 1, 0, 0).is_err()
+        );
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -471,7 +471,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             state.parents = offspring;
             // Restore parent-count σ vector.
             let mu = Self::mu(params.kind);
@@ -592,7 +592,7 @@ where
         update_best(&mut state, &offspring, &fitness_host);
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -704,7 +704,7 @@ mod tests {
                 break;
             }
         }
-        harness.latest_metrics().unwrap().best_fitness_ever
+        harness.latest_metrics().unwrap().best_fitness_ever()
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/ga.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga.rs
@@ -376,7 +376,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -404,7 +404,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &next_fitness, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -503,9 +503,9 @@ mod tests {
         }
         let m = harness.latest_metrics().unwrap();
         assert!(
-            m.best_fitness_ever < 1e-2,
+            m.best_fitness_ever() < 1e-2,
             "expected Sphere-D2 convergence, got best_fitness_ever={}",
-            m.best_fitness_ever
+            m.best_fitness_ever()
         );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/ga_binary.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga_binary.rs
@@ -323,7 +323,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             state.population = offspring;
             return (state, m);
         }
@@ -362,7 +362,7 @@ where
         state.fitness.clone_from(&next_fit);
         state.generation += 1;
         let m = StrategyMetrics::from_host_fitness(state.generation, &next_fit, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -477,7 +477,7 @@ mod tests {
                 break;
             }
         }
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         // OneMax optimum: all ones → fitness == D.
         #[allow(clippy::cast_precision_loss)]
         let optimum = dim as f32;

--- a/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
 use rand::{Rng, RngExt};
 use rayon::prelude::*;
+use rlevo_core::config::{self, ConfigError};
 
 use crate::fitness::BatchFitnessFn;
 use crate::function_set::{FunctionSet, Symbol};
@@ -19,20 +20,92 @@ use super::operators::{
 };
 
 /// Generation state for [`GepStrategy`].
+///
+/// Fields are private so the host-side fitness cache cannot fall out of sync
+/// with the population from outside this module; build one with
+/// [`try_new`](GepState::try_new) and read it through the accessors.
 #[derive(Debug, Clone)]
 pub struct GepState<B: Backend> {
     /// Current population, shape `(pop_size, genome_len)`, `i32` symbol ids.
-    pub population: Tensor<B, 2, Int>,
+    population: Tensor<B, 2, Int>,
     /// Host-side fitness cache for the current population, in canonical
     /// (maximise) space — *higher is better*. Empty until the first
     /// [`Strategy::tell`].
-    pub fitnesses: Vec<f32>,
+    fitnesses: Vec<f32>,
     /// Best-so-far genome, shape `(1, genome_len)`.
-    pub best_genome: Option<Tensor<B, 2, Int>>,
+    best_genome: Option<Tensor<B, 2, Int>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
+}
+
+impl<B: Backend> GepState<B> {
+    /// Assembles a GEP state, checking the fitness cache matches the
+    /// population.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `population` has zero rows or if
+    /// `fitnesses` is non-empty with a length other than `pop_size`. The
+    /// bootstrap state (empty `fitnesses`) is accepted.
+    pub fn try_new(
+        population: Tensor<B, 2, Int>,
+        fitnesses: Vec<f32>,
+        best_genome: Option<Tensor<B, 2, Int>>,
+        best_fitness: f32,
+        generation: usize,
+    ) -> Result<Self, ConfigError> {
+        let pop = population.dims()[0];
+        config::nonzero("GepState", "pop_size", pop)?;
+        if !fitnesses.is_empty() && fitnesses.len() != pop {
+            return Err(ConfigError {
+                config: "GepState",
+                field: "fitnesses",
+                kind: rlevo_core::config::ConstraintKind::Custom(
+                    "fitness cache length must equal pop_size",
+                ),
+            });
+        }
+        Ok(Self {
+            population,
+            fitnesses,
+            best_genome,
+            best_fitness,
+            generation,
+        })
+    }
+
+    /// Current population, shape `(pop_size, genome_len)`.
+    #[must_use]
+    pub fn population(&self) -> &Tensor<B, 2, Int> {
+        &self.population
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitnesses(&self) -> &[f32] {
+        &self.fitnesses
+    }
+
+    /// Best-so-far genome (shape `(1, genome_len)`), or `None` before the
+    /// first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2, Int>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
 }
 
 /// Gene Expression Programming as a generational [`Strategy`].
@@ -416,6 +489,15 @@ mod tests {
     use burn::backend::Flex;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_fitness_length() {
+        let device = Default::default();
+        let pop = Tensor::<TestBackend, 2, Int>::zeros([3, 4], &device);
+        assert!(GepState::try_new(pop.clone(), vec![], None, f32::MIN, 0).is_ok());
+        assert!(GepState::try_new(pop.clone(), vec![1.0; 3], None, 1.0, 1).is_ok());
+        assert!(GepState::try_new(pop, vec![1.0; 2], None, 1.0, 1).is_err());
+    }
 
     fn alphabet(n_vars: usize) -> Alphabet<ArithmeticFunctionSet> {
         Alphabet::new(ArithmeticFunctionSet, n_vars, vec![])

--- a/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
@@ -389,7 +389,7 @@ where
 
         let metrics =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = metrics.best_fitness_ever;
+        state.best_fitness = metrics.best_fitness_ever();
         // Cache this generation's fitness for the next `ask`'s roulette draw.
         state.fitnesses = fitness_host;
         (state, metrics)
@@ -525,7 +525,7 @@ mod tests {
                 break;
             }
         }
-        harness.latest_metrics().unwrap().best_fitness_ever
+        harness.latest_metrics().unwrap().best_fitness_ever()
     }
 
     /// Converges on `f(x) = x² + x + 1` over 20 points in [-1, 1].

--- a/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
+++ b/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
@@ -447,7 +447,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -478,7 +478,7 @@ where
         update_best(&mut state, &offspring, &fitness_host);
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -625,7 +625,7 @@ mod tests {
                 break;
             }
         }
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         // CGP should substantially beat the random-genome baseline.
         assert!(
             best < initial_error,

--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -173,13 +173,43 @@ impl<SP: Validate, LP> Validate for MemeticParams<SP, LP> {
 ///
 /// Wraps the inner strategy's state and carries the memetic generation counter
 /// (used to derive deterministic per-generation refinement seeds).
+///
+/// Fields are private for consistency with the rest of the crate's state
+/// types; the wrapped `inner` is an opaque `St` with no invariant this wrapper
+/// can check, so construction is the infallible [`new`](MemeticState::new)
+/// rather than a `try_new`.
 #[derive(Clone, Debug)]
 pub struct MemeticState<St> {
     /// The wrapped inner [`Strategy`] state.
-    pub inner: St,
+    inner: St,
     /// Number of completed `tell` calls — the generation index threaded into
     /// [`seed_stream`] so each generation refines from an independent stream.
-    pub generation: u64,
+    generation: u64,
+}
+
+impl<St> MemeticState<St> {
+    /// Wraps an inner strategy state with a memetic generation counter.
+    #[must_use]
+    pub fn new(inner: St, generation: u64) -> Self {
+        Self { inner, generation }
+    }
+
+    /// Borrows the wrapped inner strategy state.
+    #[must_use]
+    pub fn inner(&self) -> &St {
+        &self.inner
+    }
+
+    /// Mutably borrows the wrapped inner strategy state.
+    pub fn inner_mut(&mut self) -> &mut St {
+        &mut self.inner
+    }
+
+    /// Number of completed `tell` calls.
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
 }
 
 /// Wraps an inner [`Strategy`] with per-individual [`LocalSearch`] refinement.
@@ -590,6 +620,15 @@ mod tests {
     use rand::SeedableRng;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn memetic_state_new_round_trips() {
+        let mut state = MemeticState::new(7_u32, 3);
+        assert_eq!(*state.inner(), 7);
+        assert_eq!(state.generation(), 3);
+        *state.inner_mut() = 11;
+        assert_eq!(*state.inner(), 11);
+    }
 
     const BOUNDS: Bounds = Bounds::new(-5.12, 5.12);
 

--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -707,7 +707,7 @@ mod tests {
             state.generation += 1;
             let metrics =
                 StrategyMetrics::from_host_fitness(state.generation, &fit_host, state.best);
-            state.best = metrics.best_fitness_ever;
+            state.best = metrics.best_fitness_ever();
             (state, metrics)
         }
 
@@ -1107,13 +1107,13 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         let _ = harness.step(());
-        let first: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        let first: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
         loop {
             if harness.step(()).done {
                 break;
             }
         }
-        let last: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        let last: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(last.is_finite(), "best must stay finite");
         // Maximise objective: best_fitness_ever climbs toward the optimum 0.
         assert!(last >= first, "best_fitness_ever must improve: {last} >= {first}");
@@ -1145,7 +1145,7 @@ mod tests {
         for _ in 0..5 {
             let _ = harness.step(());
         }
-        assert!(harness.latest_metrics().unwrap().best_fitness_ever.is_finite());
+        assert!(harness.latest_metrics().unwrap().best_fitness_ever().is_finite());
     }
 
     // ---------------------------------------------------------------------

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
@@ -42,6 +42,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use super::len_matches_pop;
 use crate::ops::selection::{argmax_host, tournament_indices_host};
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
@@ -103,25 +104,114 @@ impl Validate for AbcConfig {
 }
 
 /// Generation state for [`ArtificialBeeColony`].
+///
+/// Fields are private so the per-bee caches cannot fall out of sync with the
+/// colony size from outside this module; construct one with
+/// [`try_new`](AbcState::try_new) and read it through the accessors.
 #[derive(Debug, Clone)]
 pub struct AbcState<B: Backend> {
     /// Current colony, shape `(pop_size, D)`.
-    pub colony: Tensor<B, 2>,
+    colony: Tensor<B, 2>,
     /// Host-side fitness cache.
-    pub fitness: Vec<f32>,
+    fitness: Vec<f32>,
     /// Per-bee trial counter.
-    pub trial: Vec<usize>,
+    trial: Vec<usize>,
     /// Target-bee mapping recorded by `ask` so `tell` knows which bee
     /// each candidate belongs to. Empty after `init` and after the
     /// bootstrap `ask` call (when `fitness` is still empty); populated
     /// with `2 · pop_size` indices from the second `ask` onward.
-    pub target_of_candidate: Vec<usize>,
+    target_of_candidate: Vec<usize>,
     /// Best-so-far genome.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
+}
+
+impl<B: Backend> AbcState<B> {
+    /// Assembles a colony state, checking the per-bee caches match the colony.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if the colony has zero rows, if `fitness` or
+    /// `trial` is non-empty with a length other than `pop_size`, or if
+    /// `target_of_candidate` is non-empty with a length other than
+    /// `2 · pop_size`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        colony: Tensor<B, 2>,
+        fitness: Vec<f32>,
+        trial: Vec<usize>,
+        target_of_candidate: Vec<usize>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+    ) -> Result<Self, ConfigError> {
+        let pop = colony.dims()[0];
+        config::nonzero("AbcState", "pop_size", pop)?;
+        len_matches_pop("AbcState", "fitness", pop, fitness.len())?;
+        len_matches_pop("AbcState", "trial", pop, trial.len())?;
+        if !target_of_candidate.is_empty() && target_of_candidate.len() != 2 * pop {
+            return Err(ConfigError {
+                config: "AbcState",
+                field: "target_of_candidate",
+                kind: ConstraintKind::Custom("length must equal 2 * pop_size"),
+            });
+        }
+        Ok(Self {
+            colony,
+            fitness,
+            trial,
+            target_of_candidate,
+            best_genome,
+            best_fitness,
+            generation,
+        })
+    }
+
+    /// Current colony, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn colony(&self) -> &Tensor<B, 2> {
+        &self.colony
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitness(&self) -> &[f32] {
+        &self.fitness
+    }
+
+    /// Per-bee trial counters, `pop_size` long.
+    #[must_use]
+    pub fn trial(&self) -> &[usize] {
+        &self.trial
+    }
+
+    /// Candidate-to-bee mapping recorded by `ask` (`2 · pop_size` long, or
+    /// empty at bootstrap).
+    #[must_use]
+    pub fn target_of_candidate(&self) -> &[usize] {
+        &self.target_of_candidate
+    }
+
+    /// Best-so-far genome, or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
 }
 
 /// Artificial Bee Colony strategy.
@@ -459,6 +549,31 @@ mod tests {
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_cache_lengths() {
+        let device = Default::default();
+        let colony = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        // Bootstrap (empty caches) and fully-populated caches both accept.
+        assert!(
+            AbcState::try_new(colony.clone(), vec![], vec![0; 3], vec![], None, f32::MIN, 0).is_ok()
+        );
+        assert!(
+            AbcState::try_new(colony.clone(), vec![1.0; 3], vec![0; 3], vec![7; 6], None, 1.0, 1)
+                .is_ok()
+        );
+        // fitness length 2 ≠ pop 3, and target_of_candidate 5 ≠ 2·pop.
+        assert!(
+            AbcState::try_new(colony.clone(), vec![1.0; 2], vec![0; 3], vec![], None, 1.0, 1)
+                .is_err()
+        );
+        assert!(
+            AbcState::try_new(colony, vec![], vec![], vec![0; 5], None, 1.0, 1).is_err()
+        );
+        // Zero-row colony is rejected.
+        let empty = Tensor::<TestBackend, 2>::zeros([0, 2], &device);
+        assert!(AbcState::try_new(empty, vec![], vec![], vec![], None, 1.0, 0).is_err());
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
@@ -422,7 +422,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -526,7 +526,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -636,7 +636,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-4, "ABC D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -347,7 +347,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -381,7 +381,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -447,7 +447,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-3, "ACO_R D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -34,6 +34,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use super::len_matches_pop;
 use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
@@ -105,25 +106,120 @@ impl Validate for BatConfig {
 #[derive(Debug, Clone)]
 pub struct BatState<B: Backend> {
     /// Current positions, shape `(pop_size, D)`.
-    pub positions: Tensor<B, 2>,
+    positions: Tensor<B, 2>,
     /// Current velocities, shape `(pop_size, D)`.
-    pub velocities: Tensor<B, 2>,
+    velocities: Tensor<B, 2>,
     /// Per-bat loudness.
-    pub loudness: Vec<f32>,
+    loudness: Vec<f32>,
     /// Per-bat pulse rate.
-    pub pulse_rate: Vec<f32>,
+    pulse_rate: Vec<f32>,
     /// Host-side fitness cache for the current positions.
-    pub fitness: Vec<f32>,
+    fitness: Vec<f32>,
     /// Best-so-far genome.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
     /// Per-generation "accept this candidate?" decisions recorded in
     /// `ask` so `tell` can gate the loudness/pulse updates consistently
     /// with the RNG draws.
-    pub pending_accept: Vec<bool>,
+    pending_accept: Vec<bool>,
+}
+
+impl<B: Backend> BatState<B> {
+    /// Assembles a bat-swarm state, checking the per-bat caches match `pop`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `positions` has zero rows or if any of
+    /// `loudness` / `pulse_rate` / `fitness` / `pending_accept` is non-empty
+    /// with a length other than `pop_size`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        positions: Tensor<B, 2>,
+        velocities: Tensor<B, 2>,
+        loudness: Vec<f32>,
+        pulse_rate: Vec<f32>,
+        fitness: Vec<f32>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+        pending_accept: Vec<bool>,
+    ) -> Result<Self, ConfigError> {
+        let pop = positions.dims()[0];
+        config::nonzero("BatState", "pop_size", pop)?;
+        len_matches_pop("BatState", "loudness", pop, loudness.len())?;
+        len_matches_pop("BatState", "pulse_rate", pop, pulse_rate.len())?;
+        len_matches_pop("BatState", "fitness", pop, fitness.len())?;
+        len_matches_pop("BatState", "pending_accept", pop, pending_accept.len())?;
+        Ok(Self {
+            positions,
+            velocities,
+            loudness,
+            pulse_rate,
+            fitness,
+            best_genome,
+            best_fitness,
+            generation,
+            pending_accept,
+        })
+    }
+
+    /// Current positions, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn positions(&self) -> &Tensor<B, 2> {
+        &self.positions
+    }
+
+    /// Current velocities, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn velocities(&self) -> &Tensor<B, 2> {
+        &self.velocities
+    }
+
+    /// Per-bat loudness, `pop_size` long.
+    #[must_use]
+    pub fn loudness(&self) -> &[f32] {
+        &self.loudness
+    }
+
+    /// Per-bat pulse rate, `pop_size` long.
+    #[must_use]
+    pub fn pulse_rate(&self) -> &[f32] {
+        &self.pulse_rate
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitness(&self) -> &[f32] {
+        &self.fitness
+    }
+
+    /// Best-so-far genome, or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
+
+    /// Per-candidate accept decisions recorded by `ask` (empty at bootstrap,
+    /// else `pop_size` long).
+    #[must_use]
+    pub fn pending_accept(&self) -> &[bool] {
+        &self.pending_accept
+    }
 }
 
 /// Bat Algorithm strategy.
@@ -431,6 +527,42 @@ mod tests {
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_cache_lengths() {
+        let device = Default::default();
+        let pos = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        let vel = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        assert!(
+            BatState::try_new(
+                pos.clone(),
+                vel.clone(),
+                vec![1.0; 3],
+                vec![0.5; 3],
+                vec![1.0; 3],
+                None,
+                1.0,
+                1,
+                vec![false; 3],
+            )
+            .is_ok()
+        );
+        // loudness length 2 ≠ pop 3.
+        assert!(
+            BatState::try_new(
+                pos,
+                vel,
+                vec![1.0; 2],
+                vec![0.5; 3],
+                vec![1.0; 3],
+                None,
+                1.0,
+                1,
+                vec![false; 3],
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -459,7 +459,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -503,7 +503,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         let _ = genome_dim;
         (state, m)
     }
@@ -604,7 +604,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 0.1, "Bat D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -38,6 +38,7 @@ use rand_distr::{Distribution as RandDistDist, Normal};
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use super::len_matches_pop;
 use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
@@ -94,15 +95,72 @@ impl Validate for CuckooConfig {
 #[derive(Debug, Clone)]
 pub struct CuckooState<B: Backend> {
     /// Current nests, shape `(pop_size, D)`.
-    pub nests: Tensor<B, 2>,
+    nests: Tensor<B, 2>,
     /// Host-side fitness cache; `+∞` for abandoned slots.
-    pub fitness: Vec<f32>,
+    fitness: Vec<f32>,
     /// Best-so-far genome.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
+}
+
+impl<B: Backend> CuckooState<B> {
+    /// Assembles a nest state, checking the fitness cache matches `pop`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `nests` has zero rows or if `fitness` is
+    /// non-empty with a length other than `pop_size`.
+    pub fn try_new(
+        nests: Tensor<B, 2>,
+        fitness: Vec<f32>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+    ) -> Result<Self, ConfigError> {
+        let pop = nests.dims()[0];
+        config::nonzero("CuckooState", "pop_size", pop)?;
+        len_matches_pop("CuckooState", "fitness", pop, fitness.len())?;
+        Ok(Self {
+            nests,
+            fitness,
+            best_genome,
+            best_fitness,
+            generation,
+        })
+    }
+
+    /// Current nests, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn nests(&self) -> &Tensor<B, 2> {
+        &self.nests
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitness(&self) -> &[f32] {
+        &self.fitness
+    }
+
+    /// Best-so-far genome, or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
 }
 
 /// Cuckoo Search strategy.
@@ -412,6 +470,17 @@ mod tests {
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_fitness_length() {
+        let device = Default::default();
+        let nests = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        assert!(CuckooState::try_new(nests.clone(), vec![1.0; 3], None, 1.0, 1).is_ok());
+        assert!(CuckooState::try_new(nests.clone(), vec![], None, f32::MIN, 0).is_ok());
+        assert!(CuckooState::try_new(nests, vec![1.0; 2], None, 1.0, 1).is_err());
+        let empty = Tensor::<TestBackend, 2>::zeros([0, 2], &device);
+        assert!(CuckooState::try_new(empty, vec![], None, 1.0, 0).is_err());
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -368,7 +368,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -447,7 +447,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -539,7 +539,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 20.0, "Cuckoo D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -401,7 +401,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -472,7 +472,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1.0, "Firefly D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -31,6 +31,7 @@ use rand::SeedableRng;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use super::len_matches_pop;
 use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
@@ -105,15 +106,72 @@ impl Validate for FireflyConfig {
 #[derive(Debug, Clone)]
 pub struct FireflyState<B: Backend> {
     /// Current positions, shape `(pop_size, D)`.
-    pub positions: Tensor<B, 2>,
+    positions: Tensor<B, 2>,
     /// Host-side fitness cache.
-    pub fitness: Vec<f32>,
+    fitness: Vec<f32>,
     /// Best-so-far genome.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
+}
+
+impl<B: Backend> FireflyState<B> {
+    /// Assembles a firefly state, checking the fitness cache matches `pop`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `positions` has zero rows or if `fitness`
+    /// is non-empty with a length other than `pop_size`.
+    pub fn try_new(
+        positions: Tensor<B, 2>,
+        fitness: Vec<f32>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+    ) -> Result<Self, ConfigError> {
+        let pop = positions.dims()[0];
+        config::nonzero("FireflyState", "pop_size", pop)?;
+        len_matches_pop("FireflyState", "fitness", pop, fitness.len())?;
+        Ok(Self {
+            positions,
+            fitness,
+            best_genome,
+            best_fitness,
+            generation,
+        })
+    }
+
+    /// Current positions, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn positions(&self) -> &Tensor<B, 2> {
+        &self.positions
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitness(&self) -> &[f32] {
+        &self.fitness
+    }
+
+    /// Best-so-far genome, or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
 }
 
 /// Firefly Algorithm strategy.
@@ -366,6 +424,17 @@ mod tests {
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_fitness_length() {
+        let device = Default::default();
+        let pos = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        assert!(FireflyState::try_new(pos.clone(), vec![1.0; 3], None, 1.0, 1).is_ok());
+        assert!(FireflyState::try_new(pos.clone(), vec![], None, f32::MIN, 0).is_ok());
+        assert!(FireflyState::try_new(pos, vec![1.0; 2], None, 1.0, 1).is_err());
+        let empty = Tensor::<TestBackend, 2>::zeros([0, 2], &device);
+        assert!(FireflyState::try_new(empty, vec![], None, 1.0, 0).is_err());
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -341,7 +341,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -457,7 +457,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-3, "GWO D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -39,6 +39,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use super::len_matches_pop;
 use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
@@ -86,15 +87,72 @@ impl Validate for GwoConfig {
 #[derive(Debug, Clone)]
 pub struct GwoState<B: Backend> {
     /// Current pack positions, shape `(pop_size, D)`.
-    pub pack: Tensor<B, 2>,
+    pack: Tensor<B, 2>,
     /// Host-side fitness cache.
-    pub fitness: Vec<f32>,
+    fitness: Vec<f32>,
     /// Best-so-far genome, shape `(1, D)` — corresponds to α.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
+}
+
+impl<B: Backend> GwoState<B> {
+    /// Assembles a wolf-pack state, checking the fitness cache matches `pop`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `pack` has zero rows or if `fitness` is
+    /// non-empty with a length other than `pop_size`.
+    pub fn try_new(
+        pack: Tensor<B, 2>,
+        fitness: Vec<f32>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+    ) -> Result<Self, ConfigError> {
+        let pop = pack.dims()[0];
+        config::nonzero("GwoState", "pop_size", pop)?;
+        len_matches_pop("GwoState", "fitness", pop, fitness.len())?;
+        Ok(Self {
+            pack,
+            fitness,
+            best_genome,
+            best_fitness,
+            generation,
+        })
+    }
+
+    /// Current pack positions, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn pack(&self) -> &Tensor<B, 2> {
+        &self.pack
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitness(&self) -> &[f32] {
+        &self.fitness
+    }
+
+    /// Best-so-far genome (α), or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
 }
 
 /// Grey Wolf Optimizer strategy.
@@ -341,6 +399,17 @@ mod tests {
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_fitness_length() {
+        let device = Default::default();
+        let pack = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        assert!(GwoState::try_new(pack.clone(), vec![1.0; 3], None, 1.0, 1).is_ok());
+        assert!(GwoState::try_new(pack.clone(), vec![], None, f32::MIN, 0).is_ok());
+        assert!(GwoState::try_new(pack, vec![1.0; 2], None, 1.0, 1).is_err());
+        let empty = Tensor::<TestBackend, 2>::zeros([0, 2], &device);
+        assert!(GwoState::try_new(empty, vec![], None, 1.0, 0).is_err());
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/mod.rs
@@ -53,3 +53,31 @@ pub mod kernels;
 pub mod pso;
 pub mod salp;
 pub mod woa;
+
+use rlevo_core::config::{ConfigError, ConstraintKind};
+
+/// Rejects a host-side per-individual vector whose length is neither `pop`
+/// nor `0`.
+///
+/// Swarm `*State` structs cache one host-side scalar per individual (fitness,
+/// trial counters, loudness, …). Every such vector must have length `pop`,
+/// except at bootstrap where `init` leaves the caches empty until the first
+/// `tell`. This is the shared length invariant checked by each state's
+/// `try_new`, so a mismatched non-empty length is rejected at construction
+/// rather than surfacing as an out-of-bounds panic generations later.
+pub(crate) fn len_matches_pop(
+    config: &'static str,
+    field: &'static str,
+    pop: usize,
+    len: usize,
+) -> Result<(), ConfigError> {
+    if len == 0 || len == pop {
+        Ok(())
+    } else {
+        Err(ConfigError {
+            config,
+            field,
+            kind: ConstraintKind::Custom("per-individual vector length must equal pop_size"),
+        })
+    }
+}

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
@@ -347,7 +347,7 @@ where
                 &fitness_host,
                 state.best_fitness,
             );
-            state.best_fitness = m.best_fitness_ever;
+            state.best_fitness = m.best_fitness_ever();
             return (state, m);
         }
 
@@ -394,7 +394,7 @@ where
             &fitness_host,
             state.best_fitness.max(state.global_best_fitness),
         );
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -465,7 +465,7 @@ mod tests {
                 break;
             }
         }
-        harness.latest_metrics().unwrap().best_fitness_ever
+        harness.latest_metrics().unwrap().best_fitness_ever()
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
@@ -294,7 +294,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -355,7 +355,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-2, "SSA D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -39,6 +39,7 @@ use rand::RngExt;
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use super::len_matches_pop;
 use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
@@ -87,15 +88,72 @@ impl Validate for WoaConfig {
 #[derive(Debug, Clone)]
 pub struct WoaState<B: Backend> {
     /// Current positions, shape `(pop_size, D)`.
-    pub positions: Tensor<B, 2>,
+    positions: Tensor<B, 2>,
     /// Host-side fitness cache.
-    pub fitness: Vec<f32>,
+    fitness: Vec<f32>,
     /// Best-so-far genome.
-    pub best_genome: Option<Tensor<B, 2>>,
+    best_genome: Option<Tensor<B, 2>>,
     /// Best-so-far fitness.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Generation counter.
-    pub generation: usize,
+    generation: usize,
+}
+
+impl<B: Backend> WoaState<B> {
+    /// Assembles a whale-swarm state, checking the fitness cache matches `pop`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `positions` has zero rows or if `fitness`
+    /// is non-empty with a length other than `pop_size`.
+    pub fn try_new(
+        positions: Tensor<B, 2>,
+        fitness: Vec<f32>,
+        best_genome: Option<Tensor<B, 2>>,
+        best_fitness: f32,
+        generation: usize,
+    ) -> Result<Self, ConfigError> {
+        let pop = positions.dims()[0];
+        config::nonzero("WoaState", "pop_size", pop)?;
+        len_matches_pop("WoaState", "fitness", pop, fitness.len())?;
+        Ok(Self {
+            positions,
+            fitness,
+            best_genome,
+            best_fitness,
+            generation,
+        })
+    }
+
+    /// Current positions, shape `(pop_size, D)`.
+    #[must_use]
+    pub fn positions(&self) -> &Tensor<B, 2> {
+        &self.positions
+    }
+
+    /// Host-side fitness cache (empty at bootstrap, else `pop_size` long).
+    #[must_use]
+    pub fn fitness(&self) -> &[f32] {
+        &self.fitness
+    }
+
+    /// Best-so-far genome, or `None` before the first `tell`.
+    #[must_use]
+    pub fn best_genome(&self) -> Option<&Tensor<B, 2>> {
+        self.best_genome.as_ref()
+    }
+
+    /// Best-so-far (canonical, maximise) fitness.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Generation counter.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
 }
 
 /// Whale Optimization Algorithm strategy.
@@ -351,6 +409,17 @@ mod tests {
     use rlevo_core::fitness::FitnessEvaluable;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn try_new_checks_fitness_length() {
+        let device = Default::default();
+        let pos = Tensor::<TestBackend, 2>::zeros([3, 2], &device);
+        assert!(WoaState::try_new(pos.clone(), vec![1.0; 3], None, 1.0, 1).is_ok());
+        assert!(WoaState::try_new(pos.clone(), vec![], None, f32::MIN, 0).is_ok());
+        assert!(WoaState::try_new(pos, vec![1.0; 2], None, 1.0, 1).is_err());
+        let empty = Tensor::<TestBackend, 2>::zeros([0, 2], &device);
+        assert!(WoaState::try_new(empty, vec![], None, 1.0, 0).is_err());
+    }
 
     #[test]
     fn default_config_validates() {

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -386,7 +386,7 @@ where
         state.generation += 1;
         let m =
             StrategyMetrics::from_host_fitness(state.generation, &fitness_host, state.best_fitness);
-        state.best_fitness = m.best_fitness_ever;
+        state.best_fitness = m.best_fitness_ever();
         (state, m)
     }
 
@@ -458,7 +458,7 @@ mod tests {
         ).expect("valid params");
         harness.reset();
         while !harness.step(()).done {}
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-4, "WOA D10 best={best}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
@@ -78,10 +78,43 @@ use crate::rng::{SeedPurpose, seed_stream};
 pub struct NasGenome<B: Backend> {
     /// Architecture index of each individual; length `pop_size`, each value in
     /// `0..num_variants`.
-    pub arch_ids: Vec<usize>,
+    arch_ids: Vec<usize>,
     /// Per-individual flat weights, shape `[pop_size, max_param_count]`. Columns
     /// beyond a variant's own parameter count are zero-padded.
-    pub weights: Tensor<B, 2>,
+    weights: Tensor<B, 2>,
+}
+
+impl<B: Backend> NasGenome<B> {
+    /// Assembles a population genome, checking one architecture id per row.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `weights` has zero rows or if `arch_ids`
+    /// does not have exactly one entry per weight row (`pop_size`).
+    pub fn try_new(arch_ids: Vec<usize>, weights: Tensor<B, 2>) -> Result<Self, ConfigError> {
+        let pop = weights.dims()[0];
+        config::nonzero("NasGenome", "pop_size", pop)?;
+        if arch_ids.len() != pop {
+            return Err(ConfigError {
+                config: "NasGenome",
+                field: "arch_ids",
+                kind: ConstraintKind::Custom("must have one architecture id per weight row"),
+            });
+        }
+        Ok(Self { arch_ids, weights })
+    }
+
+    /// Architecture index of each individual, length `pop_size`.
+    #[must_use]
+    pub fn arch_ids(&self) -> &[usize] {
+        &self.arch_ids
+    }
+
+    /// Per-individual flat weights, shape `[pop_size, max_param_count]`.
+    #[must_use]
+    pub fn weights(&self) -> &Tensor<B, 2> {
+        &self.weights
+    }
 }
 
 /// A type-erased per-variant evaluator.
@@ -160,26 +193,83 @@ impl<B: Backend> VariantEvaluator<B> {
 #[derive(Debug, Clone)]
 pub struct NasParams {
     /// Number of individuals per generation.
-    pub pop_size: usize,
+    pop_size: usize,
     /// Number of architecture variants (`arch_id` ranges over `0..num_variants`).
-    pub num_variants: usize,
+    num_variants: usize,
     /// Flat parameter count of each variant; length `num_variants`, indexed by
     /// `arch_id`.
-    pub per_variant_params: Vec<usize>,
+    per_variant_params: Vec<usize>,
     /// Width of the weight tensor — `per_variant_params.iter().max()`.
-    pub max_param_count: usize,
+    max_param_count: usize,
     /// Per-individual probability of reassigning the architecture id each
     /// generation (a changed id re-initializes that child's active weights).
-    pub arch_mutation_rate: f32,
+    arch_mutation_rate: f32,
     /// Standard deviation of the isotropic Gaussian weight perturbation.
-    pub weight_mutation_std: f32,
+    weight_mutation_std: f32,
     /// Standard deviation used to initialize (and re-initialize) weights.
-    pub weight_init_std: f32,
+    weight_init_std: f32,
     /// Tournament size for parent selection (clamped to `>= 1`).
-    pub tournament_size: usize,
+    tournament_size: usize,
     /// Number of best individuals carried over unmutated each generation
     /// (clamped to `<= pop_size`).
-    pub elite_count: usize,
+    elite_count: usize,
+}
+
+impl NasParams {
+    /// Number of individuals per generation.
+    #[must_use]
+    pub fn pop_size(&self) -> usize {
+        self.pop_size
+    }
+
+    /// Number of architecture variants (`arch_id` ranges over `0..num_variants`).
+    #[must_use]
+    pub fn num_variants(&self) -> usize {
+        self.num_variants
+    }
+
+    /// Flat parameter count of each variant, indexed by `arch_id`.
+    #[must_use]
+    pub fn per_variant_params(&self) -> &[usize] {
+        &self.per_variant_params
+    }
+
+    /// Width of the weight tensor (`per_variant_params.iter().max()`).
+    #[must_use]
+    pub fn max_param_count(&self) -> usize {
+        self.max_param_count
+    }
+
+    /// Per-individual probability of reassigning the architecture id each
+    /// generation.
+    #[must_use]
+    pub fn arch_mutation_rate(&self) -> f32 {
+        self.arch_mutation_rate
+    }
+
+    /// Standard deviation of the isotropic Gaussian weight perturbation.
+    #[must_use]
+    pub fn weight_mutation_std(&self) -> f32 {
+        self.weight_mutation_std
+    }
+
+    /// Standard deviation used to initialize (and re-initialize) weights.
+    #[must_use]
+    pub fn weight_init_std(&self) -> f32 {
+        self.weight_init_std
+    }
+
+    /// Tournament size for parent selection.
+    #[must_use]
+    pub fn tournament_size(&self) -> usize {
+        self.tournament_size
+    }
+
+    /// Number of best individuals carried over unmutated each generation.
+    #[must_use]
+    pub fn elite_count(&self) -> usize {
+        self.elite_count
+    }
 }
 
 impl Validate for NasParams {
@@ -715,6 +805,17 @@ mod tests {
     use rand::rngs::StdRng;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn nas_genome_try_new_checks_one_arch_id_per_row() {
+        let device = Default::default();
+        let weights = Tensor::<TestBackend, 2>::zeros([3, 4], &device);
+        assert!(NasGenome::try_new(vec![0, 1, 2], weights).is_ok());
+        let weights = Tensor::<TestBackend, 2>::zeros([3, 4], &device);
+        assert!(NasGenome::try_new(vec![0, 1], weights).is_err());
+        let empty = Tensor::<TestBackend, 2>::zeros([0, 4], &device);
+        assert!(NasGenome::try_new(vec![], empty).is_err());
+    }
 
     fn valid_builder_config() -> NasBuilderConfig {
         NasBuilderConfig {

--- a/crates/rlevo-evolution/src/coevolution/competitive.rs
+++ b/crates/rlevo-evolution/src/coevolution/competitive.rs
@@ -157,10 +157,10 @@ where
         state.state_a = next_a;
         state.state_b = next_b;
         state.generation += 1;
-        state.best_a = metrics_a.best_fitness_ever;
-        state.best_b = metrics_b.best_fitness_ever;
-        state.mean_a = metrics_a.mean_fitness;
-        state.mean_b = metrics_b.mean_fitness;
+        state.best_a = metrics_a.best_fitness_ever();
+        state.best_b = metrics_b.best_fitness_ever();
+        state.mean_a = metrics_a.mean_fitness();
+        state.mean_b = metrics_b.mean_fitness();
 
         let metrics = self.snapshot(&state);
         (state, metrics)

--- a/crates/rlevo-evolution/src/coevolution/cooperative.rs
+++ b/crates/rlevo-evolution/src/coevolution/cooperative.rs
@@ -326,10 +326,10 @@ where
         state.base.state_a = next_a;
         state.base.state_b = next_b;
         state.base.generation += 1;
-        state.base.best_a = metrics_a.best_fitness_ever;
-        state.base.best_b = metrics_b.best_fitness_ever;
-        state.base.mean_a = metrics_a.mean_fitness;
-        state.base.mean_b = metrics_b.mean_fitness;
+        state.base.best_a = metrics_a.best_fitness_ever();
+        state.base.best_b = metrics_b.best_fitness_ever();
+        state.base.mean_a = metrics_a.mean_fitness();
+        state.base.mean_b = metrics_b.mean_fitness();
 
         let metrics = self.snapshot(&state);
         (state, metrics)

--- a/crates/rlevo-evolution/src/local_search/hill_climbing.rs
+++ b/crates/rlevo-evolution/src/local_search/hill_climbing.rs
@@ -39,24 +39,28 @@ pub enum HillClimbVariant {
 }
 
 /// Static configuration for a [`HillClimbing`] run.
+///
+/// Fields are private: start from [`default_for`](HillClimbingParams::default_for)
+/// and override with the fluent `with_*` setters, which reject out-of-domain
+/// values at the call site rather than letting an invalid config reach `refine`.
 #[derive(Debug, Clone)]
 pub struct HillClimbingParams {
     /// Inclusive search-space bounds `(lo, hi)`; refined genomes are clamped
     /// here.
-    pub bounds: Bounds,
+    bounds: Bounds,
     /// Hard cap on the **total** number of `evaluate_one` calls per `refine`,
     /// including the mandatory initial re-evaluation of the input genome.
     /// Default `100`.
-    pub max_iters: usize,
+    max_iters: usize,
     /// Per-coordinate perturbation magnitude. Default `0.1 * (hi - lo)` via
     /// [`HillClimbingParams::default_for`].
-    pub step_size: f32,
+    step_size: f32,
     /// Multiplicative shrink applied to `step_size` after a failed probe
     /// budget. `0.5` halves the step; `1.0` keeps it fixed. Default `0.5`.
-    pub step_decay: f32,
+    step_decay: f32,
     /// Acceptance strategy. Default
     /// [`FirstImprovement`](HillClimbVariant::FirstImprovement).
-    pub variant: HillClimbVariant,
+    variant: HillClimbVariant,
 }
 
 impl HillClimbingParams {
@@ -74,6 +78,98 @@ impl HillClimbingParams {
             step_decay: 0.5,
             variant: HillClimbVariant::FirstImprovement,
         }
+    }
+
+    /// Overrides the search-space bounds.
+    #[must_use]
+    pub fn with_bounds(mut self, bounds: Bounds) -> Self {
+        self.bounds = bounds;
+        self
+    }
+
+    /// Overrides the total evaluation budget per `refine`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_iters == 0` — a `refine` must evaluate at least the
+    /// input genome once.
+    #[must_use]
+    pub fn with_max_iters(mut self, max_iters: usize) -> Self {
+        assert!(
+            max_iters >= 1,
+            "HillClimbingParams::with_max_iters: max_iters must be >= 1"
+        );
+        self.max_iters = max_iters;
+        self
+    }
+
+    /// Overrides the per-coordinate perturbation magnitude.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `step_size` is not strictly positive and finite — a
+    /// non-positive step cannot move the search.
+    #[must_use]
+    pub fn with_step_size(mut self, step_size: f32) -> Self {
+        assert!(
+            step_size.is_finite() && step_size > 0.0,
+            "HillClimbingParams::with_step_size: step_size must be finite and > 0"
+        );
+        self.step_size = step_size;
+        self
+    }
+
+    /// Overrides the multiplicative step-shrink factor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `step_decay` is outside the half-open interval `(0, 1]` — a
+    /// factor `> 1` would grow the step unboundedly and `<= 0` would zero it.
+    #[must_use]
+    pub fn with_step_decay(mut self, step_decay: f32) -> Self {
+        assert!(
+            step_decay.is_finite() && step_decay > 0.0 && step_decay <= 1.0,
+            "HillClimbingParams::with_step_decay: step_decay must be in (0, 1]"
+        );
+        self.step_decay = step_decay;
+        self
+    }
+
+    /// Overrides the acceptance strategy.
+    #[must_use]
+    pub fn with_variant(mut self, variant: HillClimbVariant) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    /// Inclusive search-space bounds.
+    #[must_use]
+    pub fn bounds(&self) -> Bounds {
+        self.bounds
+    }
+
+    /// Total evaluation budget per `refine`.
+    #[must_use]
+    pub fn max_iters(&self) -> usize {
+        self.max_iters
+    }
+
+    /// Per-coordinate perturbation magnitude.
+    #[must_use]
+    pub fn step_size(&self) -> f32 {
+        self.step_size
+    }
+
+    /// Multiplicative step-shrink factor.
+    #[must_use]
+    pub fn step_decay(&self) -> f32 {
+        self.step_decay
+    }
+
+    /// Acceptance strategy.
+    #[must_use]
+    pub fn variant(&self) -> HillClimbVariant {
+        self.variant
     }
 }
 
@@ -298,6 +394,26 @@ mod tests {
     use rand::SeedableRng;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn with_setters_override_defaults() {
+        let bounds = Bounds::new(-1.0, 1.0);
+        let hc = HillClimbingParams::default_for(bounds)
+            .with_max_iters(20)
+            .with_step_size(0.4)
+            .with_step_decay(0.5)
+            .with_variant(HillClimbVariant::BestImprovement);
+        assert_eq!(hc.max_iters(), 20);
+        assert!((hc.step_size() - 0.4).abs() < 1e-6);
+        assert!((hc.step_decay() - 0.5).abs() < 1e-6);
+        assert_eq!(hc.variant(), HillClimbVariant::BestImprovement);
+    }
+
+    #[test]
+    #[should_panic(expected = "step_size must be finite and > 0")]
+    fn with_step_size_rejects_nonpositive() {
+        let _ = HillClimbingParams::default_for(Bounds::new(-1.0, 1.0)).with_step_size(0.0);
+    }
 
     /// Negated sphere `f(x) = -Σ x_i²` — concave bump; global maximum 0 at the
     /// origin.

--- a/crates/rlevo-evolution/src/local_search/random_restart.rs
+++ b/crates/rlevo-evolution/src/local_search/random_restart.rs
@@ -360,8 +360,7 @@ mod tests {
         // full inner budget. Total evals must respect the product formula and
         // exceed a single inner run (proving the restarts actually ran).
         let searcher = RandomRestart::new(HillClimbing);
-        let mut inner = HillClimbingParams::default_for(BOUNDS);
-        inner.max_iters = 20;
+        let inner = HillClimbingParams::default_for(BOUNDS).with_max_iters(20);
         let restarts = 3_usize;
         let params = rr_params(inner.clone(), restarts);
 
@@ -377,7 +376,7 @@ mod tests {
             &mut rng,
         );
 
-        let upper = (restarts + 1) * inner.max_iters;
+        let upper = (restarts + 1) * inner.max_iters();
         assert!(
             counting.calls <= upper,
             "evals {} must not exceed product budget {}",
@@ -385,10 +384,10 @@ mod tests {
             upper
         );
         assert!(
-            counting.calls > inner.max_iters,
+            counting.calls > inner.max_iters(),
             "evals {} must exceed a single inner run ({}) — restarts must run",
             counting.calls,
-            inner.max_iters
+            inner.max_iters()
         );
     }
 
@@ -434,10 +433,10 @@ mod tests {
         // run (restarts=0) settles onto that peak; restarts with healthy
         // perturbation escape to a strictly better fitness.
         let searcher = RandomRestart::new(HillClimbing);
-        let mut inner = HillClimbingParams::default_for(BOUNDS);
         // Small step so run 0 stays trapped near the start peak.
-        inner.step_size = 0.25;
-        inner.max_iters = 120;
+        let inner = HillClimbingParams::default_for(BOUNDS)
+            .with_step_size(0.25)
+            .with_max_iters(120);
         // Start near a non-global Neg-Rastrigin local maximum (lattice point
         // (4, -3), a local minimum of the original Rastrigin).
         let start = vec![4.0_f32, -3.0];
@@ -541,10 +540,10 @@ mod tests {
     #[test]
     fn boundary_start_with_large_perturbation_stays_within_bounds() {
         let searcher = RandomRestart::new(HillClimbing);
-        let mut inner = HillClimbingParams::default_for(BOUNDS);
         // Big inner step, no decay, so probes push hard on bounds too.
-        inner.step_size = 4.0;
-        inner.step_decay = 1.0;
+        let inner = HillClimbingParams::default_for(BOUNDS)
+            .with_step_size(4.0)
+            .with_step_decay(1.0);
         let mut params = rr_params(inner, 4);
         // Large perturbation relative to range: starts will spill past bounds
         // before clamping.
@@ -607,8 +606,7 @@ mod tests {
         // step-underflow (not the budget) terminates each run, total evals drop
         // by exactly one: run 0's seeding eval.
         let searcher = RandomRestart::new(HillClimbing);
-        let mut inner = HillClimbingParams::default_for(BOUNDS);
-        inner.max_iters = 10_000;
+        let inner = HillClimbingParams::default_for(BOUNDS).with_max_iters(10_000);
         let params = rr_params(inner, 3);
         let start = vec![1.0_f32, 2.0, 3.0];
 

--- a/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
+++ b/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
@@ -44,23 +44,27 @@ pub enum CoolingSchedule {
 }
 
 /// Static configuration for a [`SimulatedAnnealing`] run.
+///
+/// Fields are private: start from [`default_for`](SimulatedAnnealingParams::default_for)
+/// and override with the fluent `with_*` setters, which reject out-of-domain
+/// values at the call site rather than letting an invalid config reach `refine`.
 #[derive(Debug, Clone)]
 pub struct SimulatedAnnealingParams {
     /// Inclusive search-space bounds `(lo, hi)`; proposals are clamped here.
-    pub bounds: Bounds,
+    bounds: Bounds,
     /// Hard cap on the **total** number of `evaluate_one` calls per `refine`,
     /// including the initial evaluation of the input genome. Default `200`.
-    pub max_iters: usize,
+    max_iters: usize,
     /// Starting temperature. Default `1.0`.
-    pub initial_temp: f32,
+    initial_temp: f32,
     /// Cooling schedule. Default `Geometric { factor: 0.95 }`.
-    pub cooling: CoolingSchedule,
+    cooling: CoolingSchedule,
     /// Early-stop temperature floor — the walk stops once `T < min_temp`.
     /// Default `1e-6`.
-    pub min_temp: f32,
+    min_temp: f32,
     /// Standard deviation of the Gaussian proposal step. Default
     /// `0.1 * (hi - lo)`.
-    pub step_size: f32,
+    step_size: f32,
 }
 
 impl SimulatedAnnealingParams {
@@ -83,6 +87,134 @@ impl SimulatedAnnealingParams {
             min_temp: 1e-6,
             step_size: 0.1 * (hi - lo),
         }
+    }
+
+    /// Overrides the search-space bounds.
+    #[must_use]
+    pub fn with_bounds(mut self, bounds: Bounds) -> Self {
+        self.bounds = bounds;
+        self
+    }
+
+    /// Overrides the total evaluation budget per `refine`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_iters == 0` — a `refine` must evaluate the input at
+    /// least once.
+    #[must_use]
+    pub fn with_max_iters(mut self, max_iters: usize) -> Self {
+        assert!(
+            max_iters >= 1,
+            "SimulatedAnnealingParams::with_max_iters: max_iters must be >= 1"
+        );
+        self.max_iters = max_iters;
+        self
+    }
+
+    /// Overrides the starting temperature.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `initial_temp` is not strictly positive and finite.
+    #[must_use]
+    pub fn with_initial_temp(mut self, initial_temp: f32) -> Self {
+        assert!(
+            initial_temp.is_finite() && initial_temp > 0.0,
+            "SimulatedAnnealingParams::with_initial_temp: initial_temp must be finite and > 0"
+        );
+        self.initial_temp = initial_temp;
+        self
+    }
+
+    /// Overrides the cooling schedule.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the schedule's parameter is out of domain: a
+    /// [`Geometric`](CoolingSchedule::Geometric) `factor` outside `(0, 1)`, or
+    /// a [`Linear`](CoolingSchedule::Linear) `delta` that is not strictly
+    /// positive and finite.
+    #[must_use]
+    pub fn with_cooling(mut self, cooling: CoolingSchedule) -> Self {
+        match cooling {
+            CoolingSchedule::Geometric { factor } => assert!(
+                factor.is_finite() && factor > 0.0 && factor < 1.0,
+                "SimulatedAnnealingParams::with_cooling: geometric factor must be in (0, 1)"
+            ),
+            CoolingSchedule::Linear { delta } => assert!(
+                delta.is_finite() && delta > 0.0,
+                "SimulatedAnnealingParams::with_cooling: linear delta must be finite and > 0"
+            ),
+        }
+        self.cooling = cooling;
+        self
+    }
+
+    /// Overrides the early-stop temperature floor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_temp` is negative or non-finite.
+    #[must_use]
+    pub fn with_min_temp(mut self, min_temp: f32) -> Self {
+        assert!(
+            min_temp.is_finite() && min_temp >= 0.0,
+            "SimulatedAnnealingParams::with_min_temp: min_temp must be finite and >= 0"
+        );
+        self.min_temp = min_temp;
+        self
+    }
+
+    /// Overrides the Gaussian proposal step size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `step_size` is not strictly positive and finite.
+    #[must_use]
+    pub fn with_step_size(mut self, step_size: f32) -> Self {
+        assert!(
+            step_size.is_finite() && step_size > 0.0,
+            "SimulatedAnnealingParams::with_step_size: step_size must be finite and > 0"
+        );
+        self.step_size = step_size;
+        self
+    }
+
+    /// Inclusive search-space bounds.
+    #[must_use]
+    pub fn bounds(&self) -> Bounds {
+        self.bounds
+    }
+
+    /// Total evaluation budget per `refine`.
+    #[must_use]
+    pub fn max_iters(&self) -> usize {
+        self.max_iters
+    }
+
+    /// Starting temperature.
+    #[must_use]
+    pub fn initial_temp(&self) -> f32 {
+        self.initial_temp
+    }
+
+    /// Cooling schedule.
+    #[must_use]
+    pub fn cooling(&self) -> CoolingSchedule {
+        self.cooling
+    }
+
+    /// Early-stop temperature floor.
+    #[must_use]
+    pub fn min_temp(&self) -> f32 {
+        self.min_temp
+    }
+
+    /// Gaussian proposal step size.
+    #[must_use]
+    pub fn step_size(&self) -> f32 {
+        self.step_size
     }
 }
 
@@ -276,6 +408,28 @@ mod tests {
     use rand::SeedableRng;
 
     type TestBackend = Flex;
+
+    #[test]
+    fn with_setters_override_defaults() {
+        let sa = SimulatedAnnealingParams::default_for(Bounds::new(-2.0, 2.0))
+            .with_max_iters(50)
+            .with_initial_temp(3.0)
+            .with_cooling(CoolingSchedule::Linear { delta: 0.1 })
+            .with_min_temp(0.01)
+            .with_step_size(0.5);
+        assert_eq!(sa.max_iters(), 50);
+        assert!((sa.initial_temp() - 3.0).abs() < 1e-6);
+        assert_eq!(sa.cooling(), CoolingSchedule::Linear { delta: 0.1 });
+        assert!((sa.min_temp() - 0.01).abs() < 1e-6);
+        assert!((sa.step_size() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    #[should_panic(expected = "geometric factor must be in (0, 1)")]
+    fn with_cooling_rejects_out_of_range_geometric_factor() {
+        let _ = SimulatedAnnealingParams::default_for(Bounds::new(-2.0, 2.0))
+            .with_cooling(CoolingSchedule::Geometric { factor: 1.5 });
+    }
 
     /// Negated sphere `f(x) = -Σ x_i²` — concave bump; global maximum 0 at the
     /// origin.

--- a/crates/rlevo-evolution/src/neuroevolution/species.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/species.rs
@@ -34,22 +34,36 @@ pub const STAGNATION_PROTECT_TOP_K: usize = 2;
 /// population stays the single owner of genome data and the partition is a cheap
 /// view. `representative` is a *cloned* genome (not an index) so it survives
 /// population turnover between generations.
+///
+/// Fields are `pub(crate)`: the NEAT speciation, reproduction, and stagnation
+/// operators (spread across `species.rs` and `neat.rs`) mutate them in place,
+/// but no code outside this crate constructs or reads a `Species` field, so
+/// crate-visibility blocks external struct-literal construction of an
+/// inconsistent species without imposing accessor churn on the operators.
 #[derive(Clone, Debug)]
 pub struct Species {
     /// Stable species id.
-    pub id: SpeciesId,
+    pub(crate) id: SpeciesId,
     /// Frozen comparison anchor for this generation's assignment pass — a
     /// randomly chosen member of the previous generation (canonical NEAT).
-    pub representative: TopologyGenome,
+    pub(crate) representative: TopologyGenome,
     /// Indices into the population `Vec` assigned to this species this generation.
-    pub members: Vec<usize>,
+    pub(crate) members: Vec<usize>,
     /// Best (maximization-oriented) fitness ever seen in this species.
-    pub best_fitness: f32,
+    pub(crate) best_fitness: f32,
     /// Generation at which `best_fitness` last improved — drives stagnation.
-    pub last_improved_generation: u64,
+    pub(crate) last_improved_generation: u64,
     /// Sum of size-adjusted fitness over members (= mean raw fitness); drives
     /// offspring allocation.
-    pub adjusted_fitness_sum: f32,
+    pub(crate) adjusted_fitness_sum: f32,
+}
+
+impl Species {
+    /// This species' stable identifier.
+    #[must_use]
+    pub fn id(&self) -> SpeciesId {
+        self.id
+    }
 }
 
 /// Compatibility distance `δ = c1·E/N + c2·D/N + c3·W̄` between two genomes

--- a/crates/rlevo-evolution/src/neuroevolution/topology.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/topology.rs
@@ -131,12 +131,20 @@ pub struct ConnectionGene {
 /// connection-gene list.
 ///
 /// See the [module docs](self) for the two structural invariants.
+///
+/// Fields are `pub(crate)` rather than public: the innovation-sort invariant on
+/// `connections` is maintained collectively by the NEAT mutation, crossover,
+/// and speciation operators (`neat.rs`, `species.rs`, `phenotype.rs`), which
+/// edit the vectors in place. Exposing them publicly would let external code
+/// build an unsorted genome by struct literal; instead, construct one with
+/// [`TopologyGenome::new`] / [`TopologyGenome::minimal`] (which establish the
+/// invariant) and extend it with [`insert_connection_sorted`](TopologyGenome::insert_connection_sorted).
 #[derive(Clone, Debug)]
 pub struct TopologyGenome {
     /// Node genes (inputs, outputs, and any hidden nodes).
-    pub nodes: Vec<NodeGene>,
+    pub(crate) nodes: Vec<NodeGene>,
     /// Connection genes, kept sorted by [`ConnectionGene::innovation`].
-    pub connections: Vec<ConnectionGene>,
+    pub(crate) connections: Vec<ConnectionGene>,
 }
 
 impl TopologyGenome {

--- a/crates/rlevo-evolution/src/probability_model.rs
+++ b/crates/rlevo-evolution/src/probability_model.rs
@@ -147,13 +147,13 @@ mod tests {
 
         let state = model.fit(&params, None, empty_pop, empty_fitness, &device);
 
-        assert_eq!(state.mean.len(), 3);
-        assert_eq!(state.variance.len(), 3);
-        for &m in &state.mean {
+        assert_eq!(state.mean().len(), 3);
+        assert_eq!(state.variance().len(), 3);
+        for &m in state.mean() {
             approx::assert_relative_eq!(m, params.init_mean, epsilon = 1e-6);
         }
         let expected_var = params.init_std * params.init_std;
-        for &v in &state.variance {
+        for &v in state.variance() {
             approx::assert_relative_eq!(v, expected_var, epsilon = 1e-6);
         }
     }

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -184,11 +184,11 @@ pub trait Strategy<B: Backend>: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct StrategyMetrics {
     /// Zero-based generation index.
-    pub generation: usize,
+    generation: usize,
     /// Number of individuals evaluated in this generation.
-    pub population_size: usize,
+    population_size: usize,
     /// Best (canonical: largest) fitness observed in this generation.
-    pub best_fitness: f32,
+    best_fitness: f32,
     /// Mean fitness across this generation's population.
     ///
     /// This is the arithmetic mean of the per-individual fitness vector
@@ -196,9 +196,9 @@ pub struct StrategyMetrics {
     /// after a run, this value reflects the *final* generation's average
     /// quality. See the struct-level docs for how to interpret the gap
     /// between this field and [`Self::best_fitness_ever`].
-    pub mean_fitness: f32,
+    mean_fitness: f32,
     /// Worst (canonical: smallest) fitness observed in this generation.
-    pub worst_fitness: f32,
+    worst_fitness: f32,
     /// Best fitness seen across *all* generations to date.
     ///
     /// This is a rolling maximum (`previous_best.max(current_generation_best)`)
@@ -207,7 +207,7 @@ pub struct StrategyMetrics {
     /// quality found during the entire run. For landscapes whose global
     /// optimum is known (e.g. Ackley → 0), the harness-reported value tells
     /// you how close the algorithm got to the theoretical optimum.
-    pub best_fitness_ever: f32,
+    best_fitness_ever: f32,
 }
 
 impl StrategyMetrics {
@@ -258,6 +258,42 @@ impl StrategyMetrics {
             worst_fitness: worst,
             best_fitness_ever: best_fitness_ever.max(best),
         }
+    }
+
+    /// Zero-based generation index.
+    #[must_use]
+    pub fn generation(&self) -> usize {
+        self.generation
+    }
+
+    /// Number of individuals evaluated in this generation.
+    #[must_use]
+    pub fn population_size(&self) -> usize {
+        self.population_size
+    }
+
+    /// Best (canonical: largest) fitness observed in this generation.
+    #[must_use]
+    pub fn best_fitness(&self) -> f32 {
+        self.best_fitness
+    }
+
+    /// Mean fitness across this generation's population.
+    #[must_use]
+    pub fn mean_fitness(&self) -> f32 {
+        self.mean_fitness
+    }
+
+    /// Worst (canonical: smallest) fitness observed in this generation.
+    #[must_use]
+    pub fn worst_fitness(&self) -> f32 {
+        self.worst_fitness
+    }
+
+    /// Best (canonical: largest) fitness seen across *all* generations to date.
+    #[must_use]
+    pub fn best_fitness_ever(&self) -> f32 {
+        self.best_fitness_ever
     }
 }
 
@@ -725,7 +761,7 @@ mod tests {
             let values = fitness.into_data().into_vec::<f32>().unwrap();
             state.generation += 1;
             let metrics = StrategyMetrics::from_host_fitness(state.generation, &values, state.best);
-            state.best = metrics.best_fitness_ever;
+            state.best = metrics.best_fitness_ever();
             (state, metrics)
         }
 
@@ -798,14 +834,15 @@ mod tests {
     #[test]
     fn from_host_fitness_computes_stats() {
         let m = StrategyMetrics::from_host_fitness(5, &[3.0, 1.0, 5.0, 2.0], 4.0);
-        assert_eq!(m.generation, 5);
-        assert_eq!(m.population_size, 4);
+        // Read through the public accessors (fields are private).
+        assert_eq!(m.generation(), 5);
+        assert_eq!(m.population_size(), 4);
         // Canonical maximise: best is the largest, worst the smallest.
-        approx::assert_relative_eq!(m.best_fitness, 5.0, epsilon = 1e-6);
-        approx::assert_relative_eq!(m.worst_fitness, 1.0, epsilon = 1e-6);
-        approx::assert_relative_eq!(m.mean_fitness, 2.75, epsilon = 1e-6);
+        approx::assert_relative_eq!(m.best_fitness(), 5.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(m.worst_fitness(), 1.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(m.mean_fitness(), 2.75, epsilon = 1e-6);
         // best_fitness_ever = max(prior=4.0, current=5.0)
-        approx::assert_relative_eq!(m.best_fitness_ever, 5.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(m.best_fitness_ever(), 5.0, epsilon = 1e-6);
     }
 
     #[test]
@@ -814,10 +851,10 @@ mod tests {
         // never becomes best, and it drags worst and mean to −∞ rather than the
         // old asymmetry where best/worst ignored it but mean turned NaN.
         let m = StrategyMetrics::from_host_fitness(0, &[1.0, f32::NAN, 3.0, 2.0], 0.0);
-        approx::assert_relative_eq!(m.best_fitness, 3.0, epsilon = 1e-6);
-        assert!(m.worst_fitness.is_infinite() && m.worst_fitness.is_sign_negative());
-        assert!(m.mean_fitness.is_infinite() && m.mean_fitness.is_sign_negative());
-        approx::assert_relative_eq!(m.best_fitness_ever, 3.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(m.best_fitness(), 3.0, epsilon = 1e-6);
+        assert!(m.worst_fitness().is_infinite() && m.worst_fitness().is_sign_negative());
+        assert!(m.mean_fitness().is_infinite() && m.mean_fitness().is_sign_negative());
+        approx::assert_relative_eq!(m.best_fitness_ever(), 3.0, epsilon = 1e-6);
     }
 
     #[test]

--- a/crates/rlevo-evolution/tests/backend_parity.rs
+++ b/crates/rlevo-evolution/tests/backend_parity.rs
@@ -88,7 +88,7 @@ where
             break;
         }
     }
-    harness.latest_metrics().unwrap().best_fitness_ever
+    harness.latest_metrics().unwrap().best_fitness_ever()
 }
 
 fn run_sphere_pso<B>(seed: u64, gens: usize, device: B::Device) -> f32
@@ -117,7 +117,7 @@ where
             break;
         }
     }
-    harness.latest_metrics().unwrap().best_fitness_ever
+    harness.latest_metrics().unwrap().best_fitness_ever()
 }
 
 #[test]

--- a/crates/rlevo-evolution/tests/cma_es_convergence.rs
+++ b/crates/rlevo-evolution/tests/cma_es_convergence.rs
@@ -61,7 +61,7 @@ where
     let mut trajectory: Vec<f32> = Vec::with_capacity(gens);
     loop {
         let step = harness.step(());
-        trajectory.push(harness.latest_metrics().unwrap().best_fitness_ever);
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness_ever());
         if step.done {
             break;
         }

--- a/crates/rlevo-evolution/tests/determinism.rs
+++ b/crates/rlevo-evolution/tests/determinism.rs
@@ -76,7 +76,7 @@ where
     let mut trajectory = Vec::with_capacity(gens);
     loop {
         let step = harness.step(());
-        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness());
         if step.done {
             break;
         }
@@ -182,7 +182,7 @@ fn run_memetic_de(seed: u64, gens: usize) -> Vec<f32> {
     let mut trajectory: Vec<f32> = Vec::with_capacity(gens);
     loop {
         let step = harness.step(());
-        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness());
         if step.done {
             break;
         }
@@ -224,7 +224,7 @@ fn run_memetic_sa(seed: u64, gens: usize) -> Vec<f32> {
     let mut trajectory: Vec<f32> = Vec::with_capacity(gens);
     loop {
         let step = harness.step(());
-        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness());
         if step.done {
             break;
         }

--- a/crates/rlevo-evolution/tests/eda_smoke.rs
+++ b/crates/rlevo-evolution/tests/eda_smoke.rs
@@ -63,7 +63,7 @@ where
     let metrics = harness.latest_metrics();
     assert!(metrics.is_some(), "latest_metrics must be Some after a run");
     assert!(
-        metrics.unwrap().best_fitness_ever.is_finite(),
+        metrics.unwrap().best_fitness_ever().is_finite(),
         "best fitness must be finite"
     );
     let best = harness.best();

--- a/crates/rlevo-evolution/tests/neuroevolution_bounded_nas.rs
+++ b/crates/rlevo-evolution/tests/neuroevolution_bounded_nas.rs
@@ -145,13 +145,13 @@ fn arch_nas_selects_architecture_and_improves_on_xor() {
         elite_count: 2,
     });
 
-    assert_eq!(params.num_variants, 3, "exactly three architecture variants");
+    assert_eq!(params.num_variants(), 3, "exactly three architecture variants");
     assert_eq!(
-        params.per_variant_params,
+        params.per_variant_params(),
         vec![33, 193, 769],
         "param counts in registration order",
     );
-    assert_eq!(params.max_param_count, 769);
+    assert_eq!(params.max_param_count(), 769);
 
     let strat = ArchNasStrategy::<TestBackend>::new();
     let mut rng = StdRng::seed_from_u64(2026);
@@ -161,7 +161,7 @@ fn arch_nas_selects_architecture_and_improves_on_xor() {
     // variants makes a missing variant astronomically unlikely).
     for arch_id in 0..3 {
         assert!(
-            state.population().arch_ids.contains(&arch_id),
+            state.population().arch_ids().contains(&arch_id),
             "architecture {arch_id} must be represented after init",
         );
     }

--- a/crates/rlevo-evolution/tests/neuroevolution_supervised.rs
+++ b/crates/rlevo-evolution/tests/neuroevolution_supervised.rs
@@ -111,7 +111,7 @@ fn weight_only_ga_fits_noisy_sine_directional() {
 
     // Generation 0.
     harness.step(());
-    let initial_best = harness.latest_metrics().unwrap().best_fitness_ever;
+    let initial_best = harness.latest_metrics().unwrap().best_fitness_ever();
 
     // Generations 1..50.
     loop {
@@ -119,7 +119,7 @@ fn weight_only_ga_fits_noisy_sine_directional() {
             break;
         }
     }
-    let final_best = harness.latest_metrics().unwrap().best_fitness_ever;
+    let final_best = harness.latest_metrics().unwrap().best_fitness_ever();
 
     assert!(
         final_best < initial_best,

--- a/crates/rlevo-examples/examples/book/ch01_sphere_ga.rs
+++ b/crates/rlevo-examples/examples/book/ch01_sphere_ga.rs
@@ -53,9 +53,9 @@ fn main() {
     loop {
         let step = harness.step(());
         if let Some(m) = harness.latest_metrics()
-            && (m.generation % PRINT_EVERY == 0 || step.done)
+            && (m.generation() % PRINT_EVERY == 0 || step.done)
         {
-            println!("gen {:>3}   best = {:.2e}", m.generation, m.best_fitness_ever);
+            println!("gen {:>3}   best = {:.2e}", m.generation(), m.best_fitness_ever());
         }
         if step.done {
             break;
@@ -96,7 +96,7 @@ mod tests {
             }
         }
 
-        let best = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(
             best < 1.0,
             "GA on Sphere-D{DIM} should reach best < 1.0 after {GENS} gens; got {best}"

--- a/crates/rlevo-examples/examples/evolution/eda_showcase.rs
+++ b/crates/rlevo-examples/examples/evolution/eda_showcase.rs
@@ -228,8 +228,8 @@ fn rosenbrock_demo() {
         |row| rosenbrock_fitness(landscape, row),
         |g, st: &UnivariateGaussianState| {
             if logged(g) {
-                let mean_abs_mu = mean(&st.mean.iter().map(|m| m.abs()).collect::<Vec<_>>());
-                let mean_sigma = mean(&st.variance.iter().map(|v| v.sqrt()).collect::<Vec<_>>());
+                let mean_abs_mu = mean(&st.mean().iter().map(|m| m.abs()).collect::<Vec<_>>());
+                let mean_sigma = mean(&st.variance().iter().map(|v| v.sqrt()).collect::<Vec<_>>());
                 println!("  {:>4} {mean_abs_mu:>12.5} {mean_sigma:>10.5}", g + 1);
             }
         },
@@ -399,7 +399,7 @@ fn onemax_demo() {
         ONEMAX_GENS,
         onemax_zeros,
         |g, st: &UnivariateBernoulliState| {
-            println!("  {:>4} {:>9.4}  {}", g + 1, mean(&st.prob), prob_bar(&st.prob));
+            println!("  {:>4} {:>9.4}  {}", g + 1, mean(st.prob()), prob_bar(st.prob()));
         },
     );
     println!("  → best fitness (0 = all-ones found): {pbil_best:.1}\n");
@@ -418,7 +418,7 @@ fn onemax_demo() {
         ONEMAX_GENS,
         onemax_zeros,
         |g, st: &CompactGeneticState| {
-            println!("  {:>4} {:>9.4}  {}", g + 1, mean(&st.prob), prob_bar(&st.prob));
+            println!("  {:>4} {:>9.4}  {}", g + 1, mean(st.prob()), prob_bar(st.prob()));
         },
     );
     println!("  → best fitness (0 = all-ones found): {cga_best:.1}\n");
@@ -566,7 +566,7 @@ fn trap_demo() {
         |row| trap_fitness(trap, row),
         |g, st: &UnivariateGaussianState| {
             if logged(g) {
-                println!("  {:>4} {:>10.5}", g + 1, mean(&st.mean));
+                println!("  {:>4} {:>10.5}", g + 1, mean(st.mean()));
             }
         },
     );

--- a/crates/rlevo-examples/examples/evolution/santa_fe_ant_support.rs
+++ b/crates/rlevo-examples/examples/evolution/santa_fe_ant_support.rs
@@ -379,7 +379,7 @@ where
         generations += 1;
         if evals_to_solved.is_none()
             && let Some(m) = harness.latest_metrics()
-            && m.best_fitness_ever >= SOLVED
+            && m.best_fitness_ever() >= SOLVED
         {
             evals_to_solved = Some(generations * pop);
         }

--- a/crates/rlevo/examples/evo/common.rs
+++ b/crates/rlevo/examples/evo/common.rs
@@ -82,7 +82,7 @@ where
     // "Reading the output" section for how to interpret the two together.
     println!(
         "{label:>30} | gens={:>4} | best={:>.6e} | mean={:>.6e}",
-        m.generation, m.best_fitness_ever, m.mean_fitness,
+        m.generation(), m.best_fitness_ever(), m.mean_fitness(),
     );
 }
 

--- a/crates/rlevo/examples/evo/memetic_showcase.rs
+++ b/crates/rlevo/examples/evo/memetic_showcase.rs
@@ -136,7 +136,7 @@ where
     let mut crossings: [Option<usize>; TARGETS.len()] = [None; TARGETS.len()];
     loop {
         let step = harness.step(());
-        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
         for (slot, &target) in crossings.iter_mut().zip(TARGETS.iter()) {
             if slot.is_none() && best < target {
                 *slot = Some(evals.load(Ordering::Relaxed));
@@ -146,7 +146,7 @@ where
             break;
         }
     }
-    let final_best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+    let final_best: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
     let cells: String = TARGETS
         .iter()
         .zip(crossings.iter())

--- a/crates/rlevo/examples/evo/memetic_showcase.rs
+++ b/crates/rlevo/examples/evo/memetic_showcase.rs
@@ -194,12 +194,11 @@ fn run_memetic_row(
 /// progress, greedy enough that each polished elite pulls the population
 /// toward a basin.
 fn headline_hc() -> HillClimbingParams {
-    let mut hc: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
-    hc.max_iters = 20;
-    hc.step_size = 0.4;
-    hc.step_decay = 0.5;
-    hc.variant = HillClimbVariant::BestImprovement;
-    hc
+    HillClimbingParams::default_for(BOUNDS)
+        .with_max_iters(20)
+        .with_step_size(0.4)
+        .with_step_decay(0.5)
+        .with_variant(HillClimbVariant::BestImprovement)
 }
 
 fn main() {

--- a/crates/rlevo/tests/determinism.rs
+++ b/crates/rlevo/tests/determinism.rs
@@ -57,7 +57,7 @@ where
     let mut trajectory = Vec::with_capacity(GENS);
     loop {
         let step = harness.step(());
-        trajectory.push(harness.latest_metrics().unwrap().best_fitness);
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness());
         if step.done {
             break;
         }

--- a/crates/rlevo/tests/eda_convergence.rs
+++ b/crates/rlevo/tests/eda_convergence.rs
@@ -110,7 +110,7 @@ where
             break;
         }
     }
-    harness.latest_metrics().unwrap().best_fitness_ever
+    harness.latest_metrics().unwrap().best_fitness_ever()
 }
 
 /// Median of a small sample; NaN-free by construction (fitness is

--- a/crates/rlevo/tests/memetic_rastrigin.rs
+++ b/crates/rlevo/tests/memetic_rastrigin.rs
@@ -123,7 +123,7 @@ fn de_evals_to_target(seed: u64, de: &DeConfig, target: f32, max_gens: usize) ->
     let mut evals_at_target: Option<usize> = None;
     loop {
         let step = harness.step(());
-        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
         trajectory.push(best);
         if evals_at_target.is_none() && best < target {
             evals_at_target = Some(evals.load(Ordering::Relaxed));
@@ -182,7 +182,7 @@ fn memetic_evals_to_target(
     let mut evals_at_target: Option<usize> = None;
     loop {
         let step = harness.step(());
-        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever;
+        let best: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
         trajectory.push(best);
         if evals_at_target.is_none() && best < target {
             evals_at_target = Some(evals.load(Ordering::Relaxed));

--- a/crates/rlevo/tests/memetic_rastrigin.rs
+++ b/crates/rlevo/tests/memetic_rastrigin.rs
@@ -211,12 +211,11 @@ fn shared_de_config() -> DeConfig {
 /// each polished elite pulls the whole population toward a basin. See the
 /// provenance block on the headline test for the eval-count data behind this.
 fn shared_hc_config() -> HillClimbingParams {
-    let mut hc: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
-    hc.max_iters = 20;
-    hc.step_size = 0.4;
-    hc.step_decay = 0.5;
-    hc.variant = HillClimbVariant::BestImprovement;
-    hc
+    HillClimbingParams::default_for(BOUNDS)
+        .with_max_iters(20)
+        .with_step_size(0.4)
+        .with_step_decay(0.5)
+        .with_variant(HillClimbVariant::BestImprovement)
 }
 
 // =====================================================================
@@ -244,12 +243,11 @@ fn calibration_explorer() {
     // max_iters=25/TopK{3} sweep, which was dominated by refinement cost on
     // easy targets).
     let make_hc = |max_iters: usize, step: f32, variant: HillClimbVariant| -> HillClimbingParams {
-        let mut hc: HillClimbingParams = HillClimbingParams::default_for(BOUNDS);
-        hc.max_iters = max_iters;
-        hc.step_size = step;
-        hc.step_decay = 0.5;
-        hc.variant = variant;
-        hc
+        HillClimbingParams::default_for(BOUNDS)
+            .with_max_iters(max_iters)
+            .with_step_size(step)
+            .with_step_decay(0.5)
+            .with_variant(variant)
     };
     let configs: Vec<(&str, HillClimbingParams, WritebackPolicy, CoveragePolicy)> = vec![
         (

--- a/crates/rlevo/tests/objective_sense_baseline.rs
+++ b/crates/rlevo/tests/objective_sense_baseline.rs
@@ -63,7 +63,7 @@ where
     harness
         .latest_metrics()
         .expect("at least one generation ran")
-        .best_fitness_ever
+        .best_fitness_ever()
 }
 
 fn ga_config() -> GaConfig {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -63,6 +63,25 @@ The filename of an example **is** its `cargo run --example <name>` target (Cargo
 - Builder chain methods: `.with_*()` (fluent), `.build()` (finalize).
 - Identity/utility methods: `zero()`, `enumerate()`, `aggregate()`, `encode()`, `decode()`.
 
+### Struct Field Encapsulation
+
+- **State / params / genome structs do not expose `pub` data-bag fields.**
+  A `*State`, `*Params`, or `*Genome` type keeps its fields private (or
+  `pub(crate)` when a family of in-crate operators mutates it in place) and
+  exposes `#[must_use]` read accessors named after the field
+  (`fitness()`, `best_fitness()`, …). This prevents external — or careless
+  internal — code from struct-literal-constructing a structurally invalid
+  value (mismatched lengths, out-of-range probabilities, a broken derived
+  tail) that only panics generations later. (issue #141; mirrors `Population`
+  and the ADR 0022/0030 accessor style.)
+- **Guarded construction.** A struct with a checkable invariant offers a
+  validating `try_new(...) -> Result<Self, ConfigError>` (structural checks:
+  lengths agree, counts non-zero, `σ > 0`) as its public entry point; the
+  trusted in-module construction path may keep a struct literal. A struct
+  with no invariant offers an infallible `new`. Hyperparameter-bearing
+  `*Params` follow the Config Validation Contract below and expose their
+  overrides through validating `with_*` setters, not `pub` fields.
+
 ### Constants and Associated Constants
 - Constants: `UPPER_SNAKE_CASE` (e.g., `ACTION_COUNT`, `MAX_STEPS`, `GOAL_STATE`).
 - Const generic parameters: `D` (observation/state rank), `AD` (action rank), `SD` (state rank).


### PR DESCRIPTION
## Summary

Closes a crate-wide convention violation across `rlevo-evolution`: dozens of `*State`, `*Params`, and `*Genome` structs exposed every field `pub`, letting external or careless internal code struct-literal-construct structurally invalid values (mismatched lengths, out-of-range probabilities, broken derived tails) that only panic generations later. This PR sweeps the crate, making fields private or `pub(crate)`, adding `#[must_use]` read accessors, and routing construction through validating `try_new`/`new`/`with_*` entry points. Codifies the resulting convention in `docs/rules.md` under a new "Struct Field Encapsulation" section.

## Change Type

- [x] Other — coordinated crate-wide encapsulation refactor (scope agreed via linked issue, done as one sweep per issue recommendation rather than ~20 near-identical one-line PRs)

## Linked Issue

Closes #141

## What Was Changed

- **EDA state structs** (`CompactGeneticState`, `UnivariateBernoulliState`, `UnivariateGaussianState`): fields private, accessors added.
- **Swarm metaheuristic states** (`AbcState`, `BatState`, `CuckooState`, `FireflyState`, `GwoState`, `WoaState`): fields private, accessors added.
- **Core strategy states** (`CmaEsState`, `MemeticState`, `EsState`, `GepState`): fields private/`pub(crate)`, accessors added.
- **NAS and NEAT genome types** (`NasParams`, `NasGenome`, `Species`, `TopologyGenome`): fields private, accessors added.
- **Local-search params** (`HillClimbingParams`, `SimulatedAnnealingParams`, random-restart params): converted to validating `try_new`/`with_*` builders per the Config Validation Contract.
- **`StrategyMetrics`**: fields private, accessors added.
- Updated all call sites across `rlevo-evolution` algorithms/coevolution/local_search/neuroevolution modules, `rlevo-evolution` tests, and downstream examples/tests in `rlevo-examples` and `rlevo` to use the new accessors/constructors instead of struct literals.
- Added a "Struct Field Encapsulation" section to `docs/rules.md` documenting the convention (private-by-default fields, `try_new`/`new` construction, `with_*` setters) for future contributions.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable (see `rust-toolchain.toml` / `rustup show`)
- Burn backend tested: ndarray (default)
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Sonnet 5). Scope: implementation of the field-encapsulation refactor across all listed files and the `docs/rules.md` convention writeup, under direct review and direction of the maintainer.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (One coordinated encapsulation sweep, per issue #141's own recommendation to avoid ~20 fragmented PRs.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

This is a refactor, which the template marks out-of-scope during alpha by default — proceeding here because it was explicitly scoped and pre-approved via issue #141, which asked for exactly this coordinated sweep rather than piecemeal PRs.

## Commits

- **refactor(evolution): Encapsulate EDA state structs**
- **refactor(evolution): Encapsulate swarm metaheuristic states**
- **refactor(evolution): Encapsulate core strategy states**
- **refactor(evolution): Encapsulate NAS and NEAT genome types**
- **refactor(evolution): Encapsulate local-search params**
- **refactor(evolution): Encapsulate StrategyMetrics**
- **docs(rules): Codify state/params/genome encapsulation**
