### PR TITLE
docs(evolution): Fix ga_binary tell doc convention

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/ga_binary.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga_binary.rs
@@ -300,8 +300,10 @@ where
     /// `pop_size − elitism_k` slots are filled with the best offspring.
     /// Both selections use [`crate::ops::selection::truncation_indices_host`].
     ///
-    /// `fitness` must have shape `(pop_size,)` with values in the
-    /// minimization (cost) convention — lower is better.
+    /// `fitness` must have shape `(pop_size,)` in the canonical maximise
+    /// convention — higher is better. The harness canonicalises a `Minimize`
+    /// objective (negation) before this call, so the strategy stays
+    /// sense-unaware per ADR 0023.
     fn tell(
         &self,
         params: &BinaryGaConfig,


### PR DESCRIPTION
## Summary

Fixes the `tell` doc comment in `BinaryGeneticAlgorithm` (`ga_binary.rs`), which claimed a minimization (lower-is-better) convention. This contradicts ADR 0023's maximise-native invariant, the method's own code (`update_best` keeps the max, truncation sorts descending), and the sibling `ga.rs` doc. The doc now states the canonical maximise convention and notes that the harness canonicalises a `Minimize` objective (via negation) before calling `tell`, so the strategy itself stays sense-unaware.

## Change Type

- [ ] Bug fix (non-breaking, includes regression test)
- [ ] New example (self-contained, demonstrates existing API surface)
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #151

## What Was Changed

- `crates/rlevo-evolution/src/algorithms/ga_binary.rs`: corrected the `tell` doc comment from "minimization (cost) convention — lower is better" to the canonical maximise convention, and noted that `Minimize` objectives are canonicalised (negated) upstream per ADR 0023.

## How It Was Tested

Doc-only change; no behavior modified.

```
cargo test --workspace
cargo clippy --all-targets --all-features
```

- Rust toolchain: stable
- Burn backend tested: N/A (doc-only)
- OS: macOS

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Claude Opus 4.8). Scope: doc comment correction in `ga_binary.rs`.

## Checklist

- [ ] `cargo build --workspace` passes with no errors.
- [ ] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

None.
