### PR TITLE
fix(box2d): car_racing reward scale and lap termination

### DIFF
--- a/crates/rlevo-environments/src/box2d/car_racing/config.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/config.rs
@@ -18,8 +18,15 @@ pub struct CarRacingConfig {
     pub track_width: f32,
     /// Fraction of track tiles that must be visited to complete a lap.
     pub lap_complete_percent: f32,
-    /// Reward per new tile visited. Total lap reward ≈ 1000.
-    pub tile_reward: f32,
+    /// Total reward for a full lap, distributed evenly across the track's tiles.
+    ///
+    /// A full lap (every tile visited) sums to exactly `lap_reward`; the
+    /// effective per-tile reward is therefore `lap_reward / total_tiles`,
+    /// computed per episode from the actual generated tile count. This matches
+    /// the canonical Gymnasium CarRacing formulation (`+1000 / len(track)` per
+    /// tile), where a full lap pays ≈ 1000 regardless of the episode's tile
+    /// count.
+    pub lap_reward: f32,
     /// Penalty applied every step regardless of tile visits.
     pub frame_penalty: f32,
     /// Car body density.
@@ -43,7 +50,7 @@ impl Default for CarRacingConfig {
             track_turn_rate: 0.31,
             track_width: 40.0,
             lap_complete_percent: 0.95,
-            tile_reward: 1000.0 / 200.0, // 200 tiles approximated
+            lap_reward: 1000.0, // full-lap total; per-tile = lap_reward / total_tiles
             frame_penalty: -0.1,
             car_density: 0.001,
             friction: 1.0,
@@ -72,7 +79,7 @@ impl Validate for CarRacingConfig {
             1.0,
             f64::from(self.lap_complete_percent),
         )?;
-        config::positive(C, "tile_reward", f64::from(self.tile_reward))?;
+        config::positive(C, "lap_reward", f64::from(self.lap_reward))?;
         config::ordered(C, "frame_penalty", f64::from(self.frame_penalty), 0.0)?;
         config::positive(C, "car_density", f64::from(self.car_density))?;
         config::in_range(C, "friction", 0.0, f64::INFINITY, f64::from(self.friction))?;
@@ -116,6 +123,15 @@ impl CarRacingConfigBuilder {
         self
     }
 
+    /// Sets the total reward paid out for completing a full lap.
+    ///
+    /// The value is distributed evenly across the track's tiles, so the
+    /// effective per-tile reward is `lap_reward / total_tiles`.
+    pub fn lap_reward(mut self, lap_reward: f32) -> Self {
+        self.inner.lap_reward = lap_reward;
+        self
+    }
+
     /// Consumes the builder and returns the configured [`CarRacingConfig`].
     ///
     /// # Errors
@@ -136,7 +152,7 @@ mod tests {
     #[test]
     fn test_default() {
         let cfg = CarRacingConfig::default();
-        assert!(cfg.tile_reward > 0.0);
+        assert!(cfg.lap_reward > 0.0);
         assert!(cfg.frame_penalty < 0.0);
         assert_eq!(cfg.track_n_checkpoints, 12);
     }

--- a/crates/rlevo-environments/src/box2d/car_racing/env.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/env.rs
@@ -19,6 +19,28 @@
 //! Tile visits are detected by a nearest-centre scan on every step, not by
 //! physics collision callbacks. A tile can only be counted once per episode.
 //!
+//! ## Tile-visit sweep proxy
+//!
+//! Canonical Gymnasium CarRacing marks *every* tile a wheel physically touches
+//! via a Box2D contact stream. rlevo has no cheap contact stream, so a fast car
+//! that skips several tiles between steps would leave gaps that a closed loop
+//! never revisits — undercounting `tiles_visited` and making completion
+//! unreachable. The proxy is a bounded contiguous **sweep**: on each step the
+//! tile-index range from the previous `current_tile` to the new nearest tile is
+//! marked (see [`sweep_visits`]), reconstructing "every tile between here and
+//! there" including across the start/finish seam. `BOUND` caps the sweep to the
+//! maximum plausible per-step tile advance given the physics speed ceiling, so a
+//! spurious nearest-jump (self-intersection) or backward motion cannot mark the
+//! whole track.
+//!
+//! rlevo keeps its own coverage-threshold termination
+//! (`tiles_visited >= lap_complete_percent × total_tiles`) rather than gym's
+//! re-cross-tile-0 rule, which couples completion to a single tile and makes
+//! `lap_complete_percent` a near-no-op (upstream Gymnasium issue #1269). The
+//! sweep makes laps *reachable in principle*; it does not make them *easy* —
+//! dynamic difficulty under the fragile stiff-joint physics is a separate,
+//! pre-existing concern.
+//!
 //! The camera-following ASCII renderer ([`AsciiRenderable`](crate::render::AsciiRenderable))
 //! shows a 20-unit-wide window centred on the car body. Full track tile geometry
 //! is available only in the report tier via `FamilyPayload::Box2D`.
@@ -40,7 +62,7 @@ use super::config::CarRacingConfig;
 use super::observation::CarRacingObservation;
 use super::rasterizer::{FRAME_SIZE, Rasterizer};
 use super::state::CarRacingState;
-use super::track::Track;
+use super::track::{Track, TrackTile};
 
 /// Viewport width in world units.
 const VIEWPORT_W: f32 = 600.0 / 30.0;
@@ -207,19 +229,37 @@ impl CarRacing {
             .map(|b| [b.translation().x, b.translation().y])
             .unwrap_or([0.0; 2]);
 
-        let nearest = self.track.nearest_tile(pos);
-        let mut tile_reward = 0.0;
-        if let Some(idx) = nearest {
-            if !self.track.tiles[idx].visited {
-                self.track.tiles[idx].visited = true;
-                self.state.tiles_visited += 1;
-                tile_reward = self.config.tile_reward;
-            }
-            self.state.current_tile = Some(idx);
+        let Some(nearest) = self.track.nearest_tile(pos) else {
+            return 0.0;
+        };
+
+        let total = self.state.total_tiles;
+        // Max plausible per-step tile advance given the physics speed ceiling:
+        // an eighth of the loop, clamped to a sane [3, 16] band. The final
+        // `.min((total-1)/2)` enforces `bound < total/2`, on which the
+        // forward/backward disambiguation relies: a backward move has
+        // `forward_gap ≈ total`, so it must never fall inside `1..=bound`.
+        // Without this cap a tiny loop (e.g. total=5 ⇒ bound=3 > 2.5) would let
+        // a reverse step be scored as forward progress.
+        let bound = (total / 8).clamp(3, 16).min(total.saturating_sub(1) / 2);
+        let prev = self.state.current_tile;
+
+        // `sweep_visits` is the single source of truth for both the newly-marked
+        // count and whether a genuine forward step (or first acquisition)
+        // occurred; `current_tile` advances only when it did.
+        let (newly, advanced) = sweep_visits(prev, nearest, total, bound, &mut self.track.tiles);
+        self.state.tiles_visited += newly;
+        if advanced {
+            self.state.current_tile = Some(nearest);
         }
 
-        let lap_threshold =
-            (self.config.lap_complete_percent * self.state.total_tiles as f32) as usize;
+        // validate() guarantees total_tiles >= 5, so this only documents the
+        // reliance; total_tiles is refreshed in reset() after regeneration.
+        debug_assert!(total > 0, "total_tiles must be positive");
+        let per_tile = self.config.lap_reward / total as f32;
+        let tile_reward = newly as f32 * per_tile;
+
+        let lap_threshold = (self.config.lap_complete_percent * total as f32) as usize;
         if self.state.tiles_visited >= lap_threshold {
             self.state.lap_complete = true;
         }
@@ -426,6 +466,63 @@ impl CarRacing {
     }
 }
 
+/// Marks the tiles newly covered by a forward step from `prev` to `nearest`
+/// along the closed tile loop.
+///
+/// Returns `(newly_marked, advanced)`: the number of tiles flipped from
+/// unvisited to visited on this call, and whether a genuine forward step (or
+/// first acquisition) occurred — the caller advances `current_tile` iff
+/// `advanced`. This makes the function the single source of truth for both the
+/// count and the advancement decision.
+///
+/// This is rlevo's proxy for gym's per-contact tile marking: because the
+/// physics layer exposes no cheap contact stream, a step that carries the car
+/// across several ordered tiles is reconstructed as the contiguous index range
+/// `prev+1 ..= nearest` (modulo `total`, so it spans the start/finish seam).
+///
+/// Marking is bounded to genuine forward progress:
+/// - `prev == None` (first acquisition): mark `nearest` alone; `advanced`.
+/// - `forward_gap == 0` (same tile / stationary): mark nothing; not advanced.
+/// - `1 <= forward_gap <= bound`: mark the whole contiguous range once;
+///   `advanced`.
+/// - `forward_gap > bound`: mark nothing, not advanced — either a spurious
+///   nearest-jump across a self-intersection, or backward motion (where
+///   `forward_gap ≈ total`); neither is real forward coverage. This
+///   disambiguation relies on the caller's `bound < total/2`.
+///
+/// Pure: integer/flag math only, no RNG and no physics, so it is unit-testable
+/// on synthetic index sequences. Each tile flips at most once, preserving the
+/// `tiles_visited <= total_tiles` invariant when the caller adds the count.
+fn sweep_visits(
+    prev: Option<usize>,
+    nearest: usize,
+    total: usize,
+    bound: usize,
+    tiles: &mut [TrackTile],
+) -> (usize, bool) {
+    let Some(prev) = prev else {
+        // First acquisition: mark the single nearest tile.
+        let newly = usize::from(!tiles[nearest].visited);
+        tiles[nearest].visited = true;
+        return (newly, true);
+    };
+
+    let forward_gap = (nearest + total - prev) % total;
+    if forward_gap == 0 || forward_gap > bound {
+        return (0, false);
+    }
+
+    let mut newly = 0;
+    for step in 1..=forward_gap {
+        let k = (prev + step) % total;
+        if !tiles[k].visited {
+            tiles[k].visited = true;
+            newly += 1;
+        }
+    }
+    (newly, true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -461,14 +558,21 @@ mod tests {
     fn test_frame_penalty_every_step() {
         let mut env = make_env();
         env.reset().unwrap();
+        let total = env.state_for_test().total_tiles();
+        let before = env.state_for_test().tiles_visited();
         let snap = env.step(CarRacingAction::new(0.0, 0.0, 0.0)).unwrap();
         let reward: f32 = (*snap.reward()).into();
+        let newly = env.state_for_test().tiles_visited() - before;
+
+        // Reward decomposes exactly as: newly-marked tiles × per-tile reward
+        // (lap_reward / total_tiles) plus the constant frame penalty.
         let config = CarRacingConfig::default();
-        // Frame penalty is always applied; tile reward may also apply on step 1.
-        // Even with one tile: tile_reward + frame_penalty < tile_reward.
+        let per_tile = config.lap_reward / total as f32;
+        let expected = newly as f32 * per_tile + config.frame_penalty;
         assert!(
-            reward < config.tile_reward,
-            "frame penalty must reduce reward below tile_reward, got {reward}"
+            (reward - expected).abs() < 1e-4,
+            "reward must equal newly * per_tile + frame_penalty; \
+             got {reward}, expected {expected} (newly={newly})"
         );
     }
 
@@ -590,5 +694,158 @@ mod tests {
                 line.chars().count()
             );
         }
+    }
+
+    // -- sweep_visits: pure, synthetic index sequences (no physics) ----------
+
+    /// Builds `n` unvisited placeholder tiles (geometry irrelevant to the sweep).
+    fn dummy_tiles(n: usize) -> Vec<TrackTile> {
+        (0..n)
+            .map(|_| TrackTile {
+                vertices: [[0.0; 2]; 4],
+                centre: [0.0; 2],
+                color: [0, 0, 0],
+                visited: false,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn sweep_first_acquisition_marks_nearest() {
+        let mut tiles = dummy_tiles(10);
+        assert_eq!(sweep_visits(None, 4, 10, 4, &mut tiles), (1, true));
+        assert!(tiles[4].visited);
+        // Re-acquiring an already-visited tile counts zero but still advances.
+        assert_eq!(sweep_visits(None, 4, 10, 4, &mut tiles), (0, true));
+    }
+
+    #[test]
+    fn sweep_forward_run_crosses_seam() {
+        let mut tiles = dummy_tiles(10);
+        tiles[8].visited = true; // prior position
+        // prev=8, nearest=1 → forward_gap = (1 + 10 - 8) % 10 = 3 → mark 9, 0, 1.
+        assert_eq!(sweep_visits(Some(8), 1, 10, 4, &mut tiles), (3, true));
+        assert!(tiles[9].visited && tiles[0].visited && tiles[1].visited);
+    }
+
+    #[test]
+    fn sweep_marks_contiguous_range_once() {
+        let mut tiles = dummy_tiles(10);
+        // prev=2, nearest=5, gap=3 → mark 3, 4, 5.
+        assert_eq!(sweep_visits(Some(2), 5, 10, 4, &mut tiles), (3, true));
+        assert!(tiles[3].visited && tiles[4].visited && tiles[5].visited);
+        // Sweeping the same range again marks nothing new but still advances.
+        assert_eq!(sweep_visits(Some(2), 5, 10, 4, &mut tiles), (0, true));
+    }
+
+    #[test]
+    fn sweep_far_jump_beyond_bound_marks_nothing() {
+        let mut tiles = dummy_tiles(10);
+        // prev=0, nearest=7, gap=7 > bound=3 → spurious jump, mark nothing.
+        assert_eq!(sweep_visits(Some(0), 7, 10, 3, &mut tiles), (0, false));
+        assert!(tiles.iter().all(|t| !t.visited));
+    }
+
+    #[test]
+    fn sweep_backward_step_marks_nothing() {
+        let mut tiles = dummy_tiles(10);
+        // prev=5, nearest=3 → forward_gap = (3 + 10 - 5) % 10 = 8 > bound → none.
+        assert_eq!(sweep_visits(Some(5), 3, 10, 4, &mut tiles), (0, false));
+        assert!(tiles.iter().all(|t| !t.visited));
+    }
+
+    #[test]
+    fn sweep_stationary_marks_nothing() {
+        let mut tiles = dummy_tiles(10);
+        // prev == nearest → forward_gap == 0 → mark nothing, no advance.
+        assert_eq!(sweep_visits(Some(4), 4, 10, 4, &mut tiles), (0, false));
+        assert!(tiles.iter().all(|t| !t.visited));
+    }
+
+    #[test]
+    fn sweep_gap_equal_to_bound_marks() {
+        let mut tiles = dummy_tiles(20);
+        // prev=2, nearest=6, forward_gap=4 == bound=4 → mark 3, 4, 5, 6.
+        assert_eq!(sweep_visits(Some(2), 6, 20, 4, &mut tiles), (4, true));
+        assert!((3..=6).all(|i| tiles[i].visited));
+    }
+
+    #[test]
+    fn sweep_gap_one_beyond_bound_marks_nothing() {
+        let mut tiles = dummy_tiles(20);
+        // prev=2, nearest=7, forward_gap=5 == bound+1 → mark nothing, no advance.
+        assert_eq!(sweep_visits(Some(2), 7, 20, 4, &mut tiles), (0, false));
+        assert!(tiles.iter().all(|t| !t.visited));
+    }
+
+    /// Reachability: driving a scripted contiguous forward sequence through the
+    /// real `update_tile_visits` (via teleport, not a fragile high-speed
+    /// rollout) marks every tile, sets `lap_complete`, and a subsequent step
+    /// returns `Terminated` — closing the previously-untested branch.
+    #[test]
+    fn lap_completes_via_scripted_contiguous_sweep() {
+        let mut env = make_env();
+        env.reset().unwrap();
+        let total = env.state_for_test().total_tiles();
+        let car = env.state_for_test().car_handle();
+
+        // Teleport the car onto each tile centre in order. Each move is a single
+        // forward step (gap == 1, within bound), so the sweep marks tiles
+        // contiguously with no reliance on physics stability.
+        for i in 0..total {
+            let centre = env.track.tiles[i].centre;
+            if let Some(body) = env.world.bodies_mut().get_mut(car) {
+                body.set_translation(Vector::new(centre[0], centre[1]), true);
+            }
+            env.update_tile_visits();
+        }
+
+        assert_eq!(
+            env.state_for_test().tiles_visited(),
+            total,
+            "scripted contiguous sweep must visit every tile"
+        );
+        assert!(
+            env.state_for_test().lap_complete(),
+            "visiting every tile must satisfy the lap-complete threshold"
+        );
+        assert!(
+            env.state_for_test().is_valid(),
+            "tiles_visited <= total_tiles invariant must hold"
+        );
+
+        let snap = env.step(CarRacingAction::new(0.0, 0.0, 0.0)).unwrap();
+        assert!(
+            matches!(snap.status(), EpisodeStatus::Terminated),
+            "a completed lap must report Terminated"
+        );
+    }
+
+    /// Headline acceptance invariant `reward_per_tile_sums_to_1000`: driving a
+    /// full contiguous traversal, the tile-reward component summed across the
+    /// lap must equal `config.lap_reward` (per-tile = `lap_reward/total_tiles`,
+    /// every tile counted exactly once).
+    #[test]
+    fn full_lap_tile_reward_sums_to_lap_reward() {
+        let mut env = make_env();
+        env.reset().unwrap();
+        let total = env.state_for_test().total_tiles();
+        let car = env.state_for_test().car_handle();
+        let lap_reward = env.config.lap_reward;
+
+        let mut tile_reward_sum = 0.0f32;
+        for i in 0..total {
+            let centre = env.track.tiles[i].centre;
+            if let Some(body) = env.world.bodies_mut().get_mut(car) {
+                body.set_translation(Vector::new(centre[0], centre[1]), true);
+            }
+            tile_reward_sum += env.update_tile_visits();
+        }
+
+        assert!(
+            (tile_reward_sum - lap_reward).abs() < 1e-3,
+            "full-lap tile reward must sum to lap_reward ({lap_reward}), \
+             got {tile_reward_sum}"
+        );
     }
 }

--- a/crates/rlevo-environments/src/box2d/car_racing/mod.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/mod.rs
@@ -13,7 +13,9 @@
 //!
 //! ## Reward structure
 //!
-//! - `+tile_reward` for each new track tile visited (total ≈ 1000 for a full lap).
+//! - Each new track tile visited pays `lap_reward / total_tiles`, so visiting
+//!   every tile sums to `lap_reward` (default 1000) for a full lap, regardless
+//!   of how many tiles the episode's track happens to have.
 //! - `frame_penalty` (default −0.1) applied every step.
 //!
 //! ## Termination conditions

--- a/crates/rlevo-environments/src/box2d/car_racing/track.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/track.rs
@@ -26,6 +26,9 @@ use super::config::CarRacingConfig;
 pub struct TrackTile {
     /// Four world-space corners of the tile quad (winding: CCW).
     pub vertices: [[f32; 2]; 4],
+    /// World-space centroid of the quad, precomputed once at generation time so
+    /// [`Track::nearest_tile`] need not recompute it on every comparison.
+    pub centre: [f32; 2],
     /// RGB colour for rendering.
     pub color: [u8; 3],
     /// Whether this tile has been visited by the car.
@@ -113,19 +116,22 @@ impl Track {
             let ny = dx / len;
 
             let color = if i % 3 == 0 { kerb_color } else { road_color };
+            let vertices = [
+                [a[0] + nx * hw, a[1] + ny * hw],
+                [a[0] - nx * hw, a[1] - ny * hw],
+                [b[0] - nx * hw, b[1] - ny * hw],
+                [b[0] + nx * hw, b[1] + ny * hw],
+            ];
+            let cx = vertices.iter().map(|v| v[0]).sum::<f32>() / 4.0;
+            let cy = vertices.iter().map(|v| v[1]).sum::<f32>() / 4.0;
             tiles.push(TrackTile {
-                vertices: [
-                    [a[0] + nx * hw, a[1] + ny * hw],
-                    [a[0] - nx * hw, a[1] - ny * hw],
-                    [b[0] - nx * hw, b[1] - ny * hw],
-                    [b[0] + nx * hw, b[1] + ny * hw],
-                ],
+                vertices,
+                centre: [cx, cy],
                 color,
                 visited: false,
             });
         }
 
-        // Update tile_reward based on actual tile count
         let start_pos = centreline[0];
         let dx = centreline[1][0] - centreline[0][0];
         let dy = centreline[1][1] - centreline[0][1];
@@ -139,15 +145,16 @@ impl Track {
     }
 
     /// Return the index of the tile closest to `pos`.
+    ///
+    /// Reads each tile's precomputed [`centre`](TrackTile::centre) rather than
+    /// recomputing the centroid inside the comparison.
     pub fn nearest_tile(&self, pos: [f32; 2]) -> Option<usize> {
         self.tiles
             .iter()
             .enumerate()
             .min_by(|(_, a), (_, b)| {
-                let ca = tile_centre(a);
-                let cb = tile_centre(b);
-                let da = dist2(pos, ca);
-                let db = dist2(pos, cb);
+                let da = dist2(pos, a.centre);
+                let db = dist2(pos, b.centre);
                 da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
             })
             .map(|(i, _)| i)
@@ -160,12 +167,6 @@ fn catmull_rom(p0: f32, p1: f32, p2: f32, p3: f32, t: f32) -> f32 {
         + (-p0 + p2) * t
         + (2.0 * p0 - 5.0 * p1 + 4.0 * p2 - p3) * t * t
         + (-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t * t * t)
-}
-
-fn tile_centre(tile: &TrackTile) -> [f32; 2] {
-    let x = tile.vertices.iter().map(|v| v[0]).sum::<f32>() / 4.0;
-    let y = tile.vertices.iter().map(|v| v[1]).sum::<f32>() / 4.0;
-    [x, y]
 }
 
 fn dist2(a: [f32; 2], b: [f32; 2]) -> f32 {


### PR DESCRIPTION
## Summary

Fixes two correctness defects in the `box2d/car_racing` environment. First, the default per-tile reward was calibrated to a phantom 200-tile track (`1000/200 = 5.0`), but the generator produces 60 tiles (12 checkpoints × 5 samples), so a full lap paid ~285 instead of the documented ≈1000 — silently mis-scaling the RL/EC learning signal. Second, the progress scan marked only the single globally-nearest tile per step, so a fast car skipped tiles and `tiles_visited` plateaued below the 95% threshold, making the `Terminated` (lap-complete) state unreachable. Both are fixed and grounded in the canonical Gymnasium CarRacing formulation (`+1000/len(track)` per tile; coverage-threshold termination).

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #121

## What Was Changed

- **`car_racing/config.rs`** — renamed the config field `tile_reward` → `lap_reward` (total lap budget, default `1000.0`); `Validate` now checks `positive("lap_reward")`; added a `CarRacingConfigBuilder::lap_reward(f32)` setter; corrected the field doc.
- **`car_racing/env.rs`** — per-tile reward now computed on-the-fly as `lap_reward / total_tiles` in `update_tile_visits` (a full lap sums to ≈`lap_reward` regardless of track length). Replaced single-nearest-tile marking with a new pure `sweep_visits(prev, nearest, total, bound, tiles) -> (usize, bool)` bounded contiguous forward-sweep (`bound = (total/8).clamp(3,16).min((total-1)/2)`), which marks every skipped tile while rejecting spurious nearest-jumps and backward/stationary motion. Kept the coverage-threshold termination condition (intentionally more robust than gym's tile-0 recross; cf. upstream Farama Gymnasium #1269). Added a module-doc section explaining the sweep proxy.
- **`car_racing/track.rs`** — precomputed `TrackTile.centre` in `generate`; `nearest_tile` reads it instead of recomputing centroids per comparison; removed the dead "Update tile_reward…" comment.
- **`car_racing/mod.rs`** — corrected the false "total ≈ 1000 for a full lap" reward doc bullet.

## How It Was Tested

```
cargo build --workspace                         # ok
cargo clippy --all-targets --all-features       # clean (box2d compiled)
cargo test --workspace                           # ok, no failures
cargo test -p rlevo-environments --features box2d car_racing   # 49 passed / 0 failed
```

Regression tests added (fail on previous code, pass here):
- `full_lap_tile_reward_sums_to_lap_reward` — end-to-end acceptance invariant: a full traversal sums to ≈`lap_reward`.
- `lap_completes_via_scripted_contiguous_sweep` — the previously-unreachable `Terminated` branch is now reachable.
- 6 `sweep_visits` unit tests (first-acquisition, seam-crossing, contiguous-range-once, far-jump-beyond-bound, backward, stationary) + 2 boundary tests (`forward_gap == bound` marks, `== bound+1` does not).

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned via `rust-toolchain.toml`)
- Burn backend tested: ndarray (CPU); rapier2d physics under `--features box2d`
- OS: macOS 26.5.2

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Opus 4.8). Scope: reconciliation against the issue/reviews, canonical-source research, design review, implementation, and QA of the entire diff. Every line has been reviewed and is defensible.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- `lap_reward` is a rename of the former `tile_reward` field (semantics change: total lap budget vs. per-tile). Acceptable in alpha; `box2d` is feature-gated and no persisted configs exist.
- Follow-ups surfaced during review (out of scope here, worth separate issues): `track.rs::generate` does not re-sort perturbed checkpoint angles, so tracks can self-intersect (the sweep bound defends against false lap completion, but the geometry defect remains); and `track_n_checkpoints ∈ {1,2}` still yields degenerate zero-area tracks (`Validate` only rejects `0`).
- The third item in the issue title — the `track_n_checkpoints == 0` panic — was already resolved by #102 (`with_config` calls `config.validate()?` before `Track::generate`, rejecting `0`); verified unreachable, so this PR does not re-address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
