### PR TITLE
fix(evolution): Sanitize NaN/Inf across EDA models

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
@@ -107,7 +107,9 @@ pub struct BayesianNetworkParams {
     pub init_prob: f32,
     /// Laplace pseudo-count `s` added per CPT cell during estimation; `s ≥ 1`
     /// keeps every probability strictly inside `(0, 1)`. Applies only to CPT
-    /// estimation for sampling, never to the BIC structure score.
+    /// estimation for sampling, never to the BIC structure score. The value is
+    /// floored to `1` inside [`fit`](ProbabilityModel::fit), so a supplied `0`
+    /// is treated as `1` to uphold the strictly-interior guarantee.
     pub smoothing_count: usize,
 }
 
@@ -162,11 +164,23 @@ pub struct BayesianNetwork;
 
 /// Build the edgeless prior state: natural order, no parents, single-cell CPTs
 /// initialised to `init_prob`.
+///
+/// `init_prob` is clamped into the open interior `(0, 1)` before it seeds the
+/// CPTs. This is the single chokepoint for every prior return, so a
+/// misconfigured or non-finite `init_prob` (e.g. `NaN`, `1.5`, `-0.3`) cannot
+/// silently produce a degenerate population during sampling. `NaN` maps to the
+/// neutral `0.5` (`f32::clamp` would *propagate* `NaN`); `±inf` clamp to the
+/// interior bounds.
 fn prior_state(d: usize, init_prob: f32) -> BayesianNetworkState {
+    let p = if init_prob.is_nan() {
+        0.5
+    } else {
+        init_prob.clamp(1e-6, 1.0 - 1e-6)
+    };
     BayesianNetworkState {
         order: (0..d).collect(),
         parents: vec![Vec::new(); d],
-        cpt: vec![vec![init_prob]; d],
+        cpt: vec![vec![p]; d],
     }
 }
 
@@ -438,7 +452,11 @@ impl<B: Backend> ProbabilityModel<B> for BayesianNetwork {
         }
 
         // CPT estimation from the final structure: one counting pass per node.
-        let s = params.smoothing_count;
+        // Floor the smoothing at 1 so every probability stays strictly inside
+        // `(0, 1)` (the field-doc guarantee): with `s ≥ 1`, `den = N(c) + 2s > 0`
+        // always, so the `0/0` case is unreachable and `count_1/count_total`
+        // cannot pin a cell to an absorbing `0.0`/`1.0`.
+        let s = params.smoothing_count.max(1);
         let mut cpt: Vec<Vec<f32>> = Vec::with_capacity(d);
         // Laplace pseudo-count as f64; `s` is a tiny smoothing constant, far
         // below f64's exact-integer range, so the cast is lossless.
@@ -458,19 +476,15 @@ impl<B: Backend> ProbabilityModel<B> for BayesianNetwork {
             for c in 0..num_configs {
                 let count_1 = counts[c * 2 + 1];
                 let count_total = counts[c * 2] + count_1;
-                let prob = if s == 0 && count_total == 0 {
-                    // Guard 0/0: unseen config with no smoothing ⇒ prior marginal.
-                    params.init_prob
-                } else {
-                    // (N(c,1) + s) / (N(c) + 2s); f64::from(u32) is lossless.
-                    let num = f64::from(count_1) + s_f;
-                    let den = f64::from(count_total) + 2.0 * s_f;
-                    // Probability in (0, 1) for s ≥ 1; the f64→f32 narrowing of a
-                    // value in [0, 1] cannot truncate meaningfully.
-                    #[allow(clippy::cast_possible_truncation)]
-                    let prob_f32 = (num / den) as f32;
-                    prob_f32
-                };
+                // (N(c,1) + s) / (N(c) + 2s); f64::from(u32) is lossless. With
+                // `s ≥ 1` the denominator is always positive, so no `0/0` guard
+                // is needed.
+                let num = f64::from(count_1) + s_f;
+                let den = f64::from(count_total) + 2.0 * s_f;
+                // Probability in (0, 1) for s ≥ 1; the f64→f32 narrowing of a
+                // value in [0, 1] cannot truncate meaningfully.
+                #[allow(clippy::cast_possible_truncation)]
+                let prob = (num / den) as f32;
                 table.push(prob);
             }
             cpt.push(table);
@@ -834,5 +848,44 @@ mod tests {
             frac > 0.9,
             "sampled columns 0 and 1 should agree on > 90% of rows, got {frac}"
         );
+    }
+
+    #[test]
+    fn nan_init_prob_clamped_on_prior() {
+        // A non-finite init_prob must not propagate into the CPTs (#129): the
+        // prior clamps it into the open interior (0, 1).
+        let mut p = BayesianNetworkParams::default_for(3);
+        p.init_prob = f32::NAN;
+        let state = fit_prior(&p);
+        for table in &state.cpt {
+            let v = table[0];
+            assert!(v.is_finite(), "clamped init_prob must be finite, got {v}");
+            assert!(v > 0.0 && v < 1.0, "clamped init_prob must be interior, got {v}");
+        }
+    }
+
+    #[test]
+    fn out_of_range_init_prob_clamped_on_prior() {
+        for bad in [1.5_f32, -0.3, f32::INFINITY] {
+            let mut p = BayesianNetworkParams::default_for(2);
+            p.init_prob = bad;
+            let state = fit_prior(&p);
+            for table in &state.cpt {
+                let v = table[0];
+                assert!(v > 0.0 && v < 1.0, "init_prob {bad} must clamp interior, got {v}");
+            }
+        }
+    }
+
+    #[test]
+    fn smoothing_count_zero_keeps_cpt_interior() {
+        // s = 0 with a constant-1 column would give count_1/count_total = 1.0
+        // (an absorbing gene) without the floor. Flooring s at 1 keeps it in
+        // (0, 1). Single gene, all ones ⇒ one CPT cell.
+        let mut p = BayesianNetworkParams::default_for(1);
+        p.smoothing_count = 0;
+        let state = refit(&p, vec![1.0, 1.0, 1.0, 1.0], 4, 1);
+        let v = state.cpt[0][0];
+        assert!(v > 0.0 && v < 1.0, "s=0 must be floored to keep CPT interior, got {v}");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
@@ -148,7 +148,14 @@ impl<B: Backend> ProbabilityModel<B> for CompactGenetic {
         let mut best_f = f32::NEG_INFINITY;
         let mut worst_f = f32::INFINITY;
         for i in 0..k {
-            let f = fit_host.get(i).copied().unwrap_or(f32::NEG_INFINITY);
+            // Sanitize `NaN → −inf` at the seam. `EdaStrategy::tell` already does
+            // this upstream, but `fit` is a public trait method reachable
+            // directly; without this a `NaN` would sort as the largest value
+            // under `total_cmp` and be selected as the winner, nudging the model
+            // toward a meaningless genome.
+            let f = crate::fitness::sanitize_fitness(
+                fit_host.get(i).copied().unwrap_or(f32::NEG_INFINITY),
+            );
             if f.total_cmp(&best_f) == std::cmp::Ordering::Greater {
                 best_f = f;
                 winner_idx = i;
@@ -368,6 +375,29 @@ mod tests {
             #[allow(clippy::float_cmp)]
             let is_binary = v == 0.0 || v == 1.0;
             assert!(is_binary);
+        }
+    }
+
+    #[test]
+    fn nan_fitness_not_selected_as_winner() {
+        // Row 0 all-ones with NaN fitness, row 1 all-zeros with finite fitness.
+        // Under total_cmp, an unsanitized NaN would sort as the largest value
+        // and be picked as the winner; with the seam guard (#129) the finite
+        // row is the winner and probabilities move toward 0.
+        let device = Default::default();
+        let p = CompactGeneticParams::default_for(2);
+        let prior = fit_prior(&p);
+        let state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 1.0, 0.0, 0.0], 2, 2),
+            fitness(vec![f32::NAN, 5.0]),
+            &device,
+        );
+        for &pj in &state.prob {
+            assert!(pj.is_finite() && (0.0..=1.0).contains(&pj), "prob out of range: {pj}");
+            assert!(pj < 0.5, "winner should be the finite-fitness zero row, got {pj}");
         }
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
@@ -173,6 +173,20 @@ impl<B: Backend> ProbabilityModel<B> for DependencyChain {
         };
 
         let [k, d] = population.dims();
+        if k < 2 {
+            // Correlation is unidentifiable from fewer than two rows: `kf` would
+            // be `0`/`1`, driving `/= kf` to `NaN`/degenerate stats that then
+            // poison `std`/`link_corr` and later panic in `sample`. Return the
+            // prior-shaped state (independent dimensions) to keep the run alive.
+            // `EdaStrategy::tell` clamps `k ≥ 2`, but `fit` is a public trait
+            // method reachable directly with a `0×D`/`1×D` population.
+            return DependencyChainState {
+                chain: (0..d).collect(),
+                mean: vec![params.init_mean; d],
+                std: vec![params.init_std; d],
+                link_corr: vec![0.0; d],
+            };
+        }
         let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
         // k is a selected-population count, far below f32's 2^24 exact-integer
         // limit; the cast is lossless in practice.
@@ -357,9 +371,22 @@ impl<B: Backend> ProbabilityModel<B> for DependencyChain {
                 let cond_mean = mu_c + r * (sigma_c / sigma_p) * (rows[base + parent] - mu_p);
                 // 1 - r² ≥ 1 - 0.9999² > 0.
                 let cond_std = (sigma_c * sigma_c * (1.0 - r * r)).sqrt();
-                let normal = Normal::new(cond_mean, cond_std)
-                    .expect("conditional std is positive and finite");
-                rows[base + cur] = normal.sample(rng);
+                // `Normal::new` rejects a non-finite std but accepts any mean, so
+                // an overflowed `cond_mean` (large parent value × near-1 `r`)
+                // would silently emit `NaN` samples and poison the next
+                // generation. If either parameter is non-finite, fall back to the
+                // marginal Gaussian of `cur` — the distribution the link
+                // degenerates to at `r = 0`.
+                rows[base + cur] = if cond_mean.is_finite() && cond_std.is_finite() && cond_std > 0.0
+                {
+                    Normal::new(cond_mean, cond_std)
+                        .expect("guarded: conditional std positive and finite")
+                        .sample(rng)
+                } else {
+                    Normal::new(mu_c, sigma_c)
+                        .expect("floored marginal std is positive and finite")
+                        .sample(rng)
+                };
             }
         }
         Tensor::<B, 2>::from_data(TensorData::new(rows, [n, d]), device)
@@ -545,5 +572,42 @@ mod tests {
         assert_eq!(a.mean, b.mean);
         assert_eq!(a.std, b.std);
         assert_eq!(a.link_corr, b.link_corr);
+    }
+
+    #[test]
+    fn fit_k_less_than_two_returns_prior() {
+        // n = 1 (k = 1): correlation is unidentifiable and `/= kf` would poison
+        // the state with NaN. The guard (#129) returns the prior-shaped state.
+        let p = DependencyChainParams::default_for(2);
+        let state = refit(&p, vec![1.0, 2.0], 1, 2);
+        assert_eq!(state.chain, vec![0, 1]);
+        assert_eq!(state.mean, vec![p.init_mean, p.init_mean]);
+        assert_eq!(state.std, vec![p.init_std, p.init_std]);
+        assert_eq!(state.link_corr, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn sample_with_degenerate_link_stays_finite() {
+        // A pathological state whose conditional link overflows (σ_c/σ_p → inf):
+        // the sample() guard (#129) must fall back to the marginal Gaussian
+        // rather than emit NaN/inf into the population.
+        let device = Default::default();
+        let state = DependencyChainState {
+            chain: vec![0, 1],
+            mean: vec![0.0, 0.0],
+            std: vec![1e-30, 1e30],
+            link_corr: vec![0.0, 0.9999],
+        };
+        let mut rng = StdRng::seed_from_u64(7);
+        let samples = <DependencyChain as ProbabilityModel<TestBackend>>::sample(
+            &DependencyChain,
+            &state,
+            16,
+            &mut rng,
+            &device,
+        );
+        for v in samples.into_data().into_vec::<f32>().unwrap() {
+            assert!(v.is_finite(), "degenerate link must yield finite samples, got {v}");
+        }
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/mod.rs
@@ -252,6 +252,13 @@ impl<B: Backend, M: ProbabilityModel<B>> Strategy<B> for EdaStrategy<B, M> {
     /// `k = ceil(selection_ratio · pop_size)` clamped to `[2, pop_size]`),
     /// and refits the model to them (passing `prev = Some(model_state)`).
     ///
+    /// The selected population is also sanitized before the refit as a coarse
+    /// backstop: non-finite genome values are mapped `NaN → 0.0` and `±inf`
+    /// clamped to `±f32::MAX`, so a single divergent gene cannot poison a
+    /// model's fitted statistics. Each model's `fit` keeps its own precise
+    /// finite-guards (which also protect direct trait callers that bypass this
+    /// path).
+    ///
     /// The `fitness` tensor is forwarded to [`ProbabilityModel::fit`]; models
     /// that weight or rank their selected individuals can use it. The five
     /// built-in models ([`UnivariateGaussian`], [`UnivariateBernoulli`],
@@ -315,6 +322,16 @@ impl<B: Backend, M: ProbabilityModel<B>> Strategy<B> for EdaStrategy<B, M> {
         let idx_vec: Vec<i64> = order.iter().map(|&i| i as i64).collect();
         let idx = Tensor::<B, 1, Int>::from_data(TensorData::new(idx_vec, [k]), &device);
         let selected = population.clone().select(0, idx);
+        // Coarse defense-in-depth backstop: sanitize non-finite genome values
+        // before forwarding to `fit`. `tell` already sanitizes *fitness*, but a
+        // single non-finite *gene* (e.g. from a divergent DRL rollout) would
+        // otherwise poison a model's fitted statistics. Replace `NaN → 0.0` and
+        // clamp `±inf → ±f32::MAX`. The per-model `fit` guards remain the precise
+        // correctness layer (and protect direct trait callers this path cannot).
+        let nan_mask = selected.clone().is_nan();
+        let selected = selected
+            .mask_fill(nan_mask, 0.0_f32)
+            .clamp(-f32::MAX, f32::MAX);
         let selected_fitness_host: Vec<f32> = order.iter().map(|&i| sanitized[i]).collect();
         let selected_fitness =
             Tensor::<B, 1>::from_data(TensorData::new(selected_fitness_host, [k]), &device);
@@ -455,6 +472,43 @@ mod tests {
         approx::assert_relative_eq!(v[0], 1.0, epsilon = 1e-6);
         approx::assert_relative_eq!(f, 9.0, epsilon = 1e-6);
         assert!(m.best_fitness().is_finite());
+    }
+
+    #[test]
+    fn nonfinite_genome_sanitized_before_fit_yields_finite_samples() {
+        // End-to-end (#129): a population carrying NaN/±inf genes must not
+        // poison the fitted model. The `tell` backstop sanitizes the selected
+        // population, and the per-model guards floor any residual non-finite
+        // statistics, so the next `ask` draws a finite population.
+        let device = Default::default();
+        let strategy = EdaStrategy::<TestBackend, _>::new(UnivariateGaussian);
+        let mut rng = StdRng::seed_from_u64(1);
+        let p = params(4, 0.75, 2);
+        let state = strategy.init(&p, &mut rng, &device);
+        let pop = make_pop(
+            &[
+                f32::NAN, 0.0, //
+                f32::INFINITY, 1.0, //
+                f32::NEG_INFINITY, 2.0, //
+                0.5, 3.0,
+            ],
+            4,
+            2,
+        );
+        let fitness = make_fitness(&[1.0, 2.0, 3.0, 4.0]);
+        let (state, _m) = strategy.tell(&p, pop, fitness, state, &mut rng);
+        // Fitted state must be finite.
+        for &m in state.model_state.mean() {
+            assert!(m.is_finite(), "fitted mean must be finite, got {m}");
+        }
+        for &v in state.model_state.variance() {
+            assert!(v.is_finite() && v > 0.0, "fitted variance must be finite/positive, got {v}");
+        }
+        // Sampling the next generation must yield an all-finite population.
+        let (next_pop, _s) = strategy.ask(&p, &state, &mut rng, &device);
+        for x in next_pop.into_data().into_vec::<f32>().unwrap() {
+            assert!(x.is_finite(), "sampled genome must be finite, got {x}");
+        }
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
@@ -148,6 +148,16 @@ impl<B: Backend> ProbabilityModel<B> for UnivariateBernoulli {
         };
 
         let [k, d] = population.dims();
+        if k == 0 {
+            // Empty selected population: the argmax/argmin below would leave
+            // `best_idx`/`worst_idx` at `0` and then index `rows[0 * d + j]` on
+            // an empty `rows`, panicking out of bounds. Return the previous
+            // probabilities unchanged. `EdaStrategy::tell` clamps `k ≥ 2`, but
+            // `fit` is a public trait method reachable directly.
+            return UnivariateBernoulliState {
+                prob: prev.prob.clone(),
+            };
+        }
         let rows = population.into_data().into_vec::<f32>().unwrap_or_default();
         let fit_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
 
@@ -158,7 +168,14 @@ impl<B: Backend> ProbabilityModel<B> for UnivariateBernoulli {
         let mut best_f = f32::NEG_INFINITY;
         let mut worst_f = f32::INFINITY;
         for i in 0..k {
-            let f = fit_host.get(i).copied().unwrap_or(f32::NEG_INFINITY);
+            // Sanitize `NaN → −inf` at the seam, mirroring `compact_genetic` so
+            // the two binary EDAs stay symmetric. `tell` sanitizes upstream, but
+            // a direct `fit` caller passing a `NaN` fitness would otherwise have
+            // it sort as the largest value under `total_cmp` and be picked as the
+            // best individual.
+            let f = crate::fitness::sanitize_fitness(
+                fit_host.get(i).copied().unwrap_or(f32::NEG_INFINITY),
+            );
             if f.total_cmp(&best_f) == std::cmp::Ordering::Greater {
                 best_f = f;
                 best_idx = i;
@@ -352,6 +369,44 @@ mod tests {
             #[allow(clippy::float_cmp)]
             let is_binary = v == 0.0 || v == 1.0;
             assert!(is_binary, "non-binary gene {v}");
+        }
+    }
+
+    #[test]
+    fn fit_empty_population_returns_prior() {
+        // k == 0 would index an empty `rows` and panic; the guard (#129) returns
+        // the previous probabilities unchanged.
+        let device = Default::default();
+        let p = UnivariateBernoulliParams::default_for(3);
+        let prior = fit_prior(&p);
+        let state = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateBernoulli,
+            &p,
+            Some(&prior),
+            pop(vec![], 0, 3),
+            fitness(vec![]),
+            &device,
+        );
+        assert_eq!(state.prob, prior.prob, "empty population must return prior unchanged");
+    }
+
+    #[test]
+    fn nan_fitness_not_selected_as_best() {
+        // Row 0 all-ones + NaN fitness; row 1 all-zeros + finite fitness. The
+        // sanitized seam (#129) must pick row 1 as best and push prob toward 0.
+        let device = Default::default();
+        let p = UnivariateBernoulliParams::default_for(2);
+        let prior = fit_prior(&p);
+        let state = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateBernoulli,
+            &p,
+            Some(&prior),
+            pop(vec![1.0, 1.0, 0.0, 0.0], 2, 2),
+            fitness(vec![f32::NAN, 5.0]),
+            &device,
+        );
+        for &pj in &state.prob {
+            assert!(pj < 0.5, "best should be the finite-fitness zero row, got {pj}");
         }
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
@@ -189,7 +189,14 @@ impl<B: Backend> ProbabilityModel<B> for UnivariateGaussian {
             }
         }
         for m in &mut mean {
-            *m /= kf;
+            let mu = *m / kf;
+            // `Normal::new` accepts any mean, so a single non-finite genome value
+            // (common from divergent DRL rollouts) would propagate into every
+            // sample for this dimension and silently poison the search. Fall back
+            // to the prior mean. (The `tell` chokepoint now also sanitizes the
+            // population as a coarse backstop; this is the precise per-dimension
+            // guard for direct `fit` callers.)
+            *m = if mu.is_finite() { mu } else { params.init_mean };
         }
 
         let mut variance = vec![0.0_f32; d];
@@ -200,7 +207,18 @@ impl<B: Backend> ProbabilityModel<B> for UnivariateGaussian {
             }
         }
         for v in &mut variance {
-            *v = (*v / kf).max(params.min_variance);
+            // Floor the lower bound AND reject non-finite estimates. `f32::max`
+            // suppresses `NaN` (returns `min_variance`), but an overflowed `inf`
+            // MLE variance would flow through as `inf` → `inf` std →
+            // `Normal::new` rejects non-finite σ → `sample` panics. Making the
+            // stored variance always finite and `≥ min_variance` keeps `sample`
+            // panic-free.
+            let mle = *v / kf;
+            *v = if mle.is_finite() && mle > params.min_variance {
+                mle
+            } else {
+                params.min_variance
+            };
         }
 
         UnivariateGaussianState { mean, variance }
@@ -408,5 +426,50 @@ mod tests {
         }
         approx::assert_relative_eq!(sum0 / 10_000.0, 3.0, epsilon = 0.1);
         approx::assert_relative_eq!(sum1 / 10_000.0, -1.0, epsilon = 0.1);
+    }
+
+    #[test]
+    fn inf_variance_floored_to_min() {
+        // Squared deviations overflow f32 → inf MLE variance. The floor (#129)
+        // must reject the non-finite estimate instead of passing inf through to
+        // sample() (where Normal::new would then panic on a non-finite σ).
+        let device = Default::default();
+        let p = UnivariateGaussianParams::default_for(1);
+        let prior = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateGaussian, &p, None, pop(vec![], 0, 0), fitness(vec![]), &device,
+        );
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateGaussian,
+            &p,
+            Some(&prior),
+            pop(vec![1e38, -1e38], 2, 1),
+            fitness(vec![0.0, 1.0]),
+            &device,
+        );
+        let v = state.variance[0];
+        assert!(v.is_finite(), "variance must be finite, got {v}");
+        approx::assert_relative_eq!(v, p.min_variance, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn nonfinite_gene_mean_falls_back_to_init_mean() {
+        // A NaN gene makes the column mean NaN; the guard (#129) falls back to
+        // init_mean so the fitted mean stays finite (and sampling stays sane).
+        let device = Default::default();
+        let mut p = UnivariateGaussianParams::default_for(1);
+        p.init_mean = 3.0;
+        let prior = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateGaussian, &p, None, pop(vec![], 0, 0), fitness(vec![]), &device,
+        );
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &UnivariateGaussian,
+            &p,
+            Some(&prior),
+            pop(vec![f32::NAN, 0.0], 2, 1),
+            fitness(vec![0.0, 1.0]),
+            &device,
+        );
+        assert!(state.mean[0].is_finite(), "mean must be finite");
+        approx::assert_relative_eq!(state.mean[0], p.init_mean, epsilon = 1e-12);
     }
 }


### PR DESCRIPTION
## Summary

Closes the NaN/Inf propagation paths across the five EDA probability models (`bayesian_network`, `compact_genetic`, `dependency_chain`, `univariate_bernoulli`, `univariate_gaussian`). Each model's public `fit`/`sample` is directly callable and cannot return `Result`, so the fix adds guards that clamp or fall back to a safe default rather than propagate non-finite values into the fitted state or the next generation's samples.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #129

## What Was Changed

- `bayesian_network.rs` — clamp `init_prob` into `(0, 1)` at the prior chokepoint (`NaN` → `0.5`), floor `smoothing_count` at `1`, removing the dead `0/0` branch that could pin a CPT cell to an absorbing `0`/`1`.
- `compact_genetic.rs` / `univariate_bernoulli.rs` — sanitize fitness at the `fit` seam so a `NaN` cannot sort as the winner under `total_cmp`; guard the empty-population case that would index-panic PBIL.
- `dependency_chain.rs` — return the prior when `k < 2` (correlation unidentifiable); fall back to the marginal Gaussian when a conditional link overflows to a non-finite mean/std.
- `univariate_gaussian.rs` — reject non-finite MLE variance in the floor; fall back to `init_mean` on a non-finite column mean.
- `eda/mod.rs` — add a coarse defense-in-depth backstop in `EdaStrategy::tell` that maps non-finite selected genes (`NaN` → `0.0`, `±inf` → `±f32::MAX`) before the refit, complementing the existing fitness sanitization.

## How It Was Tested

Regression tests lock each guard plus an end-to-end `tell` → `ask` run that feeds NaN/inf genomes and asserts a finite fitted state and finite next-generation samples.

```
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable
- Burn backend tested: ndarray (`TestBackend`)
- OS: macOS

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Claude Opus 4.8). Scope: implementation of guards and regression tests across the five EDA model files and `eda/mod.rs`, per this session's plan.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

`f32::clamp` propagates `NaN`, so `bayesian_network`'s prior clamp handles `NaN` explicitly (→ `0.5`) rather than relying on clamp bounds alone.
