### PR TITLE
chore(clippy): clear workspace clippy warnings

### DIFF
--- a/crates/rlevo-benchmarks/src/evaluator.rs
+++ b/crates/rlevo-benchmarks/src/evaluator.rs
@@ -408,7 +408,7 @@ mod tests {
             self.steps_taken += 1;
             let done = self.steps_taken >= self.steps_until_done;
             Ok(BenchStep {
-                observation: self.steps_taken as u32,
+                observation: u32::try_from(self.steps_taken).expect("stub step count fits in u32"),
                 reward: 1.0,
                 done,
             })
@@ -624,7 +624,7 @@ mod tests {
             fn reset(&mut self) -> Result<u32, BenchError> {
                 Ok(0)
             }
-            fn step(&mut self, _: ()) -> Result<BenchStep<u32>, BenchError> {
+            fn step(&mut self, (): ()) -> Result<BenchStep<u32>, BenchError> {
                 panic!("deliberate evaluator test panic");
             }
         }
@@ -670,7 +670,7 @@ mod tests {
             .map(|t| (t.key.env_idx, t.key.trial_idx))
             .collect();
         let mut expected = keys.clone();
-        expected.sort();
+        expected.sort_unstable();
         assert_eq!(keys, expected);
     }
 

--- a/crates/rlevo-environments/src/classic/acrobot.rs
+++ b/crates/rlevo-environments/src/classic/acrobot.rs
@@ -927,6 +927,51 @@ fn style_label_line(line: &str, label: &str) -> crate::render::StyledLine {
     }
 }
 
+impl<D: AcrobotDynamicsFn + Default> rlevo_core::render::payload::Classic2DPayloadSource
+    for Acrobot<D>
+{
+    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
+        use rlevo_core::render::payload::{
+            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
+        };
+        let l1 = self.config.link_length_1;
+        let l2 = self.config.link_length_2;
+        let t1 = self.state.theta1; // from downward vertical (0 = hanging down)
+        let t2 = self.state.theta2; // relative to link 1
+        // Pivot at origin; downward is -y. Absolute angle of link 2 = t1 + t2.
+        let pivot = Point2::new(0.0, 0.0);
+        let j1 = Point2::new(l1 * t1.sin(), -l1 * t1.cos());
+        let a2 = t1 + t2;
+        let j2 = Point2::new(j1.x + l2 * a2.sin(), j1.y - l2 * a2.cos());
+        let m = l1 + l2 + 0.2;
+        Classic2DSnapshot {
+            bodies: vec![
+                Classic2DBody {
+                    points: vec![pivot, j1],
+                    role: Classic2DRole::Link,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: vec![j1, j2],
+                    role: Classic2DRole::Link,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: vec![pivot],
+                    role: Classic2DRole::Hinge,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: vec![j1],
+                    role: Classic2DRole::Hinge,
+                    closed: false,
+                },
+            ],
+            bounds: (Point2::new(-m, -m), Point2::new(m, m)),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1184,50 +1229,5 @@ mod tests {
             a, b,
             "reset_with_seed must reproduce the same initial state"
         );
-    }
-}
-
-impl<D: AcrobotDynamicsFn + Default> rlevo_core::render::payload::Classic2DPayloadSource
-    for Acrobot<D>
-{
-    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
-        use rlevo_core::render::payload::{
-            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
-        };
-        let l1 = self.config.link_length_1;
-        let l2 = self.config.link_length_2;
-        let t1 = self.state.theta1; // from downward vertical (0 = hanging down)
-        let t2 = self.state.theta2; // relative to link 1
-        // Pivot at origin; downward is -y. Absolute angle of link 2 = t1 + t2.
-        let pivot = Point2::new(0.0, 0.0);
-        let j1 = Point2::new(l1 * t1.sin(), -l1 * t1.cos());
-        let a2 = t1 + t2;
-        let j2 = Point2::new(j1.x + l2 * a2.sin(), j1.y - l2 * a2.cos());
-        let m = l1 + l2 + 0.2;
-        Classic2DSnapshot {
-            bodies: vec![
-                Classic2DBody {
-                    points: vec![pivot, j1],
-                    role: Classic2DRole::Link,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: vec![j1, j2],
-                    role: Classic2DRole::Link,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: vec![pivot],
-                    role: Classic2DRole::Hinge,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: vec![j1],
-                    role: Classic2DRole::Hinge,
-                    closed: false,
-                },
-            ],
-            bounds: (Point2::new(-m, -m), Point2::new(m, m)),
-        }
     }
 }

--- a/crates/rlevo-environments/src/classic/cartpole.rs
+++ b/crates/rlevo-environments/src/classic/cartpole.rs
@@ -849,6 +849,52 @@ impl CartPoleState {
     }
 }
 
+impl rlevo_core::render::payload::Classic2DPayloadSource for CartPole {
+    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
+        use rlevo_core::render::payload::{
+            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
+        };
+        let x = self.state.x;
+        let theta = self.state.theta; // 0 = upright, +clockwise
+        let xt = self.config.x_threshold;
+        let pole_len = 2.0 * self.config.length; // full rod length = 2·half-length
+        let (cart_w, cart_h) = (0.4_f32, 0.25_f32);
+        let hinge_y = cart_h; // hinge atop the cart
+        // Cart rectangle centred at (x, cart_h/2).
+        let cy = cart_h * 0.5;
+        let cart = vec![
+            Point2::new(x - cart_w * 0.5, cy - cart_h * 0.5),
+            Point2::new(x + cart_w * 0.5, cy - cart_h * 0.5),
+            Point2::new(x + cart_w * 0.5, cy + cart_h * 0.5),
+            Point2::new(x - cart_w * 0.5, cy + cart_h * 0.5),
+        ];
+        let tip = Point2::new(x + pole_len * theta.sin(), hinge_y + pole_len * theta.cos());
+        Classic2DSnapshot {
+            bodies: vec![
+                Classic2DBody {
+                    points: vec![Point2::new(-xt, 0.0), Point2::new(xt, 0.0)],
+                    role: Classic2DRole::Track,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: cart,
+                    role: Classic2DRole::Cart,
+                    closed: true,
+                },
+                Classic2DBody {
+                    points: vec![Point2::new(x, hinge_y), tip],
+                    role: Classic2DRole::Pole,
+                    closed: false,
+                },
+            ],
+            bounds: (
+                Point2::new(-xt - 0.2, -0.4),
+                Point2::new(xt + 0.2, pole_len + 0.4),
+            ),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1179,51 +1225,5 @@ mod tests {
             a, b,
             "reset_with_seed must reproduce the same initial state"
         );
-    }
-}
-
-impl rlevo_core::render::payload::Classic2DPayloadSource for CartPole {
-    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
-        use rlevo_core::render::payload::{
-            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
-        };
-        let x = self.state.x;
-        let theta = self.state.theta; // 0 = upright, +clockwise
-        let xt = self.config.x_threshold;
-        let pole_len = 2.0 * self.config.length; // full rod length = 2·half-length
-        let (cart_w, cart_h) = (0.4_f32, 0.25_f32);
-        let hinge_y = cart_h; // hinge atop the cart
-        // Cart rectangle centred at (x, cart_h/2).
-        let cy = cart_h * 0.5;
-        let cart = vec![
-            Point2::new(x - cart_w * 0.5, cy - cart_h * 0.5),
-            Point2::new(x + cart_w * 0.5, cy - cart_h * 0.5),
-            Point2::new(x + cart_w * 0.5, cy + cart_h * 0.5),
-            Point2::new(x - cart_w * 0.5, cy + cart_h * 0.5),
-        ];
-        let tip = Point2::new(x + pole_len * theta.sin(), hinge_y + pole_len * theta.cos());
-        Classic2DSnapshot {
-            bodies: vec![
-                Classic2DBody {
-                    points: vec![Point2::new(-xt, 0.0), Point2::new(xt, 0.0)],
-                    role: Classic2DRole::Track,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: cart,
-                    role: Classic2DRole::Cart,
-                    closed: true,
-                },
-                Classic2DBody {
-                    points: vec![Point2::new(x, hinge_y), tip],
-                    role: Classic2DRole::Pole,
-                    closed: false,
-                },
-            ],
-            bounds: (
-                Point2::new(-xt - 0.2, -0.4),
-                Point2::new(xt + 0.2, pole_len + 0.4),
-            ),
-        }
     }
 }

--- a/crates/rlevo-environments/src/classic/mountain_car.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car.rs
@@ -556,6 +556,48 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for MountainCarA
     }
 }
 
+impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCar {
+    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
+        use rlevo_core::render::payload::{
+            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
+        };
+        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
+        // Terrain profile y = sin(3x), sampled across the track.
+        const SAMPLES: usize = 48;
+        let terrain: Vec<Point2> = (0..=SAMPLES)
+            .map(|i| {
+                let x = lo + (hi - lo) * (i as f32 / SAMPLES as f32);
+                Point2::new(x, (3.0 * x).sin())
+            })
+            .collect();
+        let px = self.state.position;
+        let py = (3.0 * px).sin();
+        // Car as a small square sitting on the hill.
+        let r = 0.04;
+        let car = vec![
+            Point2::new(px - r, py - r),
+            Point2::new(px + r, py - r),
+            Point2::new(px + r, py + r),
+            Point2::new(px - r, py + r),
+        ];
+        Classic2DSnapshot {
+            bodies: vec![
+                Classic2DBody {
+                    points: terrain,
+                    role: Classic2DRole::Track,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: car,
+                    role: Classic2DRole::Car,
+                    closed: true,
+                },
+            ],
+            bounds: (Point2::new(lo - 0.1, -1.1), Point2::new(hi + 0.1, 1.1)),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -765,47 +807,5 @@ mod tests {
             a, b,
             "reset_with_seed must reproduce the same initial state"
         );
-    }
-}
-
-impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCar {
-    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
-        use rlevo_core::render::payload::{
-            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
-        };
-        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
-        // Terrain profile y = sin(3x), sampled across the track.
-        const SAMPLES: usize = 48;
-        let terrain: Vec<Point2> = (0..=SAMPLES)
-            .map(|i| {
-                let x = lo + (hi - lo) * (i as f32 / SAMPLES as f32);
-                Point2::new(x, (3.0 * x).sin())
-            })
-            .collect();
-        let px = self.state.position;
-        let py = (3.0 * px).sin();
-        // Car as a small square sitting on the hill.
-        let r = 0.04;
-        let car = vec![
-            Point2::new(px - r, py - r),
-            Point2::new(px + r, py - r),
-            Point2::new(px + r, py + r),
-            Point2::new(px - r, py + r),
-        ];
-        Classic2DSnapshot {
-            bodies: vec![
-                Classic2DBody {
-                    points: terrain,
-                    role: Classic2DRole::Track,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: car,
-                    role: Classic2DRole::Car,
-                    closed: true,
-                },
-            ],
-            bounds: (Point2::new(lo - 0.1, -1.1), Point2::new(hi + 0.1, 1.1)),
-        }
     }
 }

--- a/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
@@ -618,6 +618,48 @@ fn style_track_line(line: &str, agent_glyph: char) -> crate::render::StyledLine 
     StyledLine::from_spans(spans)
 }
 
+impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCarContinuous {
+    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
+        use rlevo_core::render::payload::{
+            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
+        };
+        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
+        // Terrain profile y = sin(3x), sampled across the track.
+        const SAMPLES: usize = 48;
+        let terrain: Vec<Point2> = (0..=SAMPLES)
+            .map(|i| {
+                let x = lo + (hi - lo) * (i as f32 / SAMPLES as f32);
+                Point2::new(x, (3.0 * x).sin())
+            })
+            .collect();
+        let px = self.state.position;
+        let py = (3.0 * px).sin();
+        // Car as a small square sitting on the hill.
+        let r = 0.04;
+        let car = vec![
+            Point2::new(px - r, py - r),
+            Point2::new(px + r, py - r),
+            Point2::new(px + r, py + r),
+            Point2::new(px - r, py + r),
+        ];
+        Classic2DSnapshot {
+            bodies: vec![
+                Classic2DBody {
+                    points: terrain,
+                    role: Classic2DRole::Track,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: car,
+                    role: Classic2DRole::Car,
+                    closed: true,
+                },
+            ],
+            bounds: (Point2::new(lo - 0.1, -1.1), Point2::new(hi + 0.1, 1.1)),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -823,47 +865,5 @@ mod tests {
             a, b,
             "reset_with_seed must reproduce the same initial state"
         );
-    }
-}
-
-impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCarContinuous {
-    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
-        use rlevo_core::render::payload::{
-            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
-        };
-        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
-        // Terrain profile y = sin(3x), sampled across the track.
-        const SAMPLES: usize = 48;
-        let terrain: Vec<Point2> = (0..=SAMPLES)
-            .map(|i| {
-                let x = lo + (hi - lo) * (i as f32 / SAMPLES as f32);
-                Point2::new(x, (3.0 * x).sin())
-            })
-            .collect();
-        let px = self.state.position;
-        let py = (3.0 * px).sin();
-        // Car as a small square sitting on the hill.
-        let r = 0.04;
-        let car = vec![
-            Point2::new(px - r, py - r),
-            Point2::new(px + r, py - r),
-            Point2::new(px + r, py + r),
-            Point2::new(px - r, py + r),
-        ];
-        Classic2DSnapshot {
-            bodies: vec![
-                Classic2DBody {
-                    points: terrain,
-                    role: Classic2DRole::Track,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: car,
-                    role: Classic2DRole::Car,
-                    closed: true,
-                },
-            ],
-            bounds: (Point2::new(lo - 0.1, -1.1), Point2::new(hi + 0.1, 1.1)),
-        }
     }
 }

--- a/crates/rlevo-environments/src/classic/pendulum.rs
+++ b/crates/rlevo-environments/src/classic/pendulum.rs
@@ -587,6 +587,34 @@ impl<B: burn::tensor::backend::Backend> TensorConvertible<1, B> for PendulumActi
     }
 }
 
+impl rlevo_core::render::payload::Classic2DPayloadSource for Pendulum {
+    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
+        use rlevo_core::render::payload::{
+            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
+        };
+        let l = self.config.l;
+        let theta = self.state.theta; // 0 = upright, measured from up vertical
+        // Tip: upright (+y) at theta=0; +theta rotates clockwise.
+        let tip = Point2::new(l * theta.sin(), l * theta.cos());
+        let m = l + 0.2;
+        Classic2DSnapshot {
+            bodies: vec![
+                Classic2DBody {
+                    points: vec![Point2::new(0.0, 0.0), tip],
+                    role: Classic2DRole::Pole,
+                    closed: false,
+                },
+                Classic2DBody {
+                    points: vec![Point2::new(0.0, 0.0)],
+                    role: Classic2DRole::Hinge,
+                    closed: false,
+                },
+            ],
+            bounds: (Point2::new(-m, -m), Point2::new(m, m)),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -783,33 +811,5 @@ mod tests {
             a, b,
             "reset_with_seed must reproduce the same initial state"
         );
-    }
-}
-
-impl rlevo_core::render::payload::Classic2DPayloadSource for Pendulum {
-    fn classic2d_snapshot(&self) -> rlevo_core::render::payload::Classic2DSnapshot {
-        use rlevo_core::render::payload::{
-            Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
-        };
-        let l = self.config.l;
-        let theta = self.state.theta; // 0 = upright, measured from up vertical
-        // Tip: upright (+y) at theta=0; +theta rotates clockwise.
-        let tip = Point2::new(l * theta.sin(), l * theta.cos());
-        let m = l + 0.2;
-        Classic2DSnapshot {
-            bodies: vec![
-                Classic2DBody {
-                    points: vec![Point2::new(0.0, 0.0), tip],
-                    role: Classic2DRole::Pole,
-                    closed: false,
-                },
-                Classic2DBody {
-                    points: vec![Point2::new(0.0, 0.0)],
-                    role: Classic2DRole::Hinge,
-                    closed: false,
-                },
-            ],
-            bounds: (Point2::new(-m, -m), Point2::new(m, m)),
-        }
     }
 }

--- a/crates/rlevo-environments/src/grids/crossing.rs
+++ b/crates/rlevo-environments/src/grids/crossing.rs
@@ -427,6 +427,12 @@ impl Environment<3, 3, 1> for CrossingEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for CrossingEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -572,11 +578,5 @@ mod tests {
         let env = default_env(CrossingKind::Lava);
         assert_eq!(env.gap_col(), 3);
         assert_eq!(env.strip_rows(), vec![2, 4]);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for CrossingEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/dist_shift.rs
+++ b/crates/rlevo-environments/src/grids/dist_shift.rs
@@ -385,6 +385,12 @@ impl Environment<3, 3, 1> for DistShiftEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for DistShiftEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -525,11 +531,5 @@ mod tests {
     #[test]
     fn unknown_variant_errors() {
         assert!("variant=wat".parse::<DistShiftConfig>().is_err());
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for DistShiftEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/door_key.rs
+++ b/crates/rlevo-environments/src/grids/door_key.rs
@@ -384,6 +384,12 @@ impl Environment<3, 3, 1> for DoorKeyEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for DoorKeyEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -522,11 +528,5 @@ mod tests {
         assert_eq!(env.state().agent.x, 1);
         assert_eq!(env.state().agent.y, 2);
         assert_eq!(env.state().agent.direction, Direction::North);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for DoorKeyEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
+++ b/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
@@ -490,6 +490,12 @@ impl Environment<3, 3, 1> for DynamicObstaclesEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for DynamicObstaclesEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -684,11 +690,5 @@ mod tests {
         env.reset_with_seed(999).unwrap();
         let b = env.obstacles().to_vec();
         assert_eq!(a, b, "reset_with_seed must reproduce the same layout");
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for DynamicObstaclesEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/empty.rs
+++ b/crates/rlevo-environments/src/grids/empty.rs
@@ -347,6 +347,12 @@ impl Environment<3, 3, 1> for EmptyEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for EmptyEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,11 +532,5 @@ mod tests {
         let s = env.to_string();
         assert!(s.contains("EmptyEnv"));
         assert!(s.contains("50"));
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for EmptyEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/four_rooms.rs
+++ b/crates/rlevo-environments/src/grids/four_rooms.rs
@@ -374,6 +374,12 @@ impl Environment<3, 3, 1> for FourRoomsEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for FourRoomsEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -519,11 +525,5 @@ mod tests {
         assert_eq!(env.steps(), 2);
         env.reset().unwrap();
         assert_eq!(env.steps(), 0);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for FourRoomsEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/go_to_door.rs
+++ b/crates/rlevo-environments/src/grids/go_to_door.rs
@@ -419,6 +419,12 @@ impl Environment<3, 3, 1> for GoToDoorEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for GoToDoorEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -587,11 +593,5 @@ mod tests {
         let sb = b.reset().unwrap();
         assert_eq!(sa.observation(), sb.observation());
         assert_eq!(a.mission(), b.mission());
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for GoToDoorEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/lava_gap.rs
+++ b/crates/rlevo-environments/src/grids/lava_gap.rs
@@ -357,6 +357,12 @@ impl Environment<3, 3, 1> for LavaGapEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for LavaGapEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -482,11 +488,5 @@ mod tests {
         assert_eq!(env.steps(), 2);
         env.reset().unwrap();
         assert_eq!(env.steps(), 0);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for LavaGapEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/memory.rs
+++ b/crates/rlevo-environments/src/grids/memory.rs
@@ -389,6 +389,12 @@ impl Environment<3, 3, 1> for MemoryEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for MemoryEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -550,11 +556,5 @@ mod tests {
         let (fx, fy) = env.state().agent.front();
         assert_eq!(env.state().grid.get(fx, fy), Entity::Ball(DISTRACTOR_COLOR));
         assert!(!env.facing_match());
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for MemoryEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/multi_room.rs
+++ b/crates/rlevo-environments/src/grids/multi_room.rs
@@ -424,6 +424,12 @@ impl Environment<3, 3, 1> for MultiRoomEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for MultiRoomEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -571,11 +577,5 @@ mod tests {
         assert_eq!(env.steps(), 1);
         env.reset().unwrap();
         assert_eq!(env.steps(), 0);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for MultiRoomEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/unlock.rs
+++ b/crates/rlevo-environments/src/grids/unlock.rs
@@ -347,6 +347,12 @@ impl Environment<3, 3, 1> for UnlockEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for UnlockEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -480,11 +486,5 @@ mod tests {
         assert_eq!(env.steps(), 4);
         env.reset().unwrap();
         assert_eq!(env.steps(), 0);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for UnlockEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/grids/unlock_pickup.rs
+++ b/crates/rlevo-environments/src/grids/unlock_pickup.rs
@@ -360,6 +360,12 @@ impl Environment<3, 3, 1> for UnlockPickupEnv {
     }
 }
 
+impl rlevo_core::render::payload::GridPayloadSource for UnlockPickupEnv {
+    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
+        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -498,11 +504,5 @@ mod tests {
         env.reset().unwrap();
         assert_eq!(env.state().agent.carrying, None);
         assert_eq!(env.steps(), 0);
-    }
-}
-
-impl rlevo_core::render::payload::GridPayloadSource for UnlockPickupEnv {
-    fn grid_snapshot(&self) -> rlevo_core::render::payload::GridSnapshot {
-        crate::grids::core::render::grid_snapshot(&self.state.grid, &self.state.agent)
     }
 }

--- a/crates/rlevo-environments/src/toy_text/blackjack.rs
+++ b/crates/rlevo-environments/src/toy_text/blackjack.rs
@@ -452,6 +452,21 @@ impl crate::render::AsciiRenderable for Blackjack {
     }
 }
 
+impl rlevo_core::render::payload::TabularPayloadSource for Blackjack {
+    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
+        use rlevo_core::render::payload::{CardTable, TabularLayout, TabularSnapshot};
+        TabularSnapshot {
+            layout: TabularLayout::Cards(CardTable {
+                player_cards: self.state.player_hand.clone(),
+                player_total: self.state.player_sum,
+                usable_ace: self.state.usable_ace,
+                dealer_cards: self.state.dealer_hand.clone(),
+                dealer_showing: self.state.dealer_showing,
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 /// Unit tests for [`Blackjack`], covering actions, observations, rewards, and RNG determinism.
 mod tests {
@@ -704,21 +719,6 @@ mod tests {
                 "line exceeds 80 cols: {line:?} ({} chars)",
                 line.chars().count()
             );
-        }
-    }
-}
-
-impl rlevo_core::render::payload::TabularPayloadSource for Blackjack {
-    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
-        use rlevo_core::render::payload::{CardTable, TabularLayout, TabularSnapshot};
-        TabularSnapshot {
-            layout: TabularLayout::Cards(CardTable {
-                player_cards: self.state.player_hand.clone(),
-                player_total: self.state.player_sum,
-                usable_ace: self.state.usable_ace,
-                dealer_cards: self.state.dealer_hand.clone(),
-                dealer_showing: self.state.dealer_showing,
-            }),
         }
     }
 }

--- a/crates/rlevo-environments/src/toy_text/cliff_walking.rs
+++ b/crates/rlevo-environments/src/toy_text/cliff_walking.rs
@@ -459,6 +459,45 @@ fn cell_char(row: u8, col: u8, agent_row: u8, agent_col: u8) -> char {
     }
 }
 
+impl rlevo_core::render::payload::TabularPayloadSource for CliffWalking {
+    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
+        use rlevo_core::render::payload::{
+            TabularCell, TabularGrid, TabularLayout, TabularMarker, TabularMarkerKind,
+            TabularSnapshot,
+        };
+        // Fixed 4×12 grid: bottom-row interior is the cliff; corners are
+        // start (3,0) and goal (3,11).
+        let height: u8 = 4;
+        let mut cells = Vec::with_capacity(usize::from(height) * usize::from(NCOL));
+        for row in 0..height {
+            for col in 0..NCOL {
+                let cell = if (row, col) == START {
+                    TabularCell::Start
+                } else if (row, col) == GOAL {
+                    TabularCell::Goal
+                } else if is_cliff(row, col) {
+                    TabularCell::Hazard
+                } else {
+                    TabularCell::Empty
+                };
+                cells.push(cell);
+            }
+        }
+        TabularSnapshot {
+            layout: TabularLayout::Grid(TabularGrid {
+                width: u16::from(NCOL),
+                height: u16::from(height),
+                cells,
+                markers: vec![TabularMarker {
+                    x: u16::from(self.state.col),
+                    y: u16::from(self.state.row),
+                    kind: TabularMarkerKind::Agent,
+                }],
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 /// Unit tests for [`CliffWalking`], covering state encoding, cliff/goal transitions,
 /// boundary behaviour, slippery distributions, and RNG determinism.
@@ -696,45 +735,6 @@ mod tests {
                 "line exceeds 80 cols: {line:?} ({} chars)",
                 line.chars().count()
             );
-        }
-    }
-}
-
-impl rlevo_core::render::payload::TabularPayloadSource for CliffWalking {
-    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
-        use rlevo_core::render::payload::{
-            TabularCell, TabularGrid, TabularLayout, TabularMarker, TabularMarkerKind,
-            TabularSnapshot,
-        };
-        // Fixed 4×12 grid: bottom-row interior is the cliff; corners are
-        // start (3,0) and goal (3,11).
-        let height: u8 = 4;
-        let mut cells = Vec::with_capacity(usize::from(height) * usize::from(NCOL));
-        for row in 0..height {
-            for col in 0..NCOL {
-                let cell = if (row, col) == START {
-                    TabularCell::Start
-                } else if (row, col) == GOAL {
-                    TabularCell::Goal
-                } else if is_cliff(row, col) {
-                    TabularCell::Hazard
-                } else {
-                    TabularCell::Empty
-                };
-                cells.push(cell);
-            }
-        }
-        TabularSnapshot {
-            layout: TabularLayout::Grid(TabularGrid {
-                width: u16::from(NCOL),
-                height: u16::from(height),
-                cells,
-                markers: vec![TabularMarker {
-                    x: u16::from(self.state.col),
-                    y: u16::from(self.state.row),
-                    kind: TabularMarkerKind::Agent,
-                }],
-            }),
         }
     }
 }

--- a/crates/rlevo-environments/src/toy_text/frozen_lake.rs
+++ b/crates/rlevo-environments/src/toy_text/frozen_lake.rs
@@ -776,6 +776,38 @@ const fn tile_char(t: Tile) -> char {
     }
 }
 
+impl rlevo_core::render::payload::TabularPayloadSource for FrozenLake {
+    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
+        use rlevo_core::render::payload::{
+            TabularCell, TabularGrid, TabularLayout, TabularMarker, TabularMarkerKind,
+            TabularSnapshot,
+        };
+        let cells = self
+            .map
+            .tiles
+            .iter()
+            .map(|t| match t {
+                Tile::Start => TabularCell::Start,
+                Tile::Frozen => TabularCell::Frozen,
+                Tile::Hole => TabularCell::Hazard,
+                Tile::Goal => TabularCell::Goal,
+            })
+            .collect();
+        TabularSnapshot {
+            layout: TabularLayout::Grid(TabularGrid {
+                width: self.map.ncol as u16,
+                height: self.map.nrow as u16,
+                cells,
+                markers: vec![TabularMarker {
+                    x: u16::from(self.state.col),
+                    y: u16::from(self.state.row),
+                    kind: TabularMarkerKind::Agent,
+                }],
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 /// Unit tests for [`FrozenLake`], covering map validation, tile transitions,
 /// reward customisation, slippery distributions, random map generation, and determinism.
@@ -834,7 +866,7 @@ mod tests {
         // "SFFF / FHFH / FFFH / HFFG": start top-left, goal bottom-right, holes present.
         assert_eq!(grid.cells[0], TabularCell::Start);
         assert_eq!(grid.cells[15], TabularCell::Goal);
-        assert!(grid.cells.iter().any(|c| *c == TabularCell::Hazard));
+        assert!(grid.cells.contains(&TabularCell::Hazard));
         // One agent marker at the start cell (0, 0).
         assert_eq!(grid.markers.len(), 1);
         assert_eq!(grid.markers[0].kind, TabularMarkerKind::Agent);
@@ -1106,38 +1138,6 @@ mod tests {
                 "line exceeds 80 cols: {line:?} ({} chars)",
                 line.chars().count()
             );
-        }
-    }
-}
-
-impl rlevo_core::render::payload::TabularPayloadSource for FrozenLake {
-    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
-        use rlevo_core::render::payload::{
-            TabularCell, TabularGrid, TabularLayout, TabularMarker, TabularMarkerKind,
-            TabularSnapshot,
-        };
-        let cells = self
-            .map
-            .tiles
-            .iter()
-            .map(|t| match t {
-                Tile::Start => TabularCell::Start,
-                Tile::Frozen => TabularCell::Frozen,
-                Tile::Hole => TabularCell::Hazard,
-                Tile::Goal => TabularCell::Goal,
-            })
-            .collect();
-        TabularSnapshot {
-            layout: TabularLayout::Grid(TabularGrid {
-                width: self.map.ncol as u16,
-                height: self.map.nrow as u16,
-                cells,
-                markers: vec![TabularMarker {
-                    x: u16::from(self.state.col),
-                    y: u16::from(self.state.row),
-                    kind: TabularMarkerKind::Agent,
-                }],
-            }),
         }
     }
 }

--- a/crates/rlevo-environments/src/toy_text/taxi.rs
+++ b/crates/rlevo-environments/src/toy_text/taxi.rs
@@ -641,6 +641,53 @@ fn passenger_label(pass_loc: u8) -> &'static str {
     }
 }
 
+impl rlevo_core::render::payload::TabularPayloadSource for Taxi {
+    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
+        use rlevo_core::render::payload::{
+            TabularCell, TabularGrid, TabularLayout, TabularMarker, TabularMarkerKind,
+            TabularSnapshot,
+        };
+        // Fixed 5×5 grid. Inter-cell walls are omitted from the structured
+        // view (a deliberate stopgap, like locomotion's 2D projection); the
+        // taxi / passenger / destination markers carry the task dynamics.
+        const SIZE: u16 = 5;
+        let cells = vec![TabularCell::Empty; (SIZE * SIZE) as usize];
+        let mut markers = Vec::with_capacity(3);
+        // Taxi (LOCS entries are (row, col)).
+        markers.push(TabularMarker {
+            x: u16::from(self.state.taxi_col),
+            y: u16::from(self.state.taxi_row),
+            kind: TabularMarkerKind::Agent,
+        });
+        // Passenger: at a named location, or riding in the taxi (loc == 4).
+        let (prow, pcol) = if self.state.passenger_loc < 4 {
+            LOCS[self.state.passenger_loc as usize]
+        } else {
+            (self.state.taxi_row, self.state.taxi_col)
+        };
+        markers.push(TabularMarker {
+            x: u16::from(pcol),
+            y: u16::from(prow),
+            kind: TabularMarkerKind::Passenger,
+        });
+        // Destination.
+        let (drow, dcol) = LOCS[self.state.destination as usize];
+        markers.push(TabularMarker {
+            x: u16::from(dcol),
+            y: u16::from(drow),
+            kind: TabularMarkerKind::Destination,
+        });
+        TabularSnapshot {
+            layout: TabularLayout::Grid(TabularGrid {
+                width: SIZE,
+                height: SIZE,
+                cells,
+                markers,
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 /// Unit tests for [`Taxi`], covering state encoding, wall collisions, pickup/dropoff rewards,
 /// stochastic modes, and RNG determinism.
@@ -910,53 +957,6 @@ mod tests {
                 "line exceeds 80 cols: {line:?} ({} chars)",
                 line.chars().count()
             );
-        }
-    }
-}
-
-impl rlevo_core::render::payload::TabularPayloadSource for Taxi {
-    fn tabular_snapshot(&self) -> rlevo_core::render::payload::TabularSnapshot {
-        use rlevo_core::render::payload::{
-            TabularCell, TabularGrid, TabularLayout, TabularMarker, TabularMarkerKind,
-            TabularSnapshot,
-        };
-        // Fixed 5×5 grid. Inter-cell walls are omitted from the structured
-        // view (a deliberate stopgap, like locomotion's 2D projection); the
-        // taxi / passenger / destination markers carry the task dynamics.
-        const SIZE: u16 = 5;
-        let cells = vec![TabularCell::Empty; (SIZE * SIZE) as usize];
-        let mut markers = Vec::with_capacity(3);
-        // Taxi (LOCS entries are (row, col)).
-        markers.push(TabularMarker {
-            x: u16::from(self.state.taxi_col),
-            y: u16::from(self.state.taxi_row),
-            kind: TabularMarkerKind::Agent,
-        });
-        // Passenger: at a named location, or riding in the taxi (loc == 4).
-        let (prow, pcol) = if self.state.passenger_loc < 4 {
-            LOCS[self.state.passenger_loc as usize]
-        } else {
-            (self.state.taxi_row, self.state.taxi_col)
-        };
-        markers.push(TabularMarker {
-            x: u16::from(pcol),
-            y: u16::from(prow),
-            kind: TabularMarkerKind::Passenger,
-        });
-        // Destination.
-        let (drow, dcol) = LOCS[self.state.destination as usize];
-        markers.push(TabularMarker {
-            x: u16::from(dcol),
-            y: u16::from(drow),
-            kind: TabularMarkerKind::Destination,
-        });
-        TabularSnapshot {
-            layout: TabularLayout::Grid(TabularGrid {
-                width: SIZE,
-                height: SIZE,
-                cells,
-                markers,
-            }),
         }
     }
 }

--- a/crates/rlevo/tests/recording_episode_count.rs
+++ b/crates/rlevo/tests/recording_episode_count.rs
@@ -73,8 +73,8 @@ const EP_LEN: usize = 10;
 /// Fixed-length toy environment that terminates every `episode_len` steps,
 /// used to make episode counts predictable in recording tests.
 ///
-/// Reuses CartPole's observation, action, and reward types solely to inherit
-/// their `Observation`, `Action`, and `TensorConvertible` impls. No CartPole
+/// Reuses `CartPole`'s observation, action, and reward types solely to inherit
+/// their `Observation`, `Action`, and `TensorConvertible` impls. No `CartPole`
 /// physics is involved.
 #[derive(Debug)]
 struct FixedLenEnv {


### PR DESCRIPTION
## Summary

Clears every remaining `cargo clippy --all-targets --all-features` warning so the workspace lint gate is clean. This is a mechanical maintenance PR split out of #244 (the #241 fix) at the maintainer's request — **no behaviour changes**, only warning fixes. The bulk (21 files) is `items_after_test_module`: each affected environment module had a trailing `impl` block sitting after its `#[cfg(test)] mod tests`, which clippy asks to move above the test module.

## Change Type

- [x] Other — mechanical clippy/lint cleanup (warnings are treated as errors in CI). No API, environment, algorithm, or dependency changes.

## Linked Issue

No dedicated issue — follow-up to the clippy warnings surfaced while resolving #241 (see #244). Happy to open a tracking issue if the alpha-scope policy requires one.

## What Was Changed

- **`items_after_test_module` (21 environment modules)** — relocated the trailing `impl … for <Env>` block(s) to *before* the `#[cfg(test)] mod tests { … }` block. Pure relocation (symmetric 414-insertion / 414-deletion diff; no item altered). Files: `classic/{acrobot,cartpole,mountain_car,mountain_car_continuous,pendulum}.rs`, `grids/{crossing,dist_shift,door_key,dynamic_obstacles,empty,four_rooms,go_to_door,lava_gap,memory,multi_room,unlock,unlock_pickup}.rs`, `toy_text/{blackjack,cliff_walking,frozen_lake,taxi}.rs`.
- **`crates/rlevo-benchmarks/src/evaluator.rs`** — `cast_possible_truncation`: replaced `self.steps_taken as u32` with `u32::try_from(self.steps_taken).expect("stub step count fits in u32")` (checked conversion per docs/rules.md convention; `steps_taken` is a small test-stub counter); `stable_sort_primitive`: `sort()` → `sort_unstable()`; `ignored_unit_patterns`: explicit unit match.
- **`crates/rlevo-environments/src/toy_text/frozen_lake.rs`** — `contains()` in place of `iter().any()`.
- **`crates/rlevo/tests/recording_episode_count.rs`** — backticked two bare `CartPole` references in a doc comment (`doc_markdown`).

## How It Was Tested

```
cargo build --workspace                       # Finished, clean
cargo test --workspace                        # no failures
cargo clippy --all-targets --all-features     # zero warnings (was ~29)
cargo fmt --all --check                       # clean
```

- Rust toolchain: `1.94.1` (pinned via `rust-toolchain.toml`)
- OS: macOS (darwin, aarch64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: full change — mostly `cargo clippy --fix` auto-applied, with the `evaluator.rs` cast resolved by hand; verified via workspace build/test/clippy/fmt.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments — n/a (no API change).
- [ ] Bug fixes include a regression test — n/a (lint cleanup, no behaviour change).
- [x] This PR addresses a single concern (clippy cleanup).
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- Independent of #244 (that PR touches only `cma_es.rs`). The one incidental overlap is the `CartPole` doc backticks in `recording_episode_count.rs`, which #244 also fixes — if #244 merges first this hunk drops out cleanly (identical change).
- No new `#[allow]` attributes were added.