### PR TITLE
test(evolution): cover coevolution/neat panic gaps (#148)

### DIFF
--- a/crates/rlevo-evolution/src/coevolution/competitive.rs
+++ b/crates/rlevo-evolution/src/coevolution/competitive.rs
@@ -423,4 +423,137 @@ mod tests {
             m.mean_fitness_a
         );
     }
+
+    /// Coupled fitness returning a DISTINCT ascending ramp per population: A's
+    /// ramp peaks at `10.0`, B's at `20.0`. Because the two returned vectors
+    /// differ, this pins that population A is scored by
+    /// `evaluate_coupled(...)[0]` and B by `[1]` (index 0 → A, index 1 → B).
+    /// Maximize, so natural == canonical and the reported best is the peak.
+    struct DistinctRamps;
+
+    impl CoupledFitness<TB> for DistinctRamps {
+        fn evaluate_coupled(&self, populations: &[Tensor<TB, 2>]) -> Vec<Tensor<TB, 1>> {
+            let peaks = [10.0_f32, 20.0_f32];
+            populations
+                .iter()
+                .enumerate()
+                .map(|(k, p)| {
+                    let n = p.dims()[0];
+                    let device = p.device();
+                    let peak = peaks[k];
+                    #[allow(clippy::cast_precision_loss)]
+                    let v: Vec<f32> = (0..n)
+                        .map(|i| peak * (i as f32) / ((n - 1).max(1) as f32))
+                        .collect();
+                    Tensor::<TB, 1>::from_data(TensorData::new(v, [n]), &device)
+                })
+                .collect()
+        }
+        fn sense(&self) -> ObjectiveSense {
+            ObjectiveSense::Maximize
+        }
+    }
+
+    /// One `step` bumps `generation` from 0 to 1 (asserted via both the
+    /// returned [`CoEAMetrics`] and `metrics()` on the returned state), and the
+    /// bi-population fitness split routes each population to its own index:
+    /// A is scored by `evaluate_coupled(...)[0]` (peak `10.0`) and B by `[1]`
+    /// (peak `20.0`). Maximize sense, so natural == canonical.
+    #[test]
+    fn step_increments_generation_and_splits_fitness_by_population() {
+        let device = Default::default();
+        let algo = CompetitiveCoEA::new(
+            GeneticAlgorithm::<TB>::new(),
+            GeneticAlgorithm::<TB>::new(),
+            DistinctRamps,
+        );
+        let params: CompetitiveCoEAParams<GaConfig, GaConfig> = CompetitiveCoEAParams {
+            params_a: ga_config(),
+            params_b: ga_config(),
+        };
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = algo.init(&params, &mut rng, &device);
+        let (next, metrics) = algo.step(&params, state, &mut rng, &device);
+
+        assert_eq!(metrics.generation, 1, "one step must bump generation 0 → 1");
+        assert_eq!(
+            algo.metrics(&next).generation,
+            1,
+            "metrics() on the returned state must agree with the step snapshot"
+        );
+        // A peaks at 10.0 (index 0), B at 20.0 (index 1): the split is correct.
+        approx::assert_relative_eq!(metrics.best_fitness_a, 10.0, epsilon = 1e-6);
+        approx::assert_relative_eq!(metrics.best_fitness_b, 20.0, epsilon = 1e-6);
+    }
+
+    /// A plain [`CoupledFitness`] with no hall-of-fame archive returns an empty
+    /// `archive_sizes()` (fewer than 2 entries), so `snapshot` falls back to
+    /// `hof_size_a == 0` and `hof_size_b == 0` via `.first()` / `.get(1)` with
+    /// `.unwrap_or(0)`.
+    #[test]
+    fn snapshot_hof_size_falls_back_to_zero_without_archive() {
+        let m = run_one_step(DistinctRamps);
+        assert_eq!(m.hof_size_a, 0, "no archive → hof_size_a falls back to 0");
+        assert_eq!(m.hof_size_b, 0, "no archive → hof_size_b falls back to 0");
+    }
+
+    /// `best_fitness_a` is a rolling max (`best_fitness_ever`), so threading the
+    /// returned state through a second `step` must leave it monotonically
+    /// non-decreasing while `generation` advances 0 → 1 → 2. Deterministic under
+    /// a fixed seed.
+    #[test]
+    fn best_a_tracks_rolling_max_across_generations() {
+        let device = Default::default();
+        let algo = CompetitiveCoEA::new(
+            GeneticAlgorithm::<TB>::new(),
+            GeneticAlgorithm::<TB>::new(),
+            DistinctRamps,
+        );
+        let params: CompetitiveCoEAParams<GaConfig, GaConfig> = CompetitiveCoEAParams {
+            params_a: ga_config(),
+            params_b: ga_config(),
+        };
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = algo.init(&params, &mut rng, &device);
+        let (state, m1) = algo.step(&params, state, &mut rng, &device);
+        let (_state, m2) = algo.step(&params, state, &mut rng, &device);
+
+        assert_eq!(m2.generation, 2, "two steps must reach generation 2");
+        assert!(
+            m2.best_fitness_a >= m1.best_fitness_a,
+            "best_fitness_a is a rolling max and must be non-decreasing: {} → {}",
+            m1.best_fitness_a,
+            m2.best_fitness_a
+        );
+    }
+
+    /// Coupled fitness returning the WRONG number of vectors (one, not two),
+    /// violating the bi-population contract.
+    struct WrongLen;
+
+    impl CoupledFitness<TB> for WrongLen {
+        fn evaluate_coupled(&self, populations: &[Tensor<TB, 2>]) -> Vec<Tensor<TB, 1>> {
+            // Return only ONE vector (for population A) — one short of the two
+            // the competitive algorithm requires.
+            let p = &populations[0];
+            let n = p.dims()[0];
+            let device = p.device();
+            vec![Tensor::<TB, 1>::from_data(
+                TensorData::new(vec![0.0_f32; n], [n]),
+                &device,
+            )]
+        }
+        fn sense(&self) -> ObjectiveSense {
+            ObjectiveSense::Maximize
+        }
+    }
+
+    // Pins the debug-only bi-population length contract: `step` carries a
+    // `debug_assert_eq!(fits.len(), 2, …)` which fires under `cargo test`
+    // (debug_assertions on). A wrong-length `evaluate_coupled` must trip it.
+    #[test]
+    #[should_panic(expected = "competitive co-evolution is bi-population")]
+    fn step_panics_on_wrong_length_coupled_fitness() {
+        let _ = run_one_step(WrongLen);
+    }
 }

--- a/crates/rlevo-evolution/src/neuroevolution/species.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/species.rs
@@ -527,6 +527,130 @@ mod tests {
     }
 
     #[test]
+    fn test_compatibility_distance_empty_genome_branch() {
+        // Early-return branch (one genome has no connections): every gene of the
+        // other is excess. `excess = max(len_a, len_b)`, `N = 1` when `excess <
+        // 20` else `excess`, and δ = c1·excess/N. With 25 genes (≥ 20) N = excess,
+        // so δ = c1·excess/excess = c1 exactly.
+        let full = genome_with((0..25).map(|k| conn(k, 0.0)).collect());
+        let empty = genome_with(vec![]);
+
+        // empty-vs-full: excess = 25, N = 25 → δ = c1 = 1.0.
+        approx::assert_relative_eq!(
+            compatibility_distance(&empty, &full, 1.0, 1.0, 0.4),
+            1.0,
+            epsilon = 1e-6
+        );
+        // full-vs-empty: symmetric — same δ = 1.0.
+        approx::assert_relative_eq!(
+            compatibility_distance(&full, &empty, 1.0, 1.0, 0.4),
+            1.0,
+            epsilon = 1e-6
+        );
+        // empty-vs-empty: excess = 0, N = 1 → δ = c1·0/1 = 0.0.
+        approx::assert_relative_eq!(
+            compatibility_distance(&empty, &empty, 1.0, 1.0, 0.4),
+            0.0,
+            epsilon = 1e-6
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "population and fitness must have equal length")]
+    fn test_speciate_panics_on_length_mismatch() {
+        let mut rng = StdRng::seed_from_u64(0);
+        let population = vec![
+            genome_with(vec![conn(0, 0.0)]),
+            genome_with(vec![conn(0, 1.0)]),
+        ];
+        // Deliberately shorter than the population to trip the `assert_eq!`.
+        let fitness = vec![1.0];
+        let mut species: Vec<Species> = Vec::new();
+        let mut next_id = SpeciesId::new(0);
+        speciate(
+            &population,
+            &fitness,
+            &mut species,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            &mut next_id,
+            0,
+            &mut rng,
+        );
+    }
+
+    #[test]
+    fn test_allocate_offspring_single_species_gets_all() {
+        // n == 1 with positive adjusted fitness: share == pop_size, so the lone
+        // species receives every seat.
+        let species = vec![species_with(0, 3.0, 3.0, 0)];
+        let counts = allocate_offspring(&species, 32);
+        assert_eq!(counts, vec![32]);
+    }
+
+    #[test]
+    fn test_allocate_offspring_empty_species_returns_empty() {
+        let species: Vec<Species> = Vec::new();
+        let counts = allocate_offspring(&species, 32);
+        assert!(counts.is_empty(), "no species → no offspring counts");
+    }
+
+    #[test]
+    fn test_allocate_offspring_counts_len_equals_species_len() {
+        let species = vec![
+            species_with(0, 1.0, 1.0, 0),
+            species_with(1, 2.0, 1.0, 0),
+            species_with(2, 3.0, 1.0, 0),
+        ];
+        let counts = allocate_offspring(&species, 20);
+        assert_eq!(
+            counts.len(),
+            species.len(),
+            "one count per species, positionally aligned"
+        );
+    }
+
+    #[test]
+    fn test_remove_stagnant_keeps_best_when_all_stagnant() {
+        // All three species are stagnant (last improved gen 0; gen 30, limit 15).
+        // The top-K=2 protection shields the two highest-fitness species, so the
+        // population is never wiped: species 0 (best 9) and species 1 (best 5)
+        // survive, species 2 (best 1) is removed. (The lower `keep single best`
+        // fallback is unreachable here — top-K already keeps 2.)
+        let mut species = vec![
+            species_with(0, 1.0, 9.0, 0),
+            species_with(1, 1.0, 5.0, 0),
+            species_with(2, 1.0, 1.0, 0),
+        ];
+        remove_stagnant(&mut species, 30, 15);
+        assert_eq!(
+            species.len(),
+            2,
+            "top-K protection keeps the population alive"
+        );
+        let ids: Vec<u64> = species.iter().map(|s| s.id().get()).collect();
+        assert!(ids.contains(&0), "highest-fitness species survives");
+        assert!(ids.contains(&1), "second-highest-fitness species survives");
+        assert!(
+            !ids.contains(&2),
+            "lowest-fitness stagnant species is removed"
+        );
+        assert!(!species.is_empty(), "removal never empties the population");
+    }
+
+    #[test]
+    fn test_remove_stagnant_single_species_is_noop() {
+        // `species.len() <= 1` returns early — even a long-stagnant lone species
+        // is retained (never empty the population).
+        let mut species = vec![species_with(0, 1.0, 1.0, 0)];
+        remove_stagnant(&mut species, 1000, 15);
+        assert_eq!(species.len(), 1, "a single species is a no-op");
+        assert_eq!(species[0].id().get(), 0);
+    }
+
+    #[test]
     fn test_allocate_offspring_sums_to_pop_size() {
         // Largest-remainder over shares 1.0, 2.0, 3.0 of 64 seats.
         let species = vec![

--- a/crates/rlevo-evolution/src/neuroevolution/topology.rs
+++ b/crates/rlevo-evolution/src/neuroevolution/topology.rs
@@ -412,6 +412,127 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "weight_init_std")]
+    fn test_minimal_panics_on_nan_std() {
+        // `Normal::new(0.0, NaN)` returns `Err`, so `minimal`'s `unwrap_or_else`
+        // fires the documented `weight_init_std` panic. Registry is sized to
+        // satisfy the debug_assert first, so the std check is what panics.
+        let registry: InnovationRegistry = InnovationRegistry::new(3, 2);
+        let mut rng: StdRng = StdRng::seed_from_u64(1);
+        let _g = TopologyGenome::minimal(2, 1, &registry, &mut rng, f32::NAN);
+    }
+
+    #[test]
+    #[should_panic(expected = "weight_init_std")]
+    fn test_minimal_panics_on_infinite_std() {
+        // `+∞` std is likewise rejected by `Normal::new`, reaching the panic.
+        let registry: InnovationRegistry = InnovationRegistry::new(3, 2);
+        let mut rng: StdRng = StdRng::seed_from_u64(1);
+        let _g = TopologyGenome::minimal(2, 1, &registry, &mut rng, f32::INFINITY);
+    }
+
+    #[test]
+    #[should_panic(expected = "registry counters must start after the minimal seed")]
+    fn test_minimal_panics_on_registry_counter_disagreement() {
+        // A registry sized for a tiny seed (next_node_id = 1, next_innovation =
+        // 0) is too small for a (num_inputs=2, num_outputs=1) minimal genome,
+        // which requires next_node_id >= 3 and next_innovation >= 2. This
+        // violates the H6 precondition and trips the `debug_assert!` in
+        // `minimal`. `weight_init_std` is finite (1.0) so the *first* panic path
+        // (non-finite std) does not fire — the registry check is what panics.
+        // NOTE: this is a `debug_assert!`, so it only fires with debug
+        // assertions on; `cargo test` builds with `debug_assertions`, pinning
+        // this debug-only H6 registry precondition.
+        let registry: InnovationRegistry = InnovationRegistry::new(1, 0);
+        let mut rng: StdRng = StdRng::seed_from_u64(1);
+        let _g = TopologyGenome::minimal(2, 1, &registry, &mut rng, 1.0);
+    }
+
+    #[test]
+    fn test_minimal_negative_std_does_not_panic() {
+        // NOTE: contrary to the naive expectation, a *negative* std_dev is NOT
+        // rejected by `rand_distr::Normal::new` — only non-finite std_dev
+        // (`NaN` / `±∞`) returns `Err`. So `minimal` does not panic here; it
+        // builds a valid seed genome. This test pins that boundary so a future
+        // rand_distr change that tightens the check is caught.
+        let registry: InnovationRegistry = InnovationRegistry::new(3, 2);
+        let mut rng: StdRng = StdRng::seed_from_u64(1);
+        let g: TopologyGenome = TopologyGenome::minimal(2, 1, &registry, &mut rng, -1.0);
+        assert_eq!(g.nodes.len(), 3, "negative std still yields the I + O seed");
+        assert_eq!(
+            g.connections.len(),
+            2,
+            "negative std still yields I * O edges"
+        );
+    }
+
+    #[test]
+    fn test_empty_genome_invariants() {
+        // An empty genome exercises the vacuous / short-circuit branches of the
+        // query methods. Every assertion below is grounded in the real code.
+        let g: TopologyGenome = TopologyGenome::new(vec![], vec![]);
+
+        // `windows(2)` over an empty slice yields nothing, so `all` is vacuously
+        // true — an empty connection list counts as sorted.
+        assert!(
+            g.is_innovation_sorted(),
+            "empty connections are vacuously innovation-sorted"
+        );
+
+        // `any` over no connections is false — nothing is connected.
+        assert!(
+            !g.is_connected(NodeId::new(0), NodeId::new(1)),
+            "no edges means no connection"
+        );
+
+        // `would_create_cycle` short-circuits `source == target` to true before
+        // touching the (empty) edge set: a self-loop is always a cycle.
+        assert!(
+            g.would_create_cycle(NodeId::new(0), NodeId::new(0)),
+            "self-loop short-circuits to a cycle even with no edges"
+        );
+        // Distinct endpoints with no reachable path: the DFS pops `target`,
+        // finds no outgoing edges, and returns false.
+        assert!(
+            !g.would_create_cycle(NodeId::new(0), NodeId::new(1)),
+            "distinct nodes with no edges cannot form a cycle"
+        );
+
+        // `find` over an empty node list is None.
+        assert!(
+            g.node(NodeId::new(0)).is_none(),
+            "no nodes means lookup returns None"
+        );
+    }
+
+    #[test]
+    fn test_activation_fn_propagates_nan() {
+        // NaN handling is per-arm, not uniform. Sigmoid, Tanh, and Linear all
+        // carry NaN through their arithmetic...
+        assert!(
+            ActivationFn::Sigmoid.apply(f32::NAN).is_nan(),
+            "Sigmoid: NaN flows through exp and the reciprocal"
+        );
+        assert!(
+            ActivationFn::Tanh.apply(f32::NAN).is_nan(),
+            "Tanh: NaN.tanh() is NaN"
+        );
+        assert!(
+            ActivationFn::Linear.apply(f32::NAN).is_nan(),
+            "Linear: identity passes NaN through"
+        );
+        // ...but Relu uses `x.max(0.0)`, and `f32::max` returns the non-NaN
+        // operand when either argument is NaN. So `NaN.max(0.0)` is 0.0, NOT
+        // NaN — Relu swallows the NaN rather than propagating it.
+        let relu_nan: f32 = ActivationFn::Relu.apply(f32::NAN);
+        assert!(
+            !relu_nan.is_nan(),
+            "Relu does NOT propagate NaN: f32::max drops the NaN operand"
+        );
+        approx::assert_relative_eq!(relu_nan, 0.0, epsilon = 1e-6);
+    }
+
+    #[test]
     fn test_insert_connection_sorted_keeps_order() {
         let registry = InnovationRegistry::new(3, 2);
         let mut rng = StdRng::seed_from_u64(1);


### PR DESCRIPTION
## Summary

Closes the test-coverage gaps identified for issue #148 by the 30-06-2026 code review: `coevolution/competitive.rs` was missing state-machine and `#[should_panic]` coverage, and `neuroevolution/species.rs` / `neuroevolution/topology.rs` lacked `#[should_panic]` tests for their documented panic contracts (a direct `docs/rules.md` §5 violation). This is **test-only** — no production code changed — adding regression tests that pin the existing documented contracts and previously-untested degenerate/edge paths.

## Change Type

- [x] Bug fix (non-breaking, includes regression test) — test-coverage hardening; no behavior change

## Linked Issue

Closes #148

## What Was Changed

- **`crates/rlevo-evolution/src/coevolution/competitive.rs`** — added `step_increments_generation_and_splits_fitness_by_population` (generation increment + A=index0 / B=index1 fitness split), `snapshot_hof_size_falls_back_to_zero_without_archive`, `best_a_tracks_rolling_max_across_generations`, and `step_panics_on_wrong_length_coupled_fitness` (`#[should_panic]` on the bi-population length assertion). The pre-existing NaN/±∞/sense tests (#134, ADR 0023) were left intact.
- **`crates/rlevo-evolution/src/neuroevolution/species.rs`** — added `test_speciate_panics_on_length_mismatch` (`#[should_panic]`), `test_compatibility_distance_empty_genome_branch`, `test_allocate_offspring_single_species_gets_all` / `_empty_species_returns_empty` / `_counts_len_equals_species_len`, and `test_remove_stagnant_keeps_best_when_all_stagnant` / `_single_species_is_noop`. (§7.3 NaN case already existed as `test_speciate_sanitizes_nan_and_inf_fitness`.)
- **`crates/rlevo-evolution/src/neuroevolution/topology.rs`** — added `test_minimal_panics_on_nan_std` / `_on_infinite_std` / `_on_registry_counter_disagreement` (`#[should_panic]` for both documented `minimal` panics), `test_minimal_negative_std_does_not_panic` (boundary), `test_empty_genome_invariants`, and `test_activation_fn_propagates_nan`.

Three stale review claims were corrected against the current code: the competitive assert message (`"competitive co-evolution is bi-population"`, not the review's suggested text); `rand_distr::Normal::new` accepts zero and negative `std_dev`, so only **non-finite** std panics; and `remove_stagnant`'s single-best fallback is unreachable for `len >= 2` under the `STAGNATION_PROTECT_TOP_K = 2` guard (tests pin the real top-2-survival behavior).

## How It Was Tested

```
cargo build --workspace          # Finished, no errors
cargo test --workspace           # all pass (rlevo-evolution lib: 592 passed, 0 failed)
cargo clippy --all-targets --all-features   # Finished, no warnings
```

The `#[should_panic]` tests pin `assert!`/`panic!`/`debug_assert!` sites; each was confirmed to fire on the intended input and to match the source panic message as an `expected = "..."` substring. Note that the debug_assert-backed panics (competitive bi-population length; topology H6 registry counters) fire only because `cargo test` builds with `debug_assertions` on.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned via `rust-toolchain.toml`)
- Burn backend tested: `ndarray` (`Flex` in tests)
- OS: macOS (darwin)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: orchestrated reconciliation of the review against current code, delegated test authoring to sub-agents, and QA review; all additions are test-only and were verified via `cargo test`/`clippy`.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*. — N/A (no public API change)
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR. — the `#[should_panic]`/edge tests pin contracts that had no coverage.
- [x] This PR addresses a single concern. (test coverage for #148)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

Test-only; no behavior change. Two pre-existing, out-of-scope items surfaced during review and were intentionally deferred: the `Test`/`Mock`/`Simple`-prefix helper-naming nits (rules §7.5/§7.7), and the fact that `competitive::step` / `cooperative::step` document their bi-population `debug_assert_eq!` panic only in prose rather than a `# Panics` section (symmetric pre-existing pattern).
