### PR TITLE
chore(ci): reconcile toolchain install steps with pin

### DIFF
--- a/.github/workflows/crate-tests.yml
+++ b/.github/workflows/crate-tests.yml
@@ -53,9 +53,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -20,10 +20,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/viz-examples.yml
+++ b/.github/workflows/viz-examples.yml
@@ -34,12 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Edition 2024 / MSRV 1.85 — use a recent stable toolchain.
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
+      # The toolchain (channel + rustfmt/clippy components) is governed by
+      # rust-toolchain.toml at the repo root; rustup auto-installs the pin on
+      # the first cargo invocation.
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -58,9 +58,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
         with:
@@ -92,9 +89,6 @@ jobs:
             test: qrdqn_cartpole_acceptance
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

Removes the redundant `dtolnay/rust-toolchain@stable` install step (and its now-unnecessary `components:` lines) from all five workflows. `rust-toolchain.toml` (added in #216, pinning `1.94.1` with `rustfmt`/`clippy`) already governs the toolchain via rustup's override mechanism, which auto-installs the pinned version and its declared components on the first `cargo` invocation — so the explicit `@stable` install was wasted work and left the workflow files misrepresenting the version CI actually uses (Option B from the linked issue).

## Change Type

- [x] Other — CI cleanup: removes duplicated/stale toolchain-install steps in favor of the single `rust-toolchain.toml` source of truth. No behavior change to what toolchain CI runs; classified as CI/CD but scoped narrowly to reconciling with the already-merged #216 pin.

## Linked Issue

Closes #220

## What Was Changed

- `.github/workflows/crate-tests.yml` — removed `Install Rust toolchain` step
- `.github/workflows/fmt.yml` — removed `Install Rust toolchain` step (including `components: rustfmt`)
- `.github/workflows/integration-tests.yml` — removed `Install Rust toolchain` step
- `.github/workflows/viz-examples.yml` — removed `Install Rust toolchain` step (including `components: clippy`); replaced with a comment pointing to `rust-toolchain.toml` as the source of truth
- `.github/workflows/weekly-tests.yml` — removed both `Install Rust toolchain` steps (two jobs)

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

No source changes, only workflow YAML — verified locally that `rustup` picks up `rust-toolchain.toml`'s `1.94.1` pin automatically on `cargo` invocation. Final validation is watching this PR's own CI run go green, per the issue's acceptance criteria.

- Rust toolchain: `1.94.1` (via `rust-toolchain.toml`)
- Burn backend tested: n/a (CI workflow change only)
- OS: macOS (local), CI runs on GitHub-hosted Linux runners

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code. Scope: authored the workflow YAML edits removing redundant toolchain-install steps.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [ ] Public API additions or changes include doc comments explaining *what* and *why*. — n/a, no public API change
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. — n/a, not a bug fix
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

Split out of #216 per that issue's own follow-up, since this is only truly validated by observing a CI run rather than local commands — current state (floating `@stable` alongside the pin) is functionally correct, so this is a cleanliness/DRY fix, not a bugfix.
