### PR TITLE
perf(car_racing): move-based pixel buffer hand-off (#115)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6448,6 +6448,7 @@ name = "rlevo-environments"
 version = "0.2.0"
 dependencies = [
  "approx",
+ "bincode",
  "burn",
  "rand 0.10.1",
  "rand_distr 0.6.0",

--- a/crates/rlevo-environments/Cargo.toml
+++ b/crates/rlevo-environments/Cargo.toml
@@ -22,6 +22,7 @@ rapier3d = { workspace = true, optional = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+bincode = { version = "2", features = ["serde"] }
 
 # Render LaTeX in docs (e.g. the cartpole physics) via KaTeX on docs.rs.
 [package.metadata.docs.rs]

--- a/crates/rlevo-environments/src/box2d/car_racing/env.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/env.rs
@@ -318,7 +318,12 @@ impl CarRacing {
             .collect();
         self.rasterizer.fill_polygon(&car_px, [255, 255, 255]);
 
-        CarRacingObservation::new(*self.rasterizer.pixels())
+        // PERF(#115): zero-copy hand-off — move the rasterizer's buffer into the
+        // observation instead of copying it twice. The residual cost is one
+        // Box->Arc header-prepend copy in `from_boxed`; a future Arc-in-rasterizer
+        // design (get_mut on a shared buffer) could retire even that if profiling
+        // ever justifies the added write-path surface.
+        CarRacingObservation::from_boxed(self.rasterizer.take_pixels())
     }
 
     /// Borrow the internal physics state for in-crate invariant tests.

--- a/crates/rlevo-environments/src/box2d/car_racing/observation.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/observation.rs
@@ -11,6 +11,8 @@
 //! step is needed or expected. Consumers that feed a Burn `conv2d` must permute
 //! the frame from HWC to CHW first.
 
+use std::sync::Arc;
+
 use rlevo_core::base::{Observation, TensorConversionError, TensorConvertible};
 
 use burn::tensor::{Tensor, backend::Backend};
@@ -21,6 +23,13 @@ use super::rasterizer::{FRAME_SIZE, PIXEL_BYTES};
 ///
 /// Pixel values are stored as `u8` in `[0, 255]`, row-major, RGB.
 ///
+/// The buffer is held behind an [`Arc`] so cloning an observation — which the
+/// hot path does for the cached `last_obs` and on every `observe()` — is a
+/// refcount bump rather than a 27 KB deep copy. The `Arc` also makes the
+/// observation `Send + Sync`, which parallel EA rollouts require. Construct one
+/// on the render path with [`from_boxed`](Self::from_boxed), which moves the
+/// rasterizer's owned buffer in.
+///
 /// When converted to tensors via
 /// [`TensorConvertible`](rlevo_core::base::TensorConvertible), the buffer becomes
 /// a Burn `Tensor<B, 3>` with HWC layout `[96, 96, 3]`, each byte normalised by
@@ -30,15 +39,30 @@ use super::rasterizer::{FRAME_SIZE, PIXEL_BYTES};
 /// (synthetic pixel over grid).
 #[derive(Clone)]
 pub struct CarRacingObservation {
-    /// Raw pixel buffer: 96 × 96 × 3 = 27 648 bytes.
-    pub pixels: Box<[u8; PIXEL_BYTES]>,
+    /// Raw pixel buffer: 96 × 96 × 3 = 27 648 bytes, shared via `Arc` so clones
+    /// are cheap refcount bumps.
+    pub pixels: Arc<[u8; PIXEL_BYTES]>,
 }
 
 impl CarRacingObservation {
     /// Construct from a raw pixel array.
     pub fn new(pixels: [u8; PIXEL_BYTES]) -> Self {
         Self {
-            pixels: Box::new(pixels),
+            pixels: Arc::new(pixels),
+        }
+    }
+
+    /// Construct by moving an owned boxed buffer in — the zero-copy hand-off from
+    /// the rasterizer. Wraps the buffer in an `Arc` so later clones (the cached
+    /// `last_obs` and every `observe()`) are refcount bumps rather than 27 KB deep
+    /// copies. The `Box` → `Arc` conversion is the single residual 27 KB copy on
+    /// the render *hot path* (an `Arc` must prepend a refcount header, so the box
+    /// allocation cannot be reused). The cold [`Deserialize`](serde::Deserialize)
+    /// and [`from_tensor`](TensorConvertible::from_tensor) paths each perform one
+    /// such `Box` → `Arc` copy too, but neither runs per render step.
+    pub fn from_boxed(pixels: Box<[u8; PIXEL_BYTES]>) -> Self {
+        Self {
+            pixels: Arc::from(pixels),
         }
     }
 
@@ -57,7 +81,7 @@ impl std::fmt::Debug for CarRacingObservation {
 impl Default for CarRacingObservation {
     fn default() -> Self {
         Self {
-            pixels: Box::new([0u8; PIXEL_BYTES]),
+            pixels: Arc::new([0u8; PIXEL_BYTES]),
         }
     }
 }
@@ -91,7 +115,9 @@ impl<'de> serde::Deserialize<'de> for CarRacingObservation {
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(i, &self))?;
                 }
-                Ok(CarRacingObservation { pixels })
+                Ok(CarRacingObservation {
+                    pixels: Arc::from(pixels),
+                })
             }
         }
         deserializer.deserialize_tuple(PIXEL_BYTES, PixelVisitor)
@@ -157,13 +183,23 @@ impl<B: Backend> TensorConvertible<3, B> for CarRacingObservation {
                 .map_err(|_| TensorConversionError {
                     message: "wrong element count".into(),
                 })?;
-        Ok(Self { pixels: arr })
+        Ok(Self {
+            pixels: Arc::from(arr),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Compile-time guard for the struct doc's claim that observations cross EA
+    // rollout threads: adding a non-`Send`/`Sync` field (e.g. swapping `Arc` for
+    // `Rc`) would make this fail to compile.
+    fn _assert_send_sync() {
+        fn f<T: Send + Sync>() {}
+        f::<CarRacingObservation>();
+    }
 
     #[test]
     fn test_shape() {
@@ -174,6 +210,34 @@ mod tests {
     fn test_default_is_zeroed() {
         let obs = CarRacingObservation::default();
         assert!(obs.pixels.iter().all(|&p| p == 0));
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let mut px: [u8; PIXEL_BYTES] = [0u8; PIXEL_BYTES];
+        for (i, p) in px.iter_mut().enumerate() {
+            *p = (i % 256) as u8;
+        }
+        let obs = CarRacingObservation::new(px);
+
+        let cfg = bincode::config::standard();
+        let bytes = bincode::serde::encode_to_vec(&obs, cfg).unwrap();
+        let (back, _len): (CarRacingObservation, usize) =
+            bincode::serde::decode_from_slice(&bytes, cfg).unwrap();
+
+        // End-to-end: custom Serialize → Deserialize visitor (Box scratch → Arc).
+        assert_eq!(&*obs.pixels, &*back.pixels);
+    }
+
+    #[test]
+    fn from_boxed_preserves_pixels() {
+        let mut src = Box::new([0u8; PIXEL_BYTES]);
+        for (i, b) in src.iter_mut().enumerate() {
+            *b = (i % 256) as u8;
+        }
+        let expected = *src.clone();
+        let obs = CarRacingObservation::from_boxed(src);
+        assert_eq!(&*obs.pixels, &expected);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/car_racing/rasterizer.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/rasterizer.rs
@@ -106,6 +106,16 @@ impl Rasterizer {
     pub fn pixels(&self) -> &[u8; PIXEL_BYTES] {
         &self.buffer
     }
+
+    /// Move the filled framebuffer out, swapping in a fresh zeroed buffer.
+    ///
+    /// This is the zero-copy hand-off used on the render hot path: it transfers
+    /// ownership of the current buffer to the caller instead of copying its 27 KB.
+    /// The swapped-in buffer is zeroed; `render_frame` calls [`clear`](Self::clear)
+    /// before drawing, so the zero-init is overwritten each frame.
+    pub fn take_pixels(&mut self) -> Box<[u8; PIXEL_BYTES]> {
+        std::mem::replace(&mut self.buffer, Box::new([0u8; PIXEL_BYTES]))
+    }
 }
 
 impl Default for Rasterizer {
@@ -143,6 +153,21 @@ mod tests {
         let mut r = Rasterizer::new();
         r.fill_polygon(&[[10.0, 10.0], [20.0, 10.0]], [255, 0, 0]);
         r.fill_polygon(&[], [255, 0, 0]);
+    }
+
+    #[test]
+    fn test_take_pixels_transfers_and_zeroes() {
+        let mut r = Rasterizer::new();
+        r.clear([7, 8, 9]);
+        let taken = r.take_pixels();
+        // The taken buffer holds the filled contents.
+        for i in 0..FRAME_SIZE * FRAME_SIZE {
+            assert_eq!(taken[i * 3], 7);
+            assert_eq!(taken[i * 3 + 1], 8);
+            assert_eq!(taken[i * 3 + 2], 9);
+        }
+        // The rasterizer is left with a fresh zeroed buffer.
+        assert!(r.pixels().iter().all(|&b| b == 0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Eliminates repeated 27 KB pixel-buffer copies on the CarRacing render hot path. The 96×96×3 (27,648-byte) RGB framebuffer was deep-copied about three times per `step()` — rasterizer deref onto the stack, `Box::new` into the observation, then the cached `last_obs` clone — plus once more per `observe()`. Under population-based (EA) evaluation with parallel rollouts this was measurable waste. The render path now moves the buffer out of the rasterizer and shares it via `Arc`, dropping to a single `Box`→`Arc` copy while `last_obs`/`observe()` clones become atomic refcount bumps.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

<!-- Performance bug; no observable behavior or API-semantics change. Contained to the feature-gated `box2d` car_racing module; no new environment, algorithm, or workspace dependency (the only new dep is a `dev`-dependency already present in the workspace lock). -->

## Linked Issue

Closes #115

## What Was Changed

- `crates/rlevo-environments/src/box2d/car_racing/rasterizer.rs` — added `take_pixels(&mut self) -> Box<[u8; PIXEL_BYTES]>` (moves the filled buffer out via `mem::replace`, swaps in a fresh zeroed one); fill methods and `pixels()` unchanged. Added regression test `test_take_pixels_transfers_and_zeroes`.
- `crates/rlevo-environments/src/box2d/car_racing/observation.rs` — changed the stored buffer from `Box<[u8; N]>` to `Arc<[u8; N]>`; added `from_boxed(Box<[u8; N]>) -> Self`; updated `Default`, the `Deserialize` visitor (Box scratch → `Arc::from`), and `TensorConvertible::from_tensor` to build the `Arc`; updated struct/`from_boxed` docs. Added tests `from_boxed_preserves_pixels`, `_assert_send_sync` (compile-time `Send + Sync` guard), and `serde_round_trip`.
- `crates/rlevo-environments/src/box2d/car_racing/env.rs` — `render_frame` now ends with `CarRacingObservation::from_boxed(self.rasterizer.take_pixels())`, with a `PERF(#115)` provenance note.
- `crates/rlevo-environments/Cargo.toml` — added `bincode = { version = "2", features = ["serde"] }` as a **dev-dependency** (already in the workspace lock; mirrors `rlevo-benchmarks-report-client`) to back the serde round-trip regression test.
- `state.rs` intentionally unchanged — its `observe()`/`clone` are now cheap refcount bumps.

Net effect: 3 deep 27 KB copies/step → 1; `observe()` is now free.

## How It Was Tested

```
cargo build --workspace                       # clean
cargo clippy --all-targets --all-features     # no warnings (covers box2d)
cargo test --workspace                         # 56 suites ok, 0 failures
cargo test -p rlevo-environments --features box2d   # 950 lib + 43 integration + 95 doctests, 0 failed
```

New/updated regression tests (all pass under `--features box2d`):
- `rasterizer::tests::test_take_pixels_transfers_and_zeroes` — take-out returns filled contents, leaves buffer zeroed.
- `observation::tests::from_boxed_preserves_pixels` — byte-for-byte hand-off preservation.
- `observation::tests::serde_round_trip` — bincode 2.x encode→decode equality over the custom serde impls (exercises the `Arc::from` deserialize path).
- `observation::tests::_assert_send_sync` — compile-time guard that observations stay `Send + Sync` for cross-thread EA rollouts.
- Existing `tensor_round_trip` / `tensor_boundary_values` still pass with the `Arc` buffer.

- Rust toolchain: `stable 1.94.1`
- Burn backend tested: `ndarray` (CPU) via the crate's default `Flex` test backend
- OS: macOS (Darwin 25.5.0)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 4.8)**. Scope: **architecture validation, implementation, tests, and this PR text; reviewed by the maintainer, who is responsible for every line.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions (`take_pixels`, `from_boxed`) include doc comments explaining *what* and *why*.
- [x] Bug fix includes regression tests (buffer hand-off preservation + zeroing; serde round-trip).
- [x] This PR addresses a single concern (the pixel-copy hot path).
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- The residual single `Box`→`Arc` copy is documented in a `PERF(#115)` comment. A fuller zero-copy design (Arc-in-rasterizer + `get_mut`) was considered and deferred as a two-way door — it removes the last copy but touches every fill method and adds an invariant guard; not worth it for alpha.
- Correctness invariant: `take_pixels()` installs a zeroed buffer, so it relies on `render_frame` calling `clear()` before any fill (it does) — otherwise a stale frame could leak.
- Adjacent, out of scope here: `rlevo-environments` still lacks a `[lints] workspace = true` stanza, so pedantic lints don't cover this feature-gated module. Tracked separately in #274.
