### PR TITLE
fix(metaheuristic): Guard per-algorithm numerical divergence

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -17,7 +17,6 @@
 //!
 //! - Socha & Dorigo (2008), *Ant colony optimization for continuous domains*.
 
-use std::f32::consts::PI;
 use std::marker::PhantomData;
 
 use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
@@ -138,17 +137,26 @@ impl<B: Backend> AntColonyReal<B> {
         #[allow(clippy::cast_precision_loss)]
         let k = archive_size as f32;
         let denom = 2.0 * q * q * k * k;
-        let scale = 1.0 / (q * k * (2.0 * PI).sqrt());
+        // Drop the Gaussian-PDF normalisation constant: it cancels exactly under
+        // the sum-to-one renormalisation below, and for tiny q·k it overflows to
+        // +inf, producing inf/inf = NaN. `l` is 0-indexed here; equivalent to the
+        // paper's 1-indexed (l−1)² after normalisation.
         let mut w: Vec<f32> = (0..archive_size)
             .map(|l| {
                 #[allow(clippy::cast_precision_loss)]
                 let rank = l as f32;
-                scale * (-(rank * rank) / denom).exp()
+                (-(rank * rank) / denom).exp()
             })
             .collect();
         let total: f32 = w.iter().sum();
-        for v in &mut w {
-            *v /= total;
+        if !total.is_finite() || total == 0.0 {
+            // Degenerate q (e.g. q == 0 / underflow): fall back to uniform so the
+            // CDF sampler in `ask` never sees all-zero / NaN weights.
+            w.fill(1.0 / k);
+        } else {
+            for v in &mut w {
+                *v /= total;
+            }
         }
         w
     }
@@ -453,6 +461,35 @@ mod tests {
         let w = AntColonyReal::<TestBackend>::compute_weights(10, 0.1);
         let total: f32 = w.iter().sum();
         approx::assert_relative_eq!(total, 1.0, epsilon = 1e-5);
+    }
+
+    #[test]
+    fn weights_normal_case_monotone_non_increasing() {
+        let w: Vec<f32> = AntColonyReal::<TestBackend>::compute_weights(10, 0.1);
+        let total: f32 = w.iter().sum();
+        approx::assert_relative_eq!(total, 1.0, epsilon = 1e-5);
+        // Rank 0 (best) must be the heaviest; weights decay with rank.
+        for pair in w.windows(2) {
+            assert!(
+                pair[0] >= pair[1],
+                "weights must be non-increasing: {} < {}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn weights_degenerate_q_fall_back_to_uniform() {
+        for q in [1e-30_f32, 0.0_f32] {
+            let w: Vec<f32> = AntColonyReal::<TestBackend>::compute_weights(10, q);
+            assert!(
+                w.iter().all(|v| v.is_finite() && *v >= 0.0),
+                "degenerate q={q} produced non-finite / negative weights: {w:?}"
+            );
+            let total: f32 = w.iter().sum();
+            approx::assert_relative_eq!(total, 1.0, epsilon = 1e-5);
+        }
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -393,8 +393,12 @@ where
             .unsqueeze_dim::<2>(1)
             .expand([pop, genome_dim]);
 
-        let new_velocities =
-            state.velocities.clone() + (state.positions.clone() - best.clone()).mul(f_mat);
+        // Clamp velocity to the search extent to prevent unbounded ±∞/NaN
+        // drift when a bat is pinned against a bound (parity with PSO's v_max).
+        let span = (hi - lo).abs();
+        let new_velocities = (state.velocities.clone()
+            + (state.positions.clone() - best.clone()).mul(f_mat))
+        .clamp(-span, span);
         let global_move = state.positions.clone() + new_velocities.clone();
         // Local walk: x_best + ε · mean(A).
         let eps =
@@ -618,5 +622,46 @@ mod tests {
         while !harness.step(()).done {}
         let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 0.1, "Bat D10 best={best}");
+    }
+
+    #[test]
+    fn velocities_stay_finite_and_bounded_under_pinning() {
+        // Regression for #156 (Bat §1.1). The velocity update
+        // `v ← v + (x − x_best)·f` is repulsive for a bat sitting away
+        // from `x_best`, and `ask` rewrites `state.velocities` every
+        // generation regardless of `tell`'s acceptance gate. A bat whose
+        // position stays fixed while `x_best` sits elsewhere therefore
+        // accrues a near-constant increment each generation, so unclamped
+        // velocities drift linearly to ±∞ and then to NaN (via `inf − inf`).
+        // The ±span clamp (parity with PSO's `v_max`) must keep every
+        // velocity finite and within the search extent no matter how long
+        // the swarm runs.
+        let device = Default::default();
+        let strategy = BatAlgorithm::<TestBackend>::new();
+        let params = BatConfig::default_for(20, 4);
+        let (lo, hi): (f32, f32) = params.bounds.into();
+        let span = (hi - lo).abs();
+        let fitness_fn = FromFitnessEvaluable::new(SphereFit, Sphere);
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            strategy, params, fitness_fn, 7, device, 100,
+        )
+        .expect("valid params");
+        harness.reset();
+        while !harness.step(()).done {}
+        let velocities: Vec<f32> = harness
+            .state()
+            .expect("state populated after stepping")
+            .velocities()
+            .clone()
+            .into_data()
+            .into_vec::<f32>()
+            .expect("velocities readable as f32");
+        for v in velocities {
+            assert!(v.is_finite(), "velocity not finite: {v}");
+            assert!(
+                v.abs() <= span + 1e-3,
+                "velocity {v} exceeds search span {span}"
+            );
+        }
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -234,6 +234,27 @@ fn gamma(z: f32) -> f32 {
     (2.0 * PI).sqrt() * t.powf(z + 0.5) * (-t).exp() * x
 }
 
+/// One Mantegna Lévy step component `u / |w|^(1/β)`.
+///
+/// Guards the measure-zero pathological draw: a Normal draw `w == 0` (or
+/// any `w` whose `|w|^(1/β)` rounds to `0` or a non-finite value) makes the
+/// denominator degenerate. Un-guarded, `0/0` is `NaN` and `x/0` is `±inf` —
+/// both survive the downstream bounds clamp and would poison a nest slot
+/// forever. A non-finite or zero denominator folds the step to `0.0`
+/// (a no-op) so the next draw can move the nest.
+///
+/// This is the pure host-side core the `ask` Lévy loop is built on; keeping
+/// it out of the tensor pipeline makes the guard directly unit-testable with
+/// injected pathological `(u, w)` inputs.
+fn levy_step(u: f32, w: f32, beta: f32) -> f32 {
+    let denom: f32 = w.abs().powf(1.0 / beta);
+    if denom.is_finite() && denom > 0.0 {
+        u / denom
+    } else {
+        0.0
+    }
+}
+
 impl<B: Backend> Strategy<B> for CuckooSearch<B>
 where
     B::Device: Clone,
@@ -320,7 +341,9 @@ where
         for v in &mut step {
             let u: f32 = normal_u.sample(&mut stream);
             let w: f32 = normal_v.sample(&mut stream);
-            *v = u / w.abs().powf(1.0 / params.beta);
+            // `levy_step` guards the degenerate `w == 0` denominator (±∞/NaN
+            // survive the bounds clamp and would poison the slot forever).
+            *v = levy_step(u, w, params.beta);
         }
         let step_tensor = Tensor::<B, 2>::from_data(TensorData::new(step, [pop, d]), device);
 
@@ -560,5 +583,42 @@ mod tests {
         while !harness.step(()).done {}
         let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 20.0, "Cuckoo D10 best={best}");
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)] // exact by design: 0.0 fold + byte-identical pass-through
+    fn levy_step_folds_pathological_denominator_to_zero() {
+        // Deterministic reproducer for #156 (Cuckoo): the Lévy step
+        // component `u / |w|^(1/β)`. A zero Normal draw `w` makes the
+        // denominator zero; un-guarded, `0/0` is `NaN` and `x/0` is `±inf`.
+        // Both survive the bounds clamp and permanently poison a nest slot,
+        // so `levy_step` folds any non-finite/zero-denominator case to `0.0`.
+        //
+        // Each pathological assertion below FAILS against the pre-fix loop
+        // body (which computed `u / denom` unconditionally), shown by the
+        // `unguarded` reference expressions being non-finite.
+        let beta: f32 = 1.5;
+
+        // w == 0, u == 0 → un-guarded `0/0 = NaN`.
+        let unguarded_nan: f32 = 0.0_f32 / 0.0_f32.abs().powf(1.0 / beta);
+        assert!(unguarded_nan.is_nan());
+        assert_eq!(levy_step(0.0, 0.0, beta), 0.0);
+
+        // w == 0, u != 0 → un-guarded `x/0 = ±inf`.
+        let unguarded_inf: f32 = 1.0_f32 / 0.0_f32.abs().powf(1.0 / beta);
+        assert!(!unguarded_inf.is_finite());
+        assert_eq!(levy_step(1.0, 0.0, beta), 0.0);
+
+        // A NaN Normal draw `w` makes the denominator non-finite → folded to 0.
+        assert_eq!(levy_step(1.0, f32::NAN, beta), 0.0);
+
+        // Normal case: finite and byte-identical to the un-guarded value
+        // (the guard is a pass-through whenever the denominator is sound).
+        let expected: f32 = 0.5_f32 / 1.2_f32.abs().powf(1.0 / beta);
+        let got: f32 = levy_step(0.5, 1.2, beta);
+        assert!(got.is_finite());
+        approx::assert_relative_eq!(got, expected, epsilon = 1e-6);
+        // Byte-identical: same operations, no reorder.
+        assert_eq!(got, expected);
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -67,12 +67,16 @@ impl FireflyConfig {
     /// non-vanishing across pairs.
     #[must_use]
     pub fn default_for(pop_size: usize, genome_dim: usize) -> Self {
+        let (lo, hi): (f32, f32) = (-5.12, 5.12);
+        let length: f32 = hi - lo;
+        // γ ≈ 1/L², Yang's canonical regime scaled to the domain extent.
+        let gamma: f32 = 1.0 / (length * length);
         Self {
             pop_size,
             genome_dim,
-            bounds: Bounds::new(-5.12, 5.12),
+            bounds: Bounds::new(lo, hi),
             beta0: 1.0,
-            gamma: 0.01,
+            gamma,
             alpha: 0.2,
         }
     }
@@ -445,6 +449,15 @@ mod tests {
     #[test]
     fn default_config_validates() {
         assert!(FireflyConfig::default_for(32, 10).validate().is_ok());
+    }
+
+    #[test]
+    fn default_gamma_matches_inverse_length_squared() {
+        let cfg = FireflyConfig::default_for(32, 10);
+        let (lo, hi): (f32, f32) = cfg.bounds.into();
+        let length: f32 = hi - lo;
+        let expected: f32 = 1.0 / (length * length);
+        approx::assert_relative_eq!(cfg.gamma, expected);
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -44,6 +44,26 @@ use crate::ops::selection::argmax_host;
 use crate::rng::{SeedPurpose, seed_stream};
 use crate::strategy::{Strategy, StrategyMetrics};
 
+/// `exp(x)` overflows f32 for x ≳ 88.7; clamp the spiral exponent so an
+/// out-of-range `b` can never produce `inf`/`NaN` in the spiral update.
+const MAX_SPIRAL_EXP: f32 = 80.0; // exp(80) ≈ 5.5e34, well under f32::MAX
+
+/// Per-element spiral bubble-net factor `exp(b·l)·cos(2π·l)`.
+///
+/// The exponent `b·l` is clamped to `±`[`MAX_SPIRAL_EXP`] before
+/// exponentiation. Without the clamp an out-of-range `b` drives
+/// `exp(b·l)` past f32's overflow threshold to `inf`; where `cos(2π·l)`
+/// is zero the product is `inf · 0 = NaN` (and elsewhere it is `±inf`) —
+/// non-finite values that the downstream bounds clamp does not sanitize.
+/// Clamping the exponent keeps the factor finite for every `l`.
+///
+/// This is the pure host-side core the `ask` spiral branch is built on;
+/// keeping it out of the tensor pipeline makes the overflow guard directly
+/// unit-testable with injected pathological `(l, b)` pairs.
+fn spiral_factor(l: f32, b: f32) -> f32 {
+    (b * l).clamp(-MAX_SPIRAL_EXP, MAX_SPIRAL_EXP).exp() * (2.0 * PI * l).cos()
+}
+
 /// Static configuration for [`WhaleOptimization`].
 #[derive(Debug, Clone)]
 pub struct WoaConfig {
@@ -311,7 +331,6 @@ where
         let c_row = Tensor::<B, 1>::from_data(TensorData::new(c_scalar, [pop_size]), device)
             .unsqueeze_dim::<2>(1)
             .expand([pop_size, genome_dim]);
-        let l_vec = Tensor::<B, 1>::from_data(TensorData::new(l_scalar, [pop_size]), device);
         let rand_idx_t =
             Tensor::<B, 1, Int>::from_data(TensorData::new(rand_idx, [pop_size]), device);
         let x_rand = state.positions.clone().select(0, rand_idx_t);
@@ -331,13 +350,16 @@ where
         // Search toward X_rand:    X_rand − A · |C · X_rand − X|
         let enc_rand =
             x_rand.clone() - a_row.mul((c_row.mul(x_rand) - state.positions.clone()).abs());
-        // Spiral toward X_best:    |X_best − X| · exp(b·l) · cos(2π·l) + X_best
+        // Spiral toward X_best:    |X_best − X| · exp(b·l) · cos(2π·l) + X_best.
+        // The per-element factor `exp(b·l)·cos(2π·l)` is computed host-side by
+        // `spiral_factor`, which clamps the exponent so an out-of-range `b`
+        // can never produce `inf · 0 = NaN` in the spiral update.
         let dist = (x_best.clone() - state.positions.clone()).abs();
-        let factor = l_vec
-            .clone()
-            .mul_scalar(params.b)
-            .exp()
-            .mul(l_vec.mul_scalar(2.0 * PI).cos());
+        let factor_host: Vec<f32> = l_scalar
+            .iter()
+            .map(|&l| spiral_factor(l, params.b))
+            .collect();
+        let factor = Tensor::<B, 1>::from_data(TensorData::new(factor_host, [pop_size]), device);
         let factor_mat = factor.unsqueeze_dim::<2>(1).expand([pop_size, genome_dim]);
         let spiral = dist.mul(factor_mat) + x_best;
 
@@ -472,5 +494,50 @@ mod tests {
         while !harness.step(()).done {}
         let best = harness.latest_metrics().unwrap().best_fitness_ever();
         assert!(best < 1e-4, "WOA D10 best={best}");
+    }
+
+    #[test]
+    fn spiral_factor_stays_finite_under_overflow() {
+        // Deterministic reproducer for #156 (WOA): the spiral factor
+        // `exp(b·l)·cos(2π·l)`. A large `b` drives `exp(b·l)` past f32's
+        // overflow threshold (≈ e^88.7). At `l = 0.75`, `cos(2π·0.75)` is
+        // (numerically) zero, so the *un-clamped* product is `inf · 0 = NaN`;
+        // at other overflow points it is `±inf`. Either way the value is
+        // non-finite and survives the downstream bounds clamp, poisoning the
+        // genome. `spiral_factor` clamps the exponent and stays finite.
+        //
+        // Each `(l, b)` pair below has `b·l > 88.7`, so the un-clamped
+        // reference is non-finite — the assertion on `spiral_factor` would
+        // FAIL against the pre-fix (un-clamped) computation, which is exactly
+        // the `unguarded` expression checked to be non-finite here.
+        for &(l, b) in &[
+            (0.75_f32, 200.0_f32),
+            (0.5, 200.0),
+            (0.9, 200.0),
+            (0.75, 500.0),
+        ] {
+            // What the pre-fix code computed (no exponent clamp).
+            let unguarded: f32 = (b * l).exp() * (2.0 * PI * l).cos();
+            assert!(
+                !unguarded.is_finite(),
+                "test setup: expected overflow for l={l}, b={b}, got {unguarded}"
+            );
+            let guarded: f32 = spiral_factor(l, b);
+            assert!(
+                guarded.is_finite(),
+                "spiral_factor non-finite for l={l}, b={b}: {guarded}"
+            );
+        }
+    }
+
+    #[test]
+    fn spiral_factor_matches_unguarded_when_in_range() {
+        // Below the overflow threshold the clamp is a no-op: the guarded
+        // factor must equal the plain `exp(b·l)·cos(2π·l)` computation.
+        for &(l, b) in &[(0.3_f32, 1.0_f32), (-0.7, 2.0), (0.25, 10.0)] {
+            let expected: f32 = (b * l).exp() * (2.0 * PI * l).cos();
+            let got: f32 = spiral_factor(l, b);
+            approx::assert_relative_eq!(got, expected, epsilon = 1e-6);
+        }
     }
 }

--- a/docs/user-book/src/appendix-a-ec-algorithms/firefly-algorithm.md
+++ b/docs/user-book/src/appendix-a-ec-algorithms/firefly-algorithm.md
@@ -55,17 +55,21 @@ of FA over a single-attractor swarm, and the reason the update is canonically
 \\(O(N^2 D)\\).
 
 The base attractiveness \\(\beta_0\\) (default \\(1.0\\)) sets the pull strength at
-zero distance; the absorption coefficient \\(\gamma\\) (default \\(0.01\\)) sets the
+zero distance; the absorption coefficient \\(\gamma\\) (default
+\\(1/L^2\\), \\(\approx 0.0095\\) on the default box) sets the
 range over which fireflies see each other; the noise scale \\(\alpha\\) (default
 \\(0.2\\)) sets the exploration floor.
 
-> **\\(\gamma\\) is scaled to the search box, not Yang's canonical \\(1.0\\).**
+> **\\(\gamma\\) is derived from the search box, not Yang's canonical \\(1.0\\).**
 > The original paper assumes positions normalised to \\([0,1]\\), where
-> \\(\gamma = 1\\) is appropriate. `rlevo`'s default domain is \\([-5.12, 5.12]\\)
-> (width \\(L \approx 10.24\\)), so distances — and hence \\(r^2\\) — are far
-> larger; the default \\(\gamma = 0.01 \approx 1/L^2\\) keeps \\(e^{-\gamma r^2}\\)
-> from collapsing to zero across typical pairs. Retune \\(\gamma\\) if you change
-> `bounds`.
+> \\(\gamma = 1\\) is appropriate. `rlevo`'s `FireflyConfig::default_for` instead
+> computes \\(\gamma = 1/L^2\\), where \\(L\\) is the search-box width, so the
+> default automatically rescales with `bounds` instead of assuming a fixed
+> extent. On `rlevo`'s default domain \\([-5.12, 5.12]\\) (\\(L \approx 10.24\\)),
+> that works out to \\(\gamma \approx 0.0095\\), which keeps \\(e^{-\gamma r^2}\\)
+> from collapsing to zero across typical pairs. Because \\(\gamma\\) now tracks
+> `bounds` automatically, you only need to override it by hand if you want a
+> sight range other than \\(1/L^2\\).
 
 ## The `O(N²D)` cost and the population cap
 
@@ -94,11 +98,13 @@ let config = FireflyConfig {
     genome_dim: 10,
     bounds:     Bounds::new(-5.12, 5.12),
     beta0:      1.0,    // attractiveness at zero distance
-    gamma:      0.01,   // absorption; scale ≈ 1/L² to your box width
+    gamma:      1.0 / (10.24 * 10.24), // absorption = 1/L²; ≈ 0.0095 here
     alpha:      0.2,    // random-walk noise scale
 };
 
-// Or use the defaults (bounds = (-5.12, 5.12), β₀ = 1.0, γ = 0.01, α = 0.2):
+// Or use the defaults (bounds = (-5.12, 5.12), β₀ = 1.0, γ = 1/L² ≈ 0.0095, α = 0.2):
+// `FireflyConfig::default_for` derives γ = 1/L² from `bounds`, so it
+// rescales automatically if you construct with a different search box.
 let config = FireflyConfig::default_for(32, 10);
 ```
 


### PR DESCRIPTION
## Summary

Adds small, self-contained numerical guards to five metaheuristics (WOA, Firefly,
Bat, Cuckoo, ACO-R) so a degenerate config or a measure-zero RNG draw can no
longer produce inf/NaN that silently corrupts a long run.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #156

## What Was Changed

- `algorithms/metaheuristic/woa.rs` — clamp the spiral exponent `b·l` before
  `exp()` so an out-of-range `b` cannot overflow to inf and yield `inf·0 = NaN`;
  spiral factor extracted into a private pure host fn for unit testing with
  injected pathological inputs
- `algorithms/metaheuristic/firefly.rs` — derive default `gamma = 1/L^2` from
  the bounds extent, matching the documented contract instead of a hardcoded
  `0.01`
- `algorithms/metaheuristic/bat.rs` — clamp velocity to the `±(hi−lo)` span,
  matching PSO's `v_max`, to stop unbounded `±∞`/NaN drift when a bat is
  pinned against a bound
- `algorithms/metaheuristic/cuckoo.rs` — fold a non-finite/zero Lévy
  denominator to `0` so a `w==0` draw cannot poison a nest slot with NaN for
  the rest of the run; Lévy step extracted into a private pure host fn for
  unit testing
- `algorithms/metaheuristic/aco_r.rs` — drop the redundant Gaussian-PDF scale
  (cancelled by renormalisation, overflows for tiny `q·k`) and add a uniform
  fallback when the weight sum is non-finite or zero
- `docs/user-book/.../appendix-a-ec-algorithms/firefly-algorithm.md` — update
  documented default gamma to `1/L^2`

ACO-R's `tell` NaN-panic (issue §1.1) was already resolved by the ADR 0034
fitness-hygiene chokepoint; no change needed there.

## How It Was Tested

```
cargo test --workspace
cargo clippy --all-targets --all-features
```

Unit tests added for each guard, including injected pathological inputs
(out-of-range `b`, zero/non-finite Lévy weight, non-finite weight sums) that
fail on the previous code and pass on this PR. Convergence tests still pass
at tolerance.

- Rust toolchain: (fill in `rustup show` output)
- Burn backend tested:
- OS: macOS (darwin)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: implementation
  of all five guards, associated unit tests, and doc update; reviewed and
  verified by maintainer.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

WOA's spiral factor moves the pop_size scalar `exp`/`cos` to the host (`l`
was already host-sampled); the genome_dim broadcast stays tensorized, so this
is O(pop_size) extra host work, not a de-vectorization of the hot path.

