### PR TITLE
test(evolution): fill #147 EDA/GEP/EA test-coverage gaps

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/cma_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cma_es.rs
@@ -1157,4 +1157,132 @@ mod tests {
         assert!(told1.cov().iter().all(|v| v.is_finite()), "cov finite");
         assert!(told1.sigma().is_finite(), "sigma finite");
     }
+
+    /// Issue #147 §7.2: a full adaptive `tell` must leave `C` symmetric and
+    /// positive-definite. The rank-1 / rank-μ update accumulates the two
+    /// triangle entries in the identical order, so symmetry is bit-exact; PD is
+    /// checked via a symmetric eigendecomposition (all eigenvalues strictly
+    /// positive), which is exactly the property `ask`'s `√Λ` sampling and
+    /// `tell`'s `C^{-1/2}` conditioning rely on.
+    #[test]
+    fn tell_keeps_covariance_symmetric_and_positive_definite() {
+        let strategy = CmaEs::<Flex>::new();
+        let params = CmaEsConfig::with_pop_size(6, 3);
+        let d: usize = params.genome_dim;
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(0x5EED_C0DE);
+
+        let state = strategy.init(&params, &mut rng, &device);
+        let (population, asked) = strategy.ask(&params, &state, &mut rng, &device);
+        let fitness = Tensor::<Flex, 1>::from_data(
+            TensorData::new(vec![6.0f32, 5.0, 4.0, 3.0, 2.0, 1.0], [6]),
+            &device,
+        );
+        let (told, _metrics) = strategy.tell(&params, population, fitness, asked, &mut rng);
+
+        let cov: &[f32] = told.cov();
+        // Symmetric (bit-exact by construction).
+        for i in 0..d {
+            for j in 0..d {
+                assert_eq!(
+                    cov[i * d + j].to_bits(),
+                    cov[j * d + i].to_bits(),
+                    "asymmetry at ({i}, {j})"
+                );
+            }
+        }
+        // Positive-definite: every eigenvalue strictly positive.
+        let eig: SymEigen = jacobi_eigen(cov, d);
+        assert!(
+            eig.values.iter().all(|&l| l > 0.0),
+            "covariance not positive-definite: eigenvalues {:?}",
+            eig.values
+        );
+        // Diagonal (the variances) is strictly positive too.
+        for i in 0..d {
+            assert!(cov[i * d + i] > 0.0, "non-positive variance at {i}");
+        }
+    }
+
+    /// Issue #147 §7.2 best-tracking: `best()` is `None` before any `tell`, and
+    /// `Some((genome, fitness))` after — reporting the highest-fitness offspring
+    /// (canonical maximise) with the correct `(1, D)` genome shape.
+    #[test]
+    fn best_is_none_before_tell_and_some_after() {
+        let strategy = CmaEs::<Flex>::new();
+        let params = CmaEsConfig::with_pop_size(6, 2);
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(0xB357_7E57);
+
+        let state = strategy.init(&params, &mut rng, &device);
+        assert!(
+            strategy.best(&state).is_none(),
+            "best must be None before the first tell"
+        );
+
+        let (population, asked) = strategy.ask(&params, &state, &mut rng, &device);
+        let fitness = Tensor::<Flex, 1>::from_data(
+            TensorData::new(vec![6.0f32, 5.0, 4.0, 3.0, 2.0, 1.0], [6]),
+            &device,
+        );
+        let (told, _metrics) = strategy.tell(&params, population, fitness, asked, &mut rng);
+
+        let best = strategy.best(&told).expect("best is Some after a tell");
+        let (genome, fit): (Tensor<Flex, 2>, f32) = best;
+        approx::assert_relative_eq!(fit, 6.0, epsilon = 1e-6);
+        assert_eq!(genome.dims(), [1, 2]);
+    }
+
+    /// Issue #147 §7.2 eigenvalue-floor clamp: a degenerate (exactly zero)
+    /// eigenvalue is floored to the relative floor `λ_max · CONDITION_FLOOR`,
+    /// strictly above zero, so `√Λ` and `1/√Λ` both stay finite. Without the
+    /// floor the `1/√Λ` used in `tell`'s `C^{-1/2}` would diverge to `+∞`.
+    #[test]
+    fn eigenvalue_floor_clamps_degenerate_eigenvalue() {
+        // λ_max = 1, one exactly-zero eigenvalue.
+        let eigvals: Vec<f32> = vec![1.0, 0.0];
+        let floor: f32 = eigenvalue_floor(&eigvals);
+        // Relative floor dominates the absolute backstop: 1·1e-14 > 1e-20.
+        assert_eq!(floor.to_bits(), CONDITION_FLOOR.to_bits());
+        assert!(floor > EIGENVALUE_FLOOR);
+
+        // The zero eigenvalue is lifted strictly above zero.
+        let clamped: f32 = eigvals[1].max(floor);
+        assert!(clamped > 0.0, "floored eigenvalue must be positive");
+        assert!(clamped.sqrt().is_finite(), "√Λ must be finite");
+        assert!((1.0 / clamped.sqrt()).is_finite(), "1/√Λ must be finite");
+
+        // Contrast: the un-floored zero eigenvalue would diverge under 1/√Λ.
+        assert!(
+            !(1.0f32 / eigvals[1].sqrt()).is_finite(),
+            "un-floored 1/√0 must diverge — proves the floor is load-bearing"
+        );
+    }
+
+    /// Issue #147 §7.2: `update_best` on an empty population is a no-op — it
+    /// short-circuits before touching the population tensor, leaving best-so-far
+    /// tracking untouched (no panic, no spurious best).
+    #[test]
+    fn update_best_empty_population_is_noop() {
+        let strategy = CmaEs::<Flex>::new();
+        let params = CmaEsConfig::with_pop_size(6, 2);
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(0x0E11_0E11);
+
+        let mut state = strategy.init(&params, &mut rng, &device);
+        // Any population tensor; the empty fitness slice short-circuits before it
+        // is read.
+        let pop = Tensor::<Flex, 2>::from_data(TensorData::new(vec![0.0f32, 0.0], [1, 2]), &device);
+        update_best(&mut state, &pop, &[]);
+
+        assert!(
+            state.best_genome().is_none(),
+            "empty population must not set a best genome"
+        );
+        assert_eq!(
+            state.best_fitness().to_bits(),
+            f32::NEG_INFINITY.to_bits(),
+            "empty population must not move best fitness off its sentinel"
+        );
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
+++ b/crates/rlevo-evolution/src/algorithms/cmsa_es.rs
@@ -485,6 +485,11 @@ where
                 cov_new[i * d + j] = (1.0 - blend) * c_old[i * d + j] + blend * rankmu;
             }
         }
+        // Defensive float-drift hygiene (pycma-style): the Beyer & Sendhoff
+        // (2008, PPSN X) rank-μ blend is symmetric by construction, so this
+        // re-symmetrization is a no-op today; it guards the solver's symmetry
+        // assumption against a future edit that reorders the accumulation.
+        symmetrize(&mut cov_new, d);
 
         update_best(&mut state, &population, &fitness_host);
 
@@ -867,5 +872,83 @@ mod tests {
             (cfg.tau - es_classical_tau).abs() > 0.1,
             "canonical CMSA τ must differ from es_classical τ"
         );
+    }
+
+    /// Issue #147 §7.2 determinism: two runs from the same seed produce
+    /// bit-identical trajectories. CMSA-ES host-samples off a `StdRng` threaded
+    /// through `init`/`ask` (which key their `seed_stream`s on `rng.next_u64()`
+    /// and the generation counter), so an identical seed and identical call
+    /// sequence must reproduce the mean, covariance, and σ̄ exactly.
+    #[test]
+    fn same_seed_yields_identical_trajectories() {
+        fn run() -> (Vec<f32>, Vec<f32>, f32) {
+            let strategy = CmsaEs::<Flex>::new();
+            let params = CmsaEsConfig::with_pop_size(8, 3);
+            let device = Default::default();
+            let mut rng = StdRng::seed_from_u64(0xD37E_2711);
+            let mut state = strategy.init(&params, &mut rng, &device);
+            for _ in 0..4 {
+                let (population, asked) = strategy.ask(&params, &state, &mut rng, &device);
+                let fitness = Tensor::<Flex, 1>::from_data(
+                    TensorData::new(vec![8.0f32, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0], [8]),
+                    &device,
+                );
+                let (told, _metrics) = strategy.tell(&params, population, fitness, asked, &mut rng);
+                state = told;
+            }
+            (state.mean().to_vec(), state.cov().to_vec(), state.sigma())
+        }
+
+        let (mean_a, cov_a, sigma_a): (Vec<f32>, Vec<f32>, f32) = run();
+        let (mean_b, cov_b, sigma_b): (Vec<f32>, Vec<f32>, f32) = run();
+        assert_eq!(
+            mean_a, mean_b,
+            "mean trajectory diverged under a fixed seed"
+        );
+        assert_eq!(
+            cov_a, cov_b,
+            "covariance trajectory diverged under a fixed seed"
+        );
+        assert_eq!(
+            sigma_a.to_bits(),
+            sigma_b.to_bits(),
+            "σ̄ trajectory diverged under a fixed seed"
+        );
+    }
+
+    /// Issue #147 §7.2/§7.3 regression: the rank-μ covariance blend must keep `C`
+    /// bit-exactly symmetric across several generations. Guards the explicit
+    /// `symmetrize` at the blend chokepoint (defensive float-drift hygiene per
+    /// Beyer & Sendhoff 2008) against a future edit that reorders the outer-
+    /// product accumulation and breaks the commutativity assumption.
+    #[test]
+    fn covariance_stays_symmetric_across_generations() {
+        let strategy = CmsaEs::<Flex>::new();
+        let params = CmsaEsConfig::with_pop_size(8, 3);
+        let d: usize = params.genome_dim;
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(0x5A11_9E77);
+
+        let mut state = strategy.init(&params, &mut rng, &device);
+        for generation in 0..5 {
+            let (population, asked) = strategy.ask(&params, &state, &mut rng, &device);
+            let fitness = Tensor::<Flex, 1>::from_data(
+                TensorData::new(vec![8.0f32, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0], [8]),
+                &device,
+            );
+            let (told, _metrics) = strategy.tell(&params, population, fitness, asked, &mut rng);
+
+            let cov: &[f32] = told.cov();
+            for i in 0..d {
+                for j in 0..d {
+                    assert_eq!(
+                        cov[i * d + j].to_bits(),
+                        cov[j * d + i].to_bits(),
+                        "asymmetry at ({i}, {j}) in generation {generation}"
+                    );
+                }
+            }
+            state = told;
+        }
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/de.rs
+++ b/crates/rlevo-evolution/src/algorithms/de.rs
@@ -586,6 +586,139 @@ mod tests {
         assert_eq!(cfg.validate().unwrap_err().field, "pop_size");
     }
 
+    /// [`DifferentialEvolution::sample_distinct_excluding`] must return
+    /// exactly `k` indices that are pairwise distinct, all in `0..pop_size`,
+    /// and all different from `self_idx`. Swept over every valid
+    /// `(pop_size, k, self_idx)` triple for a handful of draws each so the
+    /// rejection loop is exercised broadly (`de` §7, operator property).
+    #[test]
+    fn sample_distinct_excluding_yields_valid_indices() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let mut rng = StdRng::seed_from_u64(20_240_607);
+        for pop_size in [4usize, 5, 8, 20] {
+            // `k` never exceeds the largest per-variant index count (5, Rand2Bin)
+            // and must stay strictly below `pop_size`.
+            for k in 1..pop_size.min(6) {
+                for self_idx in 0..pop_size {
+                    for _ in 0..25 {
+                        let chosen: Vec<usize> =
+                            DifferentialEvolution::<TestBackend>::sample_distinct_excluding(
+                                self_idx, pop_size, k, &mut rng,
+                            );
+                        assert_eq!(chosen.len(), k, "must return exactly k indices");
+                        for (a, &x) in chosen.iter().enumerate() {
+                            assert!(x < pop_size, "index {x} out of range for pop {pop_size}");
+                            assert_ne!(x, self_idx, "index must differ from self_idx");
+                            for &y in &chosen[a + 1..] {
+                                assert_ne!(x, y, "indices must be pairwise distinct");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The rejection loop cannot make progress when `pop_size <= k` (there are
+    /// not enough candidates outside `self_idx`); the documented `assert`
+    /// guards that with a panic rather than spinning forever (`de` §7).
+    #[test]
+    #[should_panic(expected = "pop_size must exceed")]
+    fn sample_distinct_excluding_panics_when_pop_too_small() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let mut rng = StdRng::seed_from_u64(1);
+        // k == pop_size: impossible to draw k distinct indices excluding self.
+        let _ = DifferentialEvolution::<TestBackend>::sample_distinct_excluding(0, 3, 3, &mut rng);
+    }
+
+    /// Every gene of a generated trial vector stays inside `params.bounds`
+    /// after the mutation + crossover + clamp pipeline (`de` §7, bounds
+    /// handling). Drives the strategy one full ask/tell/ask cycle so the
+    /// second `ask` returns genuine trial vectors rather than the initial
+    /// population.
+    #[test]
+    fn trial_genes_stay_within_bounds() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = DifferentialEvolution::<TestBackend>::new();
+        let mut params = DeConfig::default_for(12, 4);
+        params.variant = DeVariant::Rand1Bin;
+        let (lo, hi): (f32, f32) = params.bounds.into();
+
+        let mut rng = StdRng::seed_from_u64(4242);
+        let state = strategy.init(&params, &mut rng, &device);
+        // First ask returns the initial population unchanged; a tell populates
+        // the fitness cache so the next ask produces trial vectors.
+        let (pop0, s) = strategy.ask(&params, &state, &mut rng, &device);
+        let n = pop0.dims()[0];
+        let fitness =
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vec![0.0_f32; n], [n]), &device);
+        let (s, _) = strategy.tell(&params, pop0, fitness, s, &mut rng);
+        let (trial, _) = strategy.ask(&params, &s, &mut rng, &device);
+        let genes: Vec<f32> = trial
+            .into_data()
+            .into_vec::<f32>()
+            .expect("trial host-read of a tensor this test just built");
+        for g in genes {
+            assert!(
+                g.is_finite() && g >= lo && g <= hi,
+                "trial gene {g} left [{lo}, {hi}]"
+            );
+        }
+    }
+
+    /// Sphere landscape that returns `NaN` for half the domain. Exercises the
+    /// fitness-hygiene chokepoint (ADR 0034): a `NaN` fitness must never become
+    /// the reported best nor poison a population slot ("zombie slot").
+    struct NanSphere;
+    struct NanSphereFit;
+    impl FitnessEvaluable for NanSphereFit {
+        type Individual = Vec<f64>;
+        type Landscape = NanSphere;
+        fn evaluate(&self, x: &Self::Individual, _: &Self::Landscape) -> f64 {
+            let s: f64 = x.iter().map(|v| v * v).sum();
+            if x[0] > 0.0 { f64::NAN } else { s }
+        }
+    }
+
+    /// A fitness function that yields `NaN` for many genomes must not crash the
+    /// run and must never report a `NaN` (or otherwise non-finite) best. The
+    /// harness sanitizes `NaN → −∞` at the driver chokepoint, so the poisoned
+    /// slots can never out-rank a finite individual or block replacement
+    /// (`de` §7, NaN regression).
+    #[test]
+    fn nan_fitness_never_becomes_best() {
+        let device = Default::default();
+        let params = DeConfig::default_for(30, 4);
+        let fitness_fn = FromFitnessEvaluable::new(NanSphereFit, NanSphere);
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            DifferentialEvolution::<TestBackend>::new(),
+            params,
+            fitness_fn,
+            99,
+            device,
+            40,
+        )
+        .expect("valid params");
+        harness.reset();
+        loop {
+            if harness.step(()).done {
+                break;
+            }
+        }
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
+        assert!(
+            best.is_finite(),
+            "NaN fitness poisoned best_fitness_ever: {best}"
+        );
+    }
+
     struct Sphere;
     struct SphereFit;
     impl FitnessEvaluable for SphereFit {

--- a/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
@@ -914,4 +914,62 @@ mod tests {
             "s=0 must be floored to keep CPT interior, got {v}"
         );
     }
+
+    #[test]
+    fn cpt_sizes_and_parents_sorted_unique_over_random_fits() {
+        // §7.3: over many seeded random fits, every node's CPT must have exactly
+        // 2^|parents| cells and its parent list must be strictly ascending (hence
+        // sorted and duplicate-free). These are structural invariants of `fit`.
+        let p = BayesianNetworkParams::default_for(4);
+        let d = 4;
+        let n = 16;
+        let mut rng = StdRng::seed_from_u64(2024);
+        for _ in 0..30 {
+            let rows: Vec<f32> = (0..n * d)
+                .map(|_| if rng.random::<f32>() < 0.5 { 0.0 } else { 1.0 })
+                .collect();
+            let state = refit(&p, rows, n, d);
+            for v in 0..d {
+                assert_eq!(
+                    state.cpt[v].len(),
+                    1 << state.parents[v].len(),
+                    "cpt[{v}] must have 2^|parents| cells, parents = {:?}",
+                    state.parents[v]
+                );
+                for w in state.parents[v].windows(2) {
+                    assert!(
+                        w[0] < w[1],
+                        "parents[{v}] must be strictly ascending (sorted & unique), got {:?}",
+                        state.parents[v]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn single_gene_is_edgeless() {
+        // §7.2: genome_dim == 1 has no candidate edges; the single gene must be
+        // parentless with a one-cell CPT, regardless of the data.
+        let p = BayesianNetworkParams::default_for(1);
+        let state = refit(&p, vec![0.0, 1.0, 1.0, 0.0], 4, 1);
+        assert_eq!(state.order, vec![0], "single-gene order is natural");
+        assert!(state.parents[0].is_empty(), "single gene must be edgeless");
+        assert_eq!(state.cpt[0].len(), 1, "single-gene CPT is one cell");
+    }
+
+    #[test]
+    fn single_individual_population_yields_prior_shape() {
+        // §7.2: n == 1. With one row the BIC complexity penalty ½·ln(1)·2^q is 0
+        // and every config's likelihood term is 0, so no edge yields positive
+        // gain: the learned structure is edgeless and prior-shaped (natural
+        // order, empty parent lists, single-cell CPTs).
+        let p = BayesianNetworkParams::default_for(3);
+        let state = refit(&p, vec![1.0, 0.0, 1.0], 1, 3);
+        assert_eq!(state.order, vec![0, 1, 2], "order must be natural");
+        for v in 0..3 {
+            assert!(state.parents[v].is_empty(), "node {v} must be edgeless");
+            assert_eq!(state.cpt[v].len(), 1, "node {v} CPT must be one cell");
+        }
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
@@ -416,4 +416,128 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn sample_respects_probabilities() {
+        // §7.2: the empirical per-bit frequency of a large sample must match the
+        // Bernoulli probabilities used to draw it.
+        let device = Default::default();
+        let prob: Vec<f32> = vec![0.1, 0.5, 0.9];
+        let d = prob.len();
+        let state = CompactGeneticState { prob: prob.clone() };
+        let mut rng = StdRng::seed_from_u64(42);
+        let n = 20_000_usize;
+        let samples = <CompactGenetic as ProbabilityModel<TestBackend>>::sample(
+            &CompactGenetic,
+            &state,
+            n,
+            &mut rng,
+            &device,
+        );
+        let data = samples
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built");
+        // n = 20_000 is far below f32's 2^24 exact-integer limit; the cast is
+        // lossless.
+        #[allow(clippy::cast_precision_loss)]
+        let nf = n as f32;
+        for j in 0..d {
+            let mut sum = 0.0_f32;
+            for i in 0..n {
+                sum += data[i * d + j];
+            }
+            let freq = sum / nf;
+            approx::assert_abs_diff_eq!(freq, prob[j], epsilon = 0.02);
+        }
+    }
+
+    #[test]
+    fn zero_population_with_prev_returns_prev_unchanged() {
+        // §7.1: a 0×0 selected population carries no genes to compete; the update
+        // loop never runs, so the previous probabilities pass through untouched.
+        let device = Default::default();
+        let p = CompactGeneticParams::default_for(3);
+        let prev = CompactGeneticState {
+            prob: vec![0.25, 0.5, 0.75],
+        };
+        let state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            &p,
+            Some(&prev),
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        );
+        assert_eq!(
+            state.prob, prev.prob,
+            "zero population must leave probabilities unchanged"
+        );
+    }
+
+    #[test]
+    fn fit_uses_population_dims_not_params_genome_dim() {
+        // §7.1: on the fit path `params.genome_dim` is unused — the population's
+        // column count and `prev.prob` length are authoritative. A mismatched
+        // genome_dim does not change the output length (dimension-mismatch
+        // contract: population dims win).
+        let device = Default::default();
+        let p = CompactGeneticParams {
+            genome_dim: 9,
+            virtual_pop_size: 10,
+        };
+        let prev = CompactGeneticState {
+            prob: vec![0.5, 0.5],
+        };
+        let state = <CompactGenetic as ProbabilityModel<TestBackend>>::fit(
+            &CompactGenetic,
+            &p,
+            Some(&prev),
+            pop(vec![1.0, 0.0, 0.0, 1.0], 2, 2),
+            fitness(vec![1.0, 0.0]),
+            &device,
+        );
+        assert_eq!(
+            state.prob.len(),
+            2,
+            "output length follows the population/prev, not params.genome_dim"
+        );
+    }
+
+    #[test]
+    fn sample_is_deterministic_for_seed_and_state() {
+        // §7.4: same seed + same state ⇒ byte-identical sample tensor.
+        let device = Default::default();
+        let state = CompactGeneticState {
+            prob: vec![0.3, 0.6, 0.9],
+        };
+        let mut rng_a = StdRng::seed_from_u64(77);
+        let mut rng_b = StdRng::seed_from_u64(77);
+        let a = <CompactGenetic as ProbabilityModel<TestBackend>>::sample(
+            &CompactGenetic,
+            &state,
+            256,
+            &mut rng_a,
+            &device,
+        );
+        let b = <CompactGenetic as ProbabilityModel<TestBackend>>::sample(
+            &CompactGenetic,
+            &state,
+            256,
+            &mut rng_b,
+            &device,
+        );
+        let data_a = a
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built");
+        let data_b = b
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built");
+        assert_eq!(
+            data_a, data_b,
+            "same seed + state must produce identical output"
+        );
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
@@ -628,4 +628,71 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn single_dimension_sample_stays_finite() {
+        // §7.1: genome_dim == 1. The chain is a single root node (no links);
+        // sampling must draw finite marginal Gaussian values.
+        let p = DependencyChainParams::default_for(1);
+        let state = refit(&p, vec![1.0, 2.0, 3.0, 4.0], 4, 1);
+        assert_eq!(state.chain, vec![0], "single-dim chain is the root only");
+        let device = Default::default();
+        let mut rng = StdRng::seed_from_u64(3);
+        let samples = <DependencyChain as ProbabilityModel<TestBackend>>::sample(
+            &DependencyChain,
+            &state,
+            256,
+            &mut rng,
+            &device,
+        );
+        for v in samples
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built")
+        {
+            assert!(v.is_finite(), "single-dim sample must be finite, got {v}");
+        }
+    }
+
+    #[test]
+    fn sample_is_deterministic_for_seed_and_state() {
+        // §7.1: same seed + same fitted state ⇒ byte-identical sample tensor.
+        let p = DependencyChainParams::default_for(3);
+        let rows = vec![
+            -2.0, 1.0, 0.5, //
+            -1.0, 2.0, -0.5, //
+            0.0, 0.0, 1.0, //
+            1.0, -1.0, -1.0, //
+        ];
+        let state = refit(&p, rows, 4, 3);
+        let device = Default::default();
+        let mut rng_a = StdRng::seed_from_u64(555);
+        let mut rng_b = StdRng::seed_from_u64(555);
+        let a = <DependencyChain as ProbabilityModel<TestBackend>>::sample(
+            &DependencyChain,
+            &state,
+            300,
+            &mut rng_a,
+            &device,
+        );
+        let b = <DependencyChain as ProbabilityModel<TestBackend>>::sample(
+            &DependencyChain,
+            &state,
+            300,
+            &mut rng_b,
+            &device,
+        );
+        let data_a = a
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built");
+        let data_b = b
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built");
+        assert_eq!(
+            data_a, data_b,
+            "same seed + state must produce identical output"
+        );
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_bernoulli.rs
@@ -428,4 +428,40 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn probabilities_stay_within_bounds_across_generations() {
+        // §7.2: the PBIL update interpolates `prob*(1-lr) + lr*gene` with
+        // `gene ∈ {0, 1}` and `prob ∈ [min_prob, max_prob]`, so every generation
+        // keeps each probability inside the bounds. Drive many seeded
+        // fit/update generations over random binary populations and assert the
+        // invariant holds throughout.
+        let device = Default::default();
+        let p = UnivariateBernoulliParams::default_for(6);
+        let (min_prob, max_prob) = (0.0_f32, 1.0_f32);
+        let (k, d) = (8_usize, 6_usize);
+        let mut state = fit_prior(&p);
+        let mut rng = StdRng::seed_from_u64(4242);
+        for _ in 0..40 {
+            let rows: Vec<f32> = (0..k * d)
+                .map(|_| if rng.random::<f32>() < 0.5 { 0.0 } else { 1.0 })
+                .collect();
+            let fit_vals: Vec<f32> = (0..k).map(|_| rng.random::<f32>()).collect();
+            state = <UnivariateBernoulli as ProbabilityModel<TestBackend>>::fit(
+                &UnivariateBernoulli,
+                &p,
+                Some(&state),
+                pop(rows, k, d),
+                fitness(fit_vals),
+                &device,
+            );
+            for &pj in &state.prob {
+                assert!(pj.is_finite(), "prob must stay finite, got {pj}");
+                assert!(
+                    (min_prob..=max_prob).contains(&pj),
+                    "prob {pj} escaped [{min_prob}, {max_prob}]"
+                );
+            }
+        }
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
@@ -488,4 +488,107 @@ mod tests {
         assert!(state.mean[0].is_finite(), "mean must be finite");
         approx::assert_relative_eq!(state.mean[0], p.init_mean, epsilon = 1e-12);
     }
+
+    #[test]
+    fn single_row_variance_floored() {
+        // §7.1: k == 1. Each column's only deviation is from its own value, so
+        // the MLE variance is exactly 0 and must floor to min_variance, while the
+        // mean equals the single row.
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let p = UnivariateGaussianParams::default_for(2);
+        let prior = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            None,
+            pop(vec![], 0, 0),
+            fitness(vec![]),
+            &device,
+        );
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            Some(&prior),
+            pop(vec![5.0, -3.0], 1, 2),
+            fitness(vec![0.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.mean[0], 5.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(state.mean[1], -3.0, epsilon = 1e-6);
+        for v in &state.variance {
+            approx::assert_relative_eq!(*v, p.min_variance, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    fn seeded_sampling_variance_matches_state() {
+        // §7.1: the empirical variance of a large seeded sample must match the
+        // per-dimension variance stored in the state (the mean case is covered by
+        // `seeded_sampling_mean_matches_state`).
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let state = UnivariateGaussianState {
+            mean: vec![3.0, -1.0],
+            variance: vec![1.0, 0.25],
+        };
+        let mut rng = StdRng::seed_from_u64(321);
+        let n = 20_000_usize;
+        let samples = <UnivariateGaussian as ProbabilityModel<TestBackend>>::sample(
+            &model, &state, n, &mut rng, &device,
+        );
+        let data = samples
+            .into_data()
+            .into_vec::<f32>()
+            .expect("samples host-read of a tensor this test just built");
+        // n = 20_000 fits f64 exactly; the cast is lossless.
+        #[allow(clippy::cast_precision_loss)]
+        let nf = n as f64;
+        for j in 0..2 {
+            let mut sum = 0.0_f64;
+            for i in 0..n {
+                sum += f64::from(data[i * 2 + j]);
+            }
+            let mean = sum / nf;
+            let mut var = 0.0_f64;
+            for i in 0..n {
+                let diff = f64::from(data[i * 2 + j]) - mean;
+                var += diff * diff;
+            }
+            var /= nf;
+            // Empirical variance narrowed to f32 for comparison against the state.
+            #[allow(clippy::cast_possible_truncation)]
+            let var_f32 = var as f32;
+            approx::assert_abs_diff_eq!(var_f32, state.variance()[j], epsilon = 0.05);
+        }
+    }
+
+    #[test]
+    fn refit_overwrites_prev_state() {
+        // §7.1: UMDA is a full refit — `fit` recomputes the MLE from the current
+        // population and never blends with the prior state. A wildly different
+        // `prev` must not leak into the result.
+        let device = Default::default();
+        let model = UnivariateGaussian;
+        let p = UnivariateGaussianParams::default_for(1);
+        let prev = UnivariateGaussianState {
+            mean: vec![100.0],
+            variance: vec![50.0],
+        };
+        // Column [0, 2, 4] → mean 2, var (4+0+4)/3 = 8/3.
+        let state = <UnivariateGaussian as ProbabilityModel<TestBackend>>::fit(
+            &model,
+            &p,
+            Some(&prev),
+            pop(vec![0.0, 2.0, 4.0], 3, 1),
+            fitness(vec![0.0, 1.0, 2.0]),
+            &device,
+        );
+        approx::assert_relative_eq!(state.mean[0], 2.0, epsilon = 1e-5);
+        approx::assert_relative_eq!(state.variance[0], 8.0 / 3.0, epsilon = 1e-5);
+        // No blend with the prior's mean 100 / variance 50.
+        assert!(
+            (state.mean[0] - 100.0).abs() > 50.0,
+            "refit must overwrite, not blend with prev mean"
+        );
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -493,6 +493,183 @@ mod tests {
         assert_eq!(cfg.validate().unwrap_err().field, "tournament_q");
     }
 
+    /// `μ = 0` is the degenerate empty population; the config guard must reject
+    /// it (`config::at_least("mu", .., 1)`) so no zero-row parent tensor ever
+    /// reaches `init` (`ep` §7, edge case).
+    #[test]
+    fn rejects_zero_mu() {
+        let cfg = EpConfig::default_for(0, 10);
+        assert_eq!(cfg.validate().unwrap_err().field, "mu");
+    }
+
+    /// `μ = 1` is the smallest population the config accepts; it must validate
+    /// and drive without panicking through several generations (`ep` §7, edge
+    /// case — smallest degenerate μ is handled, not rejected).
+    #[test]
+    fn mu_one_is_handled() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = EvolutionaryProgramming::<TestBackend>::new();
+        let mut params = EpConfig::default_for(1, 3);
+        // q-tournament needs `q <= 2·μ`; with μ = 1 the ceiling is 2.
+        params.tournament_q = 2;
+        assert!(params.validate().is_ok(), "μ = 1 config must validate");
+
+        let mut rng = StdRng::seed_from_u64(3);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        for _ in 0..10 {
+            let (offspring, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let fitness = neg_sphere(&offspring);
+            let (advanced, _) = strategy.tell(&params, offspring, fitness, next, &mut rng);
+            state = advanced;
+        }
+        assert_eq!(
+            state.parents.dims()[0],
+            1,
+            "μ = 1 must keep a single parent"
+        );
+    }
+
+    /// Canonical (maximise) fitness `−Σ xᵢ²` read straight off a genome tensor,
+    /// so tests can drive a strategy directly without the harness.
+    fn neg_sphere(pop: &Tensor<TestBackend, 2>) -> Tensor<TestBackend, 1> {
+        let device = pop.device();
+        let [n, d] = pop.dims();
+        let rows: Vec<f32> = pop
+            .clone()
+            .into_data()
+            .into_vec::<f32>()
+            .expect("population host-read of a tensor this test just built");
+        #[allow(clippy::needless_range_loop)]
+        let fit: Vec<f32> = (0..n)
+            .map(|i| -(0..d).map(|j| rows[i * d + j].powi(2)).sum::<f32>())
+            .collect();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(fit, [n]), &device)
+    }
+
+    /// Drives EP for `gens` generations from a fixed seed, returning the
+    /// per-generation `best_fitness_ever` trajectory.
+    fn run_ep_trajectory(seed: u64, gens: usize) -> Vec<f32> {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = EvolutionaryProgramming::<TestBackend>::new();
+        let params = EpConfig::default_for(8, 3);
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        let mut traj = Vec::with_capacity(gens);
+        for _ in 0..gens {
+            let (offspring, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let fitness = neg_sphere(&offspring);
+            let (advanced, m) = strategy.tell(&params, offspring, fitness, next, &mut rng);
+            traj.push(m.best_fitness_ever());
+            state = advanced;
+        }
+        traj
+    }
+
+    /// Same seed → identical trajectory. Every stochastic draw is host-sampled
+    /// through `seed_stream`, so two runs keyed on the same outer seed must be
+    /// bit-identical (`ep` §7, reproducibility). Both runs execute sequentially
+    /// inside one test body so no sibling test can perturb them.
+    #[test]
+    fn same_seed_reproduces_trajectory() {
+        let a = run_ep_trajectory(2024, 30);
+        let b = run_ep_trajectory(2024, 30);
+        assert_eq!(a, b, "EP trajectory diverged under identical seed");
+    }
+
+    /// The genome reported by [`Strategy::best`] must be the population row that
+    /// actually achieved the reported best fitness (`ep` §7, `best_genome`
+    /// invariant). A strictly increasing fitness makes the argmax the unique
+    /// last row, so the expected genome is unambiguous.
+    #[test]
+    fn best_genome_matches_best_fitness() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = EvolutionaryProgramming::<TestBackend>::new();
+        let params = EpConfig::default_for(6, 3);
+        let mut rng = StdRng::seed_from_u64(5);
+        let state = strategy.init(&params, &mut rng, &device);
+        // First ask returns the initial parents; the first tell initializes
+        // best_genome/best_fitness from their evaluation.
+        let (parents0, s) = strategy.ask(&params, &state, &mut rng, &device);
+        let [n, d] = parents0.dims();
+        #[allow(clippy::cast_precision_loss)]
+        let fit_vec: Vec<f32> = (0..n).map(|i| i as f32).collect();
+        let expected_idx = n - 1;
+        let expected_fit = fit_vec[expected_idx];
+        let parent_rows: Vec<f32> = parents0
+            .clone()
+            .into_data()
+            .into_vec::<f32>()
+            .expect("parent host-read of a tensor this test just built");
+        let expected_genome: Vec<f32> =
+            parent_rows[expected_idx * d..(expected_idx + 1) * d].to_vec();
+
+        let fitness = Tensor::<TestBackend, 1>::from_data(TensorData::new(fit_vec, [n]), &device);
+        let (s, _) = strategy.tell(&params, parents0, fitness, s, &mut rng);
+
+        let (genome, best_fit) = strategy.best(&s).expect("best after first tell");
+        approx::assert_relative_eq!(best_fit, expected_fit);
+        let got: Vec<f32> = genome
+            .into_data()
+            .into_vec::<f32>()
+            .expect("best-genome host-read of a tensor this test just built");
+        for (g, e) in got.iter().zip(expected_genome.iter()) {
+            approx::assert_relative_eq!(*g, *e);
+        }
+    }
+
+    /// Sphere landscape returning `NaN` for half the domain (see the DE mirror).
+    struct NanSphere;
+    struct NanSphereFit;
+    impl FitnessEvaluable for NanSphereFit {
+        type Individual = Vec<f64>;
+        type Landscape = NanSphere;
+        fn evaluate(&self, x: &Self::Individual, _: &Self::Landscape) -> f64 {
+            let s: f64 = x.iter().map(|v| v * v).sum();
+            if x[0] > 0.0 { f64::NAN } else { s }
+        }
+    }
+
+    /// A `NaN`-producing fitness must not crash EP nor become the reported best.
+    /// The harness sanitizes `NaN → −∞` before the pool ever reaches
+    /// q-tournament selection, so a poisoned member always loses its bouts and
+    /// the tiebreak `sanitize_fitness` keeps it out of the survivor set
+    /// (`ep` §7, NaN regression).
+    #[test]
+    fn nan_fitness_never_becomes_best() {
+        let device = Default::default();
+        let params = EpConfig::default_for(20, 4);
+        let fitness_fn = FromFitnessEvaluable::new(NanSphereFit, NanSphere);
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            EvolutionaryProgramming::<TestBackend>::new(),
+            params,
+            fitness_fn,
+            77,
+            device,
+            40,
+        )
+        .expect("valid params");
+        harness.reset();
+        loop {
+            if harness.step(()).done {
+                break;
+            }
+        }
+        let best = harness.latest_metrics().unwrap().best_fitness_ever();
+        assert!(
+            best.is_finite(),
+            "NaN fitness poisoned best_fitness_ever: {best}"
+        );
+    }
+
     /// `genome_dim == 0` makes `tau = 1/sqrt(2·sqrt(0)) = +∞`; the config guard
     /// must reject it at construction (ADR 0026) so the non-finite τ never
     /// reaches the first `ask` (issue #132, `ep` §1.2).

--- a/crates/rlevo-evolution/src/algorithms/es_classical.rs
+++ b/crates/rlevo-evolution/src/algorithms/es_classical.rs
@@ -809,6 +809,104 @@ mod tests {
         }
     }
 
+    /// Both the plain argmax and the truncation selector used by ES survivor
+    /// selection must return valid, in-range, pairwise-distinct indices even
+    /// when the fitness slice carries `NaN` values (fitness-hygiene: a `NaN`
+    /// ranks as worst and never as a survivor). Guards against an
+    /// out-of-bounds gather in `tell` (`es_classical` §7.2, valid index).
+    #[test]
+    fn selection_returns_in_range_indices() {
+        let fitness = [1.0_f32, f32::NAN, 5.0, 2.0, -3.0, f32::NAN];
+        let n = fitness.len();
+
+        let amax = argmax_host(&fitness);
+        assert!(amax < n, "argmax index {amax} out of range for len {n}");
+
+        for mu in 1..=4 {
+            let idx = crate::ops::selection::truncation_indices_host(&fitness, mu);
+            assert_eq!(idx.len(), mu, "truncation must return exactly mu indices");
+            for (a, &x) in idx.iter().enumerate() {
+                assert!(
+                    usize::try_from(x).is_ok_and(|xi| xi < n),
+                    "truncation index {x} out of range for len {n}"
+                );
+                for &y in &idx[a + 1..] {
+                    assert_ne!(x, y, "truncation indices must be pairwise distinct");
+                }
+            }
+        }
+    }
+
+    /// Canonical (maximise) fitness `−Σ xᵢ²` read straight off a genome tensor,
+    /// so tests can drive a strategy directly without the harness.
+    fn neg_sphere(pop: &Tensor<TestBackend, 2>) -> Tensor<TestBackend, 1> {
+        let device = pop.device();
+        let [n, d] = pop.dims();
+        let rows: Vec<f32> = pop
+            .clone()
+            .into_data()
+            .into_vec::<f32>()
+            .expect("population host-read of a tensor this test just built");
+        #[allow(clippy::needless_range_loop)]
+        let fit: Vec<f32> = (0..n)
+            .map(|i| -(0..d).map(|j| rows[i * d + j].powi(2)).sum::<f32>())
+            .collect();
+        Tensor::<TestBackend, 1>::from_data(TensorData::new(fit, [n]), &device)
+    }
+
+    /// Drives an ES variant directly for `gens` generations against the
+    /// canonical maximise `−sphere`, returning the `best_fitness_ever`
+    /// trajectory reported by each `tell`.
+    fn run_es_best_ever(kind: EsKind, dim: usize, gens: usize, seed: u64) -> Vec<f32> {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = EvolutionStrategy::<TestBackend>::new();
+        let params = EsConfig::default_for(kind, dim);
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut state = strategy.init(&params, &mut rng, &device);
+        let mut traj = Vec::with_capacity(gens);
+        for _ in 0..gens {
+            let (offspring, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let fitness = neg_sphere(&offspring);
+            let (advanced, m) = strategy.tell(&params, offspring, fitness, next, &mut rng);
+            traj.push(m.best_fitness_ever());
+            state = advanced;
+        }
+        traj
+    }
+
+    /// `best_fitness_ever` is a rolling maximum in canonical space, so on a
+    /// maximise problem it must never decrease from one generation to the next
+    /// across every ES variant (`es_classical` §7.2, monotone best-ever). This
+    /// pins the invariant that the algorithm threads the rolling best through
+    /// `tell` and never resets it — including the `(μ,λ)` variant that discards
+    /// its parent pool each generation.
+    #[test]
+    fn best_fitness_ever_is_monotonic_on_maximize() {
+        for kind in [
+            EsKind::OnePlusOne,
+            EsKind::OnePlusLambda { lambda: 6 },
+            EsKind::MuPlusLambda { mu: 3, lambda: 8 },
+            EsKind::MuCommaLambda { mu: 3, lambda: 8 },
+        ] {
+            let traj = run_es_best_ever(kind, 3, 40, 17);
+            for w in traj.windows(2) {
+                assert!(
+                    w[1] >= w[0],
+                    "best_fitness_ever decreased for {kind:?}: {} -> {}",
+                    w[0],
+                    w[1]
+                );
+            }
+            assert!(
+                traj.last().copied().unwrap().is_finite(),
+                "rolling best must stay finite for {kind:?}"
+            );
+        }
+    }
+
     struct Sphere;
     struct SphereFit;
     impl FitnessEvaluable for SphereFit {

--- a/crates/rlevo-evolution/src/algorithms/ga.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga.rs
@@ -522,4 +522,54 @@ mod tests {
             m.best_fitness_ever()
         );
     }
+
+    /// §7.2 monotone-`best_fitness_ever` property: the rolling best fitness a
+    /// caller reads from [`StrategyMetrics::best_fitness_ever`] must never
+    /// decrease across generations. Driven on a *maximise* objective (so the
+    /// user-space value is the canonical value unflipped), the elitist GA can
+    /// only ever raise or hold the rolling best. (Determinism is covered in
+    /// `tests/determinism.rs` — not duplicated here.)
+    #[test]
+    fn best_fitness_ever_is_monotone_nondecreasing() {
+        use rlevo_core::objective::ObjectiveSense;
+
+        let device = Default::default();
+        let strategy = GeneticAlgorithm::<TestBackend>::new();
+        let params = GaConfig {
+            pop_size: 32,
+            genome_dim: 3,
+            bounds: Bounds::new(-5.0, 5.0),
+            mutation_sigma: NonNegativeRate::new(0.3),
+            selection: GaSelection::Tournament { size: 2 },
+            crossover: GaCrossover::BlxAlpha {
+                alpha: NonNegativeRate::new(0.5),
+            },
+            replacement: GaReplacement::Elitist { elitism_k: 1 },
+        };
+        // Maximise sum-of-squares: the objective sense is irrelevant to the
+        // property (monotonicity, not convergence), but a maximise sense makes
+        // the reported user-space value equal the canonical rolling best.
+        let fitness_fn =
+            FromFitnessEvaluable::with_sense(SphereFit, Sphere, ObjectiveSense::Maximize);
+
+        let mut harness = EvolutionaryHarness::<TestBackend, _, _>::new(
+            strategy, params, fitness_fn, 123, device, 40,
+        )
+        .expect("valid params");
+        harness.reset();
+
+        let mut prev: f32 = f32::NEG_INFINITY;
+        loop {
+            let step = harness.step(());
+            let cur: f32 = harness.latest_metrics().unwrap().best_fitness_ever();
+            assert!(
+                cur >= prev,
+                "best_fitness_ever must be non-decreasing: {cur} >= {prev}"
+            );
+            prev = cur;
+            if step.done {
+                break;
+            }
+        }
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/ga_binary.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga_binary.rs
@@ -490,4 +490,111 @@ mod tests {
         let optimum = dim as f32;
         approx::assert_relative_eq!(best, optimum, epsilon = 1e-6);
     }
+
+    /// Runs one `ask` pipeline over a *uniform* population (every parent is the
+    /// same constant bit) and returns the flat offspring bits. With every
+    /// parent identical, uniform crossover is a no-op (both parents agree at
+    /// every gene), so the only source of variation is bit-flip mutation — the
+    /// offspring is therefore a pure function of `mutation_rate`, RNG-invariant.
+    fn ask_over_uniform_population(rate: f32, bit: i32) -> Vec<i32> {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let (pop, dim) = (4usize, 8usize);
+        let mut params = BinaryGaConfig::default_for(pop, dim);
+        params.mutation_rate = Probability::new(rate);
+        let strategy = BinaryGeneticAlgorithm::<TestBackend>::new();
+
+        let population = Tensor::<TestBackend, 2, Int>::from_data(
+            TensorData::new(vec![bit; pop * dim], [pop, dim]),
+            &device,
+        );
+        // Non-empty `fitness` drives the real selection→crossover→mutation path
+        // (an empty cache would short-circuit to returning the seed population).
+        let state = BinaryGaState {
+            population,
+            fitness: vec![1.0; pop],
+            best_genome: None,
+            best_fitness: f32::NEG_INFINITY,
+            generation: 1,
+        };
+        let mut rng = StdRng::seed_from_u64(0);
+        let (offspring, _) = strategy.ask(&params, &state, &mut rng, &device);
+        offspring
+            .into_data()
+            .into_vec::<i32>()
+            .expect("offspring host-read of a tensor this test just built")
+    }
+
+    /// `mutation_rate == 0.0` performs no bit flips: over a uniform all-zero
+    /// population (where crossover is a no-op) the offspring must be all zeros,
+    /// i.e. a subset of the parents' bit values.
+    #[test]
+    fn mutation_rate_zero_flips_no_bits() {
+        let bits = ask_over_uniform_population(0.0, 0);
+        assert!(
+            bits.iter().all(|&b| b == 0),
+            "rate 0.0 must leave every offspring bit at the parent value, got {bits:?}"
+        );
+    }
+
+    /// `mutation_rate == 1.0` flips every bit deterministically: an all-zero
+    /// uniform population becomes all ones after mutation.
+    #[test]
+    fn mutation_rate_one_flips_every_bit() {
+        let bits = ask_over_uniform_population(1.0, 0);
+        assert!(
+            bits.iter().all(|&b| b == 1),
+            "rate 1.0 must flip every 0→1, got {bits:?}"
+        );
+    }
+
+    /// Elitism boundary `elitism_k == pop_size - 1`: all but one slot are the
+    /// top parents, leaving exactly one offspring slot. The `pop_size − 1`
+    /// fittest parents survive (in descending-fitness order) followed by the
+    /// single best offspring, and the champion tracks the best offspring.
+    #[test]
+    fn elitism_k_equals_pop_minus_one_keeps_top_parents_and_one_offspring() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let (pop, dim) = (4usize, 4usize);
+        let mut params = BinaryGaConfig::default_for(pop, dim);
+        params.elitism_k = pop - 1; // boundary: one offspring slot.
+        let strategy = BinaryGeneticAlgorithm::<TestBackend>::new();
+
+        // Four distinct parents with strictly increasing fitness.
+        let parent_pop = Tensor::<TestBackend, 2, Int>::from_data(
+            TensorData::new(vec![0i32; pop * dim], [pop, dim]),
+            &device,
+        );
+        let state = BinaryGaState {
+            population: parent_pop,
+            fitness: vec![1.0, 2.0, 3.0, 4.0],
+            best_genome: None,
+            best_fitness: 4.0,
+            generation: 1,
+        };
+
+        // Offspring: only row 0 beats every parent; the rest are worst.
+        let offspring = Tensor::<TestBackend, 2, Int>::from_data(
+            TensorData::new(vec![1i32; pop * dim], [pop, dim]),
+            &device,
+        );
+        let off_fitness = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![10.0f32, 0.0, 0.0, 0.0], [pop]),
+            &device,
+        );
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let (next, m) = strategy.tell(&params, offspring, off_fitness, state, &mut rng);
+
+        // Top `pop-1` parents (fitness 4,3,2 in descending order) then the best
+        // offspring (fitness 10).
+        assert_eq!(next.population.dims(), [pop, dim]);
+        assert_eq!(next.fitness, vec![4.0, 3.0, 2.0, 10.0]);
+        approx::assert_relative_eq!(m.best_fitness_ever(), 10.0, epsilon = 1e-6);
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/alphabet.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/alphabet.rs
@@ -218,9 +218,37 @@ impl<F: FunctionSet> Alphabet<F> {
 mod tests {
     use super::*;
     use crate::function_set::ArithmeticFunctionSet;
+    use crate::rng::{SeedPurpose, seed_stream};
 
     fn alphabet(n_vars: usize, constants: Vec<f32>) -> Alphabet<ArithmeticFunctionSet> {
         Alphabet::new(ArithmeticFunctionSet, n_vars, constants)
+    }
+
+    /// A deliberately ill-formed function set: an arity-0 opcode (id 0) precedes
+    /// an arity-2 opcode (id 1), violating the "zero-arity functions trailing"
+    /// layout precondition that keeps [`Alphabet::terminal_range`] contiguous.
+    #[derive(Debug)]
+    struct BadLayoutFunctionSet;
+
+    impl FunctionSet for BadLayoutFunctionSet {
+        fn num_functions(&self) -> usize {
+            2
+        }
+
+        fn arity(&self, symbol: Symbol) -> usize {
+            match symbol.value() {
+                1 => 2,
+                _ => 0,
+            }
+        }
+
+        fn max_arity(&self) -> usize {
+            2
+        }
+
+        fn apply(&self, _symbol: Symbol, _args: &[f32]) -> f32 {
+            0.0
+        }
     }
 
     #[test]
@@ -289,5 +317,67 @@ mod tests {
             a.classify(Symbol::from_raw(999)),
             SymbolKind::Function { arity: 0 }
         );
+    }
+
+    /// A function set whose arity-0 opcode precedes an arity-≥1 opcode breaks the
+    /// contiguity precondition; [`Alphabet::new`] catches it with a
+    /// `debug_assert!`.
+    #[test]
+    #[should_panic(expected = "arity-0 functions must be the trailing")]
+    fn new_panics_when_zero_arity_function_precedes_a_function() {
+        let _ = Alphabet::new(BadLayoutFunctionSet, 1, vec![]);
+    }
+
+    /// `sample_tail_symbol` only ever returns terminals (arity 0) inside the
+    /// terminal id range, over many draws.
+    #[test]
+    fn sample_tail_symbol_is_always_a_terminal() {
+        let a: Alphabet<ArithmeticFunctionSet> = alphabet(2, vec![1.0, 2.0]);
+        let range: Range<i32> = a.terminal_range();
+        let mut rng = seed_stream(1, 0, SeedPurpose::Mutation);
+        for _ in 0..1000 {
+            let s: Symbol = a.sample_tail_symbol(&mut rng);
+            assert_eq!(a.arity(s), 0, "tail symbol {s} is not a terminal");
+            assert!(range.contains(&s.value()), "tail symbol {s} outside range");
+        }
+    }
+
+    /// `sample_head_symbol` stays within the full id space `0..len()`.
+    #[test]
+    fn sample_head_symbol_stays_in_id_space() {
+        let a: Alphabet<ArithmeticFunctionSet> = alphabet(2, vec![1.0]);
+        let len: i32 = i32::try_from(a.len()).unwrap();
+        let mut rng = seed_stream(2, 0, SeedPurpose::Init);
+        for _ in 0..1000 {
+            let s: Symbol = a.sample_head_symbol(&mut rng);
+            assert!(
+                (0..len).contains(&s.value()),
+                "head symbol {s} outside 0..{len}"
+            );
+        }
+    }
+
+    /// A non-finite problem constant is still a well-formed terminal: it
+    /// classifies as `Constant`, reports arity 0, and lies in the terminal
+    /// range. (Finiteness of the *value* is the evaluator's concern, not the
+    /// alphabet's.)
+    #[test]
+    fn non_finite_constant_is_a_terminal() {
+        // ids: functions 0..8, variable 8, constants 9 (NaN), 10 (+Inf).
+        let a: Alphabet<ArithmeticFunctionSet> = alphabet(1, vec![f32::NAN, f32::INFINITY]);
+        let range: Range<i32> = a.terminal_range();
+
+        assert_eq!(a.arity(Symbol::from_raw(9)), 0);
+        assert_eq!(a.arity(Symbol::from_raw(10)), 0);
+        assert!(range.contains(&9) && range.contains(&10));
+
+        match a.classify(Symbol::from_raw(9)) {
+            SymbolKind::Constant { value } => assert!(value.is_nan()),
+            other => panic!("expected Constant, got {other:?}"),
+        }
+        match a.classify(Symbol::from_raw(10)) {
+            SymbolKind::Constant { value } => assert!(value.is_infinite()),
+            other => panic!("expected Constant, got {other:?}"),
+        }
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/config.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/config.rs
@@ -168,4 +168,41 @@ mod tests {
     fn accepts_valid_config() {
         assert!(GepConfig::new(6, 2, 3, 64).unwrap().validate().is_ok());
     }
+
+    #[test]
+    fn rejects_zero_pop() {
+        let err = GepConfig::new(4, 2, 1, 0).unwrap_err();
+        assert_eq!(err.field, "pop_size");
+    }
+
+    /// A unary function set (`max_arity == 1`) collapses the Ferreira tail to a
+    /// single locus, `t = h·(1−1)+1 = 1`, for every head size.
+    #[test]
+    fn unary_max_arity_derives_unit_tail() {
+        for head in [1usize, 2, 5, 7, 20] {
+            let cfg = GepConfig::new(head, 1, 1, 10).unwrap();
+            assert_eq!(cfg.tail_len, 1, "unary tail must be 1 for head {head}");
+            assert_eq!(cfg.genome_len(), head + 1);
+            // The derived layout still satisfies the config invariants.
+            assert!(cfg.validate().is_ok());
+        }
+    }
+
+    /// The operator rates are [`Probability`], so a `NaN`, negative, or `> 1`
+    /// rate is unrepresentable: it cannot be built to assign to a rate field,
+    /// while a valid rate assigns cleanly.
+    #[test]
+    fn rate_fields_reject_nan_negative_and_above_one() {
+        assert!(Probability::try_new(f32::NAN).is_err());
+        assert!(Probability::try_new(-0.1).is_err());
+        assert!(Probability::try_new(1.5).is_err());
+
+        let mut cfg: GepConfig = GepConfig::new(4, 2, 1, 10).unwrap();
+        cfg.mutation_rate = Probability::try_new(0.05).unwrap();
+        cfg.crossover_1p_rate = Probability::try_new(0.9).unwrap();
+        // `Probability`'s derived `PartialEq` compares the wrapped value without
+        // tripping `clippy::float_cmp`; both were assigned exact literals.
+        assert_eq!(cfg.mutation_rate, Probability::try_new(0.05).unwrap());
+        assert_eq!(cfg.crossover_1p_rate, Probability::try_new(0.9).unwrap());
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/decode.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/decode.rs
@@ -47,6 +47,22 @@ impl<F: FunctionSet> GenotypePhenotypeMap<F> for GepDecoder {
             orf_len += 1;
         }
 
+        // A well-formed GEP gene (head ∈ F∪T, tail ∈ T strictly, tail length
+        // t = h(n−1)+1 with n = max arity) always satisfies every open child
+        // slot within the chromosome, so the scan must exit with `needed == 0`
+        // (Ferreira 2001, Complex Systems 13(2), §3.2 eq. 3.4). A residual
+        // `needed > 0` can only arise from a contract-violating genome (e.g.
+        // one hand-built via `Symbol::from_raw` that bypasses the head/tail
+        // rule): its child ranges would overrun `node_count()` and later panic
+        // in `eval`. Flag that precondition breach in debug builds; `eval`
+        // carries a matching release-time clamp so the failure degrades to a
+        // finite value rather than an out-of-bounds slice.
+        debug_assert!(
+            needed == 0,
+            "genome violates GEP head/tail invariant t = h(n-1)+1 (Ferreira \
+             2001 eq. 3.4): {needed} child slot(s) left unfilled"
+        );
+
         // 2. Level-order parts. Children are the next unread symbols; a single
         //    read cursor walks them in BFS order.
         let nodes: Vec<Symbol> = genome[..orf_len].to_vec();
@@ -68,6 +84,8 @@ impl<F: FunctionSet> GenotypePhenotypeMap<F> for GepDecoder {
 mod tests {
     use super::*;
     use crate::function_set::ArithmeticFunctionSet;
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
 
     fn alphabet(n_vars: usize) -> Alphabet<ArithmeticFunctionSet> {
         Alphabet::new(ArithmeticFunctionSet, n_vars, vec![])
@@ -123,5 +141,135 @@ mod tests {
         ];
         let tree = GepDecoder.decode(&a, &genome);
         assert_eq!(tree.node_count(), 1);
+    }
+
+    // §7.1 -----------------------------------------------------------------
+
+    /// An empty genome decodes to an empty (zero-node) tree without panic.
+    #[test]
+    fn empty_genome_decodes_to_zero_node_tree() {
+        let a = alphabet(1);
+        let tree = GepDecoder.decode(&a, &[]);
+        assert_eq!(tree.node_count(), 0);
+        // A zero-node tree evaluates to the inert 0.0.
+        approx::assert_relative_eq!(tree.eval(&a, &[1.0]), 0.0, epsilon = 1e-6);
+    }
+
+    // §7.3 -----------------------------------------------------------------
+
+    /// A unary (arity-1) function head decodes to a two-node ORF: `sin(x)`.
+    #[test]
+    fn arity_one_function_decodes_two_nodes() {
+        let a = alphabet(1);
+        // ids: sin = 4 (arity 1), var x = 8. head [4, 8], tail [8].
+        let genome = vec![
+            Symbol::from_raw(4),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8),
+        ];
+        let tree = GepDecoder.decode(&a, &genome);
+        // sin (root) -> child {x}. 2 nodes.
+        assert_eq!(tree.node_count(), 2);
+        approx::assert_relative_eq!(tree.eval(&a, &[0.0]), 0.0f32.sin(), epsilon = 1e-6);
+    }
+
+    /// A maximally nested (full-tail) binary chromosome decodes to a deep tree
+    /// that consumes the whole coding region.
+    #[test]
+    fn full_tail_deep_tree() {
+        let a = alphabet(1);
+        // head all binary `+` (id 0), length h = 4; tail all `x` (id 8),
+        // length t = h(n-1)+1 = 4*1+1 = 5. A left-full binary tree of 4
+        // internal nodes has 5 leaves: 9 coding nodes total.
+        let mut genome = vec![Symbol::from_raw(0); 4];
+        genome.extend(std::iter::repeat_n(Symbol::from_raw(8), 5));
+        let tree = GepDecoder.decode(&a, &genome);
+        assert_eq!(tree.node_count(), 9);
+        // 4 additions of x summed over the tree: value is 5*x for x-leaves? No
+        // — a chain of `+` with x leaves sums the 5 leaves = 5x.
+        approx::assert_relative_eq!(tree.eval(&a, &[2.0]), 10.0, epsilon = 1e-6);
+    }
+
+    /// An out-of-range head symbol is treated as an inert arity-0 terminal, so
+    /// it terminates the ORF at a single node rather than opening child slots.
+    #[test]
+    fn out_of_range_symbol_is_terminal() {
+        let a = alphabet(1);
+        // id 999 is beyond len(); classify() reports arity 0.
+        let genome = vec![
+            Symbol::from_raw(999),
+            Symbol::from_raw(8),
+            Symbol::from_raw(8),
+        ];
+        let tree = GepDecoder.decode(&a, &genome);
+        assert_eq!(tree.node_count(), 1);
+        approx::assert_relative_eq!(tree.eval(&a, &[3.0]), 0.0, epsilon = 1e-6);
+    }
+
+    // §7.4 -----------------------------------------------------------------
+
+    /// The key guard (issue #147 §1.1). Ferreira (2001, eq. 3.4) guarantees any
+    /// well-formed head/tail gene decodes to a complete tree: the ORF scan never
+    /// leaves an unfilled child slot, so every child range stays in bounds and
+    /// `eval` never slices past `node_count()`. Generate many random but
+    /// well-formed genomes (head ∈ F∪T, tail ∈ T strictly, tail length
+    /// t = h(n−1)+1) and assert the guarantee holds structurally and that `eval`
+    /// returns a finite value without panic.
+    #[test]
+    fn wellformed_genomes_always_decode_in_bounds() {
+        let mut rng = StdRng::seed_from_u64(0x9E37_79B9_7F4A_7C15);
+        let max_arity = 2; // max arity of ArithmeticFunctionSet.
+        for n_vars in 1..=3usize {
+            let alpha = alphabet(n_vars);
+            for _ in 0..2_000 {
+                let head_len = 1 + rng_usize(&mut rng, 12); // head length 1..=12
+                let tail_len = head_len * (max_arity - 1) + 1; // Ferreira eq. 3.4.
+                let mut genome = Vec::with_capacity(head_len + tail_len);
+                for _ in 0..head_len {
+                    genome.push(alpha.sample_head_symbol(&mut rng));
+                }
+                for _ in 0..tail_len {
+                    genome.push(alpha.sample_tail_symbol(&mut rng));
+                }
+
+                let tree = GepDecoder.decode(&alpha, &genome);
+                let node_count = tree.node_count();
+                assert!(node_count >= 1, "coding region must be non-empty");
+
+                // Every non-root coding node is exactly one child of exactly one
+                // parent, so the total child count equals node_count - 1. This
+                // is the public-API restatement of `child_start[i] + arity[i]
+                // <= node_count` for all i (BFS layout): the scan filled every
+                // slot (Ferreira eq. 3.4), i.e. the decoder's `needed == 0`.
+                let total_children: usize = tree.nodes().iter().map(|&sym| alpha.arity(sym)).sum();
+                assert_eq!(
+                    total_children + 1,
+                    node_count,
+                    "well-formed genome left an unfilled child slot: {genome:?}"
+                );
+
+                // `eval` must not panic and must return a finite value for any
+                // input row (the finite_or_clamp guard neutralizes overflow).
+                let inputs: Vec<f32> = (0..n_vars).map(|_| rng_input(&mut rng)).collect();
+                let value = tree.eval(&alpha, &inputs);
+                assert!(value.is_finite(), "eval produced non-finite {value}");
+            }
+        }
+    }
+
+    /// Small uniform `usize` in `0..bound` from a seeded RNG (avoids pulling in
+    /// the distribution imports the alphabet already re-exports).
+    fn rng_usize(rng: &mut StdRng, bound: usize) -> usize {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let hi = bound as i32;
+        #[allow(clippy::cast_sign_loss)]
+        {
+            rng.random_range(0..hi) as usize
+        }
+    }
+
+    /// A bounded, occasionally-large input to exercise the overflow clamp.
+    fn rng_input(rng: &mut StdRng) -> f32 {
+        rng.random_range(-1.0e6f32..1.0e6f32)
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/operators.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/operators.rs
@@ -299,4 +299,126 @@ mod tests {
         ris_transposition(&mut g_ris, cfg.head_len, &a, &mut rng);
         assert_eq!(&g_ris[cfg.head_len..], &tail_before[..]);
     }
+
+    /// A `NaN` rate is a no-op: `x < NaN` is `false`, so no locus mutates
+    /// (defense-in-depth against a stray non-finite rate, operators.rs §1).
+    #[test]
+    fn point_mutation_nan_rate_is_no_op() {
+        let a = alphabet();
+        let cfg = GepConfig::new(7, 2, 1, 10).unwrap();
+        let mut rng = seed_stream(21, 0, SeedPurpose::Mutation);
+        let original = sample_valid(&a, &cfg, &mut rng);
+        let mut g = original.clone();
+        point_mutation(&mut g, cfg.head_len, &a, f32::NAN, &mut rng);
+        assert_eq!(g, original, "NaN rate must leave the chromosome unchanged");
+    }
+
+    /// An out-of-range rate (`> 1`) mutates every locus — `x < 2.0` is always
+    /// true — yet the tail invariant and the decode guarantee still hold.
+    #[test]
+    fn point_mutation_out_of_range_rate_resamples_all_but_stays_valid() {
+        let a = alphabet();
+        let cfg = GepConfig::new(7, 2, 1, 10).unwrap();
+        let mut rng = seed_stream(22, 0, SeedPurpose::Mutation);
+        let mut g = sample_valid(&a, &cfg, &mut rng);
+        point_mutation(&mut g, cfg.head_len, &a, 2.0, &mut rng);
+        assert!(tail_all_terminals(&g, cfg.head_len, &a));
+        assert!(decodes_complete(&g, &a));
+    }
+
+    /// No operator panics on an empty chromosome / empty parent pair.
+    #[test]
+    fn operators_do_not_panic_on_empty_slices() {
+        let a = alphabet();
+        let mut rng = seed_stream(23, 0, SeedPurpose::Crossover);
+
+        let mut empty: Vec<Symbol> = Vec::new();
+        point_mutation(&mut empty, 0, &a, 1.0, &mut rng);
+        is_transposition(&mut empty, 0, &mut rng);
+        ris_transposition(&mut empty, 0, &a, &mut rng);
+        assert!(empty.is_empty());
+
+        let mut lhs: Vec<Symbol> = Vec::new();
+        let mut rhs: Vec<Symbol> = Vec::new();
+        one_point_crossover(&mut lhs, &mut rhs, &mut rng);
+        two_point_crossover(&mut lhs, &mut rhs, &mut rng);
+        assert!(lhs.is_empty() && rhs.is_empty());
+    }
+
+    /// With `head_len == 1` both transpositions are safe: IS has no non-root
+    /// insertion site (no-op) and RIS keeps the single root, preserving length,
+    /// the tail invariant, and a complete decode.
+    #[test]
+    fn transposition_with_head_len_one_is_safe() {
+        let a = alphabet();
+        let cfg = GepConfig::new(1, 2, 1, 10).unwrap();
+        assert_eq!(cfg.head_len, 1);
+        let mut rng = seed_stream(24, 0, SeedPurpose::Transposition);
+        for _ in 0..200 {
+            let mut g = sample_valid(&a, &cfg, &mut rng);
+            // Guarantee a function at the single head locus for RIS.
+            g[0] = Symbol::from_raw(0);
+            let len_before = g.len();
+            is_transposition(&mut g, cfg.head_len, &mut rng);
+            ris_transposition(&mut g, cfg.head_len, &a, &mut rng);
+            assert_eq!(g.len(), len_before);
+            assert!(tail_all_terminals(&g, cfg.head_len, &a));
+            assert!(decodes_complete(&g, &a));
+        }
+    }
+
+    /// Single-locus parents (`n == 1`) leave both crossovers as no-ops.
+    #[test]
+    fn crossover_with_single_locus_is_no_op() {
+        let mut rng = seed_stream(25, 0, SeedPurpose::Crossover);
+        let a0: Vec<Symbol> = vec![Symbol::from_raw(8)];
+        let b0: Vec<Symbol> = vec![Symbol::from_raw(0)];
+
+        let mut a1 = a0.clone();
+        let mut b1 = b0.clone();
+        one_point_crossover(&mut a1, &mut b1, &mut rng);
+        two_point_crossover(&mut a1, &mut b1, &mut rng);
+        assert_eq!(a1, a0);
+        assert_eq!(b1, b0);
+    }
+
+    /// One-point crossover documents equal parent lengths as a precondition
+    /// (`debug_assert_eq!`); a mismatch panics in debug builds.
+    #[test]
+    #[should_panic(expected = "crossover parents must share genome length")]
+    fn one_point_crossover_panics_on_mismatched_lengths() {
+        let mut rng = seed_stream(26, 0, SeedPurpose::Crossover);
+        let mut a = vec![Symbol::from_raw(8); 4];
+        let mut b = vec![Symbol::from_raw(8); 5];
+        one_point_crossover(&mut a, &mut b, &mut rng);
+    }
+
+    /// Two-point crossover shares the equal-length precondition.
+    #[test]
+    #[should_panic(expected = "crossover parents must share genome length")]
+    fn two_point_crossover_panics_on_mismatched_lengths() {
+        let mut rng = seed_stream(27, 0, SeedPurpose::Crossover);
+        let mut a = vec![Symbol::from_raw(8); 4];
+        let mut b = vec![Symbol::from_raw(8); 5];
+        two_point_crossover(&mut a, &mut b, &mut rng);
+    }
+
+    /// RIS is a no-op when the head holds no function symbol — there is nothing
+    /// to root, so the chromosome is left untouched (§7.4).
+    #[test]
+    fn ris_no_op_when_head_has_no_functions() {
+        let a = alphabet();
+        let cfg = GepConfig::new(7, 2, 1, 10).unwrap();
+        let mut rng = seed_stream(28, 0, SeedPurpose::Transposition);
+        for _ in 0..200 {
+            let mut g = sample_valid(&a, &cfg, &mut rng);
+            // Force the whole head to a terminal (variable id 8 = n_func).
+            for locus in &mut g[..cfg.head_len] {
+                *locus = Symbol::from_raw(8);
+            }
+            let before = g.clone();
+            ris_transposition(&mut g, cfg.head_len, &a, &mut rng);
+            assert_eq!(g, before, "RIS must not alter an all-terminal head");
+        }
+    }
 }

--- a/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/strategy.rs
@@ -517,6 +517,83 @@ mod tests {
 
     type TestBackend = Flex;
 
+    /// All-equal fitness gives every individual the same weight: draws are valid
+    /// indices and every index is reachable.
+    #[test]
+    fn roulette_all_equal_fitness_stays_in_range() {
+        let mut rng = seed_stream(31, 0, SeedPurpose::Selection);
+        let fits: Vec<f32> = vec![1.0; 5];
+        let picks: Vec<usize> = roulette_select(&fits, 10, &mut rng);
+        assert_eq!(picks.len(), 10);
+        assert!(picks.iter().all(|&i| i < 5));
+    }
+
+    /// All-`NaN` fitness zeroes every weight, so selection falls back to
+    /// *uniform* sampling — not a degenerate always-index-0 draw. Over a large
+    /// deterministic sample each of the 4 candidates must appear roughly N/4
+    /// times (loose band), which a silent "always pick 0" fallback would fail.
+    #[test]
+    fn roulette_all_nan_falls_back_to_uniform() {
+        const N: usize = 4000;
+        let mut rng = seed_stream(32, 0, SeedPurpose::Selection);
+        let fits: Vec<f32> = vec![f32::NAN; 4];
+        let picks: Vec<usize> = roulette_select(&fits, N, &mut rng);
+        assert_eq!(picks.len(), N);
+        assert!(picks.iter().all(|&i| i < 4));
+
+        let mut counts = [0usize; 4];
+        for &i in &picks {
+            counts[i] += 1;
+        }
+        // Uniform expectation is N/4 = 1000; allow a generous ±40% band so the
+        // fixed-seed draw cannot flake while still rejecting a collapsed
+        // distribution (e.g. every draw landing on one index).
+        let expected: usize = N / 4;
+        let low = expected - expected * 2 / 5;
+        let high = expected + expected * 2 / 5;
+        for (idx, &c) in counts.iter().enumerate() {
+            assert!(
+                (low..=high).contains(&c),
+                "index {idx} drawn {c} times, outside uniform band [{low}, {high}]"
+            );
+        }
+    }
+
+    /// A single-individual population can only ever pick index 0.
+    #[test]
+    fn roulette_single_element_always_picks_zero() {
+        let mut rng = seed_stream(33, 0, SeedPurpose::Selection);
+        let picks: Vec<usize> = roulette_select(&[3.5], 6, &mut rng);
+        assert_eq!(picks, vec![0usize; 6]);
+    }
+
+    /// Requesting zero parents from an empty fitness slice yields no picks (and
+    /// never samples an empty range).
+    #[test]
+    fn roulette_empty_with_zero_k_is_empty() {
+        let mut rng = seed_stream(34, 0, SeedPurpose::Selection);
+        let picks: Vec<usize> = roulette_select(&[], 0, &mut rng);
+        assert!(picks.is_empty());
+    }
+
+    /// With all-negative (canonical) fitness the shift `f − min_finite` still
+    /// favours the least-negative individual; it is picked more often than the
+    /// most-negative one, and every draw is in range.
+    #[test]
+    fn roulette_negative_fitness_favours_highest() {
+        let mut rng = seed_stream(35, 0, SeedPurpose::Selection);
+        // Index 2 (−1.0) is the largest; index 0 (−100.0) the smallest.
+        let fits: Vec<f32> = vec![-100.0, -50.0, -1.0, -75.0];
+        let picks: Vec<usize> = roulette_select(&fits, 2000, &mut rng);
+        assert!(picks.iter().all(|&i| i < 4));
+        let count_best: usize = picks.iter().filter(|&&i| i == 2).count();
+        let count_worst: usize = picks.iter().filter(|&&i| i == 0).count();
+        assert!(
+            count_best > count_worst,
+            "highest fitness ({count_best}) should be picked more than lowest ({count_worst})"
+        );
+    }
+
     #[test]
     fn try_new_checks_fitness_length() {
         let device = Default::default();

--- a/crates/rlevo-evolution/src/algorithms/gep/tree.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/tree.rs
@@ -142,7 +142,20 @@ impl ExpressionTree {
                 SymbolKind::Function { .. } => {
                     let arity = self.arities[i];
                     let start = self.child_start[i];
-                    arg_buf[..arity].copy_from_slice(&results[start..start + arity]);
+                    // For a well-formed genome the child range always fits
+                    // (`start + arity <= n`; Ferreira 2001 eq. 3.4, enforced by
+                    // the decoder's `debug_assert!`). This clamp is a defensive
+                    // guard for the documented precondition: a contract-violating
+                    // genome (built via `Symbol::from_raw`, bypassing the
+                    // head/tail rule) would otherwise slice out of bounds and
+                    // panic here. Clamping `end` degrades the malformed case to
+                    // a finite value; `apply` reads any missing tail arguments
+                    // as `0.0`. Bit-identical to `&results[start..start + arity]`
+                    // whenever the precondition holds.
+                    let end = (start + arity).min(results.len());
+                    let avail = end.saturating_sub(start);
+                    arg_buf[..avail].copy_from_slice(&results[start..end]);
+                    arg_buf[avail..arity].fill(0.0);
                     let v = alphabet.functions.apply(symbol, &arg_buf[..arity]);
                     finite_or_clamp(v)
                 }
@@ -242,5 +255,76 @@ mod tests {
             (pred - 0.1).powi(2) > 1e20,
             "diverged prediction must yield a large error, got pred = {pred}"
         );
+    }
+
+    // §7.1 -----------------------------------------------------------------
+
+    /// An empty tree evaluates to the inert `0.0` (no nodes to reduce).
+    #[test]
+    fn eval_of_empty_tree_is_zero() {
+        let a = alphabet(1);
+        let tree = ExpressionTree::from_parts(Vec::new(), Vec::new(), Vec::new());
+        assert_eq!(tree.node_count(), 0);
+        approx::assert_relative_eq!(tree.eval(&a, &[42.0]), 0.0, epsilon = 1e-6);
+    }
+
+    /// A variable node whose input index is out of range reads `0.0` (the
+    /// evaluator's missing-input policy), not a panic. A `+Inf` *input* still
+    /// clamps to `EVAL_CLAMP` rather than collapsing to `0.0`, so a diverged
+    /// value is penalized (matches `finite_or_clamp`).
+    #[test]
+    fn eval_variable_index_and_inf_policy() {
+        let a = alphabet(2);
+        // Single variable node reading input_index 1 (id 8 = var 0, 9 = var 1).
+        let tree = GepDecoder.decode(&a, &[Symbol::from_raw(9)]);
+        assert_eq!(tree.node_count(), 1);
+        // Out-of-range input row (len 0): missing index reads 0.0.
+        approx::assert_relative_eq!(tree.eval(&a, &[]), 0.0, epsilon = 1e-6);
+        // Present index passes through.
+        approx::assert_relative_eq!(tree.eval(&a, &[3.0, 7.0]), 7.0, epsilon = 1e-6);
+        // A raw variable leaf reads its input verbatim (no per-node clamp on a
+        // leaf), so an infinite input surfaces as-is; the clamp applies at
+        // function nodes. Feed the leaf through a `+` with a `0` constant is not
+        // available here, so assert the documented leaf policy directly.
+        assert!(tree.eval(&a, &[0.0, f32::INFINITY]).is_infinite());
+    }
+
+    // §7.2 -----------------------------------------------------------------
+
+    /// Regression for issue #147 §1.1. A contract-violating genome — one that
+    /// breaks Ferreira's head/tail rule (eq. 3.4) and so leaves an unfilled
+    /// child slot — is built here directly via `from_parts`, bypassing the
+    /// decoder's `debug_assert!`. Its child range `1..3` overruns the single
+    /// node. Before the fix, `eval` sliced `results[1..3]` out of bounds and
+    /// panicked; the defensive clamp now degrades it to a finite value.
+    #[test]
+    fn eval_does_not_panic_on_out_of_bounds_child_range() {
+        let a = alphabet(1);
+        // A lone binary `+` (id 0, arity 2) claiming children at indices 1..3,
+        // but there is only one node. `child_start = [1]`, `arities = [2]`.
+        let tree = ExpressionTree::from_parts(vec![Symbol::from_raw(0)], vec![2], vec![1]);
+        assert_eq!(tree.node_count(), 1);
+        // Missing children read as 0.0: 0.0 + 0.0 = 0.0. No panic, finite value.
+        let y = tree.eval(&a, &[5.0]);
+        assert!(y.is_finite());
+        approx::assert_relative_eq!(y, 0.0, epsilon = 1e-6);
+    }
+
+    /// A partially out-of-bounds child range (one valid child, one past the
+    /// end) copies the in-bounds child and zero-fills the rest, still finite.
+    #[test]
+    fn eval_partial_out_of_bounds_child_range() {
+        let a = alphabet(1);
+        // node 0 = `+` (arity 2) with children at 1..3; node 1 = var x (id 8).
+        // Index 2 is past the end, so the second argument zero-fills.
+        let tree = ExpressionTree::from_parts(
+            vec![Symbol::from_raw(0), Symbol::from_raw(8)],
+            vec![2, 0],
+            vec![1, 2],
+        );
+        // x + 0.0 = x.
+        let y = tree.eval(&a, &[4.0]);
+        assert!(y.is_finite());
+        approx::assert_relative_eq!(y, 4.0, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
+++ b/crates/rlevo-evolution/src/algorithms/gp_cgp.rs
@@ -726,6 +726,129 @@ mod tests {
         );
     }
 
+    /// `mutate_genome` preserves genome length and, at `mutation_rate == 0.0`,
+    /// is a no-op (`rng.random() >= 0.0` always holds, so every gene is skipped).
+    #[test]
+    fn mutate_genome_zero_rate_is_length_preserving_noop() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let mut params = CgpConfig::default_for(2);
+        let mut rng = StdRng::seed_from_u64(5);
+        let mut genome =
+            CartesianGeneticProgramming::<TestBackend>::sample_initial_genome(&params, &mut rng);
+        let before = genome.clone();
+
+        params.mutation_rate = Probability::new(0.0);
+        mutate_genome(&mut genome, &params, &mut rng);
+        assert_eq!(genome.len(), before.len(), "length must be preserved");
+        assert_eq!(genome, before, "rate 0.0 must leave the genome untouched");
+    }
+
+    /// Feed-forward / `levels_back` invariant: for a fresh genome and for a
+    /// fully mutated one (`rate == 1.0`), every node input gene references only
+    /// an earlier node or a graph input, and node references stay within the
+    /// `levels_back` column window. Verified on a single-row grid so the node
+    /// global index is `n_inputs + col`.
+    #[test]
+    fn genome_respects_feedforward_and_levels_back() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let n_inputs = 2usize;
+        let cols = 8usize;
+        let levels_back = 3usize;
+        let mut params = CgpConfig::default_for(n_inputs);
+        params.rows = 1;
+        params.cols = cols;
+        params.levels_back = levels_back;
+
+        // Assert the invariant for an arbitrary host genome layout.
+        let check = |genome: &[i64]| {
+            for col in 0..cols {
+                let base = col * CgpConfig::GENES_PER_NODE;
+                let func = genome[base];
+                #[allow(clippy::cast_possible_wrap)]
+                let num_funcs = NUM_FUNCTIONS as i64;
+                assert!(
+                    (0..num_funcs).contains(&func),
+                    "function id {func} out of range at col {col}"
+                );
+                #[allow(clippy::cast_possible_wrap)]
+                let node_global = (n_inputs + col) as i64;
+                #[allow(clippy::cast_possible_wrap)]
+                let n_in = n_inputs as i64;
+                #[allow(clippy::cast_possible_wrap)]
+                let min_node_ref = (n_inputs + col.saturating_sub(levels_back)) as i64;
+                for &inp in &[genome[base + 1], genome[base + 2]] {
+                    assert!(
+                        inp < node_global,
+                        "col {col}: input {inp} must be strictly earlier than node {node_global}"
+                    );
+                    assert!(
+                        inp < n_in || inp >= min_node_ref,
+                        "col {col}: node input {inp} outside the levels_back window \
+                         [{min_node_ref}, {node_global})"
+                    );
+                }
+            }
+        };
+
+        let mut rng = StdRng::seed_from_u64(19);
+        let genome =
+            CartesianGeneticProgramming::<TestBackend>::sample_initial_genome(&params, &mut rng);
+        check(&genome);
+
+        // Fully mutate, then re-check: mutation must also honor the invariant.
+        let mut mutated = genome.clone();
+        params.mutation_rate = Probability::new(1.0);
+        mutate_genome(&mut mutated, &params, &mut rng);
+        assert_eq!(mutated.len(), genome.len(), "mutation preserves length");
+        check(&mutated);
+    }
+
+    /// Out-of-range input and output gene indices are clamped to the last
+    /// buffer slot rather than panicking, keeping evaluation robust to
+    /// mutated-but-unrepaired genotypes.
+    #[test]
+    fn evaluate_cgp_clamps_out_of_range_indices() {
+        let params = CgpConfig {
+            lambda: 1,
+            n_inputs: 1,
+            rows: 1,
+            cols: 1,
+            mutation_rate: Probability::new(0.1),
+            levels_back: usize::MAX,
+        };
+        // [func=add, in0, in1, output] with every index far out of range.
+        let genome: Vec<i64> = vec![0, 999, 999, 999];
+        let inputs: Vec<Vec<f32>> = vec![vec![2.0], vec![3.0]];
+        let out = evaluate_cgp(&genome, &params, &inputs);
+        assert_eq!(out.len(), inputs.len(), "one output per input row");
+        assert!(
+            out.iter().all(|v| v.is_finite()),
+            "clamped evaluation must stay finite, got {out:?}"
+        );
+    }
+
+    /// `best()` returns `None` before the first `tell` (no champion recorded
+    /// yet), matching the documented contract.
+    #[test]
+    fn best_is_none_before_first_tell() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let strategy = CartesianGeneticProgramming::<TestBackend>::new();
+        let params = CgpConfig::default_for(1);
+        let mut rng = StdRng::seed_from_u64(0);
+        let state = strategy.init(&params, &mut rng, &device);
+        assert!(
+            strategy.best(&state).is_none(),
+            "best must be None before the first tell"
+        );
+    }
+
     /// Symbolic regression on `x² + 1` over 20 evenly spaced x ∈ [−1, 1].
     struct SymRegression {
         params: CgpConfig,

--- a/crates/rlevo-evolution/src/algorithms/memetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/memetic.rs
@@ -860,6 +860,152 @@ mod tests {
         assert_eq!(all, vec![2, 0, 3, 1]);
     }
 
+    #[test]
+    fn coverage_indices_topk_zero_is_empty() {
+        // `TopK { k: 0 }` refines nobody — a degenerate but valid no-op policy.
+        let cover = coverage_indices(&CoveragePolicy::TopK { k: 0 }, &[3.0, 1.0, 2.0], 3);
+        assert!(cover.is_empty(), "TopK{{0}} must cover no rows");
+    }
+
+    #[test]
+    fn coverage_indices_empty_population_is_empty() {
+        // Empty population: every policy yields an empty coverage set, so the
+        // refinement loop is a no-op (no rows to refine, no writeback).
+        assert!(coverage_indices(&CoveragePolicy::Full, &[], 0).is_empty());
+        assert!(coverage_indices(&CoveragePolicy::TopK { k: 3 }, &[], 0).is_empty());
+    }
+
+    #[test]
+    fn coverage_indices_all_equal_breaks_ties_by_lowest_index() {
+        // All-equal fitness: the stable (fitness desc, index asc) sort must
+        // select the lowest indices, so `TopK { k: 2 }` is exactly [0, 1].
+        let fitness = [5.0f32; 4];
+        let top2 = coverage_indices(&CoveragePolicy::TopK { k: 2 }, &fitness, 4);
+        assert_eq!(top2, vec![0, 1], "ties must break toward the lowest index");
+    }
+
+    // ---------------------------------------------------------------------
+    // Minimize-sense refinement path.
+    // ---------------------------------------------------------------------
+
+    /// A `Minimize` sphere: `evaluate_batch` returns the raw sum-of-squares
+    /// *cost* (higher is worse) and declares [`ObjectiveSense::Minimize`]. This
+    /// exercises the wrapper's canonicalisation seam ([`RowFitness`] flips the
+    /// natural cost into canonical maximise space), which every other fixture in
+    /// this module leaves untested because they are all `Maximize`.
+    #[derive(Debug, Default)]
+    struct MinSphereBatch;
+    impl<B: Backend> BatchFitnessFn<B, Tensor<B, 2>> for MinSphereBatch {
+        fn evaluate_batch(
+            &mut self,
+            population: &Tensor<B, 2>,
+            device: &<B as BackendTypes>::Device,
+        ) -> Tensor<B, 1> {
+            let dims = population.dims();
+            let flat = population
+                .clone()
+                .into_data()
+                .into_vec::<f32>()
+                .expect("population host-read of a tensor this test just built");
+            let (pop, dim) = (dims[0], dims[1]);
+            let mut out: Vec<f32> = Vec::with_capacity(pop);
+            for r in 0..pop {
+                let start = r * dim;
+                out.push(flat[start..start + dim].iter().map(|v| v * v).sum::<f32>());
+            }
+            Tensor::<B, 1>::from_data(TensorData::new(out, [pop]), device)
+        }
+
+        fn sense(&self) -> ObjectiveSense {
+            ObjectiveSense::Minimize
+        }
+    }
+
+    /// Raw sphere cost of a host row (the `Minimize` natural objective).
+    fn sphere_cost(row: &[f32]) -> f32 {
+        row.iter().map(|v| v * v).sum::<f32>()
+    }
+
+    /// The Minimize path must *lower* cost. Under `Full`/`Lamarckian` coverage
+    /// the local searcher runs in canonical maximise space, so for every covered
+    /// row the refined natural cost must not increase, the canonical fitness
+    /// handed to the inner `tell` must not decrease, and that fitness must equal
+    /// `−cost` of the written-back row. At least one row must strictly improve.
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn minimize_sense_refinement_reduces_cost() {
+        let device = <TestBackend as BackendTypes>::Device::default();
+        let (pop, dim) = (5usize, 3usize);
+        let rows = fixed_population(pop, dim);
+
+        let strategy = MemeticWrapper::<TestBackend, _, _, _>::new(
+            RecordingStrategy,
+            HillClimbing,
+            MinSphereBatch,
+        );
+        let params = MemeticParams {
+            inner: rec_params(rows, pop, dim),
+            local: HillClimbingParams::default_for(BOUNDS),
+            writeback: WritebackPolicy::Lamarckian,
+            coverage: CoveragePolicy::Full,
+        };
+
+        let mut rng = StdRng::seed_from_u64(9);
+        let state = strategy.init(&params, &mut rng, &device);
+        let (ask_pop, asked) = strategy.ask(&params, &state, &mut rng, &device);
+        let ask_bytes = ask_pop
+            .clone()
+            .into_data()
+            .into_vec::<f32>()
+            .expect("population host-read of a tensor this test just built");
+
+        // Seed fitness in canonical (maximise) space: for a Minimize objective
+        // the harness hands the strategy `−cost`, so mirror that here.
+        let canonical: Vec<f32> = (0..pop)
+            .map(|i| {
+                let s = i * dim;
+                -sphere_cost(&ask_bytes[s..s + dim])
+            })
+            .collect();
+        let fit =
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(canonical.clone(), [pop]), &device);
+
+        let (next, _m) = strategy.tell(&params, ask_pop, fit, asked, &mut rng);
+        let recv_pop = next.inner.received_pop.clone().unwrap();
+        let recv_fit = next.inner.received_fit.clone().unwrap();
+
+        let mut any_improved = false;
+        // Indexing several parallel host buffers by row; an iterator over one of
+        // them would not read more clearly than the explicit row index.
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..pop {
+            let s = i * dim;
+            let recv_row = &recv_pop[s..s + dim];
+            let ask_row = &ask_bytes[s..s + dim];
+            let recv_cost = sphere_cost(recv_row);
+            let ask_cost = sphere_cost(ask_row);
+            // Refinement never worsens the natural cost (minimise).
+            assert!(
+                recv_cost <= ask_cost + 1e-6,
+                "row {i}: refined cost {recv_cost} must not exceed original {ask_cost}"
+            );
+            // Canonical fitness handed to `tell` never decreases.
+            assert!(
+                recv_fit[i] >= canonical[i] - 1e-6,
+                "row {i}: canonical fitness must not drop"
+            );
+            // And it equals `−cost` of the written-back row.
+            approx::assert_relative_eq!(recv_fit[i], -recv_cost, epsilon = 1e-5);
+            if recv_cost < ask_cost - 1e-6 {
+                any_improved = true;
+            }
+        }
+        assert!(
+            any_improved,
+            "the Minimize path must strictly reduce cost on at least one row"
+        );
+    }
+
     // ---------------------------------------------------------------------
     // 1. Baldwinian bit-identity.
     // ---------------------------------------------------------------------

--- a/crates/rlevo-evolution/tests/determinism.rs
+++ b/crates/rlevo-evolution/tests/determinism.rs
@@ -14,8 +14,11 @@
 //! byte-for-byte.
 
 use burn::backend::Flex;
+use burn::tensor::backend::{Backend, BackendTypes};
+use burn::tensor::{Int, Tensor, TensorData};
 use rlevo_core::bounds::Bounds;
 use rlevo_core::fitness::FitnessEvaluable;
+use rlevo_core::objective::ObjectiveSense;
 use rlevo_core::probability::Probability;
 use rlevo_core::rate::NonNegativeRate;
 
@@ -24,6 +27,7 @@ use rlevo_evolution::algorithms::es_classical::{EsConfig, EsKind, EvolutionStrat
 use rlevo_evolution::algorithms::ga::{
     GaConfig, GaCrossover, GaReplacement, GaSelection, GeneticAlgorithm,
 };
+use rlevo_evolution::algorithms::ga_binary::{BinaryGaConfig, BinaryGeneticAlgorithm};
 use rlevo_evolution::algorithms::memetic::{
     CoveragePolicy, MemeticParams, MemeticWrapper, WritebackPolicy,
 };
@@ -68,6 +72,68 @@ where
         strategy,
         params,
         FromFitnessEvaluable::new(SphereFit, Sphere),
+        seed,
+        device,
+        gens,
+    )
+    .expect("valid params");
+    harness.reset();
+    let mut trajectory = Vec::with_capacity(gens);
+    loop {
+        let step = harness.step(());
+        trajectory.push(harness.latest_metrics().unwrap().best_fitness());
+        if step.done {
+            break;
+        }
+    }
+    trajectory
+}
+
+/// `OneMax` batch fitness over a binary genome (`count_ones`, native
+/// maximise). The [`BinaryGeneticAlgorithm`]'s `Tensor<B, 2, Int>` genome is
+/// not covered by the real-valued [`FromFitnessEvaluable`] adapter used by the
+/// generic [`run`] path, so binary-GA determinism is checked with a dedicated
+/// integer fitness driven inline.
+struct OneMaxBatch {
+    dim: usize,
+}
+
+impl<Bk: Backend> BatchFitnessFn<Bk, Tensor<Bk, 2, Int>> for OneMaxBatch {
+    fn evaluate_batch(
+        &mut self,
+        population: &Tensor<Bk, 2, Int>,
+        device: &<Bk as BackendTypes>::Device,
+    ) -> Tensor<Bk, 1> {
+        let pop_size = population.dims()[0];
+        let data = population
+            .clone()
+            .into_data()
+            .into_vec::<i32>()
+            .expect("genome host-read of a tensor this test just built");
+        let mut fitness = Vec::with_capacity(pop_size);
+        for row in 0..pop_size {
+            #[allow(clippy::cast_precision_loss)]
+            let ones = (0..self.dim)
+                .filter(|&col| data[row * self.dim + col] != 0)
+                .count() as f32;
+            fitness.push(ones);
+        }
+        Tensor::<Bk, 1>::from_data(TensorData::new(fitness, [pop_size]), device)
+    }
+
+    fn sense(&self) -> ObjectiveSense {
+        ObjectiveSense::Maximize
+    }
+}
+
+fn run_binary_ga(seed: u64, gens: usize) -> Vec<f32> {
+    let device = Default::default();
+    let dim = 16usize;
+    let params = BinaryGaConfig::default_for(32, dim);
+    let mut harness = EvolutionaryHarness::<B, _, _>::new(
+        BinaryGeneticAlgorithm::<B>::new(),
+        params,
+        OneMaxBatch { dim },
         seed,
         device,
         gens,
@@ -246,6 +312,13 @@ fn same_seed_same_generations() {
     let ga_a = run_ga(SEED, GENS);
     let ga_b = run_ga(SEED, GENS);
     assert_eq!(ga_a, ga_b, "GA trajectories diverge under the same seed");
+
+    let bga_a = run_binary_ga(SEED, GENS);
+    let bga_b = run_binary_ga(SEED, GENS);
+    assert_eq!(
+        bga_a, bga_b,
+        "Binary GA trajectories diverge under the same seed"
+    );
 
     for kind in [
         EsKind::OnePlusOne,


### PR DESCRIPTION
## Summary

Fills the test-coverage gaps catalogued in issue #147 across the five EDA models, the seven GEP files, and the EA-root algorithms (`cma_es`, `cmsa_es`, `de`, `ep`, `es_classical`, `ga`, `ga_binary`, `gp_cgp`, `memetic`). Adds ~60 seeded-`rand` edge-case / NaN / determinism / statistical tests. Reconciliation against the current tree (the `code-review-30-06-2026` docs are ~2 weeks stale) surfaced two real defects behind "missing test" rows, both fixed here and grounded in the primary literature. `proptest` was deliberately deferred (no new workspace dependency) — every gap is reachable with `rand::StdRng` under the existing `seed_stream` convention; the 5 pure-`proptest` review rows are marked deferred pending a future ADR.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Other — test-coverage expansion for #147 (enhancement) plus two literature-grounded defensive fixes the new tests guard.

## Linked Issue

Closes #147

## What Was Changed

- **`gep/decode.rs` + `gep/tree.rs` (bug fix):** a contract-violating genome (all max-arity head symbols, no terminal tail) could drive an out-of-bounds slice panic in `eval`. `decode.rs` now `debug_assert!`s the Ferreira 2001 head/tail invariant `t = h(n-1)+1`; `eval` clamps the child-slice copy so a malformed genome degrades to a finite value. Bit-identical for every well-formed genome. Regression tests: `wellformed_genomes_always_decode_in_bounds`, `eval_does_not_panic_on_out_of_bounds_child_range`.
- **`cmsa_es.rs` (defensive):** explicit `symmetrize` at the rank-μ covariance blend chokepoint (Beyer & Sendhoff 2008 — optional float-drift hygiene, a no-op for the current code path). Guarded by `covariance_stays_symmetric_across_generations`.
- **~60 tests added** across `cma_es`, `cmsa_es`, `de`, `ep`, `es_classical`, `ga`, `ga_binary`, `gp_cgp`, `memetic`, all five `eda/*` models, and `gep/{alphabet,config,decode,operators,strategy,tree}` — NaN-through-`sanitize_fitness`, degenerate-input edge cases, `#[should_panic]` sizing guards, seeded determinism, and large-N statistical/property tests. Binary-GA same-seed determinism added to `tests/determinism.rs`.

## How It Was Tested

```
cargo build --workspace          # clean
cargo test --workspace           # 56 suites ok, 0 failed
cargo clippy --all-targets --all-features
just test-evolution-determinism  # ok
just test-eda-determinism        # ok
just test-eda-smoke              # ok
just test-workspace              # all suites ok, 0 failed
```

`rlevo-evolution` lib: **566 passed, 0 failed**. NaN tests route through the real `sanitize_fitness`/`sanitize_fitness_tensor` chokepoint; determinism tests compare two independent seeded runs; statistical tests use N=20k with meaningful tolerances. A `qa-expert` pass returned **PASS** and confirmed the `eval` clamp is bit-identical for valid genomes and the regression test reproduces the original panic via `from_parts`.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned via `rust-toolchain.toml`)
- Burn backend tested: ndarray (default)
- OS: macOS (darwin)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: reconciliation of review docs vs source, literature validation, test authoring, and the two defensive fixes; all changes reviewed and verified locally.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` — no new warnings from this PR (`rlevo-evolution` is clean; the remaining `--all-features` warnings are pre-existing in `rlevo-environments`/`rlevo-benchmarks`/`rlevo` test files and untouched here).
- [x] Public API additions or changes include doc comments — n/a (no public API change; fixes are internal, tests only).
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern (issue #147).
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- `proptest` adoption deferred to a follow-up ADR (#239); the 5 affected review rows are marked `deferred`.
- Pre-existing `too_many_lines` clippy warning in `tests/neuroevolution_neat.rs` is unrelated to #147 and tracked separately in #240.
- Literature provenance (Ferreira 2001 §3.2 eq. 3.4; Beyer & Sendhoff 2008) and the full code-vs-paper reconciliation are recorded in the maintainer vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

