### PR TITLE
fix(evolution): Encapsulate Symbol, harden apply, pin finiteness

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/gep/alphabet.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/alphabet.rs
@@ -18,7 +18,7 @@ use crate::function_set::{FunctionSet, Symbol};
 /// the lint allowance documents that the cast is bounded by `num_functions()`.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 fn function_symbol(i: usize) -> Symbol {
-    Symbol(i as i32)
+    Symbol::from_raw(i as i32)
 }
 
 /// The semantic class of a decoded symbol.
@@ -132,7 +132,7 @@ impl<F: FunctionSet> Alphabet<F> {
     /// (variables and constants are leaves).
     #[must_use]
     pub fn arity(&self, symbol: Symbol) -> usize {
-        match usize::try_from(symbol.0) {
+        match usize::try_from(symbol.value()) {
             Ok(id) if id < self.n_func() => self.functions.arity(symbol),
             _ => 0,
         }
@@ -148,7 +148,7 @@ impl<F: FunctionSet> Alphabet<F> {
         let n_func = self.n_func();
         let n_vars = self.n_vars;
         let n_const = self.constants.len();
-        let Ok(id_u) = usize::try_from(symbol.0) else {
+        let Ok(id_u) = usize::try_from(symbol.value()) else {
             return SymbolKind::Function { arity: 0 };
         };
         if id_u < n_func {
@@ -189,13 +189,13 @@ impl<F: FunctionSet> Alphabet<F> {
     pub fn sample_head_symbol(&self, rng: &mut dyn Rng) -> Symbol {
         #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
         let upper = self.len() as i32;
-        Symbol(rng.random_range(0..upper))
+        Symbol::from_raw(rng.random_range(0..upper))
     }
 
     /// Samples a uniformly-random terminal symbol from [`terminal_range`].
     pub fn sample_tail_symbol(&self, rng: &mut dyn Rng) -> Symbol {
         let range = self.terminal_range();
-        Symbol(rng.random_range(range))
+        Symbol::from_raw(rng.random_range(range))
     }
 
     /// True iff every arity-0 function id is `>=` every arity-≥1 function id.
@@ -231,15 +231,15 @@ mod tests {
         assert_eq!(a.n_func(), 8);
         assert_eq!(a.len(), 11);
         // function id 0
-        assert_eq!(a.classify(Symbol(0)), SymbolKind::Function { arity: 2 });
+        assert_eq!(a.classify(Symbol::from_raw(0)), SymbolKind::Function { arity: 2 });
         // arity-0 function (const 1.0) id 7
-        assert_eq!(a.classify(Symbol(7)), SymbolKind::Function { arity: 0 });
+        assert_eq!(a.classify(Symbol::from_raw(7)), SymbolKind::Function { arity: 0 });
         // variables ids 8, 9
-        assert_eq!(a.classify(Symbol(8)), SymbolKind::Variable { input_index: 0 });
-        assert_eq!(a.classify(Symbol(9)), SymbolKind::Variable { input_index: 1 });
+        assert_eq!(a.classify(Symbol::from_raw(8)), SymbolKind::Variable { input_index: 0 });
+        assert_eq!(a.classify(Symbol::from_raw(9)), SymbolKind::Variable { input_index: 1 });
         // constant id 10
         assert_eq!(
-            a.classify(Symbol(10)),
+            a.classify(Symbol::from_raw(10)),
             SymbolKind::Constant { value: 2.5 }
         );
     }
@@ -261,16 +261,16 @@ mod tests {
     #[test]
     fn arity_is_zero_for_terminals() {
         let a = alphabet(2, vec![1.0]);
-        assert_eq!(a.arity(Symbol(0)), 2);
-        assert_eq!(a.arity(Symbol(7)), 0);
-        assert_eq!(a.arity(Symbol(8)), 0); // variable
-        assert_eq!(a.arity(Symbol(10)), 0); // constant
+        assert_eq!(a.arity(Symbol::from_raw(0)), 2);
+        assert_eq!(a.arity(Symbol::from_raw(7)), 0);
+        assert_eq!(a.arity(Symbol::from_raw(8)), 0); // variable
+        assert_eq!(a.arity(Symbol::from_raw(10)), 0); // constant
     }
 
     #[test]
     fn out_of_range_classifies_inert() {
         let a = alphabet(1, vec![]);
-        assert_eq!(a.classify(Symbol(-1)), SymbolKind::Function { arity: 0 });
-        assert_eq!(a.classify(Symbol(999)), SymbolKind::Function { arity: 0 });
+        assert_eq!(a.classify(Symbol::from_raw(-1)), SymbolKind::Function { arity: 0 });
+        assert_eq!(a.classify(Symbol::from_raw(999)), SymbolKind::Function { arity: 0 });
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/decode.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/decode.rs
@@ -80,13 +80,13 @@ mod tests {
         let a = alphabet(1);
         // ids: + = 0, * = 2, x = 8
         let genome = vec![
-            Symbol(0),
-            Symbol(2),
-            Symbol(8),
-            Symbol(8),
-            Symbol(8),
-            Symbol(8), // tail junk
-            Symbol(8),
+            Symbol::from_raw(0),
+            Symbol::from_raw(2),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8), // tail junk
+            Symbol::from_raw(8),
         ];
         let tree = GepDecoder.decode(&a, &genome);
         // + (root) -> children {*, x}; * -> children {x, x}. 5 nodes.
@@ -98,13 +98,13 @@ mod tests {
     fn decode_is_deterministic() {
         let a = alphabet(2);
         let genome = vec![
-            Symbol(0),
-            Symbol(1),
-            Symbol(8),
-            Symbol(9),
-            Symbol(8),
-            Symbol(9),
-            Symbol(8),
+            Symbol::from_raw(0),
+            Symbol::from_raw(1),
+            Symbol::from_raw(8),
+            Symbol::from_raw(9),
+            Symbol::from_raw(8),
+            Symbol::from_raw(9),
+            Symbol::from_raw(8),
         ];
         let t1 = GepDecoder.decode(&a, &genome);
         let t2 = GepDecoder.decode(&a, &genome);
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn all_terminal_head_is_one_node() {
         let a = alphabet(1);
-        let genome = vec![Symbol(8), Symbol(8), Symbol(8)];
+        let genome = vec![Symbol::from_raw(8), Symbol::from_raw(8), Symbol::from_raw(8)];
         let tree = GepDecoder.decode(&a, &genome);
         assert_eq!(tree.node_count(), 1);
     }

--- a/crates/rlevo-evolution/src/algorithms/gep/operators.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/operators.rs
@@ -245,7 +245,7 @@ mod tests {
         for _ in 0..200 {
             let mut g = sample_valid(&a, &cfg, &mut rng);
             // Guarantee at least one function in the head.
-            g[0] = Symbol(0);
+            g[0] = Symbol::from_raw(0);
             ris_transposition(&mut g, cfg.head_len, &a, &mut rng);
             if a.arity(g[0]) >= 1 {
                 rooted += 1;

--- a/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
@@ -166,7 +166,7 @@ fn tensor_to_rows<B: Backend>(pop: &Tensor<B, 2, Int>, genome_len: usize) -> Vec
         .into_vec::<i32>()
         .unwrap_or_default();
     flat.chunks(genome_len)
-        .map(|row| row.iter().map(|&v| Symbol(v)).collect())
+        .map(|row| row.iter().map(|&v| Symbol::from_raw(v)).collect())
         .collect()
 }
 
@@ -179,7 +179,7 @@ fn rows_to_tensor<B: Backend>(
     let pop_size = rows.len();
     let mut flat: Vec<i32> = Vec::with_capacity(pop_size * genome_len);
     for row in rows {
-        flat.extend(row.iter().map(|s| s.0));
+        flat.extend(row.iter().map(|s| s.value()));
     }
     Tensor::<B, 2, Int>::from_data(TensorData::new(flat, [pop_size, genome_len]), device)
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/tree.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/tree.rs
@@ -112,7 +112,7 @@ impl ExpressionTree {
                     let start = self.child_start[i];
                     arg_buf[..arity].copy_from_slice(&results[start..start + arity]);
                     let v = alphabet.functions.apply(symbol, &arg_buf[..arity]);
-                    if v.is_finite() { v } else { 0.0 }
+                    crate::function_set::finite_or_zero(v)
                 }
             };
         }
@@ -137,7 +137,7 @@ mod tests {
         let a = alphabet(1);
         // head [0, 8, 7], tail [8] (terminals). ORF = first 3 (add needs 2
         // children: x and const-1).
-        let genome = vec![Symbol(0), Symbol(8), Symbol(7), Symbol(8)];
+        let genome = vec![Symbol::from_raw(0), Symbol::from_raw(8), Symbol::from_raw(7), Symbol::from_raw(8)];
         let tree = GepDecoder.decode(&a, &genome);
         assert_eq!(tree.node_count(), 3);
         approx::assert_relative_eq!(tree.eval(&a, &[2.0]), 3.0, epsilon = 1e-6);
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn evaluates_x_squared_with_depth_one() {
         let a = alphabet(1);
-        let genome = vec![Symbol(2), Symbol(8), Symbol(8), Symbol(8)];
+        let genome = vec![Symbol::from_raw(2), Symbol::from_raw(8), Symbol::from_raw(8), Symbol::from_raw(8)];
         let tree = GepDecoder.decode(&a, &genome);
         assert_eq!(tree.node_count(), 3);
         assert_eq!(tree.depth(), 1);
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn single_terminal_is_leaf() {
         let a = alphabet(1);
-        let genome = vec![Symbol(8), Symbol(8), Symbol(8)];
+        let genome = vec![Symbol::from_raw(8), Symbol::from_raw(8), Symbol::from_raw(8)];
         let tree = GepDecoder.decode(&a, &genome);
         assert_eq!(tree.node_count(), 1);
         assert_eq!(tree.depth(), 0);

--- a/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
+++ b/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
@@ -337,11 +337,11 @@ pub fn evaluate_cgp_with<F: FunctionSet>(
             let b_idx = genome[base + 2] as usize;
             let a = buf[a_idx.min(buf.len() - 1)];
             let b = buf[b_idx.min(buf.len() - 1)];
-            let sym = Symbol(func);
+            let sym = Symbol::from_raw(func);
             let arity = fs.arity(sym);
             let arg_buf = [a, b];
             let v = fs.apply(sym, &arg_buf[..arity.min(arg_buf.len())]);
-            buf[n_inputs + node] = if v.is_finite() { v } else { 0.0 };
+            buf[n_inputs + node] = crate::function_set::finite_or_zero(v);
         }
         outputs.push(buf[output_idx.min(buf.len() - 1)]);
     }

--- a/crates/rlevo-evolution/src/function_set.rs
+++ b/crates/rlevo-evolution/src/function_set.rs
@@ -24,7 +24,7 @@
 //! function ids. `i32` is mandatory because populations are stored as Burn
 //! integer tensors (`Tensor<B, 2, Int>`), whose element type is `i32`.
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 /// A program symbol: an `i32` opcode id.
 ///
@@ -33,8 +33,72 @@ use std::fmt::Debug;
 /// [`Alphabet`](crate::algorithms::gep::Alphabet). The newtype keeps symbol
 /// ids from being confused with the many other `i32` indices in the genome
 /// (node indices, input indices, gene positions).
+///
+/// The inner id is private so a `Symbol` cannot be silently confused with a
+/// bare `i32`. Read it with [`value`](Symbol::value) (or `i32::from(symbol)`);
+/// construct one from a raw genome id with the crate-internal `from_raw`. Ids
+/// are not range-checked at construction — out-of-range ids classify as inert
+/// (arity `0`, `apply` → `0.0`), matching the evaluator's tolerance for
+/// mutated-but-unrepaired genotypes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Symbol(pub i32);
+pub struct Symbol(i32);
+
+impl Symbol {
+    /// The raw opcode id.
+    ///
+    /// Exposed for tensor serialization and table indexing; it is not a
+    /// constructor, so it cannot be used to fabricate an unchecked symbol from
+    /// outside the crate.
+    #[must_use]
+    #[inline]
+    pub const fn value(self) -> i32 {
+        self.0
+    }
+
+    /// Constructs a symbol from a raw `i32` id without range-checking it.
+    ///
+    /// For the GP evaluators that read ids straight from genome tensors, where
+    /// the id may legitimately fall outside the function range (an unrepaired
+    /// mutation). Out-of-range ids are inert at evaluation, so no validation is
+    /// needed here.
+    #[must_use]
+    #[inline]
+    pub(crate) const fn from_raw(id: i32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<Symbol> for i32 {
+    #[inline]
+    fn from(symbol: Symbol) -> Self {
+        symbol.0
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sym{}", self.0)
+    }
+}
+
+/// Collapses a non-finite phenotype value to the inert `0.0`.
+///
+/// This is the **node-level** numerical-stability guard: intermediate node
+/// values in the CGP ([`evaluate_cgp_with`](crate::algorithms::gp_cgp)) and GEP
+/// ([`ExpressionTree::eval`](crate::algorithms::gep::ExpressionTree::eval))
+/// evaluators are fed back into downstream node arithmetic, so a non-finite
+/// intermediate (overflow `±inf`, `0/0` `NaN`) must be neutralized *in place*
+/// with a finite value rather than allowed to poison the rest of the tree.
+///
+/// This is **not** the fitness `NaN → −inf` convention from `rules.md §3`: that
+/// rule applies to the final aggregated fitness and is handled separately by
+/// [`sanitize_fitness`](crate::fitness::sanitize_fitness). `0.0` is correct
+/// here precisely because the value is an operand, not a fitness score.
+#[must_use]
+#[inline]
+pub(crate) fn finite_or_zero(v: f32) -> f32 {
+    if v.is_finite() { v } else { 0.0 }
+}
 
 /// The function-opcode contract shared by CGP and GEP.
 ///
@@ -66,12 +130,24 @@ pub trait FunctionSet: Send + Sync + Debug {
 
     /// Applies a function opcode to its already-evaluated arguments.
     ///
-    /// # Preconditions
+    /// Callers pass `args.len() == self.arity(symbol)`. For zero-arity
+    /// functions (constants such as `1.0`), `args` is empty. Variable and
+    /// constant *terminals* are never passed here — they are resolved by the
+    /// caller's evaluator before `apply` is reached.
     ///
-    /// `args.len() == self.arity(symbol)`. For zero-arity functions
-    /// (constants such as `1.0`), `args` is empty. Variable and constant
-    /// *terminals* are never passed here — they are resolved by the caller's
-    /// evaluator before `apply` is reached.
+    /// A shorter-than-arity slice does **not** panic: missing arguments read as
+    /// `0.0`. This keeps a malformed or unrepaired genotype (runtime data) from
+    /// aborting a training run, per `rules.md §4`.
+    ///
+    /// # Numerical
+    ///
+    /// `apply` performs raw IEEE-754 `f32` arithmetic and **may return a
+    /// non-finite value** — overflow yields `±inf`, `0.0 / 0.0` yields `NaN`.
+    /// It does **not** sanitize its result. Finiteness is the caller's
+    /// responsibility at two distinct layers: intermediate node values are
+    /// collapsed to `0.0` for phenotype-evaluation stability (see the
+    /// `finite_or_zero` helper), and the final fitness is mapped to `−inf` by
+    /// the crate's `sanitize_fitness` per `rules.md §3`.
     fn apply(&self, symbol: Symbol, args: &[f32]) -> f32;
 }
 
@@ -112,7 +188,7 @@ impl FunctionSet for ArithmeticFunctionSet {
     }
 
     fn arity(&self, symbol: Symbol) -> usize {
-        usize::try_from(symbol.0)
+        usize::try_from(symbol.value())
             .ok()
             .and_then(|i| Self::ARITIES.get(i).copied())
             .unwrap_or(0)
@@ -123,21 +199,22 @@ impl FunctionSet for ArithmeticFunctionSet {
     }
 
     fn apply(&self, symbol: Symbol, args: &[f32]) -> f32 {
-        // Arms 0..=3 read two args, 4..=6 read one, 7 reads none. The caller
-        // slices `args` to the opcode's arity, so the indexing below is in
-        // bounds. Unknown ids collapse to 0.0, matching the historical
+        // Arms 0..=3 use two args, 4..=6 use one, 7 uses none. Missing
+        // arguments (a shorter-than-arity slice) read as 0.0 rather than
+        // panicking. Unknown ids collapse to 0.0, matching the historical
         // `_ => 0.0` arm of the inline CGP match.
-        match symbol.0 {
-            0 => args[0] + args[1],
-            1 => args[0] - args[1],
-            2 => args[0] * args[1],
+        let a = args.first().copied().unwrap_or(0.0);
+        let b = args.get(1).copied().unwrap_or(0.0);
+        match symbol.value() {
+            0 => a + b,
+            1 => a - b,
+            2 => a * b,
             3 => {
-                let (a, b) = (args[0], args[1]);
                 if b.abs() < 1e-6 { a } else { a / b }
             }
-            4 => args[0].sin(),
-            5 => args[0].cos(),
-            6 => args[0].tanh(),
+            4 => a.sin(),
+            5 => a.cos(),
+            6 => a.tanh(),
             7 => 1.0,
             _ => 0.0,
         }
@@ -170,7 +247,9 @@ mod tests {
             }
         };
         for func in 0..8 {
-            let sym = Symbol(i32::try_from(func).unwrap());
+            // `func` is in `0..8`, so neither truncation nor wrap can occur.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            let sym = Symbol::from_raw(func as i32);
             let arity = fs.arity(sym);
             let arg_buf = [a, b];
             let got = fs.apply(sym, &arg_buf[..arity]);
@@ -179,12 +258,33 @@ mod tests {
         }
     }
 
+    /// A shorter-than-arity slice must not panic; missing arguments read as
+    /// `0.0` (`rules.md §4`: never panic on runtime data).
+    #[test]
+    fn apply_handles_short_args_without_panic() {
+        let fs = ArithmeticFunctionSet;
+        // arity(add) == 2, but the slice is empty: 0.0 + 0.0 == 0.0.
+        approx::assert_relative_eq!(fs.apply(Symbol::from_raw(0), &[]), 0.0, epsilon = 1e-7);
+        // arity(sub) == 2 with a single arg: 5.0 - 0.0 == 5.0.
+        approx::assert_relative_eq!(fs.apply(Symbol::from_raw(1), &[5.0]), 5.0, epsilon = 1e-7);
+    }
+
+    /// `apply` does not sanitize: a `NaN` argument propagates through raw
+    /// arithmetic (finiteness is the caller's responsibility, see
+    /// [`finite_or_zero`]).
+    #[test]
+    fn apply_propagates_non_finite_arguments() {
+        let fs = ArithmeticFunctionSet;
+        assert!(fs.apply(Symbol::from_raw(0), &[f32::NAN, 1.0]).is_nan());
+        assert!(fs.apply(Symbol::from_raw(2), &[f32::INFINITY, 2.0]).is_infinite());
+    }
+
     /// Protected division returns the numerator when the denominator is near
     /// zero (no `inf`).
     #[test]
     fn protected_div_guards_small_denominator() {
         let fs = ArithmeticFunctionSet;
-        let got = fs.apply(Symbol(3), &[3.0, 1e-9]);
+        let got = fs.apply(Symbol::from_raw(3), &[3.0, 1e-9]);
         approx::assert_relative_eq!(got, 3.0, epsilon = 1e-7);
     }
 
@@ -193,9 +293,9 @@ mod tests {
     #[test]
     fn out_of_range_opcode_is_inert() {
         let fs = ArithmeticFunctionSet;
-        assert_eq!(fs.arity(Symbol(99)), 0);
-        assert_eq!(fs.arity(Symbol(-1)), 0);
-        approx::assert_relative_eq!(fs.apply(Symbol(99), &[]), 0.0, epsilon = 1e-7);
+        assert_eq!(fs.arity(Symbol::from_raw(99)), 0);
+        assert_eq!(fs.arity(Symbol::from_raw(-1)), 0);
+        approx::assert_relative_eq!(fs.apply(Symbol::from_raw(99), &[]), 0.0, epsilon = 1e-7);
     }
 
     #[test]
@@ -203,8 +303,8 @@ mod tests {
         let fs = ArithmeticFunctionSet;
         assert_eq!(fs.num_functions(), 8);
         assert_eq!(fs.max_arity(), 2);
-        assert_eq!(fs.arity(Symbol(0)), 2);
-        assert_eq!(fs.arity(Symbol(6)), 1);
-        assert_eq!(fs.arity(Symbol(7)), 0);
+        assert_eq!(fs.arity(Symbol::from_raw(0)), 2);
+        assert_eq!(fs.arity(Symbol::from_raw(6)), 1);
+        assert_eq!(fs.arity(Symbol::from_raw(7)), 0);
     }
 }


### PR DESCRIPTION
## Summary

Resolves the three high-severity findings in #163 for `function_set.rs`
and its CGP/GEP consumers: `Symbol`'s inner field is now private
(no more constructing an unchecked symbol from outside the crate),
`apply()` no longer panics on a shorter-than-arity args slice, and
the duplicated non-finite-collapse logic across `gp_cgp.rs`/`tree.rs`
is centralized behind one documented helper.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #163

## What Was Changed

- `function_set.rs`: made `Symbol`'s inner `i32` private; added
  `Symbol::value()` (accessor), `Symbol::from_raw()` (crate-internal
  constructor), `impl From<Symbol> for i32`, and `impl Display for Symbol`.
- `function_set.rs`: `ArithmeticFunctionSet::apply` reads args via
  `.first()`/`.get(1)` with a `0.0` fallback instead of indexing, so a
  short slice from a malformed/unrepaired genome can't panic a training
  run (`rules.md` §4).
- `function_set.rs`: added `finite_or_zero`, a single documented helper
  for the node-level non-finite-collapse, and clarified `apply`'s
  doc comment to state it does **not** sanitize its return value —
  finiteness is the caller's responsibility, distinct from the
  fitness-layer `NaN -> -inf` convention in `rules.md` §3.
- `algorithms/gp_cgp.rs`, `algorithms/gep/tree.rs`: replaced the
  duplicated inline `if v.is_finite() { v } else { 0.0 }` with a call
  to `finite_or_zero`.
- `algorithms/gep/{alphabet,decode,operators,strategy}.rs`: migrated all
  in-crate `Symbol(id)` construction sites to `Symbol::from_raw(id)` and
  all `symbol.0` reads to `symbol.value()`.
- Added regression tests: `apply_handles_short_args_without_panic`,
  `apply_propagates_non_finite_arguments`.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable
- Burn backend tested: ndarray (default test backend)
- OS: macOS

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code. Scope: implementation
  of the `Symbol` encapsulation, `apply` hardening, and `finite_or_zero`
  centralization, plus the two new regression tests.

## Notes

The review's literal suggestion to map the consumers' `0.0` fallback to
`-inf` (mirroring `rules.md` §3) was deliberately not followed: that
`0.0` is an intermediate *node* value fed into downstream node
arithmetic in the CGP/GEP evaluators, where `-inf` would poison the
rest of the phenotype rather than just the final score. The §3
`NaN -> -inf` rule is a fitness-layer convention, already enforced
separately by `sanitize_fitness`.
