### PR TITLE
fix(evolution): NaN/Inf fitness sanitization — GEP + chokepoint

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -34,6 +34,13 @@ use crate::ops::mutation::gaussian_mutation_per_row;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
+/// Default σ floor for the log-normal self-adaptation (see
+/// [`EpConfig::sigma_min`]).
+const DEFAULT_SIGMA_MIN: f32 = 1e-8;
+/// Default σ ceiling for the log-normal self-adaptation (see
+/// [`EpConfig::sigma_max`]).
+const DEFAULT_SIGMA_MAX: f32 = 1e6;
+
 /// Static configuration for an [`EvolutionaryProgramming`] run.
 #[derive(Debug, Clone)]
 pub struct EpConfig {
@@ -46,6 +53,21 @@ pub struct EpConfig {
     pub bounds: Bounds,
     /// Initial σ for every individual.
     pub initial_sigma: f32,
+    /// Lower clamp for the self-adaptive σ.
+    ///
+    /// The log-normal update `σ' = σ · exp(τ · N(0,1))` is an unbounded
+    /// multiplicative random walk; without a floor σ can underflow toward
+    /// `0`, collapsing the mutation amplitude so the search freezes. Must be
+    /// strictly positive and `< sigma_max`. Default [`DEFAULT_SIGMA_MIN`].
+    pub sigma_min: f32,
+    /// Upper clamp for the self-adaptive σ.
+    ///
+    /// Without a ceiling the log-normal update can overflow toward `+∞`
+    /// (genes then saturate to a bound with no error). Default
+    /// [`DEFAULT_SIGMA_MAX`] — far outside any practical step scale on the
+    /// `[-5.12, 5.12]` benchmark domain, so it never binds in normal
+    /// operation and only catches a runaway walk.
+    pub sigma_max: f32,
     /// Learning rate for the log-normal σ update. Default is
     /// `1 / sqrt(2 · sqrt(D))`.
     pub tau: f32,
@@ -69,6 +91,8 @@ impl EpConfig {
             genome_dim,
             bounds: Bounds::new(-5.12, 5.12),
             initial_sigma: 1.0,
+            sigma_min: DEFAULT_SIGMA_MIN,
+            sigma_max: DEFAULT_SIGMA_MAX,
             tau,
             tournament_q: 10,
         }
@@ -81,6 +105,13 @@ impl Validate for EpConfig {
         config::at_least(C, "mu", self.mu, 1)?;
         config::nonzero(C, "genome_dim", self.genome_dim)?;
         config::positive(C, "initial_sigma", f64::from(self.initial_sigma))?;
+        config::positive(C, "sigma_min", f64::from(self.sigma_min))?;
+        config::ordered(
+            C,
+            "sigma_max",
+            f64::from(self.sigma_min),
+            f64::from(self.sigma_max),
+        )?;
         config::positive(C, "tau", f64::from(self.tau))?;
         config::at_least(C, "tournament_q", self.tournament_q, 1)?;
         if self.tournament_q > 2 * self.mu {
@@ -255,7 +286,11 @@ where
             noise_rows.push(normal.sample(&mut sigma_rng));
         }
         let noise = Tensor::<B, 1>::from_data(TensorData::new(noise_rows, [mu]), device);
-        let offspring_sigmas = state.sigmas.clone() * noise.mul_scalar(params.tau).exp();
+        // Clamp the log-normal random walk to `[sigma_min, sigma_max]` so σ can
+        // neither underflow to 0 (search freezes) nor overflow to +∞ (genes
+        // saturate). Both bounds are construction-validated on `EpConfig`.
+        let offspring_sigmas = (state.sigmas.clone() * noise.mul_scalar(params.tau).exp())
+            .clamp(params.sigma_min, params.sigma_max);
 
         // Mutate each parent exactly once using its own σ, drawing from the
         // host `mutation_rng`.
@@ -447,6 +482,80 @@ mod tests {
         let mut cfg = EpConfig::default_for(5, 10);
         cfg.tournament_q = 11;
         assert_eq!(cfg.validate().unwrap_err().field, "tournament_q");
+    }
+
+    /// `genome_dim == 0` makes `tau = 1/sqrt(2·sqrt(0)) = +∞`; the config guard
+    /// must reject it at construction (ADR 0026) so the non-finite τ never
+    /// reaches the first `ask` (issue #132, `ep` §1.2).
+    #[test]
+    fn rejects_zero_genome_dim() {
+        let cfg = EpConfig::default_for(5, 0);
+        assert!(
+            !cfg.tau.is_finite(),
+            "precondition: derived tau is non-finite for genome_dim == 0, got {}",
+            cfg.tau
+        );
+        assert_eq!(
+            cfg.validate().unwrap_err().field,
+            "genome_dim",
+            "genome_dim == 0 must be rejected before the non-finite tau can be used"
+        );
+    }
+
+    /// An inverted σ window (`sigma_min >= sigma_max`) is rejected so the clamp
+    /// bounds are always a valid interval (`ep` §1.1).
+    #[test]
+    fn rejects_inverted_sigma_window() {
+        let mut cfg = EpConfig::default_for(5, 10);
+        cfg.sigma_min = 10.0;
+        cfg.sigma_max = 1.0;
+        assert_eq!(
+            cfg.validate().unwrap_err().field,
+            "sigma_max",
+            "sigma_min >= sigma_max must be rejected"
+        );
+    }
+
+    /// The self-adaptive σ must stay inside `[sigma_min, sigma_max]` across many
+    /// generations even under an aggressive `tau` that would otherwise drive the
+    /// log-normal random walk to `0` or `+∞` (`ep` §1.1). Drives the strategy
+    /// directly so the transient `(2μ,)` σ vector produced by `ask` is inspected.
+    #[test]
+    fn sigma_stays_within_bounds_across_updates() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = EvolutionaryProgramming::<TestBackend>::new();
+        let mut params = EpConfig::default_for(6, 3);
+        // Aggressive τ plus a tight window: without the clamp σ would leave
+        // `[sigma_min, sigma_max]` within a handful of generations.
+        params.tau = 5.0;
+        params.sigma_min = 1e-4;
+        params.sigma_max = 10.0;
+        assert!(params.validate().is_ok(), "test config must be valid");
+
+        let mut rng = StdRng::seed_from_u64(7);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        for generation in 0..60 {
+            let (offspring, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let sigmas: Vec<f32> = next.sigmas.clone().into_data().into_vec::<f32>().unwrap();
+            for &s in &sigmas {
+                assert!(
+                    s.is_finite() && s >= params.sigma_min && s <= params.sigma_max,
+                    "σ left [{}, {}] at gen {generation}: {s}",
+                    params.sigma_min,
+                    params.sigma_max
+                );
+            }
+            let n = offspring.dims()[0];
+            let fitness = Tensor::<TestBackend, 1>::from_data(
+                TensorData::new(vec![1.0_f32; n], [n]),
+                &device,
+            );
+            let (advanced, _) = strategy.tell(&params, offspring, fitness, next, &mut rng);
+            state = advanced;
+        }
     }
 
     struct Sphere;

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -62,6 +62,13 @@ impl EsKind {
     }
 }
 
+/// Default σ floor for the self-adaptive step size (see
+/// [`EsConfig::sigma_min`]).
+const DEFAULT_SIGMA_MIN: f32 = 1e-8;
+/// Default σ ceiling for the self-adaptive step size (see
+/// [`EsConfig::sigma_max`]).
+const DEFAULT_SIGMA_MAX: f32 = 1e6;
+
 /// Static configuration for an [`EvolutionStrategy`] run.
 #[derive(Debug, Clone)]
 pub struct EsConfig {
@@ -73,6 +80,21 @@ pub struct EsConfig {
     pub bounds: Bounds,
     /// Initial σ (log-normal self-adaptation modifies it in state).
     pub initial_sigma: f32,
+    /// Lower clamp for the self-adaptive σ.
+    ///
+    /// Both the log-normal update `σ' = σ · exp(τ · N(0,1))` (multi-parent
+    /// variants) and the Rechenberg 1/5-rule (`(1+1)`) are unbounded
+    /// multiplicative processes; without a floor σ can underflow toward `0`,
+    /// collapsing the mutation amplitude so the search freezes. Must be
+    /// strictly positive and `< sigma_max`. Default [`DEFAULT_SIGMA_MIN`].
+    pub sigma_min: f32,
+    /// Upper clamp for the self-adaptive σ.
+    ///
+    /// Without a ceiling σ can overflow toward `+∞` (genes then saturate to a
+    /// bound with no error). Default [`DEFAULT_SIGMA_MAX`] — far outside any
+    /// practical step scale on the `[-5.12, 5.12]` benchmark domain, so it
+    /// never binds in normal operation and only catches a runaway process.
+    pub sigma_max: f32,
     /// Learning-rate scale for log-normal σ update. Standard default is
     /// `1.0 / sqrt(2 * sqrt(D))`.
     pub tau: f32,
@@ -94,6 +116,8 @@ impl EsConfig {
             genome_dim,
             bounds: Bounds::new(-5.12, 5.12),
             initial_sigma: 1.0,
+            sigma_min: DEFAULT_SIGMA_MIN,
+            sigma_max: DEFAULT_SIGMA_MAX,
             tau,
         }
     }
@@ -104,6 +128,13 @@ impl Validate for EsConfig {
         const C: &str = "EsConfig";
         config::nonzero(C, "genome_dim", self.genome_dim)?;
         config::positive(C, "initial_sigma", f64::from(self.initial_sigma))?;
+        config::positive(C, "sigma_min", f64::from(self.sigma_min))?;
+        config::ordered(
+            C,
+            "sigma_max",
+            f64::from(self.sigma_min),
+            f64::from(self.sigma_max),
+        )?;
         config::positive(C, "tau", f64::from(self.tau))?;
         match self.kind {
             EsKind::OnePlusOne => {}
@@ -404,7 +435,11 @@ where
                 noise_rows.push(normal.sample(&mut sigma_rng));
             }
             let noise = Tensor::<B, 1>::from_data(TensorData::new(noise_rows, [lambda]), device);
-            duplicated_sigmas * noise.mul_scalar(params.tau).exp()
+            // Clamp the log-normal random walk to `[sigma_min, sigma_max]` so σ
+            // can neither underflow to 0 (search freezes) nor overflow to +∞
+            // (genes saturate). Both bounds are construction-validated.
+            (duplicated_sigmas * noise.mul_scalar(params.tau).exp())
+                .clamp(params.sigma_min, params.sigma_max)
         };
 
         // Mutate parents by the per-offspring σ, drawing from the host
@@ -513,13 +548,17 @@ where
                     let rate = state.successes_in_window as f32 / state.window_len as f32;
                     let current_sigma =
                         state.sigmas.clone().into_data().into_vec::<f32>().unwrap()[0];
+                    // The 1/5-rule is also an unbounded multiplicative process;
+                    // clamp to the same construction-validated window so σ can
+                    // neither underflow to 0 nor overflow to +∞ over a long run.
                     let new_sigma = if rate > 0.2 {
                         current_sigma * 1.22
                     } else if rate < 0.2 {
                         current_sigma / 1.22
                     } else {
                         current_sigma
-                    };
+                    }
+                    .clamp(params.sigma_min, params.sigma_max);
                     state.sigmas =
                         Tensor::<B, 1>::from_data(TensorData::new(vec![new_sigma], [1]), &device);
                     state.successes_in_window = 0;
@@ -672,6 +711,79 @@ mod tests {
     fn rejects_comma_lambda_below_mu() {
         let cfg = EsConfig::default_for(EsKind::MuCommaLambda { mu: 10, lambda: 5 }, 10);
         assert_eq!(cfg.validate().unwrap_err().field, "lambda");
+    }
+
+    /// `genome_dim == 0` makes `tau = 1/sqrt(2·sqrt(0)) = +∞`; the config guard
+    /// must reject it at construction (ADR 0026) so the non-finite τ never
+    /// reaches the first `ask` (issue #132, `es_classical` §1.1 / `ep` §1.2).
+    #[test]
+    fn rejects_zero_genome_dim() {
+        let cfg = EsConfig::default_for(EsKind::MuPlusLambda { mu: 5, lambda: 20 }, 0);
+        assert!(
+            !cfg.tau.is_finite(),
+            "precondition: derived tau is non-finite for genome_dim == 0, got {}",
+            cfg.tau
+        );
+        assert_eq!(
+            cfg.validate().unwrap_err().field,
+            "genome_dim",
+            "genome_dim == 0 must be rejected before the non-finite tau can be used"
+        );
+    }
+
+    /// An inverted σ window (`sigma_min >= sigma_max`) is rejected so the clamp
+    /// bounds are always a valid interval (`es_classical` §1.1).
+    #[test]
+    fn rejects_inverted_sigma_window() {
+        let mut cfg = EsConfig::default_for(EsKind::MuPlusLambda { mu: 5, lambda: 20 }, 10);
+        cfg.sigma_min = 10.0;
+        cfg.sigma_max = 1.0;
+        assert_eq!(
+            cfg.validate().unwrap_err().field,
+            "sigma_max",
+            "sigma_min >= sigma_max must be rejected"
+        );
+    }
+
+    /// The log-normal σ of a multi-parent variant stays inside
+    /// `[sigma_min, sigma_max]` across many generations even under an aggressive
+    /// `tau` that would otherwise drive the walk to `0` or `+∞`
+    /// (`es_classical` §1.1). Drives the strategy directly so the transient
+    /// `(μ + λ,)` σ vector produced by `ask` is inspected.
+    #[test]
+    fn sigma_stays_within_bounds_across_updates() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = EvolutionStrategy::<TestBackend>::new();
+        let mut params = EsConfig::default_for(EsKind::MuPlusLambda { mu: 4, lambda: 12 }, 3);
+        params.tau = 5.0;
+        params.sigma_min = 1e-4;
+        params.sigma_max = 10.0;
+        assert!(params.validate().is_ok(), "test config must be valid");
+
+        let mut rng = StdRng::seed_from_u64(9);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        for generation in 0..60 {
+            let (offspring, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let sigmas: Vec<f32> = next.sigmas().clone().into_data().into_vec::<f32>().unwrap();
+            for &s in &sigmas {
+                assert!(
+                    s.is_finite() && s >= params.sigma_min && s <= params.sigma_max,
+                    "σ left [{}, {}] at gen {generation}: {s}",
+                    params.sigma_min,
+                    params.sigma_max
+                );
+            }
+            let n = offspring.dims()[0];
+            let fitness = Tensor::<TestBackend, 1>::from_data(
+                TensorData::new(vec![1.0_f32; n], [n]),
+                &device,
+            );
+            let (advanced, _) = strategy.tell(&params, offspring, fitness, next, &mut rng);
+            state = advanced;
+        }
     }
 
     struct Sphere;

--- a/crates/rlevo-evolution/src/algorithms/gep/config.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/config.rs
@@ -1,6 +1,7 @@
 //! Runtime configuration for a Gene Expression Programming run.
 
 use rlevo_core::config::{self, ConfigError, Validate};
+use rlevo_core::probability::Probability;
 
 /// Static parameters for a [`GepStrategy`](super::GepStrategy) run.
 ///
@@ -27,16 +28,20 @@ pub struct GepConfig {
     pub pop_size: usize,
     /// Number of input variables the program sees.
     pub n_vars: usize,
-    /// Per-gene point-mutation probability.
-    pub mutation_rate: f32,
-    /// Per-individual probability of applying one IS transposition.
-    pub is_transpose_rate: f32,
-    /// Per-individual probability of applying one RIS transposition.
-    pub ris_transpose_rate: f32,
-    /// Per-pair probability of one-point crossover.
-    pub crossover_1p_rate: f32,
-    /// Per-pair probability of two-point crossover.
-    pub crossover_2p_rate: f32,
+    /// Per-gene point-mutation probability. Valid by construction (`[0, 1]`).
+    pub mutation_rate: Probability,
+    /// Per-individual probability of applying one IS transposition. Valid by
+    /// construction (`[0, 1]`).
+    pub is_transpose_rate: Probability,
+    /// Per-individual probability of applying one RIS transposition. Valid by
+    /// construction (`[0, 1]`).
+    pub ris_transpose_rate: Probability,
+    /// Per-pair probability of one-point crossover. Valid by construction
+    /// (`[0, 1]`).
+    pub crossover_1p_rate: Probability,
+    /// Per-pair probability of two-point crossover. Valid by construction
+    /// (`[0, 1]`).
+    pub crossover_2p_rate: Probability,
 }
 
 impl GepConfig {
@@ -47,9 +52,12 @@ impl GepConfig {
     /// complete tree. `max_arity` is the function set's largest
     /// arity ([`FunctionSet::max_arity`](crate::function_set::FunctionSet::max_arity)).
     ///
-    /// Operator rates default to canonical Ferreira (2001) values; mutate the
-    /// public fields afterwards to override. The point-mutation rate defaults
-    /// to `2 / genome_len` (≈ two genes per chromosome).
+    /// Operator rates default to canonical Ferreira (2001) values; assign a
+    /// validated [`Probability`] to the public fields afterwards to override.
+    /// The point-mutation rate defaults to `2 / genome_len` (≈ two genes per
+    /// chromosome). Because the rates are [`Probability`], a `NaN`/`Inf`/
+    /// out-of-`[0, 1]` rate is unrepresentable — the silent operator
+    /// degeneracy of a bare `f32` rate cannot occur.
     ///
     /// # Errors
     ///
@@ -67,14 +75,21 @@ impl GepConfig {
         // `max_arity` is not a stored field (it is consumed below to derive
         // `tail_len`), so it cannot be re-checked by `validate`; guard it here.
         config::at_least("GepConfig", "max_arity", max_arity, 1)?;
+        // Guard `head_len` before deriving `mutation_rate`: `head_len == 0`
+        // yields `genome_len == 1` and `2 / genome_len == 2.0`, which would
+        // panic `Probability::new` below (an invalid config that `validate`
+        // should reject, not crash on). Re-checked in `validate` too.
+        config::at_least("GepConfig", "head_len", head_len, 1)?;
 
         // Tail sized to the worst case: a head of all-max-arity functions
         // demands exactly `head_len * (max_arity - 1) + 1` terminals, so this is
         // the minimum tail that guarantees a repair-free decode.
         let tail_len = head_len * (max_arity - 1) + 1;
         let genome_len = head_len + tail_len;
+        // `genome_len >= 2` (head_len >= 1, tail_len >= 1), so `2 / genome_len`
+        // lies in `(0, 1]` — provably a valid `Probability`, hence `new`.
         #[allow(clippy::cast_precision_loss)]
-        let mutation_rate = 2.0 / genome_len as f32;
+        let mutation_rate = Probability::new(2.0 / genome_len as f32);
 
         let config = Self {
             head_len,
@@ -82,10 +97,10 @@ impl GepConfig {
             pop_size,
             n_vars,
             mutation_rate,
-            is_transpose_rate: 0.1,
-            ris_transpose_rate: 0.1,
-            crossover_1p_rate: 0.3,
-            crossover_2p_rate: 0.3,
+            is_transpose_rate: Probability::new(0.1),
+            ris_transpose_rate: Probability::new(0.1),
+            crossover_1p_rate: Probability::new(0.3),
+            crossover_2p_rate: Probability::new(0.3),
         };
         config.validate()?;
         Ok(config)
@@ -105,11 +120,8 @@ impl Validate for GepConfig {
         config::at_least(C, "tail_len", self.tail_len, 1)?;
         config::at_least(C, "n_vars", self.n_vars, 1)?;
         config::at_least(C, "pop_size", self.pop_size, 1)?;
-        config::in_range(C, "mutation_rate", 0.0, 1.0, f64::from(self.mutation_rate))?;
-        config::in_range(C, "is_transpose_rate", 0.0, 1.0, f64::from(self.is_transpose_rate))?;
-        config::in_range(C, "ris_transpose_rate", 0.0, 1.0, f64::from(self.ris_transpose_rate))?;
-        config::in_range(C, "crossover_1p_rate", 0.0, 1.0, f64::from(self.crossover_1p_rate))?;
-        config::in_range(C, "crossover_2p_rate", 0.0, 1.0, f64::from(self.crossover_2p_rate))?;
+        // The five operator rates are `Probability`: valid by construction, so
+        // no `in_range` checks here — see ADR 0031.
         Ok(())
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/operators.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/operators.rs
@@ -38,14 +38,16 @@ pub fn point_mutation<F: FunctionSet>(
     rng: &mut dyn Rng,
 ) {
     for (i, locus) in chromosome.iter_mut().enumerate() {
-        if rng.random::<f32>() >= rate {
-            continue;
+        // `< rate` reads as "mutate with probability `rate`" and is robust to a
+        // stray non-finite `rate` (`x < NaN` is `false` ⇒ no mutation). Callers
+        // pass a validated `Probability::get()`, so this is defense-in-depth.
+        if rng.random::<f32>() < rate {
+            *locus = if i < head_len {
+                alphabet.sample_head_symbol(rng)
+            } else {
+                alphabet.sample_tail_symbol(rng)
+            };
         }
-        *locus = if i < head_len {
-            alphabet.sample_head_symbol(rng)
-        } else {
-            alphabet.sample_tail_symbol(rng)
-        };
     }
 }
 
@@ -193,6 +195,33 @@ mod tests {
             );
             assert!(decodes_complete(&g, &a));
         }
+    }
+
+    /// `rate == 0.0` never mutates; `rate == 1.0` mutates every locus. Pins the
+    /// `< rate` gate semantics (finding operators.rs §1.1).
+    #[test]
+    fn test_point_mutation_rate_bounds_are_none_and_all() {
+        let a = alphabet();
+        let cfg = GepConfig::new(7, 2, 1, 100).unwrap();
+        let mut rng = seed_stream(9, 0, SeedPurpose::Mutation);
+
+        // rate 0 -> identity on every locus.
+        let original = sample_valid(&a, &cfg, &mut rng);
+        let mut g = original.clone();
+        point_mutation(&mut g, cfg.head_len, &a, 0.0, &mut rng);
+        assert_eq!(g, original, "rate 0.0 must leave the chromosome unchanged");
+
+        // rate 1 -> every locus is resampled (still a valid symbol for its class).
+        let mut g = sample_valid(&a, &cfg, &mut rng);
+        point_mutation(&mut g, cfg.head_len, &a, 1.0, &mut rng);
+        assert!(
+            tail_all_terminals(&g, cfg.head_len, &a),
+            "rate 1.0 must preserve the tail invariant: {g:?}"
+        );
+        assert!(
+            decodes_complete(&g, &a),
+            "rate 1.0 offspring must still decode completely"
+        );
     }
 
     /// 500 trials of each operator yield offspring that decode completely.

--- a/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
@@ -339,23 +339,29 @@ where
                 break;
             }
             let (left, right) = pair.split_at_mut(1);
-            if xover_rng.random::<f32>() < params.crossover_1p_rate {
+            if xover_rng.random::<f32>() < params.crossover_1p_rate.get() {
                 one_point_crossover(&mut left[0], &mut right[0], &mut xover_rng);
             }
-            if xover_rng.random::<f32>() < params.crossover_2p_rate {
+            if xover_rng.random::<f32>() < params.crossover_2p_rate.get() {
                 two_point_crossover(&mut left[0], &mut right[0], &mut xover_rng);
             }
         }
 
         // Transposition + point mutation, per individual.
         for child in &mut offspring {
-            if trans_rng.random::<f32>() < params.is_transpose_rate {
+            if trans_rng.random::<f32>() < params.is_transpose_rate.get() {
                 is_transposition(child, head_len, &mut trans_rng);
             }
-            if trans_rng.random::<f32>() < params.ris_transpose_rate {
+            if trans_rng.random::<f32>() < params.ris_transpose_rate.get() {
                 ris_transposition(child, head_len, &self.alphabet, &mut trans_rng);
             }
-            point_mutation(child, head_len, &self.alphabet, params.mutation_rate, &mut mut_rng);
+            point_mutation(
+                child,
+                head_len,
+                &self.alphabet,
+                params.mutation_rate.get(),
+                &mut mut_rng,
+            );
         }
 
         // Elitism: copy the best-so-far genome into row 0 unchanged.
@@ -425,7 +431,15 @@ impl<F: FunctionSet> GepSymRegression<F> {
     ///
     /// # Panics
     ///
-    /// Panics if `inputs` and `targets` differ in length.
+    /// Panics if:
+    /// - `inputs` is empty — an empty dataset would make MSE `0.0 / 0.0 = NaN`
+    ///   fitness (`n_points == 0`), silently poisoning the population.
+    /// - `inputs` and `targets` differ in length.
+    /// - any input row does not have exactly `alphabet.n_vars` entries — a short
+    ///   row is otherwise silently zero-padded by
+    ///   [`ExpressionTree::eval`](super::ExpressionTree::eval)
+    ///   (`inputs.get(i).unwrap_or(0.0)`), so the regression would quietly fit
+    ///   the wrong target.
     #[must_use]
     pub fn new(
         alphabet: Alphabet<F>,
@@ -433,10 +447,19 @@ impl<F: FunctionSet> GepSymRegression<F> {
         inputs: Vec<Vec<f32>>,
         targets: Vec<f32>,
     ) -> Self {
+        assert!(
+            !inputs.is_empty(),
+            "GepSymRegression: dataset must be non-empty (empty inputs give NaN fitness)"
+        );
         assert_eq!(
             inputs.len(),
             targets.len(),
             "GepSymRegression: inputs and targets must have equal length"
+        );
+        let n_vars = alphabet.n_vars;
+        assert!(
+            inputs.iter().all(|row| row.len() == n_vars),
+            "GepSymRegression: every input row must have exactly n_vars = {n_vars} entries"
         );
         Self {
             alphabet,
@@ -548,6 +571,51 @@ mod tests {
         let targets: Vec<f32> = xs.iter().map(|&x| x.sin() * x).collect();
         let best = run_gep(1, inputs, targets, 7, 500);
         assert!(best <= 0.01, "expected MSE <= 0.01, got {best}");
+    }
+
+    /// An empty dataset is rejected at construction (would give NaN fitness).
+    #[test]
+    #[should_panic(expected = "dataset must be non-empty")]
+    fn test_gep_sym_regression_rejects_empty_dataset() {
+        let _ = GepSymRegression::new(alphabet(1), 15, Vec::new(), Vec::new());
+    }
+
+    /// A row whose width differs from `n_vars` is rejected (would be silently
+    /// zero-padded and fit the wrong target).
+    #[test]
+    #[should_panic(expected = "every input row must have exactly n_vars")]
+    fn test_gep_sym_regression_rejects_mismatched_row_width() {
+        // n_vars = 2 but the single row has only one entry.
+        let _ = GepSymRegression::new(alphabet(2), 15, vec![vec![1.0]], vec![0.0]);
+    }
+
+    /// A well-formed tiny dataset yields finite fitness for the zero genome.
+    #[test]
+    fn test_gep_sym_regression_valid_dataset_is_finite() {
+        let device = Default::default();
+        let cfg = GepConfig::new(7, 2, 1, 4).unwrap();
+        let genome_len = cfg.genome_len();
+        let mut fitness =
+            GepSymRegression::new(alphabet(1), genome_len, vec![vec![0.5], vec![-0.5]], vec![
+                0.25, 0.25,
+            ]);
+        // A valid chromosome: every locus is variable `x` (id 8), which decodes
+        // to the single-node tree `x`. An all-zeros genome would be all `add`
+        // with no terminal tail — a malformed chromosome that trips the separate
+        // decode out-of-bounds path (decode.rs §1.1), unrelated to this test.
+        let pop = Tensor::<TestBackend, 2, Int>::from_data(
+            TensorData::new(vec![8i32; 4 * genome_len], [4, genome_len]),
+            &device,
+        );
+        let scores: Vec<f32> = fitness
+            .evaluate_batch(&pop, &device)
+            .into_data()
+            .into_vec()
+            .unwrap();
+        assert!(
+            scores.iter().all(|s| s.is_finite()),
+            "all fitness values must be finite, got {scores:?}"
+        );
     }
 
     /// Converges on `f(x, y) = x² + y²` over a 5×5 grid in [-2, 2]² (`n_vars` = 2).

--- a/crates/rlevo-evolution/src/algorithms/gep/tree.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/tree.rs
@@ -4,6 +4,32 @@ use crate::function_set::{FunctionSet, Symbol};
 
 use super::alphabet::{Alphabet, SymbolKind};
 
+/// Magnitude cap applied to a diverged node value in [`ExpressionTree::eval`].
+///
+/// Sized so its square stays finite (`1e15² = 1e30 < f32::MAX ≈ 3.4e38`), even
+/// summed over a large dataset, so a clamped prediction still produces a finite
+/// — but very large — MSE. A diverged (`±Inf`) subtree therefore ranks worst
+/// rather than collapsing to a deceptively small error.
+const EVAL_CLAMP: f32 = 1e15;
+
+/// Node-value sanitizer for the GEP evaluator: `NaN → 0.0`, `±Inf → ±`
+/// [`EVAL_CLAMP`], finite values unchanged.
+///
+/// `f32::clamp` *propagates* `NaN`, so `NaN` must be handled before the clamp
+/// (mirrors the EDA `bayesian_network` finiteness convention). Unlike the
+/// shared [`finite_or_zero`](crate::function_set::finite_or_zero) rule used by
+/// CGP, this preserves the sign and magnitude of an overflowed value so a
+/// bloated subtree is penalized, not hidden (finding tree.rs §1.2).
+#[must_use]
+#[inline]
+fn finite_or_clamp(v: f32) -> f32 {
+    if v.is_nan() {
+        0.0
+    } else {
+        v.clamp(-EVAL_CLAMP, EVAL_CLAMP)
+    }
+}
+
 /// A decoded expression tree stored in level-order (breadth-first) layout.
 ///
 /// The coding prefix of a chromosome decodes to this structure (see
@@ -86,8 +112,14 @@ impl ExpressionTree {
     /// Variable nodes resolve to `inputs[input_index]` (missing indices read as
     /// `0.0`); constant nodes resolve to their stored value; function nodes call
     /// [`FunctionSet::apply`](crate::function_set::FunctionSet::apply) with their
-    /// children's already-computed results. Non-finite function results collapse
-    /// to `0.0`, matching the CGP evaluator's robustness rule.
+    /// children's already-computed results, then sanitize the result via
+    /// [`finite_or_clamp`]: a `NaN` collapses to `0.0` (it has no meaningful
+    /// sign or magnitude), while `±Inf` clamps to `±`[`EVAL_CLAMP`] (sign
+    /// preserved). Clamping — rather than zeroing — a diverged (`±Inf`) subtree
+    /// keeps its magnitude large, so it yields a large MSE and ranks *worst*
+    /// instead of masquerading as a perfect `0.0` predictor near zero-valued
+    /// targets (GEP finding tree.rs §1.2). This differs from the CGP evaluator's
+    /// `finite_or_zero` rule, which zeros both.
     ///
     /// `alphabet` must be the same one the tree was decoded with.
     #[must_use]
@@ -112,7 +144,7 @@ impl ExpressionTree {
                     let start = self.child_start[i];
                     arg_buf[..arity].copy_from_slice(&results[start..start + arity]);
                     let v = alphabet.functions.apply(symbol, &arg_buf[..arity]);
-                    crate::function_set::finite_or_zero(v)
+                    finite_or_clamp(v)
                 }
             };
         }
@@ -164,5 +196,37 @@ mod tests {
         assert_eq!(tree.node_count(), 1);
         assert_eq!(tree.depth(), 0);
         approx::assert_relative_eq!(tree.eval(&a, &[7.0]), 7.0, epsilon = 1e-6);
+    }
+
+    /// `finite_or_clamp`: `NaN → 0.0`, `±Inf → ±EVAL_CLAMP`, finite passes.
+    #[test]
+    fn test_finite_or_clamp_zeroes_nan_and_clamps_inf() {
+        approx::assert_relative_eq!(finite_or_clamp(f32::NAN), 0.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(finite_or_clamp(f32::INFINITY), EVAL_CLAMP);
+        approx::assert_relative_eq!(finite_or_clamp(f32::NEG_INFINITY), -EVAL_CLAMP);
+        approx::assert_relative_eq!(finite_or_clamp(3.5), 3.5, epsilon = 1e-6);
+    }
+
+    /// An overflowing `x * x` clamps to `EVAL_CLAMP` (not `0.0`), so a diverged
+    /// tree carries a large magnitude and is penalized (finding tree.rs §1.2).
+    #[test]
+    fn test_eval_clamps_overflow_instead_of_zeroing() {
+        let a = alphabet(1);
+        // `[*, x, x]` = x * x; x = 1e30 overflows f32 to +Inf.
+        let genome = vec![
+            Symbol::from_raw(2),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8),
+        ];
+        let tree = GepDecoder.decode(&a, &genome);
+        let pred = tree.eval(&a, &[1e30]);
+        approx::assert_relative_eq!(pred, EVAL_CLAMP);
+        // The squared error against a near-zero target is huge, not near-zero:
+        // the old `finite_or_zero` rule would have made `pred == 0.0` here.
+        assert!(
+            (pred - 0.1).powi(2) > 1e20,
+            "diverged prediction must yield a large error, got pred = {pred}"
+        );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
+++ b/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
@@ -138,7 +138,14 @@ pub struct CgpState<B: Backend> {
     /// Parent genotype, shape `(1, genome_len)`.
     pub parent: Tensor<B, 2, Int>,
     /// Parent fitness (host-side scalar cache).
-    pub parent_fitness: f32,
+    ///
+    /// `None` until the first `tell` bootstraps it. Using `Option` — rather
+    /// than a `f32::NEG_INFINITY` "unset" sentinel — keeps "uninitialised"
+    /// distinct from a legitimately sanitized `−∞` fitness. A `Minimize`
+    /// landscape whose natural cost is `+∞` canonicalizes to `−∞` (ADR 0034);
+    /// with the old sentinel that value re-triggered the bootstrap branch on
+    /// the next `ask`, collapsing the `(1+λ)` loop to a single parent forever.
+    pub parent_fitness: Option<f32>,
     /// Best-so-far genotype.
     pub best_genome: Option<Tensor<B, 2, Int>>,
     /// Best-so-far fitness.
@@ -369,7 +376,7 @@ where
         );
         CgpState {
             parent,
-            parent_fitness: f32::NEG_INFINITY,
+            parent_fitness: None,
             best_genome: None,
             best_fitness: f32::NEG_INFINITY,
             generation: 0,
@@ -391,7 +398,7 @@ where
         device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> (Tensor<B, 2, Int>, CgpState<B>) {
         // First call: evaluate the parent as "offspring" of size 1.
-        if !state.parent_fitness.is_finite() {
+        if state.parent_fitness.is_none() {
             return (state.parent.clone(), state.clone());
         }
 
@@ -437,9 +444,10 @@ where
     ) -> (CgpState<B>, StrategyMetrics) {
         let fitness_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
 
-        if !state.parent_fitness.is_finite() {
-            // First tell: initial parent fitness.
-            state.parent_fitness = fitness_host[0];
+        if state.parent_fitness.is_none() {
+            // First tell: initial parent fitness. Sanitize so a NaN seed cannot
+            // masquerade as a finite parent in the later `>=` comparison.
+            state.parent_fitness = Some(crate::fitness::sanitize_fitness(fitness_host[0]));
             state.generation += 1;
             update_best(&mut state, &offspring, &fitness_host);
             let m = StrategyMetrics::from_host_fitness(
@@ -462,8 +470,13 @@ where
             .enumerate()
             .max_by(|(_, a), (_, b)| a.total_cmp(b))
             .map_or(0, |(i, _)| i);
-        let best_off_fit = fitness_host[best_off_idx];
-        if best_off_fit >= state.parent_fitness {
+        let best_off_fit = crate::fitness::sanitize_fitness(fitness_host[best_off_idx]);
+        let parent_fit = state
+            .parent_fitness
+            .expect("parent_fitness is Some after the bootstrap tell");
+        // `total_cmp` (not `>=`) so the comparison is well-defined even at the
+        // `−∞` worst-sentinel; ties still favour the offspring (neutral drift).
+        if best_off_fit.total_cmp(&parent_fit) != std::cmp::Ordering::Less {
             let device = offspring.device();
             #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
             let idx = Tensor::<B, 1, Int>::from_data(
@@ -471,7 +484,7 @@ where
                 &device,
             );
             state.parent = offspring.clone().select(0, idx);
-            state.parent_fitness = best_off_fit;
+            state.parent_fitness = Some(best_off_fit);
         }
 
         state.generation += 1;
@@ -496,15 +509,22 @@ fn update_best<B: Backend>(state: &mut CgpState<B>, pop: &Tensor<B, 2, Int>, fit
     if fitness.is_empty() {
         return;
     }
+    // Sanitize (NaN → −∞) then order with `total_cmp`: the §3 correctness floor
+    // for a direct (non-harness) caller. `best_fitness` seeds at `−∞`, so a
+    // legitimately sanitized `−∞` fitness is treated as the worst, not skipped.
+    let sane: Vec<f32> = fitness
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .collect();
     let mut best_idx = 0usize;
-    let mut best_f = fitness[0];
-    for (i, &f) in fitness.iter().enumerate().skip(1) {
-        if f > best_f {
+    let mut best_f = sane[0];
+    for (i, &f) in sane.iter().enumerate().skip(1) {
+        if f.total_cmp(&best_f) == std::cmp::Ordering::Greater {
             best_f = f;
             best_idx = i;
         }
     }
-    if best_f > state.best_fitness {
+    if best_f.total_cmp(&state.best_fitness) == std::cmp::Ordering::Greater {
         let device = pop.device();
         #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
         let idx =
@@ -532,6 +552,83 @@ mod tests {
         let mut cfg = CgpConfig::default_for(1);
         cfg.rows = 0;
         assert_eq!(cfg.validate().unwrap_err().field, "rows");
+    }
+
+    /// Regression for the `is_finite()` bootstrap sentinel vs the sanitize-to-`−∞`
+    /// convention (issue #132, `gp_cgp` §1.1 / ADR 0034). A canonical `−∞` parent
+    /// fitness (a `Minimize` `+∞` cost canonicalizes to `−∞`) must not re-trigger
+    /// the bootstrap branch: the `(1+λ)` loop has to keep emitting λ offspring.
+    #[test]
+    fn neg_inf_parent_fitness_does_not_collapse_lambda_loop() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = CartesianGeneticProgramming::<TestBackend>::new();
+        let params = CgpConfig::default_for(1);
+        let mut rng = StdRng::seed_from_u64(3);
+        let state = strategy.init(&params, &mut rng, &device);
+
+        // Bootstrap ask returns the single parent for initial evaluation.
+        let (boot, next) = strategy.ask(&params, &state, &mut rng, &device);
+        assert_eq!(boot.dims()[0], 1, "bootstrap ask returns the single parent");
+
+        // Bootstrap tell with a canonical −∞ fitness. Under the old
+        // `is_finite()` sentinel this left `parent_fitness` non-finite and the
+        // next `ask` collapsed back to a single genome.
+        let neg_inf = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NEG_INFINITY], [1]),
+            &device,
+        );
+        let (state1, _) = strategy.tell(&params, boot, neg_inf, next, &mut rng);
+        assert_eq!(
+            state1.parent_fitness,
+            Some(f32::NEG_INFINITY),
+            "bootstrap must store the sanitized −∞ parent fitness, not re-arm the sentinel"
+        );
+
+        // Next ask must produce a full λ offspring population.
+        let (offspring, _) = strategy.ask(&params, &state1, &mut rng, &device);
+        assert_eq!(
+            offspring.dims()[0],
+            params.lambda,
+            "post-bootstrap ask must emit λ offspring even with a −∞ parent fitness"
+        );
+    }
+
+    /// `update_best` treats a sanitized `−∞` fitness as the worst value (never a
+    /// champion) yet still promotes a finite winner in the same generation
+    /// (issue #132, `gp_cgp` §1.1).
+    #[test]
+    fn update_best_treats_neg_inf_as_worst() {
+        let device = Default::default();
+        let parent = Tensor::<TestBackend, 2, Int>::zeros([3, 4], &device);
+        let mut state: CgpState<TestBackend> = CgpState {
+            parent: parent.clone(),
+            parent_fitness: None,
+            best_genome: None,
+            best_fitness: f32::NEG_INFINITY,
+            generation: 0,
+        };
+
+        // An all-`−∞` generation must not promote any champion.
+        update_best(&mut state, &parent, &[f32::NEG_INFINITY; 3]);
+        assert!(
+            state.best_genome.is_none(),
+            "an all −∞ generation must not promote a champion"
+        );
+
+        // A finite winner (index 1) is recorded despite the `−∞` neighbours.
+        update_best(
+            &mut state,
+            &parent,
+            &[f32::NEG_INFINITY, 2.5, f32::NEG_INFINITY],
+        );
+        approx::assert_relative_eq!(state.best_fitness, 2.5, epsilon = 1e-6);
+        assert!(
+            state.best_genome.is_some(),
+            "a finite winner must be recorded even beside −∞ members"
+        );
     }
 
     /// Symbolic regression on `x² + 1` over 20 evenly spaced x ∈ [−1, 1].

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -355,11 +355,24 @@ where
     }
 }
 
-/// Indices of the three largest values in `xs`. Panics if `xs.len() < 3`.
+/// Indices of the three largest values in `xs` — the α, β, δ leaders.
+///
+/// Values are sanitised per the maximise convention (`rules.md` §3,
+/// ADR 0034) before comparison: `NaN → −∞` (worst), `+∞ → f32::MAX`. The
+/// harness chokepoint already pre-sanitises the fitness a [`Strategy`]
+/// receives, but a direct (non-harness) caller — a unit test or a custom
+/// driver — can seed `state.fitness` with a raw `NaN`; sanitising here keeps a
+/// non-finite value from becoming a permanent leader (a `NaN` in `xs[2]` would
+/// otherwise never lose the `v > vals[2]` comparison and be pinned as δ).
+///
+/// # Panics
+///
+/// Panics if `xs.len() < 3`.
 fn argtop3_max(xs: &[f32]) -> [usize; 3] {
     assert!(xs.len() >= 3, "argtop3_max requires at least 3 elements");
+    let sane = |i: usize| crate::fitness::sanitize_fitness(xs[i]);
     let mut idx = [0usize, 1, 2];
-    let mut vals = [xs[0], xs[1], xs[2]];
+    let mut vals = [sane(0), sane(1), sane(2)];
     // Sort the initial three descending.
     if vals[0] < vals[1] {
         vals.swap(0, 1);
@@ -373,7 +386,8 @@ fn argtop3_max(xs: &[f32]) -> [usize; 3] {
         vals.swap(0, 1);
         idx.swap(0, 1);
     }
-    for (i, &v) in xs.iter().enumerate().skip(3) {
+    for i in 3..xs.len() {
+        let v = sane(i);
         if v > vals[2] {
             vals[2] = v;
             idx[2] = i;
@@ -439,6 +453,39 @@ mod tests {
         let top = argtop3_max(&xs);
         // Values at indices: 5 (9.0), 2 (8.0), 0 (5.0).
         assert_eq!(top, [5, 2, 0]);
+    }
+
+    // Regression for the direct-caller (non-harness) bypass path: a raw NaN in
+    // `state.fitness` must sanitise to −∞ (worst) and never be pinned as a
+    // leader. Before the sanitise fix a NaN in `xs[2]` was never displaced by
+    // `v > vals[2]` (NaN loses every comparison), silently freezing it as δ.
+    #[test]
+    fn argtop3_max_nan_never_becomes_a_leader() {
+        // NaN sits at index 2 — exactly the slot that survived unsanitised.
+        let xs = [5.0_f32, 2.0, f32::NAN, 8.0, 3.0, 9.0];
+        let top = argtop3_max(&xs);
+        // The three finite maxima are at indices 5 (9.0), 3 (8.0), 0 (5.0);
+        // the NaN row (index 2) must be excluded from the leader set.
+        assert!(
+            !top.contains(&2),
+            "NaN-fitness row must not be selected as an α/β/δ leader, got {top:?}"
+        );
+        assert_eq!(
+            top, [5, 3, 0],
+            "leaders must be the three strictly-largest finite rows"
+        );
+    }
+
+    // The strictly-highest-fitness row must be picked as α (index 0 of the
+    // returned triple), proving the comparison direction matches maximise.
+    #[test]
+    fn argtop3_max_alpha_is_the_strict_maximum() {
+        let xs = [1.0_f32, 7.0, 3.0, 42.0, 2.0, 5.0];
+        let top = argtop3_max(&xs);
+        assert_eq!(
+            top[0], 3,
+            "the strictly-highest-fitness row (index 3) must be the α leader, got {top:?}"
+        );
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
@@ -739,6 +739,18 @@ impl<B: Backend> ArchNasStrategy<B> {
     /// Records the told population as the new residents, updates the best-ever
     /// `(arch_id, weights, fitness)` triple, and increments the generation.
     /// `fitness` follows the canonical maximise convention (higher is better).
+    ///
+    /// # Fitness hygiene
+    ///
+    /// This is the `ArchNasStrategy` **driver chokepoint** (ADR 0034): the
+    /// strategy is its own driver and does **not** run through
+    /// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness), so there is
+    /// no harness above it. `tell` applies
+    /// [`sanitize_fitness`](crate::fitness::sanitize_fitness) to the host fitness
+    /// vector (`NaN → −∞`, `+∞ → f32::MAX`, `−∞` and finite pass through)
+    /// **before** [`update_best`] and before it is stored as `state.fitness`, so
+    /// a non-finite fitness can never become an immortal champion nor win the
+    /// next [`ask`](Self::ask)'s elite carry or tournament.
     #[must_use]
     pub fn tell(
         &self,
@@ -748,7 +760,13 @@ impl<B: Backend> ArchNasStrategy<B> {
         mut state: NasState<B>,
         _rng: &mut dyn Rng,
     ) -> NasState<B> {
-        let fitness_host = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+        let raw = fitness.into_data().into_vec::<f32>().unwrap_or_default();
+        // Driver chokepoint (ADR 0034): sanitize before update_best/store so a
+        // NaN/±∞ can neither become the champion nor pollute the next ask.
+        let fitness_host: Vec<f32> = raw
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         update_best(&mut state, &population, &fitness_host, params.max_param_count);
         state.population = population;
         state.fitness = fitness_host;
@@ -772,6 +790,12 @@ impl<B: Backend> ArchNasStrategy<B> {
 }
 
 /// Update best-ever tracking from a freshly-evaluated population.
+///
+/// Both the argmax ([`argmax_host`], seeded at `f32::NEG_INFINITY`) and the
+/// running champion (`state.best_fitness`, initialised to `f32::NEG_INFINITY`
+/// in [`init`](ArchNasStrategy::init)) start from the maximise-space worst
+/// sentinel, so a leading broken member cannot suppress a later valid best.
+/// `fitness` is expected pre-sanitized by [`tell`](ArchNasStrategy::tell).
 fn update_best<B: Backend>(
     state: &mut NasState<B>,
     pop: &NasGenome<B>,
@@ -1054,5 +1078,54 @@ mod tests {
             "best-ever must be monotone (maximise): final {final_best} < gen0 {gen0_best}"
         );
         assert_eq!(state.generation(), 7);
+    }
+
+    /// Regression (ADR 0034, issue #133): `tell` is the `ArchNasStrategy` chokepoint
+    /// and must sanitize non-finite fitness before `update_best`/store. A `NaN`
+    /// member must never become the champion nor survive into the next ask's
+    /// selection; a `+∞` member must rank top but as a **finite** value
+    /// (`f32::MAX`).
+    #[test]
+    fn tell_sanitizes_nan_and_inf_so_nan_never_champions() {
+        let device = Default::default();
+        let (params, _fitness) = two_variant_builder(&device).build(NasBuilderConfig {
+            pop_size: 4,
+            arch_mutation_rate: 0.0,
+            weight_mutation_std: 0.0,
+            weight_init_std: 0.5,
+            tournament_size: 2,
+            elite_count: 1,
+        });
+        let strat = ArchNasStrategy::<TestBackend>::new();
+        let mut rng = StdRng::seed_from_u64(9);
+        let state = strat.init(&params, &mut rng, &device);
+
+        // One ask, then hand-craft the fitness: NaN (must never champion), +∞
+        // (ranks top but finite), two plain values. Row 1 (+∞) is the champion.
+        let (genome, next) = strat.ask(&params, &state, &mut rng, &device);
+        let champion_arch = genome.arch_ids[1];
+        let fitness = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NAN, f32::INFINITY, 1.0_f32, 2.0], [4]),
+            &device,
+        );
+        let state = strat.tell(&params, genome, fitness, next, &mut rng);
+
+        // Stored fitness is sanitized: no NaN; NaN → −∞, +∞ → f32::MAX.
+        assert!(
+            state.fitness.iter().all(|f| !f.is_nan()),
+            "no stored fitness is NaN after the tell chokepoint"
+        );
+        assert!(
+            state.fitness[0].is_infinite() && state.fitness[0].is_sign_negative(),
+            "the NaN member is sanitized to the maximise-space worst sentinel (−∞)"
+        );
+        approx::assert_relative_eq!(state.fitness[1], f32::MAX);
+
+        // The champion is the sanitized +∞ = f32::MAX (finite), at row 1 — not
+        // the NaN row.
+        let (best_arch, _weights, best_f) = strat.best(&state).expect("best exists after tell");
+        assert!(best_f.is_finite(), "champion fitness is finite (never NaN/±∞); got {best_f}");
+        approx::assert_relative_eq!(best_f, f32::MAX);
+        assert_eq!(best_arch, champion_arch, "champion is the +∞ row, never the NaN row");
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/neat.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/neat.rs
@@ -312,6 +312,18 @@ impl<B: Backend> NeatStrategy<B> {
     /// representatives all coexist consistently (so member indices stay valid and
     /// each species' next representative is cloned from a live member).
     ///
+    /// # Fitness hygiene
+    ///
+    /// This is NEAT's **driver chokepoint** (ADR 0034): NEAT is its own driver
+    /// and does **not** run through
+    /// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness), so there is
+    /// no harness above it to sanitize fitness. `tell` therefore applies
+    /// [`sanitize_fitness`](crate::fitness::sanitize_fitness) to the incoming
+    /// `fitness` (`NaN → −∞`, `+∞ → f32::MAX`, `−∞` and finite pass through)
+    /// **before** it is stored or handed to [`species::speciate`], so a
+    /// non-finite fitness can never poison speciation, offspring apportionment,
+    /// or best-so-far tracking.
+    ///
     /// # Panics
     ///
     /// Panics if `population.len()` differs from `fitness.len()`.
@@ -333,7 +345,12 @@ impl<B: Backend> NeatStrategy<B> {
         let mut rep_rng = seed_stream(rng.next_u64(), generation, SeedPurpose::Representative);
 
         state.population = population;
-        state.fitness = fitness;
+        // Driver chokepoint (ADR 0034): sanitize before store/speciate. NEAT has
+        // no harness above it, so this is the boundary that neutralizes NaN/±∞.
+        state.fitness = fitness
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         species::speciate(
             &state.population,
             &state.fitness,
@@ -1160,5 +1177,56 @@ mod tests {
         assert_eq!(state.generation, 8);
         let (_, best) = strat.best(&state).expect("best exists after tell");
         assert!(best >= 2.0, "best rewards enabled connections; got {best}");
+    }
+
+    /// Regression (ADR 0034, issue #133): `tell` is NEAT's driver chokepoint and
+    /// must sanitize non-finite fitness before storing/speciating. A `NaN` member
+    /// must never become the champion nor poison per-species bookkeeping, and a
+    /// `+∞` member must rank top but as a **finite** value (`f32::MAX`).
+    #[test]
+    fn test_tell_sanitizes_nan_and_inf_fitness() {
+        use burn::backend::Flex;
+        type TestBackend = Flex;
+
+        let device = Default::default();
+        let params = NeatParams::default_for(4, 2, 1);
+        let strat = NeatStrategy::<TestBackend>::new();
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = strat.init(&params, &mut rng, &device);
+
+        let (population, next) = strat.ask(&params, &state, &mut rng);
+        let n = population.len();
+        // Member 0 is NaN (must NOT champion), member 1 is +∞ (top but finite),
+        // the rest are a plain finite value.
+        let mut fitness: Vec<f32> = vec![1.0_f32; n];
+        fitness[0] = f32::NAN;
+        fitness[1] = f32::INFINITY;
+        let state = strat.tell(&params, population, fitness, next, &mut rng);
+
+        // Stored fitness is sanitized: none is NaN; NaN → −∞, +∞ → f32::MAX.
+        assert!(
+            state.fitness.iter().all(|f| !f.is_nan()),
+            "no stored fitness is NaN after the tell chokepoint"
+        );
+        assert!(
+            state.fitness[0].is_infinite() && state.fitness[0].is_sign_negative(),
+            "the NaN member is sanitized to the maximise-space worst sentinel (−∞)"
+        );
+        approx::assert_relative_eq!(state.fitness[1], f32::MAX);
+
+        // The champion is the sanitized +∞ = f32::MAX: ranks top but is finite,
+        // and is never the NaN member.
+        let (_, best) = strat.best(&state).expect("best exists after tell");
+        assert!(best.is_finite(), "champion fitness is finite (never NaN/±∞); got {best}");
+        approx::assert_relative_eq!(best, f32::MAX);
+
+        // No species' best or size-adjusted mean is NaN-poisoned.
+        for s in &state.species {
+            assert!(!s.best_fitness.is_nan(), "species best_fitness is not NaN");
+            assert!(
+                !s.adjusted_fitness_sum.is_nan(),
+                "a NaN member never poisons adjusted_fitness_sum"
+            );
+        }
     }
 }

--- a/crates/rlevo-evolution/src/coevolution/competitive.rs
+++ b/crates/rlevo-evolution/src/coevolution/competitive.rs
@@ -16,6 +16,7 @@ use rand::Rng;
 
 use rlevo_core::config::{ConfigError, Validate};
 
+use crate::fitness::sanitize_fitness_tensor;
 use crate::strategy::Strategy;
 
 use super::fitness::CoupledFitness;
@@ -92,6 +93,14 @@ where
         }
     }
 
+    /// Project the joint state into public [`CoEAMetrics`].
+    ///
+    /// The `best`/`mean` fields are copied from `state`, which `step` sources
+    /// from the per-population `tell` metrics computed over the **sanitized**
+    /// fitness (see the chokepoint in [`step`](Self::step) and ADR 0034). No
+    /// non-finite value can reach here as a `NaN`: means are averaged over the
+    /// finite members only (`StrategyMetrics::from_host_fitness`), so a broken
+    /// individual cannot blank a mean.
     fn snapshot(&self, state: &CoEAState<SA::State, SB::State>) -> CoEAMetrics {
         let sizes = self.fitness.archive_sizes();
         CoEAMetrics {
@@ -143,8 +152,17 @@ where
             .fitness
             .evaluate_coupled(&[pop_a.clone(), pop_b.clone()]);
         debug_assert_eq!(fits.len(), 2, "competitive co-evolution is bi-population");
-        let fit_a = fits[0].clone();
-        let fit_b = fits[1].clone();
+
+        // Fitness-hygiene chokepoint for the coupled-fitness path (ADR 0034):
+        // `evaluate_coupled` may return non-finite fitness, and — unlike the
+        // single-population `EvolutionaryHarness` — nothing above this point
+        // sanitizes. Clean each vector *once* here (`NaN → −∞` worst,
+        // `+∞ → f32::MAX`), so the per-population `tell`, the `snapshot`
+        // best/mean written into `CoEAState`, and any `HallOfFameFitness`
+        // downstream all see finite-or-`−∞` fitness. A raw positive `NaN` would
+        // otherwise `total_cmp` as the maximum and be crowned champion.
+        let fit_a = sanitize_fitness_tensor(fits[0].clone());
+        let fit_b = sanitize_fitness_tensor(fits[1].clone());
 
         // Both populations consume their relative fitness.
         let (next_a, metrics_a) = self
@@ -168,5 +186,149 @@ where
 
     fn metrics(&self, state: &Self::State) -> CoEAMetrics {
         self.snapshot(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use burn::tensor::TensorData;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    use rlevo_core::bounds::Bounds;
+    use rlevo_core::probability::Probability;
+    use rlevo_core::rate::NonNegativeRate;
+
+    use crate::algorithms::ga::{
+        GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+    };
+
+    type TB = Flex;
+
+    const POP: usize = 4;
+    const DIM: usize = 2;
+
+    fn ga_config() -> GaConfig {
+        GaConfig {
+            pop_size: POP,
+            genome_dim: DIM,
+            bounds: Bounds::new(0.0, 1.0),
+            mutation_sigma: NonNegativeRate::new(0.1),
+            selection: GaSelection::Tournament { size: 2 },
+            crossover: GaCrossover::Uniform { p: Probability::new(0.5) },
+            replacement: GaReplacement::Elitist { elitism_k: 1 },
+        }
+    }
+
+    /// Coupled fitness that poisons row 0 of every population with a
+    /// non-finite value and fills the rest with a finite ramp `1, 2, …`.
+    /// `poison` selects `NaN` or `+∞`; either must be sanitized at the
+    /// chokepoint so the finite ramp maximum (`POP - 1`) is the champion.
+    struct PoisonRow0 {
+        poison: f32,
+    }
+
+    impl CoupledFitness<TB> for PoisonRow0 {
+        fn evaluate_coupled(&self, populations: &[Tensor<TB, 2>]) -> Vec<Tensor<TB, 1>> {
+            populations
+                .iter()
+                .map(|p| {
+                    let n = p.dims()[0];
+                    let device = p.device();
+                    #[allow(clippy::cast_precision_loss)]
+                    let v: Vec<f32> = (0..n)
+                        .map(|i| if i == 0 { self.poison } else { i as f32 })
+                        .collect();
+                    Tensor::<TB, 1>::from_data(TensorData::new(v, [n]), &device)
+                })
+                .collect()
+        }
+    }
+
+    /// A single all-`NaN` coupled fitness — the degenerate whole-population
+    /// break — must sanitize to `−∞`, never `NaN`.
+    struct AllNan;
+
+    impl CoupledFitness<TB> for AllNan {
+        fn evaluate_coupled(&self, populations: &[Tensor<TB, 2>]) -> Vec<Tensor<TB, 1>> {
+            populations
+                .iter()
+                .map(|p| {
+                    let n = p.dims()[0];
+                    let device = p.device();
+                    Tensor::<TB, 1>::from_data(TensorData::new(vec![f32::NAN; n], [n]), &device)
+                })
+                .collect()
+        }
+    }
+
+    fn run_one_step<F: CoupledFitness<TB>>(fitness: F) -> CoEAMetrics {
+        let device = Default::default();
+        let algo = CompetitiveCoEA::new(
+            GeneticAlgorithm::<TB>::new(),
+            GeneticAlgorithm::<TB>::new(),
+            fitness,
+        );
+        let params: CompetitiveCoEAParams<GaConfig, GaConfig> = CompetitiveCoEAParams {
+            params_a: ga_config(),
+            params_b: ga_config(),
+        };
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = algo.init(&params, &mut rng, &device);
+        let (_next, metrics) = algo.step(&params, state, &mut rng, &device);
+        metrics
+    }
+
+    /// A `NaN` fitness from a [`CoupledFitness`] impl is sanitized to `−∞` at
+    /// the chokepoint, so it can neither become the champion nor blank a mean:
+    /// the finite ramp maximum (`POP - 1`) is `best`, and the mean is finite
+    /// (averaged over the finite members only). Regression for issue #134.
+    #[test]
+    fn nan_row_is_not_crowned_and_mean_stays_finite() {
+        let m = run_one_step(PoisonRow0 { poison: f32::NAN });
+        #[allow(clippy::cast_precision_loss)]
+        let expected_best = (POP - 1) as f32;
+        approx::assert_relative_eq!(m.best_fitness_a, expected_best, epsilon = 1e-6);
+        approx::assert_relative_eq!(m.best_fitness_b, expected_best, epsilon = 1e-6);
+        assert!(
+            m.mean_fitness_a.is_finite(),
+            "mean_fitness_a must stay finite when a NaN individual is present, got {}",
+            m.mean_fitness_a
+        );
+        assert!(
+            m.mean_fitness_b.is_finite(),
+            "mean_fitness_b must stay finite when a NaN individual is present, got {}",
+            m.mean_fitness_b
+        );
+    }
+
+    /// A `+∞` fitness is clamped to `f32::MAX` (still the top rank, but finite),
+    /// so it cannot blow the population mean up to `+∞`. Regression for the
+    /// ADR 0034 `+∞` rule on the coevolution path.
+    #[test]
+    fn pos_inf_fitness_is_clamped_finite_in_metrics() {
+        let m = run_one_step(PoisonRow0 { poison: f32::INFINITY });
+        approx::assert_relative_eq!(m.best_fitness_a, f32::MAX);
+        assert!(
+            m.mean_fitness_a.is_finite(),
+            "a +∞ individual must not push the mean to +∞, got {}",
+            m.mean_fitness_a
+        );
+    }
+
+    /// An all-`NaN` population sanitizes to `−∞` everywhere: `best`/`mean` are
+    /// the well-defined `−∞` sentinel (degenerate but flagged), never `NaN`.
+    #[test]
+    fn all_nan_population_yields_neg_inf_never_nan() {
+        let m = run_one_step(AllNan);
+        assert!(!m.best_fitness_a.is_nan(), "best must never be NaN");
+        assert!(!m.mean_fitness_a.is_nan(), "mean must never be NaN");
+        assert!(
+            m.best_fitness_a.is_infinite() && m.best_fitness_a.is_sign_negative(),
+            "all-broken population best is the −∞ sentinel, got {}",
+            m.best_fitness_a
+        );
     }
 }

--- a/crates/rlevo-evolution/src/coevolution/cooperative.rs
+++ b/crates/rlevo-evolution/src/coevolution/cooperative.rs
@@ -25,6 +25,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, RngExt};
 use rlevo_core::config::{ConfigError, ConstraintKind, Validate};
 
+use crate::fitness::sanitize_fitness_tensor;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::Strategy;
 
@@ -221,6 +222,13 @@ where
         }
     }
 
+    /// Project the joint state into public [`CoEAMetrics`].
+    ///
+    /// The `best`/`mean` fields are copied from `state.base`, which `step`
+    /// sources from the per-population `tell` metrics computed over the
+    /// **sanitized** assembled-candidate fitness (see the chokepoint in
+    /// [`step`](Self::step) and ADR 0034). Means are averaged over the finite
+    /// members only, so a broken individual cannot emit a `NaN` mean.
     fn snapshot(&self, state: &CooperativeState<SA::State, SB::State, B>) -> CoEAMetrics {
         let sizes = self.fitness.archive_sizes();
         CoEAMetrics {
@@ -312,8 +320,16 @@ where
 
         let fits = self.fitness.evaluate_coupled(&[full_a, full_b]);
         debug_assert_eq!(fits.len(), 2, "cooperative co-evolution is bi-population");
-        let fit_a = fits[0].clone();
-        let fit_b = fits[1].clone();
+
+        // Fitness-hygiene chokepoint for the coupled-fitness path (ADR 0034):
+        // the assembled-candidate fitness may be non-finite, and nothing above
+        // this point sanitizes (coevolution does not use the single-population
+        // `EvolutionaryHarness`). Clean each vector *once* here (`NaN → −∞`,
+        // `+∞ → f32::MAX`), so the per-population `tell`, the `snapshot`
+        // best/mean written into `CoEAState`, and any hall-of-fame all see
+        // finite-or-`−∞` fitness.
+        let fit_a = sanitize_fitness_tensor(fits[0].clone());
+        let fit_b = sanitize_fitness_tensor(fits[1].clone());
 
         // Each strategy consumes its own sub-population with the assembled fitness.
         let (next_a, metrics_a) = self
@@ -547,5 +563,91 @@ mod tests {
         let p = CooperativeCoEAParams::new((), (), vec![0, 1], 4, RepresentativePolicy::Best, 16)
             .unwrap();
         assert_eq!(complement(&p.dims_a, p.total_dims), vec![2, 3]);
+    }
+
+    // --- Fitness-hygiene chokepoint regression (issue #134 / ADR 0034) ---
+
+    use rand::SeedableRng;
+
+    use rlevo_core::bounds::Bounds;
+    use rlevo_core::probability::Probability;
+    use rlevo_core::rate::NonNegativeRate;
+
+    use crate::algorithms::ga::{
+        GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+    };
+
+    const COOP_POP: usize = 4;
+
+    fn ga_config_dim(dim: usize) -> GaConfig {
+        GaConfig {
+            pop_size: COOP_POP,
+            genome_dim: dim,
+            bounds: Bounds::new(0.0, 1.0),
+            mutation_sigma: NonNegativeRate::new(0.1),
+            selection: GaSelection::Tournament { size: 2 },
+            crossover: GaCrossover::Uniform { p: Probability::new(0.5) },
+            replacement: GaReplacement::Elitist { elitism_k: 1 },
+        }
+    }
+
+    /// Coupled fitness over assembled full-dimensional candidates: row 0 is
+    /// `NaN`, the rest a finite ramp `1, 2, …`. The chokepoint must sanitize
+    /// `NaN → −∞` so the finite maximum (`COOP_POP - 1`) is the champion.
+    struct PoisonRow0Nan;
+
+    impl CoupledFitness<B> for PoisonRow0Nan {
+        fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>> {
+            populations
+                .iter()
+                .map(|p| {
+                    let n = p.dims()[0];
+                    let device = p.device();
+                    #[allow(clippy::cast_precision_loss)]
+                    let v: Vec<f32> = (0..n)
+                        .map(|i| if i == 0 { f32::NAN } else { i as f32 })
+                        .collect();
+                    Tensor::<B, 1>::from_data(TensorData::new(v, [n]), &device)
+                })
+                .collect()
+        }
+    }
+
+    /// A `NaN` from a cooperative [`CoupledFitness`] is sanitized at the
+    /// assembled-candidate chokepoint, so it never becomes the champion nor
+    /// blanks a mean: `best` is the finite ramp maximum and the mean is finite.
+    /// Regression for issue #134 (cooperative §1.1).
+    #[test]
+    fn cooperative_nan_is_sanitized_in_metrics() {
+        let device = Default::default();
+        // total_dims = 2, dims_a = [0] → each sub-genome is width 1.
+        let algo = CooperativeCoEA::new(
+            GeneticAlgorithm::<B>::new(),
+            GeneticAlgorithm::<B>::new(),
+            PoisonRow0Nan,
+        );
+        let params = CooperativeCoEAParams::new(
+            ga_config_dim(1),
+            ga_config_dim(1),
+            vec![0],
+            2,
+            RepresentativePolicy::Best,
+            0,
+        )
+        .unwrap();
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = algo.init(&params, &mut rng, &device);
+        let (_next, m) = algo.step(&params, state, &mut rng, &device);
+
+        #[allow(clippy::cast_precision_loss)]
+        let expected_best = (COOP_POP - 1) as f32;
+        approx::assert_relative_eq!(m.best_fitness_a, expected_best, epsilon = 1e-6);
+        assert!(
+            m.mean_fitness_a.is_finite(),
+            "cooperative mean must stay finite when a NaN individual is present, got {}",
+            m.mean_fitness_a
+        );
+        assert!(!m.best_fitness_b.is_nan(), "best_fitness_b must never be NaN");
+        assert!(!m.mean_fitness_b.is_nan(), "mean_fitness_b must never be NaN");
     }
 }

--- a/crates/rlevo-evolution/src/coevolution/fitness.rs
+++ b/crates/rlevo-evolution/src/coevolution/fitness.rs
@@ -60,6 +60,17 @@ pub trait CoupledFitness<B: Backend>: Send + Sync {
     /// `populations[i]` is a `(pop_size_i, genome_dim_i)` tensor. Returns one
     /// fitness vector per input population, each of length `pop_size_i`, on
     /// the same device as its population.
+    ///
+    /// # Sanitization boundary
+    ///
+    /// The returned fitness vectors **may contain `NaN` or `±∞`** —
+    /// implementors are not required to sanitize. Co-evolution is its own
+    /// driver (there is no [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness)
+    /// above it), so the co-evolutionary algorithms sanitize at their
+    /// state-write chokepoint (`NaN → −∞`, `+∞ → f32::MAX`) immediately after
+    /// this call, before any per-population `tell`, metric, or hall-of-fame
+    /// sees the fitness (ADR 0034). A direct caller that bypasses those
+    /// algorithms must apply the same hygiene itself.
     fn evaluate_coupled(&self, populations: &[Tensor<B, 2>]) -> Vec<Tensor<B, 1>>;
 
     /// Per-population archive sizes, used to populate co-evolution metrics.

--- a/crates/rlevo-evolution/src/coevolution/harness.rs
+++ b/crates/rlevo-evolution/src/coevolution/harness.rs
@@ -188,6 +188,14 @@ where
         // Canonical maximise: the weaker population (lower canonical fitness)
         // is the binding constraint, and a higher binding value is better — so
         // the reward is the binding value directly, with no negation.
+        //
+        // Fitness hygiene (ADR 0034): `best_fitness_{a,b}` are sourced from the
+        // per-population `tell` metrics over the fitness the coupled-fitness
+        // chokepoint already sanitized (competitive/cooperative `step`), so each
+        // is finite-or-`−∞`, never `NaN`. `f32::min` therefore yields a
+        // finite-or-`−∞` binding value — the reward is never `NaN`. (Even a
+        // stray `NaN` operand would be dropped by IEEE `f32::min`, which returns
+        // the non-`NaN` argument; the chokepoint makes that path unreachable.)
         let binding = metrics.best_fitness_a.min(metrics.best_fitness_b);
         let reward = f64::from(binding);
 
@@ -227,5 +235,92 @@ where
 
     fn step(&mut self, action: Self::Action) -> Result<BenchStep<Self::Observation>, BenchError> {
         Ok(CoEvolutionaryHarness::<B, C>::step(self, action))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::Flex;
+    use burn::tensor::{Tensor, TensorData};
+
+    use rlevo_core::bounds::Bounds;
+    use rlevo_core::probability::Probability;
+    use rlevo_core::rate::NonNegativeRate;
+
+    use crate::algorithms::ga::{
+        GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
+    };
+    use crate::coevolution::{CompetitiveCoEA, CompetitiveCoEAParams, CoupledFitness};
+
+    type TB = Flex;
+
+    const POP: usize = 4;
+    const DIM: usize = 2;
+
+    fn ga_config() -> GaConfig {
+        GaConfig {
+            pop_size: POP,
+            genome_dim: DIM,
+            bounds: Bounds::new(0.0, 1.0),
+            mutation_sigma: NonNegativeRate::new(0.1),
+            selection: GaSelection::Tournament { size: 2 },
+            crossover: GaCrossover::Uniform { p: Probability::new(0.5) },
+            replacement: GaReplacement::Elitist { elitism_k: 1 },
+        }
+    }
+
+    /// Row 0 is `NaN`, the rest a finite ramp — for both populations.
+    struct PoisonRow0Nan;
+
+    impl CoupledFitness<TB> for PoisonRow0Nan {
+        fn evaluate_coupled(&self, populations: &[Tensor<TB, 2>]) -> Vec<Tensor<TB, 1>> {
+            populations
+                .iter()
+                .map(|p| {
+                    let n = p.dims()[0];
+                    let device = p.device();
+                    #[allow(clippy::cast_precision_loss)]
+                    let v: Vec<f32> = (0..n)
+                        .map(|i| if i == 0 { f32::NAN } else { i as f32 })
+                        .collect();
+                    Tensor::<TB, 1>::from_data(TensorData::new(v, [n]), &device)
+                })
+                .collect()
+        }
+    }
+
+    /// A `NaN` fitness from a [`CoupledFitness`] impl cannot make the harness
+    /// reward `NaN`: the coupled-fitness chokepoint sanitizes before `best_a`/
+    /// `best_b` are computed, so `min(best_a, best_b)` is finite-or-`−∞`.
+    /// Regression for issue #134 (harness §1.1) / ADR 0034.
+    #[test]
+    fn harness_reward_is_never_nan_with_nan_fitness() {
+        let device = Default::default();
+        let algo = CompetitiveCoEA::new(
+            GeneticAlgorithm::<TB>::new(),
+            GeneticAlgorithm::<TB>::new(),
+            PoisonRow0Nan,
+        );
+        let params: CompetitiveCoEAParams<GaConfig, GaConfig> = CompetitiveCoEAParams {
+            params_a: ga_config(),
+            params_b: ga_config(),
+        };
+        let mut harness =
+            CoEvolutionaryHarness::<TB, _>::new(algo, params, 7, device, 3).expect("valid params");
+        harness.reset();
+        let step = harness.step(());
+
+        assert!(!step.reward.is_nan(), "harness reward must never be NaN");
+        // The finite ramp maximum (POP - 1) binds both populations, so the
+        // reward is that finite value — the NaN row was sanitized, not crowned.
+        assert!(
+            step.reward.is_finite(),
+            "reward should be the finite binding value, got {}",
+            step.reward
+        );
+        #[allow(clippy::cast_precision_loss)]
+        let expected = f64::from((POP - 1) as f32);
+        approx::assert_relative_eq!(step.reward, expected, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/fitness.rs
+++ b/crates/rlevo-evolution/src/fitness.rs
@@ -51,6 +51,13 @@ pub trait BatchFitnessFn<B: Backend, G>: Send {
     /// `device`. Row order is preserved: `fitness[i]` corresponds to the
     /// individual at row `i` of `population`. Cost objectives return their
     /// natural cost; the harness reconciles direction via [`sense`](Self::sense).
+    ///
+    /// The returned tensor **may contain `NaN` or `±∞`** — implementors are not
+    /// required to sanitize. The
+    /// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness) canonicalizes
+    /// and then sanitizes (ADR 0034) before any [`Strategy::tell`](crate::strategy::Strategy::tell),
+    /// so a non-finite fitness cannot poison selection or best-so-far tracking on
+    /// harness-driven runs.
     fn evaluate_batch(&mut self, population: &G, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Tensor<B, 1>;
 
     /// The optimisation direction of this objective.
@@ -250,28 +257,63 @@ where
     }
 }
 
-/// Maps a `NaN` fitness to [`f32::NEG_INFINITY`], passing finite values through.
+/// Sanitizes one **canonical (maximise-space)** fitness value: `NaN →`
+/// [`f32::NEG_INFINITY`], `+∞ →` [`f32::MAX`], everything else (including `−∞`)
+/// passes through.
 ///
-/// `−inf` is the worst value under the maximise convention, so a sanitized
-/// `NaN` can never seed or displace a finite best-so-far and thus never
-/// propagates to a returned fitness. This is the crate-wide fitness-hygiene
-/// primitive: it is applied by
-/// [`BudgetedEval::eval`](crate::local_search::BudgetedEval) (every probe,
-/// including the seeding eval), the searchers'
+/// This is the crate-wide fitness-hygiene primitive and the single rule of the
+/// canonical convention (ADR 0023 / ADR 0034):
+///
+/// - `NaN → −∞`: `−∞` is the worst value under the maximise convention, so a
+///   sanitized `NaN` can never seed or displace a finite best-so-far. Rust's
+///   `f32::NAN` is a *positive* NaN, so `total_cmp` would otherwise rank it as
+///   the **maximum** (`rules.md` §3) — the exact inversion this prevents.
+/// - `+∞ → f32::MAX`: a genuinely optimal individual (a landscape hitting its
+///   optimum, an unbounded reward) still ranks top, but as a **finite** value —
+///   so it cannot blow a population `mean`/`variance`/reward to `+∞`.
+/// - `−∞` passes through: it is the worst-value sentinel *and* the
+///   uninitialized `best_fitness_ever` seed, and it must stay non-finite so the
+///   mean-over-finite statistic in
+///   [`StrategyMetrics::from_host_fitness`](crate::strategy::StrategyMetrics::from_host_fitness)
+///   can see and count it as a broken member.
+///
+/// Applied by [`BudgetedEval::eval`](crate::local_search::BudgetedEval) (every
+/// probe, including the seeding eval), the searchers'
 /// [`refine_with_known_fitness`](crate::local_search::LocalSearch::refine_with_known_fitness)
-/// overrides (applied to the `known_fitness` hint, which does not flow through
-/// `BudgetedEval`), the EDA `tell` chokepoint
+/// overrides, the EDA `tell` chokepoint
 /// ([`crate::algorithms::eda::EdaStrategy`]), and every NaN-safe fitness sort
-/// across the crate (selection, replacement, the ES/NEAT/ACO rankers) so a `NaN`
-/// can neither become the best-so-far nor corrupt an ordering. For the finite
-/// benchmark landscapes the searchers ship against this branch is never taken,
-/// so it costs only one `is_nan` check.
+/// across the crate (selection, replacement, the ES/NEAT/ACO rankers). For the
+/// finite benchmark landscapes the searchers ship against no branch is taken, so
+/// it costs only one `is_nan` / `is_infinite` check.
 pub(crate) fn sanitize_fitness(f: f32) -> f32 {
     if f.is_nan() {
         f32::NEG_INFINITY
+    } else if f.is_infinite() && f.is_sign_positive() {
+        // `f == f32::INFINITY` would trip the float-equality lint (rules §5/§8).
+        f32::MAX
     } else {
         f
     }
+}
+
+/// Tensor-level [`sanitize_fitness`] for the driver chokepoints — a single
+/// device op over a `(pop_size,)` **canonical-space** fitness vector.
+///
+/// Applies the same rule (`NaN → −∞`, `+∞ → f32::MAX`, `−∞` pass-through) to a
+/// whole fitness tensor without a device→host→device round-trip, so the
+/// [`EvolutionaryHarness`](crate::strategy::EvolutionaryHarness) and the
+/// coevolution coupled-fitness path can sanitize on the hot path (ADR 0034).
+///
+/// Order matters: the `NaN → −∞` `mask_fill` runs first (so no `NaN` reaches the
+/// clamp, which would propagate it), then `clamp_max(f32::MAX)` caps `+∞` while
+/// leaving `−∞` and every finite value untouched. Mirrors the `is_nan` +
+/// `mask_fill` + clamp idiom already used by `EdaStrategy::tell`'s gene backstop.
+#[must_use]
+pub(crate) fn sanitize_fitness_tensor<B: Backend>(fitness: Tensor<B, 1>) -> Tensor<B, 1> {
+    let nan_mask = fitness.clone().is_nan();
+    fitness
+        .mask_fill(nan_mask, f32::NEG_INFINITY)
+        .clamp_max(f32::MAX)
 }
 
 #[cfg(test)]
@@ -335,6 +377,40 @@ mod tests {
         fn evaluate(&self, x: &[f64]) -> f64 {
             x.iter().map(|v| v * v).sum()
         }
+    }
+
+    /// The scalar hygiene rule (ADR 0034): `NaN → −∞`, `+∞ → f32::MAX`, `−∞` and
+    /// finite values pass through unchanged.
+    #[test]
+    fn sanitize_fitness_scalar_applies_canonical_rule() {
+        // `−∞` sentinel: assert via `is_infinite`/sign, not float `==` (rules §5/§8).
+        let nan_out: f32 = sanitize_fitness(f32::NAN);
+        assert!(nan_out.is_infinite() && nan_out.is_sign_negative(), "NaN → −∞");
+        approx::assert_relative_eq!(sanitize_fitness(f32::INFINITY), f32::MAX);
+        let neg_out: f32 = sanitize_fitness(f32::NEG_INFINITY);
+        assert!(neg_out.is_infinite() && neg_out.is_sign_negative(), "−∞ passes through");
+        approx::assert_relative_eq!(sanitize_fitness(2.5), 2.5, epsilon = 1e-6);
+        approx::assert_relative_eq!(sanitize_fitness(-7.0), -7.0, epsilon = 1e-6);
+    }
+
+    /// The tensor sibling applies the identical rule element-wise, and — crucially
+    /// — leaves `−∞` non-finite (it is not clamped to `−f32::MAX`) so downstream
+    /// mean-over-finite logic can still detect and count it.
+    #[test]
+    fn sanitize_fitness_tensor_matches_scalar_rule() {
+        let device = Default::default();
+        let data = TensorData::new(
+            vec![f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 3.0_f32, -4.0],
+            [5],
+        );
+        let t = Tensor::<TestBackend, 1>::from_data(data, &device);
+        let out = sanitize_fitness_tensor(t).into_data().into_vec::<f32>().unwrap();
+
+        assert!(out[0].is_infinite() && out[0].is_sign_negative(), "NaN → −∞");
+        approx::assert_relative_eq!(out[1], f32::MAX); // +∞ → f32::MAX
+        assert!(out[2].is_infinite() && out[2].is_sign_negative(), "−∞ passes through, stays non-finite");
+        approx::assert_relative_eq!(out[3], 3.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(out[4], -4.0, epsilon = 1e-6);
     }
 
     /// Regression test for the load-bearing `BatchFitnessFn` invariant

--- a/crates/rlevo-evolution/src/neuroevolution/species.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/species.rs
@@ -205,6 +205,15 @@ pub fn compatibility_distance(
 /// `fitness`, and the prior species' cloned representatives all coexist
 /// consistently.
 ///
+/// # Fitness hygiene
+///
+/// Each `fitness[i]` is passed through
+/// [`sanitize_fitness`](crate::fitness::sanitize_fitness) before it feeds a
+/// per-species best or `adjusted_fitness_sum` reduction (ADR 0034 correctness
+/// floor). This guards direct (non-harness) callers — `NeatStrategy::tell`
+/// sanitizes too, so the guard is idempotent on that path — and stops a single
+/// `NaN` member from poisoning offspring apportionment for the whole run.
+///
 /// # Panics
 ///
 /// Panics if `fitness.len()` differs from `population.len()`.
@@ -264,18 +273,34 @@ pub fn speciate(
     species.retain(|s| !s.members.is_empty());
 
     // 4. Update best/stagnation and size-adjusted fitness (maximization).
+    //
+    // Sanitize NaN → −inf / +∞ → f32::MAX (ADR 0034) before *every* reduction: a
+    // raw NaN member would otherwise poison `adjusted_fitness_sum` (a NaN sum),
+    // corrupting offspring apportionment for *all* species for the rest of the
+    // run. `speciate` is `pub` and directly callable/tested, so it guards here
+    // itself (correctness floor, rules.md §3) rather than trusting the caller;
+    // `NeatStrategy::tell` also sanitizes, which makes this idempotent on the
+    // harness-analogue path. `remove_stagnant` already sanitizes — this keeps
+    // the module consistent.
     for s in species.iter_mut() {
         let species_best = s
             .members
             .iter()
-            .map(|&i| fitness[i])
+            .map(|&i| crate::fitness::sanitize_fitness(fitness[i]))
             .fold(f32::NEG_INFINITY, f32::max);
         if species_best > s.best_fitness {
             s.best_fitness = species_best;
             s.last_improved_generation = generation;
         }
-        let sum: f32 = s.members.iter().map(|&i| fitness[i]).sum();
-        // `adjusted_fitness_sum = Σ raw/|species| = mean raw fitness`.
+        let sum: f32 = s
+            .members
+            .iter()
+            .map(|&i| crate::fitness::sanitize_fitness(fitness[i]))
+            .sum();
+        // `adjusted_fitness_sum = Σ raw/|species| = mean raw fitness`. A broken
+        // (sanitized-to-−inf) member drives this species' mean to −inf; the
+        // downstream `.max(0.0)` in `allocate_offspring` floors its share to 0,
+        // preserving the non-negative fitness-sharing precondition.
         #[allow(clippy::cast_precision_loss)]
         let mean = sum / s.members.len() as f32;
         s.adjusted_fitness_sum = mean;
@@ -547,5 +572,48 @@ mod tests {
         assert_eq!(species.len(), 2, "distinct genome forms its own species");
         let sizes: Vec<usize> = species.iter().map(|s| s.members.len()).collect();
         assert!(sizes.contains(&2) && sizes.contains(&1), "g0 and its clone share a species");
+    }
+
+    /// Regression (ADR 0034, issue #133): `speciate` sanitizes each member's
+    /// fitness before the per-species best / `adjusted_fitness_sum` reductions.
+    /// A raw `NaN` must not become a species best nor poison the size-adjusted
+    /// mean (which would corrupt offspring apportionment for the whole run); a
+    /// `+∞` member ranks top but as a **finite** value (`f32::MAX`).
+    #[test]
+    fn test_speciate_sanitizes_nan_and_inf_fitness() {
+        let mut rng = StdRng::seed_from_u64(0);
+        // Three near-clones → a single species, so all three feed one reduction.
+        let population = vec![
+            genome_with(vec![conn(0, 0.0)]),
+            genome_with(vec![conn(0, 0.01)]),
+            genome_with(vec![conn(0, 0.02)]),
+        ];
+        // Member 0 NaN (must NOT become best / poison the sum), member 1 +∞
+        // (ranks top but finite), member 2 a plain 2.0.
+        let fitness = vec![f32::NAN, f32::INFINITY, 2.0];
+        let mut species: Vec<Species> = Vec::new();
+        let mut next_id = SpeciesId::new(0);
+        speciate(&population, &fitness, &mut species, 1.0, 1.0, 1.0, 1.0, &mut next_id, 0, &mut rng);
+        assert_eq!(species.len(), 1, "near-clones form a single species");
+
+        let s = &species[0];
+        // best_fitness is the sanitized +∞ = f32::MAX — finite, never NaN.
+        assert!(!s.best_fitness.is_nan(), "a NaN member never becomes a species best");
+        approx::assert_relative_eq!(s.best_fitness, f32::MAX);
+        // The size-adjusted mean is not NaN: sanitizing the NaN to −∞ makes the
+        // mean −∞ (not NaN), which the downstream `.max(0.0)` floors — the key
+        // regression is that it can no longer poison apportionment to NaN.
+        assert!(
+            !s.adjusted_fitness_sum.is_nan(),
+            "a NaN member never poisons adjusted_fitness_sum"
+        );
+
+        // Apportionment stays well-defined (sums exactly) despite the broken member.
+        let counts = allocate_offspring(&species, 8);
+        assert_eq!(
+            counts.iter().sum::<usize>(),
+            8,
+            "offspring apportionment sums exactly, uncorrupted by a NaN member"
+        );
     }
 }

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -138,6 +138,17 @@ pub trait Strategy<B: Backend>: Send + Sync {
     /// `fitness` has shape `(pop_size,)` on the same device as the
     /// population. Strategies pull it to host only if they need to —
     /// e.g. for tournament index lookups.
+    ///
+    /// # Invariants
+    ///
+    /// When driven by [`EvolutionaryHarness`], the `fitness` tensor is
+    /// **canonical (maximise) and sanitized** (ADR 0034): every element is finite
+    /// or `f32::NEG_INFINITY` — no `NaN`, no `+∞`. A `tell` impl may therefore
+    /// build leaders / personal-best / global-best directly from it without a
+    /// finite check. Callers that invoke `tell` **directly, bypassing the
+    /// harness**, do *not* get this guarantee and must apply
+    /// [`sanitize_fitness`](crate::fitness::sanitize_fitness) at every
+    /// ordering/aggregation site (`rules.md` §3).
     fn tell(
         &self,
         params: &Self::Params,
@@ -208,20 +219,33 @@ pub struct StrategyMetrics {
     /// optimum is known (e.g. Ackley → 0), the harness-reported value tells
     /// you how close the algorithm got to the theoretical optimum.
     best_fitness_ever: f32,
+    /// Number of individuals whose sanitized fitness was non-finite (`−∞`) in
+    /// this generation — i.e. members that evaluated to `NaN` (or a genuine
+    /// worst-sentinel `−∞`) and were therefore **excluded from
+    /// [`mean_fitness`](Self::mean_fitness)** (ADR 0034). Zero on a healthy run;
+    /// a non-zero value flags a population carrying broken individuals without
+    /// letting them blank the mean to `−∞`.
+    broken_count: usize,
 }
 
 impl StrategyMetrics {
     /// Computes population statistics from a host-side fitness slice.
     ///
-    /// Each value is passed through the crate's NaN-hygiene primitive
+    /// Each value is passed through the crate's fitness-hygiene primitive
     /// [`sanitize_fitness`](crate::fitness::sanitize_fitness) before folding, so
-    /// a `NaN` is treated as `f32::NEG_INFINITY` (the worst value under the
-    /// maximise convention, ADR 0023) *consistently* across every statistic. A
-    /// generation containing any `NaN` therefore yields `worst_fitness = −∞` and
-    /// `mean_fitness = −∞` while `best_fitness` remains the largest finite value —
-    /// degenerate but well-defined, rather than the old silent asymmetry where
-    /// `best`/`worst` ignored the `NaN` (comparisons against `NaN` are false) yet
-    /// `mean` propagated it.
+    /// `NaN → −∞` and `+∞ → f32::MAX` (the maximise convention, ADR 0023/0034)
+    /// *consistently* across every statistic — `best`/`worst` can no longer
+    /// silently drop a `NaN` (comparisons against `NaN` are false) while the sum
+    /// propagates it.
+    ///
+    /// `mean_fitness` is computed **over the finite members only**: a sanitized
+    /// `−∞` member (a `NaN` evaluation, or a genuine worst-sentinel) is excluded
+    /// from the average and counted in [`broken_count`](Self::broken_count)
+    /// instead (ADR 0034). This keeps a single broken individual from blanking
+    /// the whole mean to `−∞` while still surfacing that the population is
+    /// unhealthy. `+∞ → f32::MAX` members are finite and *are* included, so an
+    /// optimal individual cannot blow the mean to `+∞`. If *every* member is
+    /// broken, `mean_fitness = −∞` (degenerate but well-defined).
     ///
     /// # Panics
     ///
@@ -233,11 +257,15 @@ impl StrategyMetrics {
         assert!(!fitnesses.is_empty(), "fitness slice must be non-empty");
         let population_size = fitnesses.len();
         // Canonical (maximise) space: best is the largest value, worst the
-        // smallest, and best-ever a rolling maximum. Each value is sanitized
-        // (NaN → −∞) up front so all three statistics agree on the crate-wide
-        // NaN convention instead of best/worst silently dropping NaN while the
-        // sum propagates it.
-        let (mut best, mut worst, mut sum) = (f32::NEG_INFINITY, f32::INFINITY, 0.0_f32);
+        // smallest, best-ever a rolling maximum. Each value is sanitized up front
+        // so all statistics agree on the crate-wide convention. The mean is taken
+        // over finite members only; non-finite (`−∞`) members are counted as
+        // broken rather than dragging the mean to `−∞`.
+        let mut best = f32::NEG_INFINITY;
+        let mut worst = f32::INFINITY;
+        let mut finite_sum = 0.0_f32;
+        let mut finite_n = 0_usize;
+        let mut broken_count = 0_usize;
         for &f in fitnesses {
             let f = crate::fitness::sanitize_fitness(f);
             if f > best {
@@ -246,10 +274,21 @@ impl StrategyMetrics {
             if f < worst {
                 worst = f;
             }
-            sum += f;
+            if f.is_finite() {
+                finite_sum += f;
+                finite_n += 1;
+            } else {
+                broken_count += 1;
+            }
         }
-        #[allow(clippy::cast_precision_loss)]
-        let mean = sum / population_size as f32;
+        let mean = if finite_n > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let n = finite_n as f32;
+            finite_sum / n
+        } else {
+            // Every member is broken: no finite value to average.
+            f32::NEG_INFINITY
+        };
         Self {
             generation,
             population_size,
@@ -257,6 +296,7 @@ impl StrategyMetrics {
             mean_fitness: mean,
             worst_fitness: worst,
             best_fitness_ever: best_fitness_ever.max(best),
+            broken_count,
         }
     }
 
@@ -279,9 +319,22 @@ impl StrategyMetrics {
     }
 
     /// Mean fitness across this generation's population.
+    ///
+    /// Averaged over the **finite** members only; broken (`−∞`) members are
+    /// excluded and reported by [`broken_count`](Self::broken_count) (ADR 0034).
     #[must_use]
     pub fn mean_fitness(&self) -> f32 {
         self.mean_fitness
+    }
+
+    /// Number of non-finite (broken) individuals excluded from
+    /// [`mean_fitness`](Self::mean_fitness) this generation (ADR 0034).
+    ///
+    /// Zero on a healthy run; non-zero flags a population carrying `NaN`/`−∞`
+    /// members.
+    #[must_use]
+    pub fn broken_count(&self) -> usize {
+        self.broken_count
     }
 
     /// Worst (canonical: smallest) fitness observed in this generation.
@@ -581,6 +634,14 @@ where
             ObjectiveSense::Maximize => fitness_natural,
             ObjectiveSense::Minimize => fitness_natural.neg(),
         };
+        // Fitness-hygiene chokepoint (ADR 0034). Sanitize in CANONICAL (maximise)
+        // space — `NaN → −∞` (worst), `+∞ → f32::MAX` — so no `Strategy::tell`
+        // impl can be poisoned by a non-finite fitness and every downstream best/
+        // leader/metric is finite-or-`−∞`. This runs *after* the `sense` negation
+        // on purpose: "NaN = worst" is defined in maximise space, so sanitizing
+        // the natural tensor before `neg()` would flip a `NaN` cost to `+∞`
+        // (canonical *best*) under `Minimize`.
+        let fitness_canon = crate::fitness::sanitize_fitness_tensor(fitness_canon);
         let (new_state, metrics_canon) =
             self.strategy
                 .tell(&self.params, population, fitness_canon, state, &mut self.rng);
@@ -605,6 +666,8 @@ where
             mean_fitness: sense.from_canonical(metrics_canon.mean_fitness),
             worst_fitness: sense.from_canonical(metrics_canon.worst_fitness),
             best_fitness_ever: sense.from_canonical(metrics_canon.best_fitness_ever),
+            // A count, not a value — sense-invariant, carried through verbatim.
+            broken_count: metrics_canon.broken_count,
         };
         // Structured per-generation event. Picked up by the
         // canonical-metric registry in
@@ -620,6 +683,7 @@ where
             mean_fitness = f64::from(metrics.mean_fitness),
             worst_fitness = f64::from(metrics.worst_fitness),
             best_fitness_ever = f64::from(metrics.best_fitness_ever),
+            broken_count = metrics.broken_count,
             "evolution generation",
         );
         if let (Some(observer), Some(fitnesses)) = (self.observer.as_ref(), snapshot_fitness) {
@@ -847,14 +911,174 @@ mod tests {
 
     #[test]
     fn from_host_fitness_sanitizes_nan() {
-        // A NaN is sanitized to −∞ (worst under maximise) *consistently*: it
-        // never becomes best, and it drags worst and mean to −∞ rather than the
-        // old asymmetry where best/worst ignored it but mean turned NaN.
+        // A NaN is sanitized to −∞ (worst under maximise): it never becomes best,
+        // and it drags `worst` to −∞. Under ADR 0034 it is *excluded* from the
+        // mean (counted as broken) rather than blanking the mean to −∞: the mean
+        // is over the finite members {1, 3, 2} = 2.0, with broken_count == 1.
         let m = StrategyMetrics::from_host_fitness(0, &[1.0, f32::NAN, 3.0, 2.0], 0.0);
         approx::assert_relative_eq!(m.best_fitness(), 3.0, epsilon = 1e-6);
         assert!(m.worst_fitness().is_infinite() && m.worst_fitness().is_sign_negative());
-        assert!(m.mean_fitness().is_infinite() && m.mean_fitness().is_sign_negative());
+        approx::assert_relative_eq!(m.mean_fitness(), 2.0, epsilon = 1e-6);
+        assert_eq!(m.broken_count(), 1);
         approx::assert_relative_eq!(m.best_fitness_ever(), 3.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn from_host_fitness_pos_inf_ranks_top_but_mean_stays_finite() {
+        // +∞ → f32::MAX (ADR 0034): it stays best/finite and is *included* in the
+        // mean (no −∞/broken), so an optimal individual cannot blow the mean up.
+        let m = StrategyMetrics::from_host_fitness(0, &[1.0, f32::INFINITY, 3.0], 0.0);
+        approx::assert_relative_eq!(m.best_fitness(), f32::MAX);
+        assert_eq!(m.broken_count(), 0);
+        assert!(m.mean_fitness().is_finite());
+    }
+
+    #[test]
+    fn from_host_fitness_all_broken_yields_neg_inf_mean() {
+        // Degenerate but well-defined: every member broken → mean = −∞.
+        let m = StrategyMetrics::from_host_fitness(0, &[f32::NAN, f32::NAN], 0.0);
+        assert_eq!(m.broken_count(), 2);
+        assert!(m.mean_fitness().is_infinite() && m.mean_fitness().is_sign_negative());
+    }
+
+    /// A misbehaving objective: row 0 → `NaN`, row 1 → `+∞`, the rest finite.
+    /// `Maximize` so natural == canonical (no `neg()` obscuring the sanitize).
+    struct NonFiniteFitness;
+    impl<B: Backend> BatchFitnessFn<B, Tensor<B, 2>> for NonFiniteFitness {
+        fn evaluate_batch(
+            &mut self,
+            population: &Tensor<B, 2>,
+            device: &<B as burn::tensor::backend::BackendTypes>::Device,
+        ) -> Tensor<B, 1> {
+            let n = population.dims()[0];
+            #[allow(clippy::cast_precision_loss)] // tiny test population indices
+            let mut vals: Vec<f32> = (0..n).map(|i| i as f32).collect();
+            vals[0] = f32::NAN;
+            if n > 1 {
+                vals[1] = f32::INFINITY;
+            }
+            Tensor::<B, 1>::from_data(TensorData::new(vals, [n]), device)
+        }
+        fn sense(&self) -> ObjectiveSense {
+            ObjectiveSense::Maximize
+        }
+    }
+
+    /// A strategy that **trusts the harness guarantee** (ADR 0034): its `tell`
+    /// stores the fitness tensor it receives verbatim, *without* re-sanitizing.
+    /// This is the whole point of the chokepoint — a `tell` impl should be able
+    /// to build best/leaders directly from `fitness`. `received` lets the test
+    /// assert what actually crossed the seam.
+    #[derive(Debug, Clone, Copy)]
+    struct TrustingStrategy;
+
+    #[derive(Debug, Clone)]
+    struct TrustingState {
+        generation: usize,
+        best: f32,
+        received: Vec<f32>,
+    }
+
+    impl Strategy<TestBackend> for TrustingStrategy {
+        type Params = Params;
+        type State = TrustingState;
+        type Genome = Tensor<TestBackend, 2>;
+
+        fn init(
+            &self,
+            _: &Params,
+            _: &mut dyn Rng,
+            _: &<TestBackend as burn::tensor::backend::BackendTypes>::Device,
+        ) -> TrustingState {
+            TrustingState {
+                generation: 0,
+                best: f32::NEG_INFINITY,
+                received: Vec::new(),
+            }
+        }
+
+        fn ask(
+            &self,
+            params: &Params,
+            state: &TrustingState,
+            _: &mut dyn Rng,
+            device: &<TestBackend as burn::tensor::backend::BackendTypes>::Device,
+        ) -> (Tensor<TestBackend, 2>, TrustingState) {
+            let data = TensorData::new(
+                vec![0.0f32; params.pop_size * params.dim],
+                [params.pop_size, params.dim],
+            );
+            (Tensor::<TestBackend, 2>::from_data(data, device), state.clone())
+        }
+
+        fn tell(
+            &self,
+            _: &Params,
+            _: Tensor<TestBackend, 2>,
+            fitness: Tensor<TestBackend, 1>,
+            mut state: TrustingState,
+            _: &mut dyn Rng,
+        ) -> (TrustingState, StrategyMetrics) {
+            // Deliberately NOT sanitized here — the harness must have done it.
+            let values: Vec<f32> = fitness.into_data().into_vec::<f32>().unwrap();
+            state.received = values.clone();
+            state.generation += 1;
+            let metrics: StrategyMetrics =
+                StrategyMetrics::from_host_fitness(state.generation, &values, state.best);
+            state.best = metrics.best_fitness_ever();
+            (state, metrics)
+        }
+
+        fn best(&self, _: &TrustingState) -> Option<(Tensor<TestBackend, 2>, f32)> {
+            None
+        }
+    }
+
+    /// End-to-end proof that the `EvolutionaryHarness::step` chokepoint (ADR
+    /// 0034) sanitizes a non-finite fitness **before** it reaches a real
+    /// `Strategy::tell`. This is the widest-blast-radius line in the design
+    /// (it covers every `Strategy` impl), so it gets a direct test rather than
+    /// relying on `StrategyMetrics::from_host_fitness`'s own sanitize: the
+    /// `TrustingStrategy` captures the raw tensor it was handed, so deleting or
+    /// mis-ordering the harness sanitize (relative to `neg()`) fails here.
+    #[test]
+    fn harness_sanitizes_non_finite_fitness_before_tell() {
+        let device = Default::default();
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            TrustingStrategy,
+            Params { pop_size: 4, dim: 2 },
+            NonFiniteFitness,
+            7,
+            device,
+            1,
+        )
+        .expect("valid params");
+        harness.reset();
+        harness.step(());
+
+        let received = &harness.state().expect("state after step").received;
+        assert_eq!(received.len(), 4);
+        // The chokepoint guarantee: what `tell` saw is finite-or-`−∞`.
+        assert!(
+            received.iter().all(|f| !f.is_nan()),
+            "harness must strip NaN before tell; got {received:?}"
+        );
+        assert!(
+            received.iter().all(|f| !(f.is_infinite() && f.is_sign_positive())),
+            "harness must clamp +∞ before tell; got {received:?}"
+        );
+        // Row 0 was NaN → −∞ (worst); row 1 was +∞ → f32::MAX (finite best).
+        assert!(
+            received[0].is_infinite() && received[0].is_sign_negative(),
+            "NaN row → −∞"
+        );
+        approx::assert_relative_eq!(received[1], f32::MAX);
+
+        // Metrics stay honest: best is finite (the f32::MAX row), one broken member.
+        let m = harness.latest_metrics().expect("metrics after step");
+        assert!(m.best_fitness().is_finite(), "best must be finite, got {}", m.best_fitness());
+        assert_eq!(m.broken_count(), 1, "the NaN row is the one broken member");
+        assert!(m.mean_fitness().is_finite(), "mean over finite members stays finite");
     }
 
     #[test]

--- a/docs/adr/0034-fitness-hygiene-chokepoint-convention.md
+++ b/docs/adr/0034-fitness-hygiene-chokepoint-convention.md
@@ -1,0 +1,171 @@
+---
+project: rlevo
+status: active
+type: decision
+date: 2026-07-07
+tags: [adr, decision, fitness, nan, inf, sanitization, canonical, chokepoint, rlevo-evolution]
+---
+
+# ADR 0034: Fitness-hygiene chokepoint convention
+
+## Status
+
+**Accepted (2026-07-07).** Resolves the fitness-hygiene half of issues #131
+(metaheuristics), #132 (EA-root), #133 (neuroevolution), and #134 (coevolution),
+and generalizes the per-model fixes already shipped for #129 (EDA, PR #214) and
+#130 (GEP). **Extends ADR [0023](0023-objective-sense-and-maximize-convention.md)** — it
+preserves the `NaN → −∞` rule verbatim and adds an `+∞` rule; ADR 0023 stays
+`active`.
+
+**Chosen shape:** one fitness-hygiene primitive in `rlevo-evolution`, applied at
+the small number of *driver chokepoints*, backed by the per-site
+"sanitize-then-`total_cmp`" convention (`rules.md` §3) as the correctness floor.
+
+## Context
+
+Five issues (#129–#134) each name "NaN/Inf fitness sanitization" across a
+different algorithm family. Read together they are not one defect but **three
+classes** wearing one label:
+
+1. **Fitness hygiene** — a non-finite fitness poisons ordering, best-so-far
+   tracking, species allocation, hall-of-fame champions, and public metrics. Rust's
+   `f32::NAN` is a *positive* NaN, so `total_cmp` ranks a raw `NaN` as the
+   **maximum** (`rules.md` §3): a `NaN`-fitness member becomes an immortal
+   champion. This class *is* addressable at a chokepoint.
+2. **Canonical-ordering-direction bugs** — e.g. an onlooker tournament using `<` in
+   maximise space, or an argmax initialized from `fitness[0]` instead of `−∞`. A
+   perfectly sanitized tensor still selects the wrong individual. **Not**
+   chokepoint-fixable.
+3. **Parameter-numerics / config guards** — e.g. an unfloored `σ`, `genome_dim == 0
+   ⇒ tau = inf`, a dataset silently zero-padded into `NaN` fitness. These are
+   construction-time (`Validate`, ADR 0026) or field-newtype (ADR 0027/0031)
+   concerns applied *before* fitness exists. **Not** chokepoint-fixable.
+
+Before this ADR, class 1 was handled ad-hoc: a `pub(crate)`, scalar,
+**NaN-only** `sanitize_fitness` was applied at some sites (`StrategyMetrics`,
+`hof.rs`, `species::remove_stagnant`, local-search `BudgetedEval`, `EdaStrategy::
+tell`) and forgotten at most others, so each new family re-discovered the same
+poisoning bug in review.
+
+The key structural observation is that the engine already funnels every
+`Strategy<B>` run through **one place**: `EvolutionaryHarness::step` evaluates the
+batch, canonicalizes via `sense`, and hands the fitness tensor to
+`Strategy::tell`. Three other drivers exist outside it — `NeatStrategy::tell`,
+`ArchNasStrategy::tell` (both inherent, not `Strategy`), and the coevolution
+coupled-fitness path — each its own analogous funnel.
+
+## Decision
+
+1. **One primitive, extended Inf policy.** In `rlevo-evolution/src/fitness.rs`,
+   `sanitize_fitness(f: f32) -> f32` applies the single canonical rule:
+   - `NaN → f32::NEG_INFINITY` (worst under maximise — preserved from ADR 0023),
+   - `+∞ → f32::MAX` (ranks top but **finite**, so it cannot blow a `mean`,
+     `variance`, or reward to `+∞`),
+   - `−∞` and finite values pass through (`−∞` is the worst-sentinel *and* the
+     uninitialized `best_fitness_ever` seed, and must stay non-finite so
+     mean-over-finite logic can detect it).
+
+   Add a device-op sibling `sanitize_fitness_tensor<B>(Tensor<B,1>) ->
+   Tensor<B,1>` — `is_nan` → `mask_fill(−∞)` → `clamp_max(f32::MAX)` — so the
+   tensor-holding chokepoints sanitize on the hot path with no host round-trip.
+   Both stay `pub(crate)`: every caller is in `rlevo-evolution`. (Reuse note per
+   the "check Burn built-ins" rule: the `is_nan` + `mask_fill` + clamp idiom is
+   already used by `EdaStrategy::tell`'s gene backstop; no new hand-rolled op.)
+
+2. **Apply at the four driver chokepoints:**
+   - `EvolutionaryHarness::step` — `sanitize_fitness_tensor` on the **canonical**
+     tensor (after the `sense` negation). Sanitizing the *natural* tensor before
+     `neg()` would flip a `NaN` cost to `+∞` = canonical *best* under `Minimize`;
+     "NaN = worst" is only well-defined in maximise space. This one insert covers
+     **every** `Strategy<B>` impl — all metaheuristics (#131), all EA-root
+     algorithms (#132), EDA, and `WeightOnly`.
+   - `NeatStrategy::tell` → before `state.fitness` / `speciate`.
+   - `ArchNasStrategy::tell` → before `update_best` (and init best from `−∞`).
+   - Coevolution coupled-fitness → `CoEAState` write sites + the `min(best_a,
+     best_b)` metric.
+
+3. **Keep the per-site `rules.md` §3 convention as the correctness floor.** The
+   chokepoint is an *amortization* (sanitize once, downstream stored fitness is
+   clean), **not** a guarantee for callers that bypass the harness (unit tests,
+   custom drivers, the three non-`Strategy` drivers). Every ordering / argmax /
+   champion-write site still sanitizes locally. The chokepoint does not delete
+   these; it makes them redundant on the common path and load-bearing on the rest.
+
+4. **Metrics: mean over finite members.** `StrategyMetrics::from_host_fitness`
+   averages the finite members only and reports a `broken_count` of the non-finite
+   (`−∞`) ones, so a single broken individual flags the population without
+   blanking the mean to `−∞`; a `+∞ → f32::MAX` member is finite and is included.
+
+5. **Contract amendments.** `BatchFitnessFn::evaluate_batch` documents that its
+   output may be non-finite and the harness sanitizes; `Strategy::tell` documents
+   the harness-scoped finite-or-`−∞` guarantee *and* the bypass caveat;
+   `CoupledFitness::evaluate_coupled` and the NEAT/NAS `tell` docs state their own
+   sanitization boundary (they are their own drivers, with no harness above them).
+
+**Explicitly out of scope** (separate work-streams, not owned by this ADR):
+class-2 ordering-direction bugs and class-3 parameter-numerics/config guards
+above; and the GEP #130 per-eval `1e15` bloat clamp, which is a domain modeling
+penalty inside `tree.rs`, not fitness hygiene, and is deliberately *not* routed
+through this primitive.
+
+## Consequences
+
+### Positive
+- **One rule, four inserts, closes a whole defect class.** ~25 per-site fixes the
+  individual reviews proposed collapse to a shared primitive plus four chokepoints.
+- **New families are safe by default.** Any future `Strategy<B>` inherits the
+  hygiene guarantee from the harness with no per-algorithm code.
+- **Honest metrics.** `+∞` can no longer masquerade as an infinite mean, and a
+  broken member is surfaced (`broken_count`) instead of silently blanking the mean.
+
+### Neutral
+- `StrategyMetrics` gains a `broken_count` field and accessor. Field names feed the
+  benchmark TUI's canonical-metric registry; the new tracing field is additive.
+
+### Negative / accepted costs
+- **Documented bypass hole.** Direct (non-harness) `tell` callers are not covered
+  by the chokepoint; correctness there rests on the §3 per-site convention. This is
+  stated in the `Strategy::tell` docs. If the hole recurs in practice, the
+  sanctioned escalation is a `CanonicalFitness<B>` newtype (below).
+- **`−∞` still yields a `−∞` mean when the whole population is broken.** Accepted:
+  degenerate but well-defined, and flagged by `broken_count == population_size`.
+
+## Alternatives considered
+
+- **`CanonicalFitness<B>` newtype** wrapping `Tensor<B,1>`, constructible only via
+  the sanitizing constructor, as `Strategy::tell`'s parameter — makes "hand raw
+  fitness to `tell`" a *compile error*, closing the bypass hole by type (the
+  `Probability`/`NonNegativeRate`/opaque-id lineage, ADR 0027/0031/0032). Deferred,
+  not rejected: it changes the central trait signature and touches every `Strategy`
+  impl. Named here as the fast-follow if a bypass regression recurs.
+- **Per-site fixes only (as each issue's review proposed).** Rejected as the
+  primary structure: ~25 edit sites, and every future family re-discovers the bug.
+  Retained only as the correctness floor (decision 4/§3), not the main mechanism.
+- **Move the primitive to `rlevo-core`.** Rejected: `rlevo-core` is a contract crate
+  (no implementation logic beyond `util`), and `NaN → −∞ = worst` is the *engine's*
+  canonical-space convention, not an abstract objective primitive. All four
+  chokepoints are in `rlevo-evolution`. Promote only when a second crate needs it.
+- **`assert!(fitness.is_finite())` (proposed in the metaheuristic review).**
+  Rejected: `rules.md` §4 forbids panicking on user-supplied runtime data, and a
+  landscape returning `0/0` *is* runtime data. Sanitize to a sentinel instead; a
+  `debug_assert!` tripwire is acceptable, a hard `assert!` is not.
+- **Map all non-finite → −∞ (drop the `+∞ → f32::MAX` distinction).** Rejected: in a
+  maximise objective `+∞` means *optimal*; mapping it to *worst* would silently
+  delete the best individual (e.g. runaway-weight architectures that legitimately
+  peg the objective).
+
+## References
+- Issues #131 / #132 / #133 / #134 — fitness-hygiene halves resolved here; their
+  class-2/class-3 items split to follow-up issues.
+- Issues #129 (PR #214, EDA) / #130 (GEP) — the per-model precedents this
+  generalizes.
+- ADR [0023](0023-objective-sense-and-maximize-convention.md) — maximise-native canonical
+  convention, extended (not superseded) here.
+- ADR [0026](0026-shared-config-validation-convention.md) — construction-time `Validate`
+  boundary where the class-3 guards belong.
+- `rules.md` §Optimisation direction — the per-site sanitize-then-`total_cmp`
+  correctness floor.
+- Code: `crates/rlevo-evolution/src/fitness.rs` (primitive + tensor sibling),
+  `src/strategy.rs` (harness chokepoint + `StrategyMetrics`), `src/neuroevolution/
+  species.rs`, `src/algorithms/neuroevolution/{neat,arch_nas}.rs`,
+  `src/coevolution/{fitness,competitive,cooperative,harness}.rs`.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -127,8 +127,9 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
 - Every `Strategy`, operator, shaping rule, local searcher, and metric
   aggregation in `rlevo-evolution` works purely in **canonical (maximise)**
   space and is **sense-unaware** — it never sees an `ObjectiveSense`. Best is the
-  largest value; the worst-value sentinel is `f32::NEG_INFINITY`; `NaN` sanitises
-  to `−inf`.
+  largest value; the worst-value sentinel is `f32::NEG_INFINITY`. Fitness hygiene
+  is one rule (ADR 0034): `NaN → −inf` (worst), `+∞ → f32::MAX` (ranks top but
+  finite, so it cannot blow a `mean`/reward up), `−inf` passes through.
 - An objective declares its natural direction with
   `rlevo_core::objective::ObjectiveSense { Minimize, Maximize }`. Fitness
   functions and landscape adapters return **natural** values — **never
@@ -160,7 +161,12 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
   order.sort_by(|&a, &b| sane[b].total_cmp(&sane[a])); // best first; NaN last
   ```
   Non-fitness float comparisons (geometry, eigenvalues, argmax over logits) use
-  plain `total_cmp` — only *fitness* needs the sanitise step.
+  plain `total_cmp` — only *fitness* needs the sanitise step. This per-site rule is
+  the **correctness floor** and stays even where a driver chokepoint pre-sanitizes
+  (ADR 0034): direct (non-harness) callers — unit tests, custom drivers — bypass
+  the chokepoint, so every ordering/argmax/champion-write site sanitizes locally.
+  For a whole `Tensor<B, 1>` on the hot path use `sanitize_fitness_tensor`
+  (one device op) instead of a host round-trip.
 
 ---
 

--- a/docs/user-book/src/appendix-d-suppl/ask-tell-contract.md
+++ b/docs/user-book/src/appendix-d-suppl/ask-tell-contract.md
@@ -93,6 +93,10 @@ setting changes the contract rather than just the syntax:
   end-to-end (higher is better) and lets a cost objective declare
   `ObjectiveSense::Minimize`, reconciled at one chokepoint; see the
   [fitness chapter](../part-1-foundations/evolutionary-computation/23-fitness.md#the-engine-maximises--and-you-declare-your-objectives-sense).
+  On a harness-driven run that same chokepoint also **sanitises** the tensor
+  (ADR 0034), so the fitness `tell` receives is always finite or `−∞` — never a
+  `NaN` or `+∞` (drive a strategy directly and you sanitise at your own comparison
+  sites; see [fitness hygiene](../part-1-foundations/evolutionary-computation/23-fitness.md#fitness-hygiene-nan-and-inf)).
 - **Randomness is a host stream, not a threaded key.** evosax splits and threads
   explicit JAX `PRNGKey`s. `rlevo` passes `&mut dyn Rng` and derives every draw
   from a single host `seed_stream` (below) — different plumbing for the same

--- a/docs/user-book/src/part-1-foundations/evolutionary-computation/21-ops.md
+++ b/docs/user-book/src/part-1-foundations/evolutionary-computation/21-ops.md
@@ -214,8 +214,10 @@ least two contenders).
 ### Truncation selection
 
 Deterministic: sort by fitness descending and take the `top_k` highest, returned
-best-first. Ties break by `f32::partial_cmp` with `NaN` sorted last (so a stray
-`NaN` fitness can never masquerade as a good solution).
+best-first. Each fitness is first mapped through `sanitize_fitness` (`NaN → −∞`),
+then ordered with `f32::total_cmp` — a deterministic total order in which a stray
+`NaN` sorts last and can never masquerade as a good solution (`rules.md` §3;
+`partial_cmp` is never used on fitness).
 
 ```rust
 pub fn truncation_indices_host(fitness: &[f32], top_k: usize) -> Vec<i32>;

--- a/docs/user-book/src/part-1-foundations/evolutionary-computation/23-fitness.md
+++ b/docs/user-book/src/part-1-foundations/evolutionary-computation/23-fitness.md
@@ -138,6 +138,7 @@ omission. The two landscape adapters carry it for you:
 | Improvement test | every `tell`; hill-climbing `local_search/hill_climbing.rs` | `if f > best` — never `<` |
 | **Sense declaration** (your objective) | `BatchFitnessFn::sense`; `Landscape::sense` (defaults `Minimize`) | required on the fitness fn; only a landscape defaults |
 | **Canonicalisation** (the chokepoint) | `strategy.rs` (`EvolutionaryHarness::step`); `fitness.rs` (`FromLandscape`/`FromFitnessEvaluable`) | `Minimize` → negate before `tell`; `from_canonical` for reporting |
+| **Fitness hygiene** (same chokepoint) | `strategy.rs` (`EvolutionaryHarness::step`); `fitness.rs` (`sanitize_fitness`/`sanitize_fitness_tensor`) | `NaN → −∞` (worst), `+∞ → f32::MAX` (finite top); the fitness handed to `tell` is finite-or-`−∞` (ADR 0034) |
 | Convergence assertions | `algorithms/*.rs` tests; `crates/rlevo/tests/rastrigin_run_suite.rs` | `assert!(best < tolerance)` on zero-at-optimum landscapes — in *natural* space |
 
 A [`Landscape`](https://docs.rs/rlevo-core) is a cost surface by definition, so its
@@ -163,6 +164,34 @@ assert!(harness.latest_metrics().unwrap().best_fitness_ever < 1e-3); // Sphere �
 > `reward = -best_fitness_ever` negation is gone, and so is the "negate your
 > maximisation objective" advice: a reward objective declares
 > `ObjectiveSense::Maximize` and is passed straight through.
+
+### Fitness hygiene: `NaN` and `Inf`
+
+A fitness function is *your* code, and real objectives misbehave — a `0/0` in a
+reward, an overflow in a simulated rollout, a diverging surrogate all produce a
+`NaN` or an `±∞`. Left alone, a `NaN` is worse than a bad score: Rust's `f32::NAN`
+is a *positive* NaN, so a naïve `total_cmp` ranks it as the **maximum** — a broken
+individual would masquerade as the champion and never be displaced.
+
+So the same chokepoint that canonicalises also **sanitises**, in one rule
+(ADR 0034), right before every `tell`:
+
+- `NaN → −∞` — the worst value under the maximise convention, so a broken
+  individual can never seed or displace a real best;
+- `+∞ → f32::MAX` — a genuinely optimal individual still ranks top, but as a
+  *finite* value, so it cannot blow `mean_fitness` or a reward up to `+∞`;
+- `−∞` passes through unchanged (it is the worst-value sentinel).
+
+The upshot for you as a caller: **the fitness a strategy's `tell` receives on a
+harness-driven run is always finite or `−∞`** — you never have to guard your
+objective against non-finite output, and a broken generation shows up honestly as
+a `broken_count > 0` rather than a silent `NaN` champion. (If you drive a strategy
+directly, bypassing the harness, apply
+[`sanitize_fitness`](https://docs.rs/rlevo-evolution) at your comparison sites
+yourself — the per-site rule is the correctness floor.) This is distinct from a
+program-*evaluation* collapse like GEP's or CGP's `non-finite → 0.0` node rule,
+which tames an intermediate arithmetic result *inside* one individual, not the
+fitness that ranks the population.
 
 ## Bridging a host objective: the two adapters
 
@@ -300,16 +329,22 @@ landscape reads as its natural cost), so the four fitness fields tell the story 
 the space you expect:
 
 - `best_fitness` — the best cost/score **this** generation;
-- `mean_fitness` — the generation's average;
+- `mean_fitness` — the generation's average, taken over the **finite** members only;
 - `worst_fitness` — the worst this generation;
-- `best_fitness_ever` — the best across **all** generations.
+- `best_fitness_ever` — the best across **all** generations;
+- `broken_count` — how many individuals evaluated to a non-finite fitness this
+  generation (a `NaN`, sanitised to `−∞`) and were therefore *excluded* from
+  `mean_fitness`. Zero on a healthy run; a non-zero value flags a population
+  carrying broken individuals (ADR 0034 — see [fitness hygiene](#fitness-hygiene-nan-and-inf)).
 
 The most informative reading is the *gap* between `best_fitness_ever` and
 `mean_fitness` in the final generation. A large gap signals **premature
 convergence** — a few elites found a good basin while the rest of the population is
 still scattered. A small gap means the whole population has settled near the same
 optimum. For landscapes with a known optimum (Ackley → 0), `best_fitness_ever`
-doubles as a direct "how close did we get" readout.
+doubles as a direct "how close did we get" readout. Averaging `mean_fitness` over
+the finite members keeps one broken individual from collapsing the whole statistic
+to `−∞`; `broken_count` surfaces that individual instead of hiding it.
 
 ## Putting it together
 


### PR DESCRIPTION
## Summary

Closes the three GEP-specific NaN/Inf holes named in issue #130 (unsanitized
operator rates, empty/mismatched-dataset division, Inf-collapsing-to-0.0 in
tree MSE), then generalizes the per-model fixes from #129 (EDA) and #130
(GEP) into a single fitness-hygiene chokepoint (ADR 0034):
`EvolutionaryHarness::step` now sanitizes the canonical (maximise-space)
fitness tensor before every `Strategy::tell`, so no `tell` implementation can
be poisoned by a non-finite fitness value. This closes the fitness-hygiene
half of #131/#132/#133/#134 centrally, with targeted follow-up fixes in
neuroevolution, coevolution, and metaheuristic call sites that write fitness
outside the harness chokepoint.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [ ] Documentation correction (typo, broken link, misleading doc comment)
- [x] Other — _adds `ADR 0034` (fitness-hygiene chokepoint convention) and
  user-book documentation; scope agreed via issues #129–#134 filed from
  code review of the evolution crate_

## Linked Issue

Closes #130

Also addresses the fitness-hygiene portion of #131, #132, #133, #134
(centralized by the new chokepoint in `strategy.rs`; per-algorithm
finite-check follow-ups outside the chokepoint may still be tracked on those
issues).

## What Was Changed

- `algorithms/gep/config.rs`, `operators.rs`, `strategy.rs`, `tree.rs` —
  GEP operator rates become `rlevo_core::Probability` (unrepresentable
  NaN/Inf/out-of-range), reject empty/mismatched-width datasets instead of
  silently zero-padding into NaN fitness, and `finite_or_clamp` now maps
  `Inf → ±EVAL_CLAMP` instead of collapsing to `0.0`.
- `fitness.rs` — extended `sanitize_fitness` to the canonical rule
  (`NaN → −∞`, `+∞ → f32::MAX`, `−∞` pass-through) and added a device-op
  sibling `sanitize_fitness_tensor` for the hot path.
- `strategy.rs` — `EvolutionaryHarness::step` sanitizes the canonical
  fitness tensor before every `Strategy::tell`; `StrategyMetrics` now means
  over finite members only and reports `broken_count`.
- `algorithms/ep.rs`, `es_classical.rs` — sigma floor + NaN mean handling.
- `algorithms/gp_cgp.rs` — fixed `is_finite()` sentinel vs `-inf` conflict.
- `algorithms/metaheuristic/gwo.rs` — sanitized `argtop3` leader selection.
- `algorithms/neuroevolution/arch_nas.rs`, `neuroevolution/species.rs`,
  `algorithms/neuroevolution/neat.rs` — NaN-safe `tell`/`update_best`
  initialization and `speciate` no longer lets NaN poison
  `adjusted_fitness_sum`.
- `coevolution/competitive.rs`, `cooperative.rs`, `harness.rs`, `fitness.rs`
  — route fitness through `sanitize_fitness` at every state-write /
  aggregation site.
- `docs/adr/0034-fitness-hygiene-chokepoint-convention.md` — new ADR.
- `docs/rules.md` — extended the maximise-direction section with the Inf
  policy and the per-site sanitize-then-`total_cmp` correctness floor.
- `docs/user-book/...` — documented the fitness-hygiene convention.

## How It Was Tested

```
cargo test --workspace
cargo clippy --all-targets --all-features
```

New/changed regression tests cover: `Probability`-typed GEP rates rejecting
NaN/Inf/out-of-range, empty/mismatched-width dataset construction errors,
`finite_or_clamp` Inf handling in tree eval, and a mutation-verified
`harness_sanitizes_non_finite_fitness_before_tell` test asserting the
sanitize step runs *after* sense negation (in canonical space) and *before*
`tell`.

- Rust toolchain: `stable 1.94.1`
- Burn backend tested: ndarray (CPU)
- OS: macOS (Darwin 25.5.0, arm64)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Claude Opus 4.8 / Sonnet 5).
  Scope: implementation of all sanitization fixes, ADR 0034 drafting, and
  user-book documentation, under direct review and direction.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [ ] This PR addresses a single concern. (It grew from a GEP-only fix into a
  crate-wide chokepoint plus scoped follow-ups — flagging for reviewer
  judgment on whether to split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

This PR is broader than issue #130 alone: while implementing the GEP fix it
became clear the same defect (unsanitized fitness reaching `tell`) repeated
across nearly every algorithm family, so ADR 0034 centralizes the fix at the
`EvolutionaryHarness::step` chokepoint rather than patching each call site.
Issues #131–#134 are only partially closed — any `tell`-bypassing call sites
not yet covered remain open follow-up work on those issues.

## Commits

- **fix(gep): Sanitize NaN/Inf fitness paths**
- **feat(evolution): Add fitness-hygiene chokepoint**
- **fix(neuroevolution): Sanitize NaN/Inf fitness**
- **fix(coevolution): Sanitize coupled fitness**
- **fix(gwo): Sanitize argtop3 leader selection**
- **fix(evolution): Clamp sigma; fix gp_cgp sentinel**
- **docs(user-book): Document fitness hygiene**
