### PR TITLE
test(evolution): Lock reshaper panics, document aliasing

### DIFF
--- a/crates/rlevo-evolution/src/module_eval_fn.rs
+++ b/crates/rlevo-evolution/src/module_eval_fn.rs
@@ -97,9 +97,17 @@ where
     R: ParamReshaper<B>,
     F: Fn(&R::Module) -> f32 + Send,
 {
+    /// Score every row of `population` by reconstructing one module per row.
+    ///
+    /// # Panics
+    ///
+    /// Panics at batch entry if the population width (`population.dims()[1]`)
+    /// differs from the reshaper's [`num_params`](ParamReshaper::num_params),
+    /// failing fast before any per-row work rather than mid-loop inside
+    /// [`ParamReshaper::unflatten`].
     fn evaluate_batch(&mut self, population: &Tensor<B, 2>, device: &B::Device) -> Tensor<B, 1> {
         let [pop_size, num_params] = population.dims();
-        debug_assert_eq!(
+        assert_eq!(
             num_params,
             self.reshaper.num_params(),
             "population genome width must equal reshaper num_params"
@@ -134,11 +142,11 @@ mod tests {
 
     /// Single linear layer `2 -> 1`: 2 weights + 1 bias = 3 float leaves.
     #[derive(Module, Debug)]
-    struct Tiny<B: Backend> {
+    struct TestTiny<B: Backend> {
         l: Linear<B>,
     }
 
-    impl<B: Backend> Tiny<B> {
+    impl<B: Backend> TestTiny<B> {
         fn new(device: &B::Device) -> Self {
             Self {
                 l: LinearConfig::new(2, 1).init(device),
@@ -151,16 +159,16 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_batch_preserves_shape_and_order() {
+    fn test_module_eval_fn_evaluate_batch_preserves_shape_and_order() {
         let device = Default::default();
-        let reshaper = ModuleReshaper::new(Tiny::<TestBackend>::new(&device));
+        let reshaper = ModuleReshaper::new(TestTiny::<TestBackend>::new(&device));
         let num_params = reshaper.num_params();
         assert_eq!(num_params, 3);
 
         // Scorer: forward a fixed input [1, 1] through the reconstructed net and
         // return the scalar output — deterministic given the genome.
         let dev = device;
-        let mut eval = ModuleEvalFn::new(reshaper, move |m: &Tiny<TestBackend>| {
+        let mut eval = ModuleEvalFn::new(reshaper, move |m: &TestTiny<TestBackend>| {
             let x = Tensor::<TestBackend, 2>::from_data(TensorData::new(vec![1.0f32, 1.0], [1, 2]), &dev);
             let y = m.forward(x);
             y.into_data().into_vec::<f32>().unwrap()[0]

--- a/crates/rlevo-evolution/src/param_reshaper.rs
+++ b/crates/rlevo-evolution/src/param_reshaper.rs
@@ -9,7 +9,9 @@
 //!   deterministic order and concatenates them into a 1-D tensor.
 //! - [`unflatten`](ParamReshaper::unflatten) clones a template module and
 //!   replaces each float leaf with the matching slice of a flat tensor, in the
-//!   *same* order.
+//!   *same* order. The reconstructed leaves are **views into the flat tensor's
+//!   storage**, not copies — see [`unflatten`](ParamReshaper::unflatten)'s
+//!   `# Aliasing` note.
 //!
 //! [`ModuleReshaper`] is the concrete implementation. It relies on the fact
 //! that Burn's `#[derive(Module)]` generates `visit`/`map` traversals that
@@ -80,6 +82,15 @@ pub trait ParamReshaper<B: Backend>: Send + Sync {
     /// Clone the template module and replace its float leaves with slices of
     /// `flat`, in the same order as [`flatten`](Self::flatten).
     ///
+    /// # Aliasing
+    ///
+    /// The returned module's leaves are **views into `flat`'s storage** (Burn
+    /// `Tensor::clone` is a refcount bump; `slice`/`reshape` are view ops). This
+    /// is allocation-free and safe for the forward-only scoring this bridge
+    /// exists for. Do **not** mutate `flat` or the returned module's weights in
+    /// place while the other is live — they share backing storage. The output
+    /// module inherits `flat`'s device.
+    ///
     /// # Panics
     ///
     /// Panics if `flat.dims()[0] != self.num_params()`.
@@ -96,14 +107,8 @@ pub trait ParamReshaper<B: Backend>: Send + Sync {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use rlevo_evolution::param_reshaper::{ModuleReshaper, ParamReshaper};
-///
-/// let template = MyMlp::<B>::new(&device);
-/// let reshaper = ModuleReshaper::new(template.clone());
-/// let flat = reshaper.flatten(&template, &device);
-/// let restored = reshaper.unflatten(flat);
-/// ```
+/// See the [`module_eval_fn`](crate::module_eval_fn) tests for a runnable
+/// end-to-end example of `flatten`/`unflatten` in the weight-only pipeline.
 pub struct ModuleReshaper<B: Backend, M: Module<B>> {
     template: M,
     num_params: usize,
@@ -254,13 +259,13 @@ mod tests {
     /// Float-leaf count: `3*4 + 4` (l1 weight + bias) `+ 4*2 + 2`
     /// (l2 weight + bias) = `26`.
     #[derive(Module, Debug)]
-    struct Mlp<B: Backend> {
+    struct TestMlp<B: Backend> {
         l1: Linear<B>,
         act: Relu,
         l2: Linear<B>,
     }
 
-    impl<B: Backend> Mlp<B> {
+    impl<B: Backend> TestMlp<B> {
         fn new(device: &B::Device) -> Self {
             Self {
                 l1: LinearConfig::new(3, 4).init(device),
@@ -271,8 +276,8 @@ mod tests {
     }
 
     fn approx_eq(a: &Tensor<TestBackend, 1>, b: &Tensor<TestBackend, 1>) {
-        let av = a.clone().into_data().into_vec::<f32>().unwrap();
-        let bv = b.clone().into_data().into_vec::<f32>().unwrap();
+        let av = a.to_data().into_vec::<f32>().unwrap();
+        let bv = b.to_data().into_vec::<f32>().unwrap();
         assert_eq!(av.len(), bv.len(), "length mismatch");
         for (x, y) in av.iter().zip(bv.iter()) {
             approx::assert_relative_eq!(x, y, epsilon = 1e-6);
@@ -280,20 +285,45 @@ mod tests {
     }
 
     #[test]
-    fn num_params_matches_expected() {
+    fn test_module_reshaper_num_params_matches_expected() {
         let device = Default::default();
-        let mlp = Mlp::<TestBackend>::new(&device);
+        let mlp = TestMlp::<TestBackend>::new(&device);
         let reshaper = ModuleReshaper::new(mlp);
         assert_eq!(reshaper.num_params(), 26);
+    }
+
+    /// `flatten` panics when the module has no float leaves — locks the
+    /// documented `# Panics` contract. `Relu` is a `Module` with zero
+    /// parameters, so its visitor collects no parts.
+    #[test]
+    #[should_panic(expected = "module has no float parameters to flatten")]
+    fn test_module_reshaper_flatten_panics_on_empty_module() {
+        let device = Default::default();
+        let reshaper = ModuleReshaper::<TestBackend, Relu>::new(Relu::new());
+        let _ = reshaper.flatten(&Relu::new(), &device);
+    }
+
+    /// `unflatten` panics when the flat length differs from `num_params` —
+    /// locks the documented `# Panics` contract.
+    #[test]
+    #[should_panic(expected = "flat length")]
+    fn test_module_reshaper_unflatten_panics_on_length_mismatch() {
+        let device = Default::default();
+        let reshaper = ModuleReshaper::new(TestMlp::<TestBackend>::new(&device));
+        let wrong = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![0f32; 10], [10]),
+            &device,
+        );
+        let _ = reshaper.unflatten(wrong);
     }
 
     /// AC #2: `unflatten(flatten(m)) ≈ m`. We compare via re-flatten, which is
     /// element-wise injective over the deterministic leaf order, so equality of
     /// the flat vectors is equivalent to equality of the modules' float leaves.
     #[test]
-    fn round_trip_mlp() {
+    fn test_module_reshaper_round_trip_mlp() {
         let device = Default::default();
-        let mlp = Mlp::<TestBackend>::new(&device);
+        let mlp = TestMlp::<TestBackend>::new(&device);
         let reshaper = ModuleReshaper::new(mlp.clone());
 
         let flat = reshaper.flatten(&mlp, &device);
@@ -307,9 +337,9 @@ mod tests {
     /// Property test catching leaf-ordering bugs: a known flat buffer survives
     /// `unflatten -> flatten` unchanged.
     #[test]
-    fn round_trip_arbitrary_flat() {
+    fn test_module_reshaper_round_trip_arbitrary_flat() {
         let device = Default::default();
-        let mlp = Mlp::<TestBackend>::new(&device);
+        let mlp = TestMlp::<TestBackend>::new(&device);
         let reshaper = ModuleReshaper::new(mlp);
 
         #[allow(clippy::cast_precision_loss)]
@@ -328,7 +358,7 @@ mod tests {
     /// therefore exposes `4*d` float leaves: `gamma`, `beta`, `running_mean`,
     /// `running_var`.
     #[test]
-    fn batchnorm_running_stats_are_traversed() {
+    fn test_module_reshaper_batchnorm_running_stats_traversed() {
         let device = Default::default();
         let d = 5;
         let bn: BatchNorm<TestBackend> = BatchNormConfig::new(d).init(&device);
@@ -348,7 +378,7 @@ mod tests {
     /// A non-trivial module with a conv layer also round-trips, confirming the
     /// reshaper is not MLP-specific.
     #[test]
-    fn round_trip_conv() {
+    fn test_module_reshaper_round_trip_conv() {
         let device = Default::default();
         let conv: Conv2d<TestBackend> = Conv2dConfig::new([2, 3], [3, 3]).init(&device);
         let reshaper = ModuleReshaper::new(conv.clone());
@@ -369,12 +399,12 @@ mod tests {
 
     /// Minimal one-hidden-layer MLP variant for the enum-derive probe.
     #[derive(Module, Debug)]
-    struct SmallMlp<B: Backend> {
+    struct TestSmallMlp<B: Backend> {
         l1: Linear<B>,
         l2: Linear<B>,
     }
 
-    impl<B: Backend> SmallMlp<B> {
+    impl<B: Backend> TestSmallMlp<B> {
         fn new(device: &B::Device) -> Self {
             Self {
                 l1: LinearConfig::new(2, 4).init(device),
@@ -385,13 +415,13 @@ mod tests {
 
     /// Minimal two-hidden-layer MLP variant for the enum-derive probe.
     #[derive(Module, Debug)]
-    struct LargeMlp<B: Backend> {
+    struct TestLargeMlp<B: Backend> {
         l1: Linear<B>,
         l2: Linear<B>,
         l3: Linear<B>,
     }
 
-    impl<B: Backend> LargeMlp<B> {
+    impl<B: Backend> TestLargeMlp<B> {
         fn new(device: &B::Device) -> Self {
             Self {
                 l1: LinearConfig::new(2, 8).init(device),
@@ -408,21 +438,21 @@ mod tests {
     #[allow(clippy::large_enum_variant)]
     #[derive(Module, Debug)]
     enum TestArch<B: Backend> {
-        Shallow(SmallMlp<B>),
-        Deep(LargeMlp<B>),
+        Shallow(TestSmallMlp<B>),
+        Deep(TestLargeMlp<B>),
     }
 
     /// Probe: confirm `#[derive(Module)]` on a heterogeneous-arm enum compiles
     /// and that the enum can be visited as a `Module` (flattened) — i.e. the
     /// derive emits real `visit`/`map` traversals, not just a stub.
     #[test]
-    fn burn_enum_derive_probe() {
+    fn test_module_reshaper_enum_derive_compiles() {
         let device = Default::default();
 
-        let shallow = TestArch::<TestBackend>::Shallow(SmallMlp::new(&device));
-        let deep = TestArch::<TestBackend>::Deep(LargeMlp::new(&device));
+        let shallow = TestArch::<TestBackend>::Shallow(TestSmallMlp::new(&device));
+        let deep = TestArch::<TestBackend>::Deep(TestLargeMlp::new(&device));
 
-        // SmallMlp: 2*4 + 4 + 4*1 + 1 = 17 ; LargeMlp: 2*8+8 + 8*4+4 + 4*1+1 = 65.
+        // TestSmallMlp: 2*4 + 4 + 4*1 + 1 = 17 ; TestLargeMlp: 2*8+8 + 8*4+4 + 4*1+1 = 65.
         let shallow_reshaper = ModuleReshaper::new(shallow);
         let deep_reshaper = ModuleReshaper::new(deep);
 


### PR DESCRIPTION
## Summary

Closes untested-panic and undocumented-aliasing gaps in `param_reshaper.rs`: promotes the `evaluate_batch` width check from `debug_assert_eq!` to `assert_eq!` so it fails fast in release builds too, adds regression tests locking the `flatten`/`unflatten` panic contracts, and documents the view/aliasing semantics of `unflatten`'s output.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [ ] Other — _describe and justify scope below_

## Linked Issue

Closes #162

## What Was Changed

- `crates/rlevo-evolution/src/module_eval_fn.rs`: promoted the population-width check in `evaluate_batch` from `debug_assert_eq!` to `assert_eq!` so the panic contract holds in release builds, and documented it under a `# Panics` doc section; renamed test-only module structs (`Tiny` → `TestTiny`) and the test fn for consistent naming.
- `crates/rlevo-evolution/src/param_reshaper.rs`: added `# Aliasing` doc section on `ParamReshaper::unflatten` clarifying that returned leaves are views into the flat tensor's storage (refcount bump / view ops), not copies, and must not be mutated in place while the source is live; replaced the `ignore`d doctest example with a pointer to the runnable `module_eval_fn` test; added `test_module_reshaper_flatten_panics_on_empty_module` and `test_module_reshaper_unflatten_panics_on_length_mismatch` to lock the documented `# Panics` contracts; renamed test-only module structs (`Mlp`, `SmallMlp`, `LargeMlp` → `TestMlp`, `TestSmallMlp`, `TestLargeMlp`) and test fns for consistent naming; switched `approx_eq` to `to_data()` instead of `clone().into_data()`.

## How It Was Tested

```
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: `stable-aarch64-apple-darwin`
- Burn backend tested: ndarray (default test backend)
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Sonnet 5). Scope: implemented the promoted assertion, new panic-contract tests, and aliasing documentation; reviewed and verified by the maintainer.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).
