### PR TITLE
fix(metaheuristic): axis-target squeeze for genome_dim=1 (#233)

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -254,7 +254,7 @@ where
         let diffs = (archive_l.expand([k, k, d]) - archive_e.expand([k, k, d])).abs();
         #[allow(clippy::cast_precision_loss)]
         let inv = params.xi / ((k - 1).max(1) as f32);
-        let sigma = diffs.sum_dim(0).squeeze::<2>().mul_scalar(inv); // (k, d)
+        let sigma = diffs.sum_dim(0).squeeze_dim::<2>(0).mul_scalar(inv); // (k, d)
 
         // Weighted index sampling (host-side) — `m · d` independent draws.
         let mut stream = seed_stream(
@@ -706,11 +706,7 @@ mod tests {
     }
 
     // Gap (d): the smallest archive (`archive_size = 2`, so the σ pairwise
-    // distance has exactly one term) drives a full run without panicking. The
-    // `genome_dim = 1` half of this gap is SKIPPED: the on-device σ reduction
-    // `diffs.sum_dim(0).squeeze::<2>()` collapses *two* singleton axes when
-    // `d == 1` and panics inside burn's `Squeeze` — a latent limitation of the
-    // production kernel, out of scope for a test-only change.
+    // distance has exactly one term) drives a full run without panicking.
     #[test]
     fn boundary_archive_size_two_runs() {
         let device: FlexDevice = Default::default();
@@ -730,6 +726,33 @@ mod tests {
                 .best_fitness_ever()
                 .is_finite(),
             "non-finite best for archive_size = 2"
+        );
+    }
+
+    // Gap (d'): the `genome_dim = 1` case (issue #233). The σ reduction
+    // `diffs.sum_dim(0).squeeze_dim::<2>(0)` now removes only the reduced axis,
+    // so the `(1, k, 1)` intermediate correctly collapses to `(k, 1)` instead of
+    // panicking inside burn's `Squeeze` rank-check. Runs a full harness to
+    // completion and asserts a finite best.
+    #[test]
+    fn boundary_genome_dim_one_runs() {
+        let device: FlexDevice = Default::default();
+        let strategy = AntColonyReal::<TestBackend>::new();
+        let params = AcoRConfig::default_for(8, 4, 1);
+        let fitness_fn = FromFitnessEvaluable::new(SphereFit, Sphere);
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            strategy, params, fitness_fn, 6, device, 6,
+        )
+        .expect("valid params");
+        harness.reset();
+        while !harness.step(()).done {}
+        assert!(
+            harness
+                .latest_metrics()
+                .unwrap()
+                .best_fitness_ever()
+                .is_finite(),
+            "non-finite best for genome_dim = 1"
         );
     }
 

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -236,7 +236,7 @@ impl<B: Backend> FireflyAlgorithm<B> {
         let xi = positions.clone().unsqueeze_dim::<3>(1); // (N, 1, D)
         let xj = positions.clone().unsqueeze_dim::<3>(0); // (1, N, D)
         let diff = xj.expand([pop, pop, d]) - xi.expand([pop, pop, d]); // (N, N, D)
-        let r2 = diff.clone().powi_scalar(2).sum_dim(2).squeeze::<2>(); // (N, N)
+        let r2 = diff.clone().powi_scalar(2).sum_dim(2).squeeze_dim::<2>(2); // (N, N)
         let beta = r2.mul_scalar(-gamma).exp().mul_scalar(beta0); // (N, N)
 
         // Brightness mask: bright[i, j] = 1 iff fitness[j] > fitness[i].
@@ -256,7 +256,7 @@ impl<B: Backend> FireflyAlgorithm<B> {
         let beta_m = beta.mask_where(bright_mask.bool_not(), zero);
         let weight = beta_m.unsqueeze_dim::<3>(2).expand([pop, pop, d]); // (N, N, D)
         let weighted = diff.mul(weight); // (N, N, D)
-        let attr_sum = weighted.sum_dim(1).squeeze::<2>(); // (N, D)
+        let attr_sum = weighted.sum_dim(1).squeeze_dim::<2>(1); // (N, D)
 
         // Noise: α · (U[0,1] - 0.5). Host-sample from the supplied seed so
         // the draw is reproducible across thread schedules rather than
@@ -600,6 +600,38 @@ mod tests {
         approx::assert_relative_eq!(d[3], 0.0, epsilon = 1e-6);
     }
 
+    // Gap (b') / issue #233: the `genome_dim = 1` (D == 1) pure-tensor path. The
+    // reductions `sum_dim(2).squeeze_dim::<2>(2)` and `sum_dim(1).squeeze_dim::<2>(1)`
+    // now strip only the reduced axis, so the trailing size-1 genome axis survives
+    // and the kernel no longer panics in burn's `Squeeze` rank-check. Firefly 0 is
+    // dimmer, so it is pulled toward the brighter firefly 1 along the single axis.
+    #[test]
+    fn pure_tensor_attract_d1_pulls_toward_brighter() {
+        let device = Default::default();
+        // 1-D positions: firefly 0 at [0.0], firefly 1 at [1.0].
+        let positions = Tensor::<TestBackend, 2>::from_data(
+            TensorData::new(vec![0.0_f32, 1.0], [2, 1]),
+            &device,
+        );
+        // firefly 1 is brighter (higher canonical fitness).
+        let fitness = [0.0_f32, 1.0];
+        let delta = FireflyAlgorithm::<TestBackend>::pure_tensor_attract(
+            &positions, &fitness, 1.0, // beta0
+            0.0, // gamma → attractiveness == beta0
+            0.0, // alpha → no noise
+            &device, 0,
+        );
+        assert_eq!(delta.dims(), [2, 1], "displacement is (pop, d)");
+        let d = delta
+            .into_data()
+            .into_vec::<f32>()
+            .expect("delta readable as f32");
+        // Firefly 0 moves +1·(x_1 − x_0) = +1 toward the brighter one.
+        approx::assert_relative_eq!(d[0], 1.0, epsilon = 1e-6);
+        // Brightest firefly has no brighter neighbour → no attraction.
+        approx::assert_relative_eq!(d[1], 0.0, epsilon = 1e-6);
+    }
+
     // Gap (c): `argmax_host` edge cases. Empty slice panics; an all-`NaN` slice
     // (nothing exceeds the `−∞` seed) falls back to index 0; a single element is
     // trivially the max.
@@ -708,5 +740,29 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() > 0, "expected a broken (NaN) member");
+    }
+
+    // Gap (b') cont. / issue #233: a full `genome_dim = 1` run drives the harness
+    // to completion without panicking and records a finite best.
+    #[test]
+    fn boundary_genome_dim_one_runs() {
+        let device = Default::default();
+        let strategy = FireflyAlgorithm::<TestBackend>::new();
+        let params = FireflyConfig::default_for(8, 1);
+        let fitness_fn = FromFitnessEvaluable::new(SphereFit, Sphere);
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            strategy, params, fitness_fn, 6, device, 6,
+        )
+        .expect("valid params");
+        harness.reset();
+        while !harness.step(()).done {}
+        assert!(
+            harness
+                .latest_metrics()
+                .unwrap()
+                .best_fitness_ever()
+                .is_finite(),
+            "non-finite best for genome_dim = 1"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a `genome_dim = 1` panic in the `aco_r` and `firefly` metaheuristics. Burn 0.21's `Tensor::squeeze::<2>()` strips **every** size-1 axis and then asserts the resulting rank equals 2; when `genome_dim = 1` the reduced tensor carries a second singleton axis, so the rank collapses below 2 and burn's `Squeeze` rank-check panics. The three affected reductions now use axis-targeted `squeeze_dim::<2>(reduced_axis)` matching the preceding `sum_dim`, so the 1-D genome column survives. Reduction math is unchanged for `d > 1`; no public-API impact.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #233

## What Was Changed

- `crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs`: L257 `sum_dim(0).squeeze::<2>()` → `sum_dim(0).squeeze_dim::<2>(0)`; rewrote the stale "genome_dim=1 SKIPPED" comment; added regression test `boundary_genome_dim_one_runs`.
- `crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs`: L239 `sum_dim(2).squeeze::<2>()` → `sum_dim(2).squeeze_dim::<2>(2)`; L259 `sum_dim(1).squeeze::<2>()` → `sum_dim(1).squeeze_dim::<2>(1)`; added regression tests `pure_tensor_attract_d1_pulls_toward_brighter` and `boundary_genome_dim_one_runs`.

## How It Was Tested

Regression tests fail on the previous code (panic in burn `Squeeze`) and pass on this PR. Full workspace suite green.

```
cargo build --workspace          # Finished, clean
cargo test --workspace           # all suites pass, 0 failed
cargo clippy --all-targets --all-features
```

- Rust toolchain: `stable 1.94.1` (pinned via rust-toolchain.toml)
- Burn backend tested: ndarray (Flex test backend)
- OS: macOS (darwin)

Note on clippy: the changed crate (`rlevo-evolution`) is clippy-clean. The workspace run surfaces a few **pre-existing** warnings outside this diff (`crates/rlevo/tests/recording_episode_count.rs`, `crates/rlevo-benchmarks-report-client/src/charts.rs`) — untouched by this PR and out of scope.

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: root-cause reconciliation against burn 0.21 `squeeze` semantics, the three `squeeze_dim` edits, and the three regression tests; reviewed and verified by the maintainer.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [ ] `cargo clippy --all-targets --all-features` passes with no warnings — changed crate is clean; only pre-existing warnings outside this diff remain (see note above).
- [x] Public API additions or changes include doc comments explaining *what* and *why* — N/A, no public API change.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

Localized kernel change; the reduction results are identical for `genome_dim > 1`. The `squeeze_dim(axis)` index must stay in sync with the preceding `sum_dim(axis)` — a mismatch would silently reshape the reduction rather than panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)