### PR TITLE
chore(docs): Ignore private specs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ runs/
 # example source dir crates/rlevo-examples/examples/book/)
 docs/user-book/book/
 docs/contributor-book/book/
+
+# private specs, sessions, etc.
+docs/.private/


### PR DESCRIPTION
## Summary

Adds `docs/.private/` to `.gitignore` so local developer artefacts — private
specs, session notes, scratch plans — stay out of version control alongside
the already-ignored rendered mdBook output.

## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #

## What Was Changed

- `.gitignore`: added `docs/.private/` entry for private specs/sessions/scratch plans.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

No source files changed; build/test/clippy are unaffected by this change.

- Rust toolchain:
- Burn backend tested: N/A (docs-only change)
- OS:

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code. Scope: drafted the `.gitignore` entry and commit message.

## Checklist

- [ ] `cargo build --workspace` passes with no errors.
- [ ] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*. (N/A — no public API touched)
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR. (N/A — not a bug fix)
- [x] This PR addresses a single concern.
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

Verify no tracked files already live under `docs/.private/` before merging — if
any do, `git rm --cached` is needed to untrack them.
