### PR TITLE
chore(benchmarks-report-client): clear clippy warnings

### DIFF
--- a/crates/rlevo-benchmarks-report-client/src/adapters/box2d.rs
+++ b/crates/rlevo-benchmarks-report-client/src/adapters/box2d.rs
@@ -1,4 +1,4 @@
-//! Box2D adapter (LunarLander, BipedalWalker, CarRacing).
+//! `Box2D` adapter (`LunarLander`, `BipedalWalker`, `CarRacing`).
 //!
 //! Consumes a [`FamilyPayload::Box2dBodies`] payload and renders each
 //! [`RigidBody2D`] as a transformed SVG `<polygon>`, with per-body

--- a/crates/rlevo-benchmarks-report-client/src/adapters/fallback.rs
+++ b/crates/rlevo-benchmarks-report-client/src/adapters/fallback.rs
@@ -1,7 +1,7 @@
 //! Fallback adapter for env families that lack a bespoke renderer.
 //!
 //! [`render`] is called by other adapters when a frame's [`FamilyPayload`]
-//! variant does not match what the adapter expects (e.g. a Box2D adapter
+//! variant does not match what the adapter expects (e.g. a `Box2D` adapter
 //! receiving a Classic payload).  It delegates to `frame_body`,
 //! which emits a styled ASCII projection when one is present and raw text
 //! otherwise, then appends a `<figcaption>` banner so users know they are

--- a/crates/rlevo-benchmarks-report-client/src/adapters/landscape.rs
+++ b/crates/rlevo-benchmarks-report-client/src/adapters/landscape.rs
@@ -3,7 +3,7 @@
 //! Consumes a [`FamilyPayload::Landscape2D`] payload and renders the
 //! search domain as a bounded SVG viewport with:
 //!
-//! - the search rectangle (bounds_x × bounds_y);
+//! - the search rectangle (`bounds_x` × `bounds_y`);
 //! - a trail polyline (most recent candidate positions, oldest first);
 //! - the current candidate as a filled circle (cyan + bold stroke);
 //! - the best-so-far as an open ring with a cross-hair (green) when
@@ -55,6 +55,9 @@ pub fn render(frame: &FrameRecord) -> AnyView {
 /// with cross-hair (when present), and the current candidate as a filled
 /// disk.  Returns an error paragraph if either axis of `bounds` has zero
 /// span.
+// Single paint-ordered SVG scene builder; grid-index→f32 casts for the heatmap
+// cells lose precision harmlessly at texture resolution.
+#[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
 fn view_with_payload(payload: &Landscape2DPayload) -> AnyView {
     let (xlo, xhi) = payload.bounds_x;
     let (ylo, yhi) = payload.bounds_y;
@@ -87,7 +90,7 @@ fn view_with_payload(payload: &Landscape2DPayload) -> AnyView {
         .join(" ");
 
     let (cx, cy) = xform(&payload.current);
-    let best_marker = payload.best.as_ref().map(|b| xform(b));
+    let best_marker = payload.best.as_ref().map(xform);
 
     let label = payload.label.clone();
     let label_display = label.clone();

--- a/crates/rlevo-benchmarks-report-client/src/adapters/locomotion.rs
+++ b/crates/rlevo-benchmarks-report-client/src/adapters/locomotion.rs
@@ -98,6 +98,9 @@ fn bounds(values: &[f32]) -> Option<(f32, f32)> {
 /// user units with a y-flip (physics-up → SVG-down).  Renders in paint order:
 /// ground line, bones, joints, contacts, centre-of-mass cross-hair.  Returns
 /// an error paragraph if the computed bounds are degenerate on either axis.
+// Single paint-ordered SVG scene builder; splitting the passes would only thread
+// the shared affine map through helpers.
+#[allow(clippy::too_many_lines)]
 fn view_with_payload(payload: &Locomotion2DPayload) -> AnyView {
     let (x_lo, x_hi, y_lo, y_hi) = payload_bounds(payload);
     let span_x = x_hi - x_lo;

--- a/crates/rlevo-benchmarks-report-client/src/app.rs
+++ b/crates/rlevo-benchmarks-report-client/src/app.rs
@@ -31,6 +31,9 @@ use crate::wire::{EnvFamily, EpisodeRecord, ObjectiveSense, RunManifest};
 /// mount_to_body(App);
 /// ```
 #[component]
+// The Leptos `#[component]` macro re-emits `App`, so a `#[must_use]` here is not
+// preserved on the generated fn; suppress the pedantic lint instead.
+#[allow(clippy::must_use_candidate)]
 pub fn App() -> impl IntoView {
     let manifest = read_manifest();
     let family: Option<EnvFamily> = manifest.as_ref().ok().map(|m| m.env_family);
@@ -289,6 +292,9 @@ fn episode_table(
 }
 
 /// Renders a single `<tr>` for one episode; adds the `selected` CSS class reactively.
+// Taken by value: the returned `impl IntoView` would otherwise capture a borrow
+// of `m` under the Rust 2024 `impl Trait` lifetime-capture rules.
+#[allow(clippy::needless_pass_by_value)]
 fn episode_row(
     m: EpisodeMeta,
     selected: ReadSignal<Option<String>>,

--- a/crates/rlevo-benchmarks-report-client/src/charts.rs
+++ b/crates/rlevo-benchmarks-report-client/src/charts.rs
@@ -9,8 +9,8 @@ use leptos::prelude::*;
 use rlevo_metrics_registry::{MetricKind, descriptor, is_per_generation, title_for};
 
 use crate::series::{
-    AxisMode, BandPoint, BoxStats, available_metric_names, distinct_seed_count, diversity_series,
-    downsample_minmax, ensure_svg_header, episode_axis, episode_length_series,
+    AxisMode, BandPoint, BoxStats, FitnessRangeSeries, available_metric_names, distinct_seed_count,
+    diversity_series, downsample_minmax, ensure_svg_header, episode_axis, episode_length_series,
     episode_reward_series, fitness_range_series, low_diversity_threshold, metric_band,
     metric_series, nearest_by_x, population_box_data, remap_episode_series, rolling_mean,
     selection_pressure_series,
@@ -40,14 +40,18 @@ const METRIC_WINDOW: usize = 20;
 /// for discrete x axes (episode / generation / step) and `false` for
 /// continuous ones (wall-clock seconds).
 #[must_use]
+// Straight-line SVG path builder + hover handler; extracting pieces would only
+// scatter the shared scale closures without improving readability. `sx_of`/`sy_of`
+// are the conventional scale-x/scale-y closures.
+#[allow(clippy::too_many_lines, clippy::similar_names)]
 pub fn interactive_line_view(
     title: String,
     x_title: &str,
     y_title: &str,
     x_as_int: bool,
     raw_full: Vec<(f64, f64)>,
-    decimated: Vec<(f64, f64)>,
-    smoothed: Option<Vec<(f64, f64)>>,
+    decimated: &[(f64, f64)],
+    smoothed: Option<&[(f64, f64)]>,
 ) -> AnyView {
     use std::fmt::Write as _;
     if decimated.is_empty() {
@@ -69,7 +73,7 @@ pub fn interactive_line_view(
     };
     let mut y_min = f64::INFINITY;
     let mut y_max = f64::NEG_INFINITY;
-    for &(_, y) in decimated.iter().chain(smoothed.iter().flatten()) {
+    for &(_, y) in decimated.iter().chain(smoothed.into_iter().flatten()) {
         if y.is_finite() {
             y_min = y_min.min(y);
             y_max = y_max.max(y);
@@ -100,12 +104,12 @@ pub fn interactive_line_view(
     let sy_of = move |y: f64| BOX_M_T + (1.0 - (y - y_min) / (y_max - y_min)) * plot_h;
 
     let mut raw_path = String::new();
-    for &(x, y) in &decimated {
+    for &(x, y) in decimated {
         if y.is_finite() {
             let _ = write!(raw_path, "{:.2},{:.2} ", sx_of(x), sy_of(y));
         }
     }
-    let smoothed_path = smoothed.as_ref().map(|s| {
+    let smoothed_path = smoothed.map(|s| {
         let mut p = String::new();
         for &(x, y) in s {
             if y.is_finite() {
@@ -146,7 +150,7 @@ pub fn interactive_line_view(
     let overlay = move || match hover.get() {
         Some((sx, sy, dx, dy)) => {
             // Clamp the label x so it stays inside the viewBox.
-            let label_x = sx.min(BOX_VB_W - 90.0).max(BOX_M_L);
+            let label_x = sx.clamp(BOX_M_L, BOX_VB_W - 90.0);
             let label = format!("{dx:.2}, {dy:.4}");
             view! {
                 <line class="rlevo-crosshair" x1={sx} y1={BOX_M_T} x2={sx} y2={PLOT_BOTTOM} />
@@ -248,7 +252,7 @@ pub fn convergence_panel_view(records: &[EpisodeRecord], _family: EnvFamily) -> 
             "step"
         };
         let panel = if is_per_generation(&name) {
-            interactive_line_view(title, x_title, &y_title, true, raw_full, dec_xy, None)
+            interactive_line_view(title, x_title, &y_title, true, raw_full, &dec_xy, None)
         } else {
             let smoothed: Vec<(f64, f64)> = rolling_mean(&decimated, METRIC_WINDOW)
                 .iter()
@@ -260,8 +264,8 @@ pub fn convergence_panel_view(records: &[EpisodeRecord], _family: EnvFamily) -> 
                 &y_title,
                 true,
                 raw_full,
-                dec_xy,
-                Some(smoothed),
+                &dec_xy,
+                Some(&smoothed),
             )
         };
         match descriptor(&name).map(|d| d.kind) {
@@ -325,8 +329,8 @@ fn episode_outcome_panels(records: &[EpisodeRecord], window: usize) -> AnyView {
                     "reward",
                     x_as_int,
                     reward_xy.clone(),
-                    reward_xy,
-                    Some(reward_sm),
+                    &reward_xy,
+                    Some(&reward_sm),
                 )}
                 {interactive_line_view(
                     format!("Episode length (x: {x_label})"),
@@ -334,8 +338,8 @@ fn episode_outcome_panels(records: &[EpisodeRecord], window: usize) -> AnyView {
                     "frames",
                     x_as_int,
                     length_xy.clone(),
-                    length_xy,
-                    Some(length_sm),
+                    &length_xy,
+                    Some(&length_sm),
                 )}
             </div>
         }
@@ -555,6 +559,8 @@ fn nice_ticks(min: f64, max: f64, target: usize) -> Vec<f64> {
     if !(min.is_finite() && max.is_finite()) || (max - min).abs() < f64::EPSILON {
         return vec![min];
     }
+    // Tick count → f64 for axis spacing; precision loss irrelevant at these sizes.
+    #[allow(clippy::cast_precision_loss)]
     let raw_step = (max - min) / target as f64;
     let mag = 10f64.powf(raw_step.abs().log10().floor());
     let norm = raw_step / mag;
@@ -770,7 +776,9 @@ fn export_panel_svg(ev: &leptos::ev::MouseEvent, filename: &str) {
 /// would alter all jitter positions and break screenshot stability.
 fn jitter_unit(i: u64) -> f64 {
     let h = i.wrapping_mul(0x9E37_79B9_7F4A_7C15);
-    // Top 53 bits → [0, 1), then map to [-1, 1).
+    // Top 53 bits → [0, 1), then map to [-1, 1). Both operands fit f64's mantissa
+    // exactly (numerator masked to 53 bits, denominator is 2^53), so no real loss.
+    #[allow(clippy::cast_precision_loss)]
     let unit = (h >> 11) as f64 / (1u64 << 53) as f64;
     unit.mul_add(2.0, -1.0)
 }
@@ -787,10 +795,10 @@ fn jitter_unit(i: u64) -> f64 {
 /// `overlays` is the `(best, median, worst)` triple returned by
 /// [`crate::series::fitness_range_series`].
 #[must_use]
-pub fn population_box_view(
-    stats: &[BoxStats],
-    overlays: (Vec<(u32, f64)>, Vec<(u32, f64)>, Vec<(u32, f64)>),
-) -> AnyView {
+// Single cohesive box-and-whisker SVG builder; splitting the tick/box/overlay
+// passes would only thread the shared scale closures through helpers.
+#[allow(clippy::too_many_lines)]
+pub fn population_box_view(stats: &[BoxStats], overlays: FitnessRangeSeries) -> AnyView {
     if stats.is_empty() {
         return view! {
             <figure class="rlevo-chart-card rlevo-chart-empty">
@@ -988,6 +996,8 @@ pub fn population_box_view(
 /// guideline the card border pulses and the title gains a ⚠ glyph — both
 /// colour-redundant so the alert survives a B/W screenshot.
 #[must_use]
+// `sx_of`/`sy_of` are the conventional scale-x/scale-y closures.
+#[allow(clippy::similar_names)]
 pub fn diversity_panel_view(diversity: &[(u32, f64)]) -> AnyView {
     use std::fmt::Write as _;
     if diversity.is_empty() {
@@ -1124,7 +1134,7 @@ pub fn population_panel_view(samples: &[PopulationSample], sense: ObjectiveSense
             "ratio",
             true,
             pressure_xy.clone(),
-            pressure_xy,
+            &pressure_xy,
             None,
         ));
     }

--- a/crates/rlevo-benchmarks-report-client/src/inline_data.rs
+++ b/crates/rlevo-benchmarks-report-client/src/inline_data.rs
@@ -201,9 +201,8 @@ pub fn read_episode_record(script_id: &str) -> Result<EpisodeRecord, InlineError
 pub fn read_all_episode_records() -> &'static Vec<EpisodeRecord> {
     static CACHE: OnceLock<Vec<EpisodeRecord>> = OnceLock::new();
     CACHE.get_or_init(|| {
-        let index = match read_episode_index() {
-            Ok(v) => v,
-            Err(_) => return Vec::new(),
+        let Ok(index) = read_episode_index() else {
+            return Vec::new();
         };
         index
             .iter()

--- a/crates/rlevo-benchmarks-report-client/src/lib.rs
+++ b/crates/rlevo-benchmarks-report-client/src/lib.rs
@@ -49,6 +49,12 @@ use wasm_bindgen::prelude::*;
 /// WASM entry point invoked once at module load via `wasm-bindgen`'s
 /// `start` attribute. Installs a panic hook so dev-tools see real
 /// stack traces, then mounts the Leptos app on `#rlevo-app`.
+///
+/// # Panics
+///
+/// Panics if the host page lacks a `#rlevo-app` element or it is not an
+/// `HtmlElement` — the report emitter always writes that mount div, so this
+/// indicates a malformed host page.
 #[wasm_bindgen(start)]
 pub fn main() {
     console_error_panic_hook::set_once();

--- a/crates/rlevo-benchmarks-report-client/src/playback.rs
+++ b/crates/rlevo-benchmarks-report-client/src/playback.rs
@@ -54,7 +54,7 @@ pub fn clamp_idx(requested: usize, frame_count: usize) -> usize {
 /// multiplier. Clamps to a floor so 10× doesn't burn the browser.
 #[must_use]
 pub fn play_interval_ms(speed: u32) -> u64 {
-    let s = speed.max(1) as u64;
+    let s = u64::from(speed.max(1));
     (PLAY_BASE_INTERVAL_MS / s).max(20)
 }
 
@@ -79,6 +79,16 @@ const SPEEDS: &[u32] = &[1, 2, 5, 10];
 /// auto-pauses rather than wrapping.
 ///
 /// Returns an error placeholder when `record.frames` is empty.
+///
+/// # Panics
+///
+/// Panics if the scrubber's `<input type="range">` event fires without a target
+/// element — an invariant guaranteed by the DOM, so this cannot happen in
+/// practice.
+#[must_use]
+// Single reactive-panel builder wiring signals, the play loop, and the scrubber;
+// splitting it would fragment the shared signal graph.
+#[allow(clippy::too_many_lines)]
 pub fn playback_panel(family: EnvFamily, record: EpisodeRecord) -> AnyView {
     let frame_count = record.frames.len();
 

--- a/crates/rlevo-benchmarks-report-client/src/series.rs
+++ b/crates/rlevo-benchmarks-report-client/src/series.rs
@@ -150,6 +150,9 @@ impl AxisMode {
 ///   `episode_wall_clock_secs` terminal metric. If no episode carries that
 ///   metric the axis would be all-zero, so it falls back to the episode index.
 #[must_use]
+// Episode/frame counts → f64 axis coordinates; precision loss is irrelevant at
+// realistic episode counts.
+#[allow(clippy::cast_precision_loss)]
 pub fn episode_axis(records: &[EpisodeRecord], mode: AxisMode) -> Vec<f64> {
     let n = records.len();
     match mode {
@@ -233,6 +236,9 @@ pub struct LandscapeField {
 /// bounds. Values are min/max-normalised across the grid so the ramp uses the
 /// full range regardless of the surface's absolute scale.
 #[must_use]
+// Grid indices → f64 sample coordinates and the normalised f64→f32 cell ramp;
+// both lose precision harmlessly at texture resolution.
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 pub fn landscape_field(
     label: &str,
     bounds_x: (f32, f32),
@@ -395,6 +401,9 @@ pub fn distinct_seed_count(records: &[EpisodeRecord]) -> usize {
 /// seed has data there). Steps are returned in ascending order. Non-finite
 /// values are ignored. Returns empty when no seed has a finite sample.
 #[must_use]
+// Seed count → f64 divisor for the cross-seed mean/variance; precision loss is
+// irrelevant at realistic seed counts.
+#[allow(clippy::cast_precision_loss)]
 pub fn metric_band(records: &[EpisodeRecord], name: &str) -> Vec<BandPoint> {
     use std::collections::BTreeMap;
     // step -> seed -> (sum, count) for averaging within a seed.
@@ -676,11 +685,15 @@ pub fn selection_pressure_series(
 /// [`ObjectiveSense::Maximize`] best is the largest value and worst the
 /// smallest; for [`ObjectiveSense::Minimize`] the ends swap. Callers pass
 /// the run's declared sense (treating `None` as `Maximize`).
+/// The `(best, median, worst)` per-generation fitness overlays returned by
+/// [`fitness_range_series`]; each element is a `(generation, value)` series.
+pub type FitnessRangeSeries = (Vec<(u32, f64)>, Vec<(u32, f64)>, Vec<(u32, f64)>);
+
 #[must_use]
 pub fn fitness_range_series(
     samples: &[PopulationSample],
     sense: ObjectiveSense,
-) -> (Vec<(u32, f64)>, Vec<(u32, f64)>, Vec<(u32, f64)>) {
+) -> FitnessRangeSeries {
     let mut best = Vec::new();
     let mut median = Vec::new();
     let mut worst = Vec::new();
@@ -710,6 +723,10 @@ pub fn fitness_range_series(
 
 #[cfg(test)]
 mod tests {
+    // Assertions compare against exact integer-valued fixtures (2.0, 3.0, …), so
+    // exact float equality is intentional here. Test-only index→f32 casts are
+    // likewise harmless.
+    #![allow(clippy::float_cmp, clippy::cast_precision_loss)]
     use super::*;
     use crate::wire::{
         EnvFamily, EpisodeKind, EpisodeRecordHeader, FORMAT_VERSION, FamilyPayload, FrameRecord,
@@ -1027,7 +1044,7 @@ mod tests {
         let div = vec![(0u32, 4.0), (1, 2.0), (2, 8.0)];
         let t = low_diversity_threshold(&div).unwrap();
         // sorted [2,4,8]; 5th pct interpolates near the low end.
-        assert!(t >= 2.0 && t < 4.0, "got {t}");
+        assert!((2.0..4.0).contains(&t), "got {t}");
     }
 
     #[test]

--- a/crates/rlevo-benchmarks-report-client/src/styled.rs
+++ b/crates/rlevo-benchmarks-report-client/src/styled.rs
@@ -68,15 +68,15 @@ fn styled_span_view(span: &StyledSpan) -> AnyView {
 #[must_use]
 pub fn span_classes(style: &SpanStyle) -> String {
     let mut parts: Vec<&'static str> = Vec::new();
-    if let Some(fg) = style.fg {
-        if let Some(c) = color_class(fg, true) {
-            parts.push(c);
-        }
+    if let Some(fg) = style.fg
+        && let Some(c) = color_class(fg, true)
+    {
+        parts.push(c);
     }
-    if let Some(bg) = style.bg {
-        if let Some(c) = color_class(bg, false) {
-            parts.push(c);
-        }
+    if let Some(bg) = style.bg
+        && let Some(c) = color_class(bg, false)
+    {
+        parts.push(c);
     }
     parts.extend(modifier_classes(style.modifier));
     parts.join(" ")
@@ -86,7 +86,7 @@ pub fn span_classes(style: &SpanStyle) -> String {
 /// `Reset` and `Indexed(_)` return `None` — the span renders unstyled.
 #[must_use]
 pub fn color_class(color: Color, foreground: bool) -> Option<&'static str> {
-    let table_fg = [
+    let foreground_classes = [
         // (Color, fg class)
         (Color::Black, "rlevo-fg-black"),
         (Color::Red, "rlevo-fg-red"),
@@ -105,7 +105,7 @@ pub fn color_class(color: Color, foreground: bool) -> Option<&'static str> {
         (Color::LightCyan, "rlevo-fg-lightcyan"),
         (Color::White, "rlevo-fg-white"),
     ];
-    let table_bg = [
+    let background_classes = [
         (Color::Black, "rlevo-bg-black"),
         (Color::Red, "rlevo-bg-red"),
         (Color::Green, "rlevo-bg-green"),
@@ -124,9 +124,9 @@ pub fn color_class(color: Color, foreground: bool) -> Option<&'static str> {
         (Color::White, "rlevo-bg-white"),
     ];
     let table = if foreground {
-        &table_fg[..]
+        &foreground_classes[..]
     } else {
-        &table_bg[..]
+        &background_classes[..]
     };
     table.iter().find(|(c, _)| *c == color).map(|(_, cls)| *cls)
 }

--- a/crates/rlevo-benchmarks-report-client/src/wire.rs
+++ b/crates/rlevo-benchmarks-report-client/src/wire.rs
@@ -109,7 +109,7 @@ impl Point2 {
     }
 }
 
-/// Semantic role of a [`RigidBody2D`] within a Box2D scene.
+/// Semantic role of a [`RigidBody2D`] within a `Box2D` scene.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum BodyKind {
@@ -129,7 +129,7 @@ pub enum BodyKind {
     Other,
 }
 
-/// Wire mirror of a single rigid body in a Box2D scene.
+/// Wire mirror of a single rigid body in a `Box2D` scene.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RigidBody2D {
     /// Local-frame polygon vertices, ordered for rendering.
@@ -159,7 +159,7 @@ pub struct Landscape2DPayload {
     pub label: String,
 }
 
-/// Per-frame snapshot for a Box2D physics environment.
+/// Per-frame snapshot for a `Box2D` physics environment.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Box2dPayload {
     /// Axis-aligned bounding box of the visible world, as `(min, max)`.
@@ -415,15 +415,15 @@ pub struct RunId(pub String);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum EnvFamily {
-    /// CartPole, MountainCar, Pendulum, Acrobot.
+    /// `CartPole`, `MountainCar`, Pendulum, Acrobot.
     Classic,
     /// Minigrid-style grid worlds (empty, four-rooms, door-key, …).
     Grids,
-    /// FrozenLake, CliffWalking, Taxi, Blackjack.
+    /// `FrozenLake`, `CliffWalking`, Taxi, Blackjack.
     ToyText,
-    /// LunarLander, BipedalWalker, CarRacing (Box2D physics).
+    /// `LunarLander`, `BipedalWalker`, `CarRacing` (`Box2D` physics).
     Box2d,
-    /// Ant, HalfCheetah, Hopper, Walker2D (MuJoCo / locomotion).
+    /// Ant, `HalfCheetah`, Hopper, `Walker2D` (`MuJoCo` / locomotion).
     Locomotion,
     /// Sphere, Ackley, Rastrigin (black-box optimisation landscapes).
     Landscapes,
@@ -440,9 +440,9 @@ pub enum FamilyPayload {
     Ascii,
     /// 2-D landscape-search snapshot (Sphere, Ackley, Rastrigin, …).
     Landscape2D(Landscape2DPayload),
-    /// Box2D rigid-body scene (LunarLander, BipedalWalker, …).
+    /// `Box2D` rigid-body scene (`LunarLander`, `BipedalWalker`, …).
     Box2dBodies(Box2dPayload),
-    /// Sagittal-plane locomotion skeleton (Ant, HalfCheetah, …).
+    /// Sagittal-plane locomotion skeleton (Ant, `HalfCheetah`, …).
     Locomotion2D(Locomotion2DPayload),
     /// Structured tile grid (empty, four-rooms, door-key, …). Added in
     /// `FORMAT_VERSION = 5`.


### PR DESCRIPTION
## Summary

Clears the 64 clippy warnings (79 with test-target duplicates) emitted by `rlevo-benchmarks-report-client` — the last crate in a workspace that otherwise treats clippy warnings as errors. Surfaced during #233 / PR #235, where the workspace-wide clippy checklist item could not be fully checked because of these pre-existing warnings. No production crate depends on the benchmark/viz layer (per `docs/rules.md`), so the blast radius is contained to this one crate; behavior is unchanged.

## Change Type

- [x] Other — a `chore`-labeled lint cleanup scoped to a single non-production crate, tracked by issue #236. No API behavior changes.

## Linked Issue

Closes #236

## What Was Changed

- **Mechanical (`cargo clippy --fix`)**: `doc_markdown` backticks across `wire.rs`, `adapters/box2d.rs`, `adapters/fallback.rs`; plus `collapsible_if`, `redundant_closure`, `manual_let_else` (`inline_data.rs`), `cast_lossless`.
- **`series.rs`**: module-level `#![allow(clippy::float_cmp, clippy::cast_precision_loss)]` in the test module (exact integer-valued fixtures / test-only casts); scoped `#[allow(clippy::cast_precision_loss)]` on `episode_axis`, `metric_band`, and `landscape_field` (+ `cast_possible_truncation`) for chart-coordinate casts; extracted the `(best, median, worst)` return triple into a `pub type FitnessRangeSeries`.
- **`charts.rs`**: `interactive_line_view` now borrows `decimated: &[(f64,f64)]` / `smoothed: Option<&[(f64,f64)]>` (5 call sites updated); `manual_clamp` → `.clamp()`; scoped casts on `nice_ticks` / `jitter_unit`; `too_many_lines` / `similar_names` allowed on the cohesive SVG builders; consumes `FitnessRangeSeries`.
- **`app.rs`**: `episode_row` kept by-value with a scoped `#[allow(clippy::needless_pass_by_value)]` (see Notes); `must_use_candidate` allowed on the `#[component] App` fn.
- **`playback.rs`, `lib.rs`**: added `# Panics` doc sections; `too_many_lines` allowed on `playback_panel`.
- **`styled.rs`**: renamed `table_fg` / `table_bg` → `foreground_classes` / `background_classes`.
- No explicit `let x: Type = …` annotations were stripped (project rule).

## How It Was Tested

```
cargo build --workspace          # clean from scratch
cargo test --workspace           # 56 test binaries, 0 failures
cargo clippy -p rlevo-benchmarks-report-client --all-targets --all-features   # warning-free
cargo clippy --all-targets --all-features
cargo fmt --all --check          # clean
just test-report-smoke           # record_then_report_round_trips ... ok
```

- Rust toolchain: `stable 1.94.1`
- Burn backend tested: ndarray / wgpu (default features)
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: applied the `cargo clippy --fix` mechanical pass and authored the hand-fixes (scoped allows with rationale, the `&[..]` borrow refactor, the `FitnessRangeSeries` alias, `# Panics` docs). All changes reviewed and verified by the author.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. _(N/A — lint cleanup, no behavior change.)_
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- `episode_row` in `app.rs` is intentionally left taking `EpisodeMeta` by value with a scoped `#[allow(clippy::needless_pass_by_value)]`: switching to `&EpisodeMeta` makes the returned `impl IntoView` capture the borrow under the Rust 2024 `impl Trait` lifetime-capture rules, which does not compile.
- Out of scope: the other pre-existing workspace warning in `crates/rlevo/tests/recording_episode_count.rs` — file separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
