### PR TITLE
docs(evolution): complete # Panics contract sweep (#149)

### DIFF
--- a/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/bayesian_network.rs
@@ -336,8 +336,17 @@ impl<B: Backend> ProbabilityModel<B> for BayesianNetwork {
     ///
     /// # Panics
     ///
-    /// Does not panic; the closing `debug_assert_eq!` checks the topological
-    /// order covers all `D` nodes (guaranteed by the DAG invariant).
+    /// In release builds, panics if the `population` tensor cannot be read back
+    /// as `f32` (`.expect("population tensor must be readable as f32")`).
+    ///
+    /// In debug builds, additionally panics on the following `debug_assert`
+    /// checks (all disabled in release):
+    ///
+    /// - the population column count disagrees with `params.genome_dim`;
+    /// - `params.max_parents >= usize::BITS` (which would overflow the
+    ///   `1usize << q` CPT table sizing);
+    /// - the closing topological order fails to cover all `D` nodes (guaranteed
+    ///   by the DAG invariant).
     // The counting passes, gain-cached greedy search, CPT estimation, and
     // topological ordering form one coherent fit; splitting them would scatter
     // the shared `bits`/`parents` buffers without aiding readability.

--- a/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/compact_genetic.rs
@@ -120,6 +120,14 @@ impl<B: Backend> ProbabilityModel<B> for CompactGenetic {
     /// and argmin (loser) of the fitness vector (canonical maximise: higher is
     /// better), then nudges each gene where winner and loser disagree by
     /// `±1 / virtual_pop_size` (toward the winner), clamped to `[0, 1]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `population` or `fitness` tensor cannot be read back as
+    /// `f32` (`.expect("population tensor must be readable as f32")` /
+    /// `.expect("fitness tensor must be readable as f32")`). Also panics with an
+    /// out-of-bounds index if the population column count `d` exceeds
+    /// `prev.prob.len()` (the per-gene probability vector carried in `prev`).
     fn fit(
         &self,
         params: &Self::Params,
@@ -200,6 +208,11 @@ impl<B: Backend> ProbabilityModel<B> for CompactGenetic {
     /// `0.0` otherwise, using the supplied host RNG (never `Tensor::random` /
     /// `B::seed`). The returned tensor has shape `(n, D)` and contains only
     /// `0.0` and `1.0` values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `n * d` element count overflows allocation or `TensorData`
+    /// capacity (`Vec::with_capacity(n * d)` / the `(n, D)` `TensorData`).
     fn sample(
         &self,
         state: &Self::State,

--- a/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/dependency_chain.rs
@@ -143,8 +143,12 @@ impl<B: Backend> ProbabilityModel<B> for DependencyChain {
     ///
     /// # Panics
     ///
-    /// Does not panic. The `unwrap()` on the last greedy-chain iteration is
-    /// safe because at least one unvisited dimension remains when `d > 1`.
+    /// Panics if the `population` tensor cannot be read back as `f32`
+    /// (`.expect("population tensor must be readable as f32")`), or with an
+    /// out-of-bounds index if the host buffer is shorter than `k * d`. Callers
+    /// must therefore pass an `f32`, `(k, d)`-shaped population tensor. The
+    /// `unwrap()` on the last greedy-chain iteration does not fire: at least one
+    /// unvisited dimension remains when `d > 1`.
     // The MI matrix, greedy chain ordering, and per-link conditional
     // extraction form one coherent algorithmic unit; splitting it would
     // scatter the shared intermediate buffers without aiding readability.

--- a/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
+++ b/crates/rlevo-evolution/src/algorithms/eda/univariate_gaussian.rs
@@ -151,9 +151,10 @@ impl<B: Backend> ProbabilityModel<B> for UnivariateGaussian {
     ///
     /// # Panics
     ///
-    /// Does not panic. The `expect` inside `sample` (not `fit`) is guarded
-    /// by the variance floor, which guarantees a positive, finite standard
-    /// deviation for every dimension.
+    /// Panics if the `population` tensor cannot be read back as `f32`
+    /// (`.expect("population tensor must be readable as f32")`), or with an
+    /// out-of-bounds index if the host buffer is shorter than `k * d`. Callers
+    /// must therefore pass an `f32`, `(k, d)`-shaped population tensor.
     fn fit(
         &self,
         params: &Self::Params,
@@ -234,9 +235,14 @@ impl<B: Backend> ProbabilityModel<B> for UnivariateGaussian {
     ///
     /// # Panics
     ///
-    /// Does not panic under normal operation. The internal `Normal::new`
-    /// constructor is guarded by `min_variance`, ensuring the standard
-    /// deviation is always strictly positive and finite.
+    /// The internal `Normal::new` constructor is guarded by `min_variance`,
+    /// ensuring the standard deviation is always strictly positive and finite,
+    /// so `.expect("floored std is positive and finite")` does not fire. Any
+    /// non-finite genome values are already contained in [`fit`](Self::fit):
+    /// a non-finite mean falls back to `init_mean`, and the MLE variance is
+    /// floored to a finite, positive value at least `min_variance`. Given a
+    /// state produced by `fit`, this method does not panic under normal
+    /// operation.
     fn sample(
         &self,
         state: &Self::State,

--- a/crates/rlevo-evolution/src/algorithms/ga_binary.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga_binary.rs
@@ -73,6 +73,13 @@ impl BinaryGaConfig {
     ///
     /// Mutation rate defaults to `1 / D` (the standard "one expected
     /// flip per genome" rule from the binary-GA literature).
+    ///
+    /// # Panics
+    ///
+    /// Panics when `genome_dim == 0`: the `1 / D` mutation rate becomes
+    /// non-finite (`1.0 / 0.0 == +∞`), which [`Probability::new`] rejects as
+    /// outside `[0, 1]`. This is the sanctioned builder-time panic on an
+    /// unusable config (ADR 0026); pass a non-zero `genome_dim`.
     #[must_use]
     pub fn default_for(pop_size: usize, genome_dim: usize) -> Self {
         Self {
@@ -228,6 +235,18 @@ where
     ///   (probability `crossover_p`);
     /// - `SeedPurpose::Mutation` — per-gene bit-flip
     ///   (probability `mutation_rate`).
+    ///
+    /// # Panics
+    ///
+    /// Propagates the programming-error panics of the delegated host operators
+    /// once `state.fitness` is non-empty:
+    /// [`tournament_indices_host`]
+    /// panics if the fitness slice is empty or `tournament_size == 0`, and the
+    /// crossover / mutation operators assume shape-consistent inputs.
+    /// `validate()` rules
+    /// these out for a well-formed config, but `BinaryGaState` / `BinaryGaConfig`
+    /// fields are public and can be mutated into an invalid state after
+    /// validation.
     fn ask(
         &self,
         params: &BinaryGaConfig,
@@ -305,6 +324,17 @@ where
     /// convention — higher is better. The harness canonicalises a `Minimize`
     /// objective (negation) before this call, so the strategy stays
     /// sense-unaware per ADR 0023.
+    ///
+    /// # Panics
+    ///
+    /// Propagates the programming-error panics of the delegated host path on the
+    /// elitist-replacement branch:
+    /// [`truncation_indices_host`]
+    /// and the bare `state.fitness[i]` indexing assume a `pop_size`-consistent
+    /// fitness buffer. `validate()` rules this out for a well-formed config, but
+    /// `BinaryGaState` / `BinaryGaConfig` fields are public and can be mutated
+    /// into an inconsistent state after validation. Also panics if `fitness`
+    /// cannot be read back as `f32`.
     fn tell(
         &self,
         params: &BinaryGaConfig,

--- a/crates/rlevo-evolution/src/algorithms/gep/decode.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/decode.rs
@@ -10,8 +10,41 @@ use super::tree::ExpressionTree;
 /// Implementors decode `genome` (a head/tail symbol string) against `alphabet`
 /// into an [`ExpressionTree`]. The decode is deterministic: the same genome and
 /// alphabet always yield the same tree.
+///
+/// # Invariants
+///
+/// The `genome` is expected to satisfy the GEP head/tail layout: a head region
+/// whose loci may hold functions or terminals, followed by a terminal-only tail
+/// of length `t = h(n - 1) + 1`, where `h` is the head length and `n` the
+/// alphabet's maximum arity (Ferreira 2001, eq. 3.4). Any chromosome produced by
+/// the sampling and operator paths in this crate satisfies this by construction;
+/// a hand-built genome that violates it is a precondition breach (see the
+/// implementation's `# Panics`).
 pub trait GenotypePhenotypeMap<F: FunctionSet> {
     /// Decodes a chromosome into its phenotype.
+    ///
+    /// # Arguments
+    ///
+    /// * `alphabet` — the symbol alphabet used to classify each locus (its
+    ///   arity and kind); must be the same alphabet the `genome` was sampled
+    ///   against.
+    /// * `genome` — a linear head/tail chromosome (see the trait-level
+    ///   `# Invariants`). An empty genome decodes to an empty tree.
+    ///
+    /// # Returns
+    ///
+    /// The [`ExpressionTree`] phenotype: the open-reading-frame coding region of
+    /// `genome` in level order.
+    ///
+    /// # Panics
+    ///
+    /// Debug builds assert the head/tail precondition
+    /// (`debug_assert!(needed == 0, ...)`); a genome that violates it panics here
+    /// in debug. In release the assertion is absent — `decode` itself does not
+    /// panic, but a malformed tree silently degrades to a finite-but-incorrect
+    /// value on evaluation (see [`ExpressionTree::eval`]'s defensive clamp,
+    /// issue #147).
+    #[must_use]
     fn decode(&self, alphabet: &Alphabet<F>, genome: &[Symbol]) -> ExpressionTree;
 }
 
@@ -29,6 +62,34 @@ pub trait GenotypePhenotypeMap<F: FunctionSet> {
 ///    order, a node's children are simply the next unread symbols. A running
 ///    read cursor assigns each node `arity` contiguous children — no explicit
 ///    queue is needed, since array order *is* BFS order.
+///
+/// # Examples
+///
+/// ```
+/// use rlevo_evolution::algorithms::gep::{Alphabet, GenotypePhenotypeMap, GepDecoder};
+/// use rlevo_evolution::function_set::ArithmeticFunctionSet;
+/// use rlevo_evolution::rng::{seed_stream, SeedPurpose};
+///
+/// // A one-variable arithmetic alphabet (functions over a single `x`).
+/// let alphabet = Alphabet::new(ArithmeticFunctionSet, 1, vec![]);
+///
+/// // Sample a valid head/tail genome: head loci draw any symbol, tail loci
+/// // draw terminals only, with the tail sized per Ferreira (2001) eq. 3.4.
+/// let mut rng = seed_stream(42, 0, SeedPurpose::Mutation);
+/// let head_len = 3;
+/// let tail_len = head_len * (alphabet.max_arity() - 1) + 1;
+/// let mut genome = Vec::with_capacity(head_len + tail_len);
+/// for _ in 0..head_len {
+///     genome.push(alphabet.sample_head_symbol(&mut rng));
+/// }
+/// for _ in 0..tail_len {
+///     genome.push(alphabet.sample_tail_symbol(&mut rng));
+/// }
+///
+/// // Decode the linear chromosome into its expression-tree phenotype.
+/// let tree = GepDecoder.decode(&alphabet, &genome);
+/// assert!(tree.node_count() >= 1);
+/// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct GepDecoder;
 

--- a/crates/rlevo-evolution/src/algorithms/gep/operators.rs
+++ b/crates/rlevo-evolution/src/algorithms/gep/operators.rs
@@ -108,9 +108,14 @@ pub fn ris_transposition<F: FunctionSet>(
 
 /// One-point crossover: swaps the suffixes of two equal-length parents at a
 /// random cut. Class-aligned, so the tail stays terminal-only.
+///
+/// # Panics
+///
+/// Panics if `a.len() != b.len()` — crossover parents must share the genome
+/// layout. This is a programming error, not a recoverable condition.
 pub fn one_point_crossover(a: &mut [Symbol], b: &mut [Symbol], rng: &mut dyn Rng) {
     let n = a.len();
-    debug_assert_eq!(n, b.len(), "crossover parents must share genome length");
+    assert_eq!(n, b.len(), "crossover parents must share genome length");
     if n < 2 {
         return;
     }
@@ -120,9 +125,14 @@ pub fn one_point_crossover(a: &mut [Symbol], b: &mut [Symbol], rng: &mut dyn Rng
 
 /// Two-point crossover: swaps the middle segment between two random cuts.
 /// Class-aligned, so the tail stays terminal-only.
+///
+/// # Panics
+///
+/// Panics if `a.len() != b.len()` — crossover parents must share the genome
+/// layout. This is a programming error, not a recoverable condition.
 pub fn two_point_crossover(a: &mut [Symbol], b: &mut [Symbol], rng: &mut dyn Rng) {
     let n = a.len();
-    debug_assert_eq!(n, b.len(), "crossover parents must share genome length");
+    assert_eq!(n, b.len(), "crossover parents must share genome length");
     if n < 2 {
         return;
     }
@@ -386,7 +396,7 @@ mod tests {
     }
 
     /// One-point crossover documents equal parent lengths as a precondition
-    /// (`debug_assert_eq!`); a mismatch panics in debug builds.
+    /// (`assert_eq!`); a mismatch panics in all builds with the named message.
     #[test]
     #[should_panic(expected = "crossover parents must share genome length")]
     fn one_point_crossover_panics_on_mismatched_lengths() {

--- a/crates/rlevo-evolution/src/ops/replacement.rs
+++ b/crates/rlevo-evolution/src/ops/replacement.rs
@@ -80,6 +80,12 @@ pub fn elitist<B: Backend>(
     );
 
     let n_offspring_to_keep = pop_size - k;
+    assert!(
+        n_offspring_to_keep <= offspring_fitness.len(),
+        "elitist: not enough offspring ({}) to backfill {} slots after {k} elites",
+        offspring_fitness.len(),
+        n_offspring_to_keep,
+    );
     let offspring_keep_idx = truncation_indices_host(offspring_fitness, n_offspring_to_keep);
     let kept_offspring = offspring_pop.select(
         0,

--- a/crates/rlevo-evolution/src/ops/selection.rs
+++ b/crates/rlevo-evolution/src/ops/selection.rs
@@ -134,6 +134,8 @@ pub fn tournament_indices_host(
 ///
 /// Inherits the panic conditions of [`tournament_indices_host`]:
 /// `fitness.is_empty()` or `tournament_size == 0`.
+///
+/// Panics if `population.dims()[0] != fitness.len()`.
 #[must_use]
 pub fn tournament_select<B: Backend>(
     population: &Tensor<B, 2>,
@@ -143,6 +145,13 @@ pub fn tournament_select<B: Backend>(
     rng: &mut dyn Rng,
     device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
+    assert_eq!(
+        population.dims()[0],
+        fitness.len(),
+        "tournament_select: population rows ({}) must equal fitness.len() ({})",
+        population.dims()[0],
+        fitness.len(),
+    );
     let winners = tournament_indices_host(fitness, tournament_size, n_winners, rng);
     let indices = Tensor::<B, 1, Int>::from_data(TensorData::new(winners, [n_winners]), device);
     population.clone().select(0, indices)
@@ -211,6 +220,8 @@ pub fn truncation_indices_host(fitness: &[f32], top_k: usize) -> Vec<i32> {
 ///
 /// Inherits the panic conditions of [`truncation_indices_host`]:
 /// `fitness.is_empty()` or `top_k > fitness.len()`.
+///
+/// Panics if `population.dims()[0] != fitness.len()`.
 #[must_use]
 pub fn truncation_select<B: Backend>(
     population: &Tensor<B, 2>,
@@ -218,6 +229,13 @@ pub fn truncation_select<B: Backend>(
     top_k: usize,
     device: &<B as burn::tensor::backend::BackendTypes>::Device,
 ) -> Tensor<B, 2> {
+    assert_eq!(
+        population.dims()[0],
+        fitness.len(),
+        "truncation_select: population rows ({}) must equal fitness.len() ({})",
+        population.dims()[0],
+        fitness.len(),
+    );
     let winners = truncation_indices_host(fitness, top_k);
     let indices = Tensor::<B, 1, Int>::from_data(TensorData::new(winners, [top_k]), device);
     population.clone().select(0, indices)

--- a/crates/rlevo-evolution/src/probability_model.rs
+++ b/crates/rlevo-evolution/src/probability_model.rs
@@ -58,6 +58,15 @@ use rand::Rng;
 /// - **`Sync` state.** [`State`](Self::State) requires `Sync`, deliberately
 ///   exceeding [`crate::Strategy::State`]'s `Send`-only bound, to leave room for
 ///   a future thread-shared CMA-ES state.
+/// - **Sanitized input assumed.** [`fit`](Self::fit) and
+///   [`sample`](Self::sample) are infallible by design. The
+///   [`EdaStrategy`](crate::algorithms::eda::EdaStrategy) driver sanitizes
+///   fitness (`NaN` → `-inf`) and clamps the selected-row count to `≥ 2` before
+///   calling `fit`, so the supported call path never supplies empty populations
+///   or non-finite fitness. Callers that invoke `fit`/`sample` directly
+///   (bypassing the driver) must uphold the same preconditions; otherwise
+///   behaviour is unspecified — implementations may emit `NaN` statistics or
+///   panic in `sample`.
 ///
 /// # Examples
 ///
@@ -116,6 +125,13 @@ pub trait ProbabilityModel<B: Backend>: Send + Sync {
     /// All randomness must be drawn from `rng` (host RNG only — never
     /// `Tensor::random`/`B::seed`). The returned tensor has shape `(n, D)`
     /// where `D` is the model's genome dimensionality.
+    ///
+    /// # Panics
+    ///
+    /// Implementations may panic if `state` was not produced by a prior
+    /// [`fit`](Self::fit) call — e.g. a user-constructed state with non-finite
+    /// mean or variance (concrete impls call `Normal::new(...).expect(...)`,
+    /// which panics on non-finite parameters).
     fn sample(
         &self,
         state: &Self::State,

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -205,19 +205,27 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
 | `MultiDiscreteAction::from_indices(arr)` | any `arr[i] >= space[i]` |
 | Builder `with_capacity(n)` | `n == 0` |
 | Builder `with_alpha(x)` | `x ∉ [0.0, 1.0]` |
+| `SimulatedAnnealingParams::with_max_iters` | `max_iters == 0` |
+| `SimulatedAnnealingParams::with_initial_temp` | value not finite or not `> 0` |
+| `SimulatedAnnealingParams::with_cooling` | `Geometric` `factor ∉ (0, 1)`; `Linear` `delta` not finite or not `> 0` |
+| `SimulatedAnnealingParams::with_min_temp` | `min_temp` not finite or `< 0` |
+| `SimulatedAnnealingParams::with_step_size` | `step_size` not finite or not `> 0` |
 | Batch rank assertion | `BD != D + 1` or `BAD != AD + 1` |
 | `ops::selection::tournament_*` | `fitness.is_empty()` or `tournament_size < 2` |
 | `ops::selection::truncation_*` | `fitness.is_empty()` or `top_k > fitness.len()` |
+| `ops::selection::{tournament_select, truncation_select}` | `population.dims()[0] != fitness.len()` |
 | `ops::crossover::{blx_alpha, uniform_crossover, binary_uniform_crossover}` | parents differ in shape |
 | `ops::mutation::gaussian_mutation_per_row` | `sigmas.len() != population N` |
 | `ops::replacement::elitist` | `k > pop_size` or `pop_size − k > offspring count` |
 | `ops::replacement::mu_plus_lambda` | `mu > parent count + offspring count` |
 | `ops::replacement::mu_comma_lambda` | `mu > offspring count` (i.e. `λ < μ`) |
+| `local_search::simulated_annealing::{refine, refine_with_known_fitness}` (via `refine_impl`) | `max_iters == 0` |
 
-The `Builder with_capacity(n)` / `with_alpha(x)` rows are the blessed
-**setter-guard** exception: a single `with_*` method may panic on an
-out-of-domain argument because the panic points at the offending call site.
-They do **not** replace whole-config validation — see below.
+The `Builder with_capacity(n)` / `with_alpha(x)` and
+`SimulatedAnnealingParams::with_*` rows are the blessed **setter-guard**
+exception: a single `with_*` method may panic on an out-of-domain argument
+because the panic points at the offending call site. They do **not** replace
+whole-config validation — see below.
 
 ### Config Validation Contract (ADR 0026)
 


### PR DESCRIPTION
## Summary

Brings the `rlevo-evolution` public API into compliance with `docs/rules.md` §6's zero-exception documentation policy: every public function that can panic now has an accurate `# Panics` section, and each panic site is registered in the Documented Panic Contracts table. This closes the recurring documentation-policy gap tracked in #149. It was correctly sequenced after the upstream validation/panic-contract work (PRs #213–#235), which has already landed, so the `# Panics` sections describe the tightened contracts rather than the old ad-hoc behavior.

## Change Type

- [x] Documentation correction (misleading/false doc comments)
- [x] Other — three implicit programming-error panics were made explicit and documented (small `assert!`/`assert_eq!` guards + a `debug_assert_eq!`→`assert_eq!` promotion). These are precondition guards for programming errors, not algorithm-behavior changes; they are prescribed by the linked review documents and sanctioned by `rules.md` §4 and ADR 0026.

## Linked Issue

Closes #149

## What Was Changed

Documentation corrections (no logic change):
- `probability_model.rs` — added a "Sanitized input assumed" `# Invariants` bullet and a `# Panics` section on `sample`.
- `eda/bayesian_network.rs`, `eda/univariate_gaussian.rs`, `eda/dependency_chain.rs` — replaced three factually **false** "Does not panic" claims on `fit` with accurate contracts (`.expect` on non-f32 tensor reads, debug-assert sites).
- `eda/compact_genetic.rs` — added missing `# Panics` on `fit`/`sample`.
- `ga_binary.rs` — added `# Panics` on `default_for` (panics when `genome_dim == 0` via `Probability::new`), `ask`, and `tell`.
- `gep/decode.rs` — completed doc sections (`# Arguments`/`# Returns`/`# Panics`/`# Examples`) + `#[must_use]` + trait `# Invariants`.
- `docs/rules.md` — added Documented Panic Contracts rows: SA `refine`/`refine_with_known_fitness`, five `SimulatedAnnealingParams::with_*` setter guards, and the new `ops::selection` dims-mismatch guard.

Explicit programming-error guards (small code change, each with a matching documented message):
- `gep/operators.rs` — promoted the crossover length check from `debug_assert_eq!` to `assert_eq!` so the named contract holds in release; added `# Panics` to both crossovers.
- `ops/replacement.rs::elitist` — added an explicit `assert!` for the offspring-backfill precondition (previously an opaque delegated panic).
- `ops/selection.rs` — added `assert_eq!(population.dims()[0], fitness.len())` to `tournament_select`/`truncation_select`, pre-empting an opaque Burn backend panic, plus matching `# Panics` lines.

Intentionally left undocumented: `cmsa_es::default_for` is now infallible (its `with_pop_size` no longer panics), so per policy it needs no `# Panics` section.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

All three pass with no errors/warnings. `cargo fmt --all --check` is clean. The existing `#[should_panic]` crossover tests (`one_point_crossover_panics_on_mismatched_lengths`, `two_point_crossover_panics_on_mismatched_lengths`) still pass against the promoted `assert_eq!`, and the new `GepDecoder` `# Examples` doctest compiles and runs.

- Rust toolchain: `stable 1.94.1`
- Burn backend tested: ndarray (default test backend)
- OS: macOS (darwin)

## AI-Assisted Content

- [ ] No AI-generated content in this PR.
- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: reconciliation of the linked review items against current source, the documentation edits, and the three precondition guards, followed by an adversarial QA review pass.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR. — N/A: no runtime bug fixed; the promoted `assert_eq!` is already covered by the pre-existing `#[should_panic]` crossover tests.
- [x] This PR addresses a single concern (the #149 `# Panics` sweep).
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- The `# Panics` sections describe the tightened contracts from the already-merged upstream validation work (NaN/Inf sanitization, `genome_dim` guards, CMA/CMSA hardening); "issues 8-11" in the issue body refers to the reviews' internal tracking list, which has landed.
- Deliberately out of scope for this docs sweep and still tracked in the review docs: `bayesian_network.rs` §3.1 `init_prob` validation and `compact_genetic.rs` §5.2 shape assert (both are behavior-hardening, not documentation). Happy to file fast-follow issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)