### PR TITLE
fix(evolution): NaN-safe Gaussian sampling, drop Normal expects

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/cma_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cma_es.rs
@@ -39,7 +39,6 @@ use std::marker::PhantomData;
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rand::Rng;
 use rand::RngExt;
-use rand_distr::{Distribution as _, Normal};
 
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate, Violations};
@@ -562,10 +561,11 @@ where
             state.generation as u64,
             SeedPurpose::CmaSampling,
         );
-        let normal = Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
         let mut rows: Vec<f32> = Vec::with_capacity(lambda * d);
         for _ in 0..lambda {
-            let z: Vec<f32> = (0..d).map(|_| normal.sample(&mut stream)).collect();
+            let z: Vec<f32> = (0..d)
+                .map(|_| crate::sampling::standard_normal(&mut stream))
+                .collect();
             let bdz: Vec<f32> = matvec(&bd, &z, d);
             for (mean_i, bdz_i) in state.mean.iter().zip(bdz.iter()) {
                 rows.push(mean_i + state.sigma * bdz_i);

--- a/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
@@ -44,7 +44,6 @@ use std::marker::PhantomData;
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rand::Rng;
 use rand::RngExt;
-use rand_distr::{Distribution as _, Normal};
 
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
@@ -382,8 +381,6 @@ where
             state.generation as u64,
             SeedPurpose::CmaSampling,
         );
-        let normal = Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
-
         let mut rows: Vec<f32> = Vec::with_capacity(lambda * d);
         let mut sigmas: Vec<f32> = Vec::with_capacity(lambda);
         for _ in 0..lambda {
@@ -394,9 +391,12 @@ where
             // cma_es.rs. A floored σᵢ yields a *benign zero step* — the
             // offspring collapses to ≈m and contributes ~0 to the rank-μ blend —
             // not a corrected tiny step.
-            let sigma_i: f32 = (state.sigma * (params.tau * normal.sample(&mut stream)).exp())
-                .max(f32::MIN_POSITIVE);
-            let z: Vec<f32> = (0..d).map(|_| normal.sample(&mut stream)).collect();
+            let sigma_i: f32 = (state.sigma
+                * (params.tau * crate::sampling::standard_normal(&mut stream)).exp())
+            .max(f32::MIN_POSITIVE);
+            let z: Vec<f32> = (0..d)
+                .map(|_| crate::sampling::standard_normal(&mut stream))
+                .collect();
             let s: Vec<f32> = matvec(&factor, &z, d);
             for (mean_i, s_i) in state.mean.iter().zip(s.iter()) {
                 rows.push(mean_i + sigma_i * s_i);

--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -25,7 +25,6 @@ use std::marker::PhantomData;
 use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
 use rand::Rng;
 use rand::RngExt;
-use rand_distr::{Distribution as _, Normal};
 
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
@@ -288,10 +287,9 @@ where
         // Log-normal σ update for every parent. Host-sample the N(0,1)
         // noise from the deterministic `sigma_rng` so it is reproducible
         // across thread schedules.
-        let normal = Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
         let mut noise_rows = Vec::with_capacity(mu);
         for _ in 0..mu {
-            noise_rows.push(normal.sample(&mut sigma_rng));
+            noise_rows.push(crate::sampling::standard_normal(&mut sigma_rng));
         }
         let noise = Tensor::<B, 1>::from_data(TensorData::new(noise_rows, [mu]), device);
         // Clamp the log-normal random walk to `[sigma_min, sigma_max]` so σ can

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -25,7 +25,6 @@ use std::marker::PhantomData;
 use burn::tensor::{Tensor, TensorData, backend::Backend};
 use rand::Rng;
 use rand::RngExt;
-use rand_distr::{Distribution as _, Normal};
 
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
@@ -435,10 +434,9 @@ where
         } else {
             // Host-sample the N(0,1) noise from the deterministic `sigma_rng`
             // so the log-normal σ update is reproducible across schedules.
-            let normal = Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
             let mut noise_rows = Vec::with_capacity(lambda);
             for _ in 0..lambda {
-                noise_rows.push(normal.sample(&mut sigma_rng));
+                noise_rows.push(crate::sampling::standard_normal(&mut sigma_rng));
             }
             let noise = Tensor::<B, 1>::from_data(TensorData::new(noise_rows, [lambda]), device);
             // Clamp the log-normal random walk to `[sigma_min, sigma_max]` so σ

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -22,7 +22,6 @@ use std::marker::PhantomData;
 use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
 use rand::Rng;
 use rand::RngExt;
-use rand_distr::{Distribution as RandDistDist, Normal};
 
 use rlevo_core::bounds::Bounds;
 use rlevo_core::config::{self, ConfigError, Validate};
@@ -307,8 +306,14 @@ where
             SeedPurpose::Mutation,
         );
         for (idx, out) in offspring.iter_mut().enumerate() {
-            let normal = Normal::new(mean_rows[idx], sigma_rows[idx]).expect("sigma > 0");
-            *out = normal.sample(&mut sample_rng);
+            // A non-finite σ falls back to the archive mean rather than
+            // panicking (σ is already floored to 1e-12 above, so this is a
+            // belt-and-braces guard). A NaN mean would pass through unchanged;
+            // the clamp below bounds finite draws but does NOT launder a NaN —
+            // that is neutralized by the ADR-0034 fitness-hygiene chokepoint
+            // downstream.
+            *out =
+                crate::sampling::normal_or_mean(mean_rows[idx], sigma_rows[idx], &mut sample_rng);
         }
         let (lo, hi): (f32, f32) = params.bounds.into();
         for v in &mut offspring {
@@ -430,6 +435,9 @@ mod tests {
     use crate::fitness::FromFitnessEvaluable;
     use crate::strategy::EvolutionaryHarness;
     use burn::backend::Flex;
+    use burn::backend::flex::FlexDevice;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
     use rlevo_core::fitness::FitnessEvaluable;
 
     #[test]
@@ -489,6 +497,106 @@ mod tests {
             );
             let total: f32 = w.iter().sum();
             approx::assert_relative_eq!(total, 1.0, epsilon = 1e-5);
+        }
+    }
+
+    // --- NaN-safe sampling coverage through the real `ask` call site ---
+    //
+    // These exercise the `sampling::normal_or_mean` guard end-to-end: a
+    // non-finite value is injected into the archive that `ask` reads, and we
+    // assert `ask` neither panics nor returns garbage where the guard should
+    // recover. Directly injectable because every `AcoRState` field is `pub`.
+
+    /// Builds a 3-row archive whose weights force the roulette in `ask` to
+    /// always select archive row 0 (`weights = [1, 0, 0]` ⇒ CDF `[1, 1, 1]` ⇒
+    /// `pick(u) == 0` for every `u ∈ [0, 1)`), so the sampled mean is
+    /// deterministically `archive[0, :]`.
+    fn state_forcing_row_zero(
+        archive_vals: Vec<f32>,
+        device: FlexDevice,
+    ) -> AcoRState<TestBackend> {
+        let archive: Tensor<TestBackend, 2> =
+            Tensor::from_data(TensorData::new(archive_vals, [3, 2]), &device);
+        AcoRState {
+            archive,
+            // Non-empty so `ask` takes the sampling path, not the first-call
+            // early return.
+            archive_fitness: vec![3.0, 0.0, -3.0],
+            weights: vec![1.0, 0.0, 0.0],
+            best_genome: None,
+            best_fitness: f32::NEG_INFINITY,
+            generation: 1,
+        }
+    }
+
+    #[test]
+    fn ask_recovers_from_infinite_sigma_via_mean_fallback() {
+        // Row 1, column 0 holds +∞. The on-device σ for column 0 becomes
+        // Σ_e |archive[e,0] − archive[0,0]| ⊇ |∞ − 1| = ∞, and ∞.max(1e-12) == ∞
+        // survives the floor — so `normal_or_mean(mean=1.0, std=∞)` hits the
+        // `Err` fallback and returns the finite mean instead of panicking.
+        let device: FlexDevice = Default::default();
+        let strategy: AntColonyReal<TestBackend> = AntColonyReal::new();
+        let params: AcoRConfig = AcoRConfig::default_for(3, 4, 2);
+        let state: AcoRState<TestBackend> =
+            state_forcing_row_zero(vec![1.0, 2.0, f32::INFINITY, 0.5, -1.0, -2.0], device);
+
+        let mut rng: StdRng = StdRng::seed_from_u64(21);
+        // Must not panic.
+        let (pop, _next): (Tensor<TestBackend, 2>, AcoRState<TestBackend>) =
+            strategy.ask(&params, &state, &mut rng, &device);
+        let vals: Vec<f32> = pop
+            .into_data()
+            .into_vec::<f32>()
+            .expect("offspring tensor must be readable as f32");
+
+        // Every offspring is finite; column 0 recovers exactly to the finite
+        // mean archive[0,0] = 1.0 (the fallback draw, clamped inside bounds).
+        assert_eq!(vals.len(), 4 * 2);
+        for (idx, &v) in vals.iter().enumerate() {
+            assert!(v.is_finite(), "offspring[{idx}] = {v} is not finite");
+        }
+        for i in 0..4 {
+            approx::assert_relative_eq!(vals[i * 2], 1.0_f32, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn ask_passes_nan_mean_through_for_downstream_hygiene() {
+        // Row 0, column 0 holds NaN and is the always-selected mean. σ for
+        // column 0 is NaN, but NaN.max(1e-12) == 1e-12 (the floor launders the
+        // NaN σ), so `normal_or_mean(mean=NaN, std=1e-12)` takes the `Ok` path
+        // and the NaN *mean* propagates: `ask` intentionally does NOT launder it
+        // (that is the ADR-0034 fitness-hygiene chokepoint's job downstream).
+        let device: FlexDevice = Default::default();
+        let strategy: AntColonyReal<TestBackend> = AntColonyReal::new();
+        let params: AcoRConfig = AcoRConfig::default_for(3, 4, 2);
+        let state: AcoRState<TestBackend> =
+            state_forcing_row_zero(vec![f32::NAN, 2.0, 1.0, 0.5, -1.0, -2.0], device);
+
+        let mut rng: StdRng = StdRng::seed_from_u64(23);
+        // Must not panic despite the NaN in the read path.
+        let (pop, _next): (Tensor<TestBackend, 2>, AcoRState<TestBackend>) =
+            strategy.ask(&params, &state, &mut rng, &device);
+        let vals: Vec<f32> = pop
+            .into_data()
+            .into_vec::<f32>()
+            .expect("offspring tensor must be readable as f32");
+
+        assert_eq!(vals.len(), 4 * 2);
+        for i in 0..4 {
+            // Column 0: NaN mean passes through unchanged.
+            assert!(
+                vals[i * 2].is_nan(),
+                "expected NaN passthrough at column 0, got {}",
+                vals[i * 2]
+            );
+            // Column 1: finite mean/σ still yield a finite draw.
+            assert!(
+                vals[i * 2 + 1].is_finite(),
+                "column 1 offspring should stay finite, got {}",
+                vals[i * 2 + 1]
+            );
         }
     }
 

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -336,11 +336,10 @@ where
             SeedPurpose::Mutation,
         );
         let normal_u = Normal::new(0.0_f32, sigma_u).expect("σ_u > 0");
-        let normal_v = Normal::new(0.0_f32, 1.0_f32).unwrap();
         let mut step = vec![0f32; pop * d];
         for v in &mut step {
             let u: f32 = normal_u.sample(&mut stream);
-            let w: f32 = normal_v.sample(&mut stream);
+            let w: f32 = crate::sampling::standard_normal(&mut stream);
             // `levy_step` guards the degenerate `w == 0` denominator (±∞/NaN
             // survive the bounds clamp and would poison the slot forever).
             *v = levy_step(u, w, params.beta);

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/arch_nas.rs
@@ -578,7 +578,7 @@ impl<B: Backend> ArchNasStrategy<B> {
     ///
     /// # Panics
     ///
-    /// Panics if `weight_init_std` is negative (degenerate normal).
+    /// Panics if `weight_init_std` is non-finite (`+∞` or `NaN`).
     #[must_use]
     pub fn init(
         &self,
@@ -599,8 +599,12 @@ impl<B: Backend> ArchNasStrategy<B> {
             .collect();
 
         let mut weight_rng = seed_stream(rng.next_u64(), 0, SeedPurpose::Init);
-        let normal = Normal::new(0.0f32, params.weight_init_std)
-            .expect("weight_init_std must be finite and non-negative");
+        let normal = Normal::new(0.0f32, params.weight_init_std).unwrap_or_else(|err| {
+            panic!(
+                "weight_init_std must be finite, got {}: {err}",
+                params.weight_init_std
+            )
+        });
         let mut data = vec![0.0f32; pop * max];
         for (i, &arch) in arch_ids.iter().enumerate() {
             let n = params.per_variant_params[arch];
@@ -637,8 +641,9 @@ impl<B: Backend> ArchNasStrategy<B> {
     ///
     /// # Panics
     ///
-    /// Panics if `weight_init_std` or `weight_mutation_std` is negative, or if
-    /// the resident weight tensor cannot be read back to the host as `f32`.
+    /// Panics if `weight_init_std` or `weight_mutation_std` is non-finite
+    /// (`+∞` or `NaN`), or if the resident weight tensor cannot be read back to
+    /// the host as `f32`.
     #[must_use]
     pub fn ask(
         &self,
@@ -666,10 +671,18 @@ impl<B: Backend> ArchNasStrategy<B> {
         let mut arch_rng = seed_stream(rng.next_u64(), gen_idx, SeedPurpose::Representative);
         let mut winit_rng = seed_stream(rng.next_u64(), gen_idx, SeedPurpose::Other);
 
-        let perturb = Normal::new(0.0f32, params.weight_mutation_std)
-            .expect("weight_mutation_std must be finite and non-negative");
-        let reinit = Normal::new(0.0f32, params.weight_init_std)
-            .expect("weight_init_std must be finite and non-negative");
+        let perturb = Normal::new(0.0f32, params.weight_mutation_std).unwrap_or_else(|err| {
+            panic!(
+                "weight_mutation_std must be finite, got {}: {err}",
+                params.weight_mutation_std
+            )
+        });
+        let reinit = Normal::new(0.0f32, params.weight_init_std).unwrap_or_else(|err| {
+            panic!(
+                "weight_init_std must be finite, got {}: {err}",
+                params.weight_init_std
+            )
+        });
 
         let resident: Vec<f32> = state
             .population

--- a/crates/rlevo-evolution/src/algorithms/neuroevolution/neat.rs
+++ b/crates/rlevo-evolution/src/algorithms/neuroevolution/neat.rs
@@ -202,7 +202,7 @@ impl<B: Backend> NeatStrategy<B> {
     ///
     /// # Panics
     ///
-    /// Panics if `weight_init_std` is negative (degenerate normal).
+    /// Panics if `weight_init_std` is non-finite (`+∞` or `NaN`).
     #[must_use]
     pub fn init(
         &self,
@@ -646,12 +646,21 @@ const ADD_CONNECTION_ATTEMPTS: usize = 20;
 ///
 /// # Panics
 ///
-/// Panics if `weight_perturb_std` or `weight_init_std` is negative.
+/// Panics if `weight_perturb_std` or `weight_init_std` is non-finite
+/// (`+∞` or `NaN`).
 fn mutate_weights(genome: &mut TopologyGenome, params: &NeatParams, rng: &mut StdRng) {
-    let perturb = Normal::new(0.0_f32, params.weight_perturb_std)
-        .expect("weight_perturb_std must be finite and non-negative");
-    let replace = Normal::new(0.0_f32, params.weight_init_std)
-        .expect("weight_init_std must be finite and non-negative");
+    let perturb = Normal::new(0.0_f32, params.weight_perturb_std).unwrap_or_else(|err| {
+        panic!(
+            "weight_perturb_std must be finite, got {}: {err}",
+            params.weight_perturb_std
+        )
+    });
+    let replace = Normal::new(0.0_f32, params.weight_init_std).unwrap_or_else(|err| {
+        panic!(
+            "weight_init_std must be finite, got {}: {err}",
+            params.weight_init_std
+        )
+    });
 
     for conn in &mut genome.connections {
         if rng.random::<f32>() < params.p_weight_replace {
@@ -678,15 +687,19 @@ fn mutate_weights(genome: &mut TopologyGenome, params: &NeatParams, rng: &mut St
 ///
 /// # Panics
 ///
-/// Panics if `weight_init_std` is negative.
+/// Panics if `weight_init_std` is non-finite (`+∞` or `NaN`).
 fn mutate_add_connection(
     genome: &mut TopologyGenome,
     params: &NeatParams,
     registry: &InnovationRegistry,
     rng: &mut StdRng,
 ) {
-    let init = Normal::new(0.0_f32, params.weight_init_std)
-        .expect("weight_init_std must be finite and non-negative");
+    let init = Normal::new(0.0_f32, params.weight_init_std).unwrap_or_else(|err| {
+        panic!(
+            "weight_init_std must be finite, got {}: {err}",
+            params.weight_init_std
+        )
+    });
 
     // Sources may be any non-output node; targets any non-input node.
     let sources: Vec<NodeId> = genome

--- a/crates/rlevo-evolution/src/lib.rs
+++ b/crates/rlevo-evolution/src/lib.rs
@@ -58,6 +58,7 @@ pub mod param_reshaper;
 pub mod population;
 pub mod probability_model;
 pub mod rng;
+pub(crate) mod sampling;
 pub mod shaping;
 pub mod strategy;
 

--- a/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
+++ b/crates/rlevo-evolution/src/local_search/simulated_annealing.rs
@@ -22,7 +22,6 @@
 
 use burn::tensor::backend::Backend;
 use rand::{Rng, RngExt};
-use rand_distr::{Distribution as _, Normal};
 
 use crate::fitness::FitnessFn;
 use crate::local_search::{BudgetedEval, LocalSearch, clamp_vec, sanitize_fitness};
@@ -312,18 +311,17 @@ impl SimulatedAnnealing {
             return (best, best_fit);
         }
 
-        // Unit Gaussian sampled through the passed rng (same path as the crate's
+        // Unit Gaussian sampled through the passed rng via
+        // `sampling::standard_normal` (the same path as the crate's
         // `gaussian_mutation`); scaled by `step_size` per coordinate to realise
         // an `N(0, step_size)` proposal step.
-        let normal: Normal<f32> = Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
-
         let mut temp: f32 = params.initial_temp;
 
         loop {
             // Propose: current walker + per-coordinate Gaussian noise.
             let mut candidate: Vec<f32> = current.clone();
             for x in &mut candidate {
-                *x += params.step_size * normal.sample(rng);
+                *x += params.step_size * crate::sampling::standard_normal(rng);
             }
             clamp_vec(&mut candidate, params.bounds);
 

--- a/crates/rlevo-evolution/src/neuroevolution/topology.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/topology.rs
@@ -233,7 +233,7 @@ impl TopologyGenome {
     ///
     /// # Panics
     ///
-    /// Panics if `weight_init_std` is negative (degenerate normal), or (in debug
+    /// Panics if `weight_init_std` is non-finite (`+∞` or `NaN`), or (in debug
     /// builds) if `registry`'s counters disagree with the seed sizes.
     #[must_use]
     pub fn minimal(
@@ -248,8 +248,9 @@ impl TopologyGenome {
                 && registry.next_innovation().get() >= (num_inputs * num_outputs) as u64,
             "registry counters must start after the minimal seed (H6)"
         );
-        let normal = Normal::new(0.0_f32, weight_init_std)
-            .expect("weight_init_std must be finite and non-negative");
+        let normal = Normal::new(0.0_f32, weight_init_std).unwrap_or_else(|err| {
+            panic!("weight_init_std must be finite, got {weight_init_std}: {err}")
+        });
 
         let mut nodes: Vec<NodeGene> = Vec::with_capacity(num_inputs + num_outputs);
         for i in 0..num_inputs {

--- a/crates/rlevo-evolution/src/ops/mutation.rs
+++ b/crates/rlevo-evolution/src/ops/mutation.rs
@@ -11,17 +11,15 @@
 
 use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
 use rand::{Rng, RngExt};
-use rand_distr::{Distribution as _, Normal};
 use rlevo_core::probability::Probability;
 use rlevo_core::rate::NonNegativeRate;
 
 /// Builds an `(n·d,)` host vector of `N(0, 1)` draws sized for a
 /// `(n, d)` tensor.
 fn standard_normal_rows(n: usize, d: usize, rng: &mut dyn Rng) -> Vec<f32> {
-    let normal = Normal::new(0.0f32, 1.0).expect("unit normal is well-defined");
     let mut rows = Vec::with_capacity(n * d);
     for _ in 0..n * d {
-        rows.push(normal.sample(rng));
+        rows.push(crate::sampling::standard_normal(rng));
     }
     rows
 }
@@ -34,8 +32,8 @@ fn standard_normal_rows(n: usize, d: usize, rng: &mut dyn Rng) -> Vec<f32> {
 /// equal to the input.
 ///
 /// The `n·d` standard-normal draws are taken from the caller-supplied host
-/// `rng` via [`rand_distr::Normal`] and loaded onto the device using
-/// [`Tensor::from_data`]; no backend-global RNG state is touched.
+/// `rng` via [`crate::sampling::standard_normal`] and loaded onto the device
+/// using [`Tensor::from_data`]; no backend-global RNG state is touched.
 ///
 /// The input tensor must have shape `(N, D)` where `N` is the population size
 /// and `D` is the genome length; the returned tensor has the same shape.

--- a/crates/rlevo-evolution/src/sampling.rs
+++ b/crates/rlevo-evolution/src/sampling.rs
@@ -1,0 +1,120 @@
+//! NaN-safe Gaussian sampling helpers shared across evolution operators.
+//!
+//! These draw from a caller-owned host RNG (typically produced by
+//! [`crate::rng::seed_stream`]); they never touch backend-global RNG state,
+//! preserving the crate's reproducibility convention.
+
+use rand::Rng;
+use rand_distr::{Distribution as _, Normal, StandardNormal};
+
+/// Draws one `N(0, 1)` sample from a caller-owned host `rng`.
+///
+/// Uses [`rand_distr::StandardNormal`], which has no fallible constructor — the
+/// unit normal is always well-defined, so there is no `expect`/`unwrap` and no
+/// panic path. The sample is drawn as `f64` and narrowed to `f32` to preserve
+/// tail precision, matching the RL crate's `standard_normal_tensor` convention.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "narrowing f64 -> f32 is the intended tail-precision convention"
+)]
+pub(crate) fn standard_normal<R: Rng + ?Sized>(rng: &mut R) -> f32 {
+    let x: f64 = StandardNormal.sample(rng);
+    x as f32
+}
+
+/// Draws one `N(mean, std)` sample, falling back to `mean` on a degenerate σ.
+///
+/// Guards against [`Normal::new`] failure by returning `mean` — the degenerate,
+/// zero-perturbation draw — instead of panicking. In `rand_distr` 0.6,
+/// [`Normal::new`] fails only when `std` is **non-finite** (`NaN` or `±∞`); a
+/// negative-but-finite `std` is accepted (it mirrors the distribution but still
+/// yields finite samples) and `std = 0.0` is accepted (every draw is exactly
+/// `mean`). A `NaN` `mean` passes through unchanged and is *not* laundered here;
+/// it is neutralized downstream by the ADR-0034 fitness-hygiene chokepoint.
+///
+/// An `rng` draw is consumed only on the `Ok` path: constructing the [`Normal`]
+/// distribution does not touch the `rng`, so the fallback leaves the stream
+/// position unchanged. This matches the previous
+/// `Normal::new(...).expect(...); .sample(rng)` behavior exactly on the success
+/// path.
+pub(crate) fn normal_or_mean<R: Rng + ?Sized>(mean: f32, std: f32, rng: &mut R) -> f32 {
+    match Normal::new(mean, std) {
+        Ok(d) => d.sample(rng),
+        Err(_) => mean,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    #[test]
+    fn standard_normal_is_finite() {
+        let mut rng: StdRng = StdRng::seed_from_u64(7);
+        for _ in 0..1_000 {
+            let x: f32 = standard_normal(&mut rng);
+            assert!(x.is_finite(), "standard_normal produced non-finite {x}");
+        }
+    }
+
+    #[test]
+    fn standard_normal_same_seed_is_deterministic() {
+        let mut a: StdRng = StdRng::seed_from_u64(42);
+        let mut b: StdRng = StdRng::seed_from_u64(42);
+        for _ in 0..64 {
+            let xa: f32 = standard_normal(&mut a);
+            let xb: f32 = standard_normal(&mut b);
+            assert_eq!(xa.to_bits(), xb.to_bits());
+        }
+    }
+
+    #[test]
+    fn standard_normal_different_seeds_differ() {
+        let mut a: StdRng = StdRng::seed_from_u64(1);
+        let mut b: StdRng = StdRng::seed_from_u64(2);
+        let seq_a: Vec<u32> = (0..16).map(|_| standard_normal(&mut a).to_bits()).collect();
+        let seq_b: Vec<u32> = (0..16).map(|_| standard_normal(&mut b).to_bits()).collect();
+        assert_ne!(seq_a, seq_b);
+    }
+
+    #[test]
+    fn normal_or_mean_falls_back_on_nonfinite_std() {
+        // `rand_distr::Normal::new` fails only for a non-finite `std`, so those
+        // are the cases that trigger the `mean` fallback.
+        let mean: f32 = 3.5;
+        for std in [f32::INFINITY, f32::NEG_INFINITY, f32::NAN] {
+            let mut rng: StdRng = StdRng::seed_from_u64(11);
+            let out: f32 = normal_or_mean(mean, std, &mut rng);
+            assert_eq!(
+                out.to_bits(),
+                mean.to_bits(),
+                "expected fallback to mean for std = {std}"
+            );
+        }
+    }
+
+    #[test]
+    fn normal_or_mean_zero_std_yields_exact_mean() {
+        // A zero variance is a valid (degenerate) distribution: every draw is
+        // exactly `mean`. It goes through the `Ok` path and consumes an rng draw.
+        let mean: f32 = -2.25;
+        let mut rng: StdRng = StdRng::seed_from_u64(17);
+        let out: f32 = normal_or_mean(mean, 0.0, &mut rng);
+        assert_eq!(out.to_bits(), mean.to_bits());
+    }
+
+    #[test]
+    fn normal_or_mean_samples_finite_for_finite_std() {
+        // Valid positive σ, plus a negative-but-finite σ (accepted by
+        // `rand_distr`, mirrors the distribution): both must yield finite draws.
+        let mut rng: StdRng = StdRng::seed_from_u64(13);
+        for _ in 0..1_000 {
+            let x: f32 = normal_or_mean(0.0, 1.0, &mut rng);
+            let y: f32 = normal_or_mean(0.0, -1.0, &mut rng);
+            assert!(x.is_finite(), "normal_or_mean produced non-finite {x}");
+            assert!(y.is_finite(), "normal_or_mean produced non-finite {y}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces panic-prone `Normal::new(mean, std).expect(...)` call sites across `rlevo-evolution` with a shared `sampling` module. Draws that use a *data-derived* σ (e.g. ACO-R's archive-based sigma) now fall back to the mean instead of panicking when σ is non-finite, so a single degenerate row can't abort an entire generation. Config-supplied σ sites (NEAT, arch-NAS, topology mutation) intentionally stay fail-fast per `docs/rules.md` §4, but their panic messages and `# Panics` docs are corrected to say what `rand_distr` 0.6 actually rejects: a non-finite σ, not a negative one.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #145

## What Was Changed

- Added `crates/rlevo-evolution/src/sampling.rs`: `standard_normal` (unit-normal draw via `rand_distr::StandardNormal`, no fallible constructor) and `normal_or_mean` (`Normal::new` with fallback to `mean` on a non-finite σ), both host-RNG-only per the crate's `seed_stream` convention.
- `algorithms/metaheuristic/aco_r.rs`: `ask` now calls `sampling::normal_or_mean` instead of `Normal::new(...).expect("sigma > 0")`, keeping generation alive when an archive-derived σ is non-finite; added `ask_recovers_from_infinite_sigma_via_mean_fallback` and `ask_passes_nan_mean_through_for_downstream_hygiene` tests exercising the guard through the real `ask` call site.
- `algorithms/cma_es.rs`, `cmsa_es.rs`, `ep.rs`, `es_classical.rs`, `local_search/simulated_annealing.rs`, `ops/mutation.rs`, `algorithms/metaheuristic/cuckoo.rs`: switched unit-normal draws to `sampling::standard_normal`.
- `algorithms/neuroevolution/arch_nas.rs`, `neat.rs`, `neuroevolution/topology.rs`: config-std sites stay fail-fast but now use `unwrap_or_else` with a message reporting the actual value and `rand_distr` error, and `# Panics` docs corrected from "negative" to "non-finite (`+∞` or `NaN`)" to match `rand_distr` 0.6's actual validation (a negative-but-finite σ is accepted).
- `lib.rs`: registers the new `sampling` module.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
cargo fmt --all --check
```

New tests in `sampling.rs` (`standard_normal_is_finite`, `standard_normal_same_seed_is_deterministic`, `standard_normal_different_seeds_differ`, `normal_or_mean_falls_back_on_nonfinite_std`, `normal_or_mean_zero_std_yields_exact_mean`, `normal_or_mean_samples_finite_for_finite_std`) and in `aco_r.rs` (`ask_recovers_from_infinite_sigma_via_mean_fallback`, `ask_passes_nan_mean_through_for_downstream_hygiene`) cover the regression: the old code panicked on a non-finite σ in `ask`, the new code doesn't.

- Rust toolchain: pinned via `rust-toolchain.toml`
- Burn backend tested: Flex (default)
- OS: macOS (Darwin)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Claude Opus 4.8). Scope: implementation of `sampling.rs`, call-site migrations, and regression tests, per the commit's `Co-Authored-By` trailer.

## Checklist

- [ ] `cargo build --workspace` passes with no errors.
- [ ] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [ ] This PR is marked **Ready for Review** (not Draft).

## Notes

`normal_or_mean` only consumes an RNG draw on the `Ok` path, so the non-finite fallback leaves the seeded stream position unchanged relative to the pre-fix behavior on the success path. A `NaN` mean is deliberately *not* laundered by the sampler — it passes through to the ADR-0034 fitness-hygiene chokepoint downstream, which is the intended place to neutralize it.

