### PR TITLE
fix(environments): Reject degenerate landscape dim (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   call `reset()` to start a new episode. So far only the `toy_text` family and
   the `TimeLimit` wrapper enforce this — the remaining environments are tracked
   in #289.
+- **Every n-dimensional landscape constructor is now fallible and its `dim` is
+  private** (resolves #110) — `Sphere::new(dim)` and its 14 siblings return
+  `Result<Self, ConfigError>` instead of `Self`, rejecting a degenerate `dim`
+  at construction via the ADR 0026 `config::nonzero` / `config::at_least`
+  helpers, exactly as ADR 0030 did for `Population`. Ten landscapes require
+  `dim >= 1` (`Sphere`, `Rastrigin`, `Ackley`, `Griewank`, `Schwefel`,
+  `Alpine1`, `Deb1`, `Needle`, `Michalewicz`, `Penalized1`); four require
+  `dim >= 2` because their sum runs over adjacent coordinate pairs and is empty
+  at `n = 1` (`Rosenbrock`, `RosenbrockFlat`, `Eggholder`,
+  `LunacekBiRastrigin`); `ConcatenatedTrap::new` requires both `num_blocks` and
+  `block_size` to be non-zero and their product to not overflow `usize`.
+  Migration: `Sphere::new(d)` becomes `Sphere::new(d).expect("dim >= 1")` at a
+  setup boundary (`main`, a test), or `?` where a `Result` is already threaded.
+  The `dim` field is no longer `pub` — read it through the new
+  `#[must_use] pub const fn dim(&self) -> usize`, and construct through `new`
+  rather than a struct literal. `new` is also no longer `const`; no `const` or
+  `static` landscape item existed in the workspace, so nothing else moves. No
+  persisted data is affected — landscapes carry no serialized form.
 
 ### `rlevo-core`
 
@@ -207,6 +225,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **A zero-dimensional landscape reported itself as *solved*** (resolves #110) —
+  every n-D landscape constructor accepted `dim == 0` unchecked, and the
+  resulting evaluator did not fail: it lied. `Sphere`, `Rastrigin`, `Alpine1`,
+  `Schwefel`, `Needle` and `Griewank` evaluated over an empty slice and returned
+  their own **global optimum**, so a misconfigured run read as converged —
+  `Griewank` via `sum − prod + 1 = 0 − 1 + 1 = 0`, where the empty product is
+  `1`. `Ackley` and `Deb1` divided by `n` and returned `NaN`, and
+  `Penalized1` was worse still — `y[0]`
+  indexed an empty `Vec` and `self.dim - 1` underflowed `usize`, panicking in
+  debug but *wrapping* in release. `ConcatenatedTrap` accepted a zero
+  `block_size`, where `chunks_exact(0)` panicked with std's anonymous "chunk
+  size must be non-zero" and an all-zeros genome scored the optimum.
+  `LunacekBiRastrigin` was the sharpest case: its `dim >= 2` assert lived inside
+  `evaluate`, but the *public* `s()` and `mu2()` accessors bypass `evaluate`
+  entirely, and below `n = 2` the depth-scaling parameter
+  `s = 1 − 1/(2√(n+20) − 8.2)` goes non-positive (`s(1) ≈ −0.036`), making
+  `mu2 = −√((μ₁² − d)/s)` a silent `NaN` that no assert could reach. The
+  existing tests missed all of this because they only ever constructed
+  *sensible* dimensions, and — per ADR 0034 — the fitness-hygiene chokepoint
+  maps `NaN → −inf`, so even the NaN cases surfaced as "the optimizer failed to
+  converge" rather than "the landscape is misconfigured". The guard now lives at
+  construction, where it is unreachable-by-design rather than merely asserted,
+  and a table-driven regression test pins all 15 constructors so a future
+  landscape cannot land unguarded.
 - **Post-terminal `step()` silently resurrected a finished episode across the
   whole `toy_text` family** (ADR 0044, resolves #105) — no environment tracked
   terminality, so a `step()` after a terminal snapshot kept mutating state.

--- a/crates/rlevo-environments/src/landscapes/ackley.rs
+++ b/crates/rlevo-environments/src/landscapes/ackley.rs
@@ -9,11 +9,13 @@
 
 use std::f64::consts::{E, PI};
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Ackley function evaluator with configurable dimensionality and constants.
 #[derive(Debug, Clone, Copy)]
 pub struct Ackley {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
     /// Outer scaling constant (canonical: `20.0`).
     pub a: f64,
     /// Inner exponential decay constant (canonical: `0.2`).
@@ -24,14 +26,27 @@ pub struct Ackley {
 
 impl Ackley {
     /// Build an Ackley with Ackley's canonical constants (`a=20`, `b=0.2`, `c=2π`).
-    #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: both mean terms divide by `n`, so
+    /// a zero-dimensional instance evaluates `0.0 / 0.0` and returns `NaN`,
+    /// which silently poisons every downstream fitness comparison.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Ackley";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self {
             dim,
             a: 20.0,
             b: 0.2,
             c: 2.0 * PI,
-        }
+        })
+    }
+
+    /// Number of input dimensions.
+    #[must_use]
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Ackley function at `x`.
@@ -99,14 +114,24 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Ackley::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Ackley::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_origin() {
-        let a = Ackley::new(5);
+        let a = Ackley::new(5).expect("dim >= 1");
         assert_relative_eq!(a.evaluate(&[0.0; 5]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_elsewhere() {
-        let a = Ackley::new(3);
+        let a = Ackley::new(3).expect("dim >= 1");
         assert!(a.evaluate(&[1.0, 2.0, 3.0]) > 0.0);
     }
 
@@ -114,7 +139,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let a = Ackley::new(2);
+        let a = Ackley::new(2).expect("dim >= 1");
         let plain_no_trailing: String = a.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(a.render_styled().plain_text(), plain_no_trailing);
     }
@@ -124,7 +149,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let a = Ackley::new(2);
+        let a = Ackley::new(2).expect("dim >= 1");
         let styled = a.render_styled();
         let label = styled.lines[0]
             .spans
@@ -139,7 +164,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let a = Ackley::new(2);
+        let a = Ackley::new(2).expect("dim >= 1");
         for line in a.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/alpine1.rs
+++ b/crates/rlevo-environments/src/landscapes/alpine1.rs
@@ -11,18 +11,33 @@
 //! Note: the canonical formula is `|x_i·sin(x_i) + 0.1·x_i|`; some libraries
 //! (e.g. NiaPy) drop the leading `x_i` factor — that is a different function.
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Alpine function No.01 evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Alpine1 {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Alpine1 {
     /// Creates a `dim`-dimensional Alpine No.01 evaluator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: `f` is a sum of per-coordinate
+    /// absolute values, so an empty coordinate set sums to `0` — the Alpine
+    /// No.01 global minimum `f* = 0` — making every evaluation look optimal.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Alpine1";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Alpine No.01 function at `x`.
@@ -88,14 +103,24 @@ mod tests {
     use std::f64::consts::PI;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Alpine1::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Alpine1::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_known_location() {
-        let a = Alpine1::new(4);
+        let a = Alpine1::new(4).expect("dim >= 1");
         assert_relative_eq!(a.evaluate(&[0.0; 4]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let a = Alpine1::new(3);
+        let a = Alpine1::new(3).expect("dim >= 1");
         assert!(
             a.evaluate(&[5.0, -3.0, 7.0]) > 0.0,
             "value away from the origin must exceed the minimum 0"
@@ -104,7 +129,7 @@ mod tests {
 
     #[test]
     fn non_negative_everywhere() {
-        let a = Alpine1::new(5);
+        let a = Alpine1::new(5).expect("dim >= 1");
         for x in [1.0, -3.7, 5.5, -9.1, 0.01_f64] {
             assert!(
                 a.evaluate(&[x; 5]) >= 0.0,
@@ -116,7 +141,7 @@ mod tests {
     #[test]
     fn known_value_at_pi() {
         // At x = π: |π·sin(π) + 0.1·π| = 0.1π.
-        let a = Alpine1::new(1);
+        let a = Alpine1::new(1).expect("dim >= 1");
         let expected = (PI * PI.sin() + 0.1 * PI).abs();
         assert_relative_eq!(a.evaluate(&[PI]), expected, epsilon = 1e-10);
     }
@@ -125,7 +150,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let a = Alpine1::new(2);
+        let a = Alpine1::new(2).expect("dim >= 1");
         let plain_no_trailing: String = a.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(a.render_styled().plain_text(), plain_no_trailing);
     }
@@ -135,7 +160,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let a = Alpine1::new(2);
+        let a = Alpine1::new(2).expect("dim >= 1");
         let styled = a.render_styled();
         let label = styled.lines[0]
             .spans
@@ -150,7 +175,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let a = Alpine1::new(2);
+        let a = Alpine1::new(2).expect("dim >= 1");
         for line in a.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/concatenated_trap.rs
+++ b/crates/rlevo-environments/src/landscapes/concatenated_trap.rs
@@ -46,26 +46,57 @@
 //! - Pelikan, M., Goldberg, D. E. & Cantú-Paz, E. (1999). "BOA: The Bayesian
 //!   Optimization Algorithm." *Proceedings of GECCO-99*, 525–532.
 
+use rlevo_core::config::{self, ConfigError, ConstraintKind};
+
 /// Concatenated trap evaluator: `num_blocks` order-`block_size` traps.
+///
+/// Construct with [`new`](Self::new), which rejects the degenerate
+/// configurations (see its `# Errors` section); the fields are private so a
+/// constructed value always has a well-defined, non-zero
+/// [`dim`](Self::dim).
 #[derive(Debug, Clone, Copy)]
 pub struct ConcatenatedTrap {
-    /// Number of contiguous, non-overlapping trap blocks.
-    pub num_blocks: usize,
-    /// Trap order `k` — the number of bits in each block.
-    pub block_size: usize,
+    /// Number of contiguous, non-overlapping trap blocks. Always non-zero.
+    num_blocks: usize,
+    /// Trap order `k` — the number of bits in each block. Always non-zero.
+    block_size: usize,
 }
 
 impl ConcatenatedTrap {
     /// Creates a concatenated trap of `num_blocks` blocks, each an order-`block_size` trap.
-    #[must_use]
-    pub const fn new(num_blocks: usize, block_size: usize) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// - [`ConstraintKind::Zero`] when `num_blocks == 0` or `block_size == 0`:
+    ///   either yields a zero-dimensional genome, and a zero `block_size` also
+    ///   makes [`evaluate`](Self::evaluate) partition with `chunks_exact(0)`
+    ///   (a panic) while scoring an empty genome at the *optimum* cost `0` —
+    ///   a misconfigured run would read as "solved".
+    /// - [`ConstraintKind::Custom`] when `num_blocks · block_size` overflows
+    ///   `usize`: the genome dimension cannot be represented, so
+    ///   [`dim`](Self::dim) has no correct answer to return.
+    pub fn new(num_blocks: usize, block_size: usize) -> Result<Self, ConfigError> {
+        const C: &str = "ConcatenatedTrap";
+        config::nonzero(C, "num_blocks", num_blocks)?;
+        config::nonzero(C, "block_size", block_size)?;
+        if num_blocks.checked_mul(block_size).is_none() {
+            return Err(ConfigError {
+                config: C,
+                field: "num_blocks",
+                kind: ConstraintKind::Custom("num_blocks * block_size must not overflow usize"),
+            });
+        }
+        Ok(Self {
             num_blocks,
             block_size,
-        }
+        })
     }
 
-    /// Total genome dimension: `num_blocks · block_size`.
+    /// Total genome dimension: `num_blocks · block_size`. Always non-zero.
+    ///
+    /// The multiplication cannot overflow: [`new`](Self::new) rejects any
+    /// `(num_blocks, block_size)` whose product exceeds `usize`, and the fields
+    /// are private, so no other value can exist.
     #[must_use]
     pub const fn dim(&self) -> usize {
         self.num_blocks * self.block_size
@@ -174,28 +205,67 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
 
+    /// A valid trap-5 × 4 for the happy-path tests.
+    fn trap_5x4() -> ConcatenatedTrap {
+        ConcatenatedTrap::new(4, 5).expect("4 blocks of 5 bits is a valid trap")
+    }
+
     #[test]
     fn dim_is_blocks_times_block_size() {
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         assert_eq!(t.dim(), 20, "4 blocks of 5 bits must yield dim 20");
     }
 
     #[test]
+    fn new_rejects_zero_num_blocks() {
+        let err = ConcatenatedTrap::new(0, 5).expect_err("zero blocks must be rejected");
+        assert_eq!(err.config, "ConcatenatedTrap");
+        assert_eq!(err.field, "num_blocks");
+        assert_eq!(err.kind, ConstraintKind::Zero);
+    }
+
+    #[test]
+    fn new_rejects_zero_block_size() {
+        // A zero block size would panic in `chunks_exact(0)` and score the
+        // empty genome at the optimum — the silent-success failure mode.
+        let err = ConcatenatedTrap::new(4, 0).expect_err("zero block size must be rejected");
+        assert_eq!(err.field, "block_size");
+        assert_eq!(err.kind, ConstraintKind::Zero);
+    }
+
+    #[test]
+    fn new_rejects_overflowing_dim() {
+        let err =
+            ConcatenatedTrap::new(usize::MAX, 2).expect_err("an overflowing dim must be rejected");
+        assert_eq!(err.field, "num_blocks");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::Custom("num_blocks * block_size must not overflow usize"),
+        );
+    }
+
+    #[test]
+    fn new_accepts_the_largest_representable_dim() {
+        let t = ConcatenatedTrap::new(usize::MAX, 1).expect("dim == usize::MAX is representable");
+        assert_eq!(t.dim(), usize::MAX);
+    }
+
+    #[test]
     fn global_minimum_all_ones() {
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         assert_relative_eq!(t.evaluate(&[1.0; 20]), 0.0, epsilon = 1e-6);
     }
 
     #[test]
     fn deceptive_optimum_all_zeros_costs_num_blocks() {
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         // Each all-zeros block costs cost(0) = 1, so 4 blocks cost 4.
         assert_relative_eq!(t.evaluate(&[0.0; 20]), 4.0, epsilon = 1e-6);
     }
 
     #[test]
     fn single_flip_from_all_zeros_is_strictly_worse() {
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         let baseline = t.evaluate(&[0.0; 20]);
         for i in 0..t.dim() {
             let mut x = [0.0_f64; 20];
@@ -213,7 +283,7 @@ mod tests {
 
     #[test]
     fn per_block_cost_curve_matches_trap() {
-        let t = ConcatenatedTrap::new(1, 5);
+        let t = ConcatenatedTrap::new(1, 5).expect("valid trap");
         let expected = [1.0, 2.0, 3.0, 4.0, 5.0, 0.0];
         for (u, &want) in expected.iter().enumerate() {
             let mut x = [0.0_f64; 5];
@@ -226,8 +296,8 @@ mod tests {
 
     #[test]
     fn additively_decomposable_across_blocks() {
-        let block = ConcatenatedTrap::new(1, 5);
-        let two = ConcatenatedTrap::new(2, 5);
+        let block = ConcatenatedTrap::new(1, 5).expect("valid trap");
+        let two = ConcatenatedTrap::new(2, 5).expect("valid trap");
         // Two distinct blocks: one with u=2 leading ones, one with u=3.
         let a = [1.0, 1.0, 0.0, 0.0, 0.0];
         let b = [1.0, 1.0, 1.0, 0.0, 0.0];
@@ -243,7 +313,7 @@ mod tests {
 
     #[test]
     fn threshold_rounds_genes_to_bits() {
-        let t = ConcatenatedTrap::new(1, 5);
+        let t = ConcatenatedTrap::new(1, 5).expect("valid trap");
         // 0.49 -> 0, 0.5 -> 1, 0.51 -> 1, 1.0 -> 1, 0.99 -> 1 ⇒ u = 4 ⇒ cost 5.
         assert_relative_eq!(
             t.evaluate(&[0.5, 0.49, 0.51, 1.0, 0.99]),
@@ -255,7 +325,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "input dimension mismatch")]
     fn evaluate_panics_on_dimension_mismatch() {
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         let _ = t.evaluate(&[0.0; 19]);
     }
 
@@ -263,7 +333,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         let plain_no_trailing: String = t.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(
             t.render_styled().plain_text(),
@@ -277,7 +347,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         let styled = t.render_styled();
         let label = styled.lines[0]
             .spans
@@ -299,7 +369,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let t = ConcatenatedTrap::new(4, 5);
+        let t = trap_5x4();
         for line in t.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/deb1.rs
+++ b/crates/rlevo-environments/src/landscapes/deb1.rs
@@ -12,18 +12,33 @@
 
 use std::f64::consts::PI;
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Deb's function No.01 evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Deb1 {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Deb1 {
     /// Creates a `dim`-dimensional Deb No.01 evaluator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: the `1/n` averaging factor divides
+    /// the empty sum by zero, so evaluation yields `0.0 / 0.0` = `NaN` rather
+    /// than a comparable fitness value.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Deb1";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate Deb's function No.01 at `x`.
@@ -80,16 +95,26 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Deb1::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Deb1::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_known_location() {
         // x_i = 0.1 ⇒ sin(π/2)⁶ = 1 in every dimension ⇒ f = −1.
-        let d = Deb1::new(3);
+        let d = Deb1::new(3).expect("dim >= 1");
         assert_relative_eq!(d.evaluate(&[0.1; 3]), -1.0, epsilon = 1e-10);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
         // f ∈ [−1, 0]; a non-optimal point exceeds the minimum −1.
-        let d = Deb1::new(1);
+        let d = Deb1::new(1).expect("dim >= 1");
         assert!(
             d.evaluate(&[0.15]) > -1.0,
             "non-optimal point must exceed the minimum −1"
@@ -98,14 +123,14 @@ mod tests {
 
     #[test]
     fn global_minimum_at_sample_optima() {
-        let d = Deb1::new(3);
+        let d = Deb1::new(3).expect("dim >= 1");
         assert_relative_eq!(d.evaluate(&[0.1, 0.1, 0.1]), -1.0, epsilon = 1e-10);
         assert_relative_eq!(d.evaluate(&[-0.9, 0.3, 0.7]), -1.0, epsilon = 1e-10);
     }
 
     #[test]
     fn local_minimum_shallower() {
-        let d = Deb1::new(1);
+        let d = Deb1::new(1).expect("dim >= 1");
         assert!(d.evaluate(&[0.15]) > -1.0);
     }
 
@@ -113,7 +138,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let d = Deb1::new(2);
+        let d = Deb1::new(2).expect("dim >= 1");
         let plain_no_trailing: String = d.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(d.render_styled().plain_text(), plain_no_trailing);
     }
@@ -123,7 +148,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let d = Deb1::new(2);
+        let d = Deb1::new(2).expect("dim >= 1");
         let styled = d.render_styled();
         let label = styled.lines[0]
             .spans
@@ -138,7 +163,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let d = Deb1::new(2);
+        let d = Deb1::new(2).expect("dim >= 1");
         for line in d.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/eggholder.rs
+++ b/crates/rlevo-environments/src/landscapes/eggholder.rs
@@ -11,32 +11,62 @@
 //! absolute-value arguments cross zero.
 //!
 //! Evaluated over `[-512, 512]^n`. Requires `n ≥ 2`.
+//!
+//! # Provenance of the n-dimensional form
+//!
+//! The **canonical Eggholder is 2-D only**; the `n`-dimensional adjacent-pair
+//! generalization implemented here (the `Σ_{i=1}^{n-1}` over `windows(2)` above)
+//! is a *lower-confidence extension* relative to the peer-reviewed sources behind
+//! the other landscapes in this module. Its traceable citation is S. Mishra
+//! (2006), *"Some New Test Functions for Global Optimization and Performance of
+//! Repulsive Particle Swarm Method"*, MPRA working paper — reproduced as `f53` in
+//! Jamil & Yang (2013), *"A Literature Survey of Benchmark Functions for Global
+//! Optimisation Problems"*. Mishra is a **non-peer-reviewed working paper**, and
+//! Jamil & Yang's reproduction carries a notation inconsistency (it bounds the sum
+//! by `m` while stating the domain over `i = 1..n`). Treat results for `n > 2` as
+//! resting on that weaker footing; the `n = 2` optimum below is solid.
+
+use rlevo_core::config::{self, ConfigError};
 
 /// Eggholder function evaluator with configurable dimensionality.
+///
+/// The canonical function is 2-D; `dim > 2` uses the adjacent-pair generalization
+/// whose provenance is discussed in the [module docs](self).
 #[derive(Debug, Clone, Copy)]
 pub struct Eggholder {
-    /// Number of input dimensions. Must be `≥ 2`.
-    pub dim: usize,
+    /// Number of input dimensions. Always `≥ 2` — enforced by [`Eggholder::new`].
+    dim: usize,
 }
 
 impl Eggholder {
     /// Creates a `dim`-dimensional Eggholder evaluator.
     ///
-    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim < 2`. Every term couples a coordinate to
+    /// its successor (`x_i` with `x_{i+1}`), so the sum is empty for a single
+    /// coordinate and the function collapses to the constant `0` — with none of
+    /// the boundary-pinned optimum the benchmark exists to expose.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Eggholder";
+        config::at_least(C, "dim", dim, 2)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Eggholder function at `x`.
     ///
     /// # Panics
     ///
-    /// Panics if `x.len() != self.dim`, or if `self.dim < 2`.
+    /// Panics if `x.len() != self.dim`.
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");
-        assert!(self.dim >= 2, "Eggholder requires dim >= 2");
         x.windows(2)
             .map(|w| {
                 let (xi, xn) = (w[0], w[1]);
@@ -100,14 +130,14 @@ mod tests {
 
     #[test]
     fn global_minimum_at_known_location() {
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         assert_relative_eq!(e.evaluate(&[512.0, 404.2318]), -959.6407, epsilon = 1e-2);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
         // The origin scores well above the boundary-pinned optimum.
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         assert!(
             e.evaluate(&[0.0, 0.0]) > e.evaluate(&[512.0, 404.2318]),
             "interior point must score worse than the global optimum"
@@ -116,7 +146,7 @@ mod tests {
 
     #[test]
     fn known_n2_global_minimum() {
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         assert_relative_eq!(e.evaluate(&[512.0, 404.2318]), -959.6407, epsilon = 1e-2);
     }
 
@@ -124,22 +154,34 @@ mod tests {
     fn no_nan_in_domain() {
         // At a zero crossing of the first absolute-value argument (x2 = x1 − 47),
         // sqrt(0) must not produce NaN.
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         let v = e.evaluate(&[47.0, 0.0]);
         assert!(!v.is_nan(), "NaN at zero crossing");
     }
 
     #[test]
-    #[should_panic(expected = "requires dim >= 2")]
-    fn panics_on_dim_one() {
-        let _ = Eggholder::new(1).evaluate(&[0.0]);
+    fn new_rejects_dim_one() {
+        assert!(
+            Eggholder::new(1).is_err(),
+            "dim = 1 leaves the adjacent-pair sum empty"
+        );
+    }
+
+    #[test]
+    fn new_rejects_dim_zero() {
+        assert!(Eggholder::new(0).is_err(), "dim = 0 has no coordinates");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Eggholder::new(7).expect("dim >= 2").dim(), 7);
     }
 
     #[test]
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         let plain_no_trailing: String = e.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(e.render_styled().plain_text(), plain_no_trailing);
     }
@@ -149,7 +191,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         let styled = e.render_styled();
         let label = styled.lines[0]
             .spans
@@ -164,7 +206,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let e = Eggholder::new(2);
+        let e = Eggholder::new(2).expect("dim >= 2");
         for line in e.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/griewank.rs
+++ b/crates/rlevo-environments/src/landscapes/griewank.rs
@@ -11,18 +11,33 @@
 //!
 //! Requires `n ≥ 1`.
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Griewank function evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Griewank {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Griewank {
     /// Creates a `dim`-dimensional Griewank evaluator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: the quadratic term is an empty sum
+    /// (`0`) and the cosine term an empty product (`1`), so `f = 0 − 1 + 1 = 0`
+    /// — precisely the Griewank's global minimum — for every input.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Griewank";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Griewank function at `x`.
@@ -95,15 +110,25 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Griewank::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Griewank::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_known_location() {
         // sum_sq = 0, prod_cos = 1, so f(0) = 0 − 1 + 1 = 0 exactly.
-        let g = Griewank::new(5);
+        let g = Griewank::new(5).expect("dim >= 1");
         assert_relative_eq!(g.evaluate(&[0.0; 5]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let g = Griewank::new(3);
+        let g = Griewank::new(3).expect("dim >= 1");
         assert!(
             g.evaluate(&[100.0, -50.0, 25.0]) > 0.0,
             "Griewank must exceed its minimum away from the origin"
@@ -113,7 +138,7 @@ mod tests {
     #[test]
     fn known_value_at_ones() {
         // f([1,1]) = 2/4000 − cos(1)·cos(1/√2) + 1.
-        let g = Griewank::new(2);
+        let g = Griewank::new(2).expect("dim >= 1");
         let expected = 2.0 / 4000.0 - (1.0_f64).cos() * (1.0_f64 / 2.0_f64.sqrt()).cos() + 1.0;
         assert_relative_eq!(g.evaluate(&[1.0, 1.0]), expected, epsilon = 1e-12);
     }
@@ -122,7 +147,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let g = Griewank::new(2);
+        let g = Griewank::new(2).expect("dim >= 1");
         let plain_no_trailing: String = g.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(g.render_styled().plain_text(), plain_no_trailing);
     }
@@ -132,7 +157,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let g = Griewank::new(2);
+        let g = Griewank::new(2).expect("dim >= 1");
         let styled = g.render_styled();
         let label = styled.lines[0]
             .spans
@@ -147,7 +172,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let g = Griewank::new(2);
+        let g = Griewank::new(2).expect("dim >= 1");
         for line in g.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/lunacek_bi_rastrigin.rs
+++ b/crates/rlevo-environments/src/landscapes/lunacek_bi_rastrigin.rs
@@ -21,6 +21,8 @@
 
 use std::f64::consts::PI;
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Global-funnel centre `μ₁`.
 const MU1: f64 = 2.5;
 /// Depth offset `d` of the deceptive funnel.
@@ -30,29 +32,52 @@ const D: f64 = 1.0;
 ///
 /// The depth-scaling `s` and deceptive-funnel centre `μ₂` are derived from `n`
 /// on demand (see [`s`](Self::s) / [`mu2`](Self::mu2)) because they require a
-/// `sqrt`, which cannot run in a `const fn` constructor.
+/// `sqrt`, which cannot run in a `const fn` constructor. Both are total only
+/// because [`new`](Self::new) rejects `dim < 2`: `s` is non-positive below `n = 2`,
+/// which would send `μ₂` through the square root of a negative number.
 #[derive(Debug, Clone, Copy)]
 pub struct LunacekBiRastrigin {
-    /// Number of input dimensions. Must be `≥ 2`.
-    pub dim: usize,
+    /// Number of input dimensions. Always `≥ 2` — enforced by [`LunacekBiRastrigin::new`].
+    dim: usize,
 }
 
 impl LunacekBiRastrigin {
     /// Creates a `dim`-dimensional Lunacek bi-Rastrigin evaluator.
     ///
-    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
-    #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim < 2`. The depth-scaling parameter
+    /// `s = 1 − 1/(2√(n+20) − 8.2)` is non-positive for `n < 2` (`s(0) ≈ −0.344`,
+    /// `s(1) ≈ −0.036`), which makes `μ₂ = −√((μ₁² − d)/s)` the square root of a
+    /// negative number — i.e. `NaN`, propagated silently through
+    /// [`evaluate`](Self::evaluate) with no panic and no diagnostic. This bound is
+    /// *derived* from the published parameterization (Lunacek, Whitley & Sutton,
+    /// PPSN X, 2008); the paper does not state it explicitly.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "LunacekBiRastrigin";
+        config::at_least(C, "dim", dim, 2)?;
+        Ok(Self { dim })
     }
 
-    /// Depth-scaling parameter `s = 1 − 1/(2√(n+20) − 8.2)`. Positive for all `n ≥ 2`.
+    /// Number of input dimensions.
+    #[must_use]
+    pub const fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Depth-scaling parameter `s = 1 − 1/(2√(n+20) − 8.2)`.
+    ///
+    /// Always strictly positive: `s` crosses zero between `n = 1` (`≈ −0.036`) and
+    /// `n = 2` (`≈ +0.153`), and [`new`](Self::new) rejects `dim < 2`.
     #[must_use]
     pub fn s(&self) -> f64 {
         1.0 - 1.0 / (2.0 * (self.dim as f64 + 20.0).sqrt() - 8.2)
     }
 
     /// Deceptive-funnel centre `μ₂ = −√((μ₁² − d)/s)`.
+    ///
+    /// Always finite: [`s`](Self::s) is positive for every constructible `dim`, so
+    /// the radicand `(μ₁² − d)/s` is positive and the `sqrt` is real.
     #[must_use]
     pub fn mu2(&self) -> f64 {
         -((MU1 * MU1 - D) / self.s()).sqrt()
@@ -62,11 +87,10 @@ impl LunacekBiRastrigin {
     ///
     /// # Panics
     ///
-    /// Panics if `x.len() != self.dim`, or if `self.dim < 2`.
+    /// Panics if `x.len() != self.dim`.
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");
-        assert!(self.dim >= 2, "Lunacek bi-Rastrigin requires dim >= 2");
         let n = self.dim as f64;
         let s = self.s();
         let mu2 = self.mu2();
@@ -133,13 +157,13 @@ mod tests {
 
     #[test]
     fn global_minimum_at_known_location() {
-        let f = LunacekBiRastrigin::new(4);
+        let f = LunacekBiRastrigin::new(4).expect("dim >= 2");
         assert_relative_eq!(f.evaluate(&[MU1; 4]), 0.0, epsilon = 1e-10);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let f = LunacekBiRastrigin::new(3);
+        let f = LunacekBiRastrigin::new(3).expect("dim >= 2");
         assert!(
             f.evaluate(&[0.0; 3]) > 0.0,
             "value away from μ₁ must exceed the minimum 0"
@@ -148,29 +172,63 @@ mod tests {
 
     #[test]
     fn global_minimum_at_mu1() {
-        let f = LunacekBiRastrigin::new(5);
+        let f = LunacekBiRastrigin::new(5).expect("dim >= 2");
         assert_relative_eq!(f.evaluate(&[2.5; 5]), 0.0, epsilon = 1e-10);
     }
 
     #[test]
     fn s_parameter_positive() {
         for n in 2..=50 {
-            let f = LunacekBiRastrigin::new(n);
+            let f = LunacekBiRastrigin::new(n).expect("dim >= 2");
             assert!(f.s() > 0.0, "s must be positive for n={n}");
         }
     }
 
+    /// The funnel parameters are the reason `dim >= 2` is a *construction*
+    /// invariant: `s` goes non-positive below `n = 2`, and `mu2` then takes the
+    /// square root of a negative number and yields NaN with no panic. Pin both at
+    /// the boundary dimension, where `s` is smallest and closest to the zero
+    /// crossing (`s(2) ≈ 0.153`).
     #[test]
-    #[should_panic(expected = "requires dim >= 2")]
-    fn panics_on_dim_one() {
-        let _ = LunacekBiRastrigin::new(1).evaluate(&[2.5]);
+    fn funnel_parameters_finite_at_minimum_dim() {
+        let f = LunacekBiRastrigin::new(2).expect("dim >= 2");
+        assert!(
+            f.s() > 0.0,
+            "s must be positive at the minimum dim, got {}",
+            f.s()
+        );
+        assert!(
+            f.mu2().is_finite(),
+            "mu2 must be finite at the minimum dim, got {}",
+            f.mu2()
+        );
+        assert!(f.mu2() < 0.0, "mu2 is the negative root by definition");
+        // The whole surface stays finite too — no NaN leaks into evaluate.
+        assert!(f.evaluate(&[0.0, 0.0]).is_finite());
+    }
+
+    #[test]
+    fn new_rejects_dim_one() {
+        // s(1) ≈ −0.036 ⇒ mu2 = −√(negative) = NaN, silently.
+        assert!(LunacekBiRastrigin::new(1).is_err());
+    }
+
+    #[test]
+    fn new_rejects_dim_zero() {
+        // s(0) ≈ −0.344 ⇒ same NaN hole.
+        assert!(LunacekBiRastrigin::new(0).is_err());
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(LunacekBiRastrigin::new(7).expect("dim >= 2").dim(), 7);
     }
 
     #[test]
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let f = LunacekBiRastrigin::new(2);
+        let f = LunacekBiRastrigin::new(2).expect("dim >= 2");
         let plain_no_trailing: String = f.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(f.render_styled().plain_text(), plain_no_trailing);
     }
@@ -180,7 +238,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let f = LunacekBiRastrigin::new(2);
+        let f = LunacekBiRastrigin::new(2).expect("dim >= 2");
         let styled = f.render_styled();
         let label = styled.lines[0]
             .spans
@@ -195,7 +253,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let f = LunacekBiRastrigin::new(2);
+        let f = LunacekBiRastrigin::new(2).expect("dim >= 2");
         for line in f.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/michalewicz.rs
+++ b/crates/rlevo-environments/src/landscapes/michalewicz.rs
@@ -13,11 +13,13 @@
 
 use std::f64::consts::{FRAC_PI_2, PI};
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Michalewicz function evaluator with configurable dimensionality and steepness.
 #[derive(Debug, Clone, Copy)]
 pub struct Michalewicz {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
     /// Steepness parameter; the canonical value is `10`. Lower values (e.g. `2`)
     /// produce a smoother surface useful for debugging gradient-based agents.
     pub m: u32,
@@ -25,9 +27,22 @@ pub struct Michalewicz {
 
 impl Michalewicz {
     /// Creates a `dim`-dimensional Michalewicz evaluator with canonical `m = 10`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: the sum over dimensions is empty,
+    /// so `f ≡ 0` — a perfectly flat surface with no local minima, no gradient,
+    /// and no certified optimum to converge on.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Michalewicz";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim, m: 10 })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim, m: 10 }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Michalewicz function at `x`.
@@ -101,9 +116,19 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Michalewicz::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Michalewicz::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_known_location() {
         // Certified n=2 optimum f* ≈ −1.8013 near (2.20, π/2).
-        let m = Michalewicz::new(2);
+        let m = Michalewicz::new(2).expect("dim >= 1");
         assert_relative_eq!(
             m.evaluate(&[2.20290552, FRAC_PI_2]),
             -1.8013,
@@ -115,7 +140,7 @@ mod tests {
     fn positive_or_greater_elsewhere() {
         // f is ≤ 0 everywhere; a generic interior point exceeds (is greater than)
         // the global minimum value.
-        let m = Michalewicz::new(2);
+        let m = Michalewicz::new(2).expect("dim >= 1");
         assert!(
             m.evaluate(&[0.5, 0.5]) > m.evaluate(&[2.20290552, FRAC_PI_2]),
             "interior point must score worse than the global optimum"
@@ -125,7 +150,7 @@ mod tests {
     #[test]
     fn always_non_positive() {
         // The outer minus sign and sin^{2m} ∈ [0, 1] keep f ≤ 0 across the domain.
-        let m = Michalewicz::new(3);
+        let m = Michalewicz::new(3).expect("dim >= 1");
         for &xi in &[0.1, 0.8, 1.6, 2.4, 3.0] {
             assert!(
                 m.evaluate(&[xi; 3]) <= 1e-12,
@@ -136,7 +161,7 @@ mod tests {
 
     #[test]
     fn known_value_n2() {
-        let m = Michalewicz::new(2);
+        let m = Michalewicz::new(2).expect("dim >= 1");
         assert_relative_eq!(
             m.evaluate(&[2.20290552, FRAC_PI_2]),
             -1.8013,
@@ -148,8 +173,9 @@ mod tests {
     fn lower_m_produces_smoother_surface() {
         // Structural sanity check: a steeper m yields a sharper (more negative or
         // equal) value at a near-ridge point than a smoother m does.
-        let steep = Michalewicz { dim: 2, m: 10 };
-        let smooth = Michalewicz { dim: 2, m: 2 };
+        let steep = Michalewicz::new(2).expect("dim >= 1"); // canonical m = 10
+        let mut smooth = Michalewicz::new(2).expect("dim >= 1");
+        smooth.m = 2;
         let _ = smooth.evaluate(&[1.0, 1.5]);
         let _ = steep.evaluate(&[1.0, 1.5]);
     }
@@ -158,7 +184,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let m = Michalewicz::new(2);
+        let m = Michalewicz::new(2).expect("dim >= 1");
         let plain_no_trailing: String = m.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(m.render_styled().plain_text(), plain_no_trailing);
     }
@@ -168,7 +194,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let m = Michalewicz::new(2);
+        let m = Michalewicz::new(2).expect("dim >= 1");
         let styled = m.render_styled();
         let label = styled.lines[0]
             .spans
@@ -183,7 +209,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let m = Michalewicz::new(2);
+        let m = Michalewicz::new(2).expect("dim >= 1");
         for line in m.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/needle_eye.rs
+++ b/crates/rlevo-environments/src/landscapes/needle_eye.rs
@@ -12,11 +12,13 @@
 //! astronomically small (volume fraction `≈ 10⁻¹⁰` at `n = 2`), so this is a
 //! failure-demonstration function, not a solvable test. Requires `n ≥ 1`.
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Needle-Eye function evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Needle {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Needle {
@@ -24,9 +26,23 @@ impl Needle {
     pub const EYE: f64 = 1e-4;
 
     /// Creates a `dim`-dimensional Needle-Eye evaluator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: the "inside the eye" predicate
+    /// `∀i. |x_i| ≤ EYE` is vacuously true over an empty coordinate set, so
+    /// every point returns the global minimum `f* = 1` and the needle can never
+    /// be missed.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Needle";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Needle-Eye function at `x`.
@@ -102,15 +118,25 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Needle::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Needle::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_known_location() {
         // Inside the needle, f = 1 (the minimum).
-        let n = Needle::new(3);
+        let n = Needle::new(3).expect("dim >= 1");
         assert_relative_eq!(n.evaluate(&[0.0, 0.0, 0.0]), 1.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let n = Needle::new(1);
+        let n = Needle::new(1).expect("dim >= 1");
         assert!(
             n.evaluate(&[1.0]) > 1.0,
             "value outside the needle must exceed the minimum 1"
@@ -119,14 +145,14 @@ mod tests {
 
     #[test]
     fn inside_eye_gives_one() {
-        let n = Needle::new(3);
+        let n = Needle::new(3).expect("dim >= 1");
         assert_relative_eq!(n.evaluate(&[0.0, 0.0, 0.0]), 1.0, epsilon = 1e-12);
         assert_relative_eq!(n.evaluate(&[5e-5, -5e-5, 0.0]), 1.0, epsilon = 1e-12);
     }
 
     #[test]
     fn outside_eye_gives_penalty() {
-        let n = Needle::new(1);
+        let n = Needle::new(1).expect("dim >= 1");
         // |1.0| > EYE, so f = 100 + 1.0 = 101.0.
         assert_relative_eq!(n.evaluate(&[1.0]), 101.0, epsilon = 1e-10);
     }
@@ -135,7 +161,7 @@ mod tests {
     fn exact_boundary_stays_at_minimum() {
         // A point exactly on the boundary |x_i| = EYE is inside the eye, so
         // f = 1 — never below the global minimum.
-        let n = Needle::new(2);
+        let n = Needle::new(2).expect("dim >= 1");
         assert_relative_eq!(
             n.evaluate(&[Needle::EYE, -Needle::EYE]),
             1.0,
@@ -145,7 +171,7 @@ mod tests {
 
     #[test]
     fn just_outside_eye_gives_penalty() {
-        let n = Needle::new(1);
+        let n = Needle::new(1).expect("dim >= 1");
         let x = 1.1e-4_f64; // just outside the eye
         assert!(n.evaluate(&[x]) > 1.0);
     }
@@ -154,7 +180,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let n = Needle::new(2);
+        let n = Needle::new(2).expect("dim >= 1");
         let plain_no_trailing: String = n.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(n.render_styled().plain_text(), plain_no_trailing);
     }
@@ -164,7 +190,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let n = Needle::new(2);
+        let n = Needle::new(2).expect("dim >= 1");
         let styled = n.render_styled();
         let label = styled.lines[0]
             .spans
@@ -179,7 +205,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let n = Needle::new(2);
+        let n = Needle::new(2).expect("dim >= 1");
         for line in n.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/penalized1.rs
+++ b/crates/rlevo-environments/src/landscapes/penalized1.rs
@@ -22,6 +22,8 @@
 
 use std::f64::consts::PI;
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Quartic boundary penalty `u(x)` with `a = 10`, `k = 100`, `m = 4`.
 fn penalty(x: f64) -> f64 {
     // non-differentiable in f'' at x = ±10 (penalty activation) — explicit
@@ -39,14 +41,32 @@ fn penalty(x: f64) -> f64 {
 #[derive(Debug, Clone, Copy)]
 pub struct Penalized1 {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Penalized1 {
     /// Creates a `dim`-dimensional Penalized No.01 evaluator.
+    ///
+    /// `dim == 1` is valid: the `Σ_{i=1}^{n-1}` term is empty and drops out, but
+    /// the `10·sin²(π·y_1)` and `(y_n − 1)²` terms sit outside that sum and
+    /// survive (with `y_n == y_1`), so the function stays non-constant and the
+    /// published optimum `f(−1) = 0` still holds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when `dim == 0`: the `π/n` prefactor would divide
+    /// by zero (yielding `inf`/`NaN`) and the `y[0]` / `y[n−1]` accesses would
+    /// index out of bounds.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Penalized1";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Penalized No.01 function at `x`.
@@ -81,10 +101,9 @@ impl Penalized1 {
     /// Coordinates beyond the first two are fixed at `−1.0` (the per-dimension
     /// optimum) so the rendered slice passes through the global minimum.
     fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+        // `new` guarantees `dim >= 1`, so index 0 always exists.
         let mut p = vec![-1.0_f64; self.dim];
-        if !p.is_empty() {
-            p[0] = x;
-        }
+        p[0] = x;
         if p.len() >= 2 {
             p[1] = y;
         }
@@ -122,13 +141,13 @@ mod tests {
     #[test]
     fn global_minimum_at_known_location() {
         // x_i = −1 ⇒ y_i = 1 ⇒ every sinusoidal term and penalty vanishes.
-        let p = Penalized1::new(4);
+        let p = Penalized1::new(4).expect("dim >= 1");
         assert_relative_eq!(p.evaluate(&[-1.0; 4]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let p = Penalized1::new(3);
+        let p = Penalized1::new(3).expect("dim >= 1");
         assert!(
             p.evaluate(&[0.0, 0.0, 0.0]) > 0.0,
             "Penalized1 must exceed its minimum away from (−1,…,−1)"
@@ -137,13 +156,51 @@ mod tests {
 
     #[test]
     fn global_minimum_at_neg_one() {
-        let p = Penalized1::new(2);
+        let p = Penalized1::new(2).expect("dim >= 1");
         assert_relative_eq!(p.evaluate(&[-1.0, -1.0]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Penalized1::new(0).is_err());
+    }
+
+    #[test]
+    fn dim_one_is_well_defined_and_attains_optimum() {
+        // n = 1 is valid (Yao, Liu & Lin 1999, f12): the Σ_{i=1}^{n-1} term is
+        // empty, but 10·sin²(π·y_1) and (y_n−1)² sit outside it and survive with
+        // y_n == y_1. The published optimum x* = (−1), f(x*) = 0 still holds.
+        // Do NOT tighten the guard to `dim >= 2`.
+        let p = Penalized1::new(1).expect("dim = 1 is valid for Penalized1");
+        assert_eq!(p.dim(), 1);
+
+        let at_opt = p.evaluate(&[-1.0]);
+        assert!(
+            at_opt.is_finite(),
+            "f must be finite at n = 1, got {at_opt}"
+        );
+        assert_relative_eq!(at_opt, 0.0, epsilon = 1e-12);
+
+        // Not bit-exact 0.0: x = −1 ⇒ y_1 = 1.0 exactly, but sin(π_f64) ≈ 1.22e-16
+        // (π is not exactly representable), so 10·sin²(π·y_1) ≈ 1.5e-31 and
+        // f(−1) ≈ 4.7e-31. This is the same fp residue the dim = 2 / dim = 4
+        // optimum tests above carry (≈ 2.4e-31), not an n = 1 pathology. Bound it
+        // tightly so a genuinely nonzero optimum would still fail here.
+        assert!(
+            at_opt.abs() < 1e-28,
+            "f(−1) must be zero up to the sin(π) fp residue, got {at_opt:e}"
+        );
+
+        // Non-constant at n = 1: some other point must exceed the optimum.
+        assert!(
+            p.evaluate(&[0.0]) > at_opt,
+            "Penalized1 must be non-constant at n = 1"
+        );
+    }
+
+    #[test]
     fn penalty_activates_outside_soft_bounds() {
-        let p = Penalized1::new(1);
+        let p = Penalized1::new(1).expect("dim >= 1");
         assert!(
             p.evaluate(&[11.0]) > p.evaluate(&[9.0]),
             "penalty must raise f beyond +10"
@@ -167,7 +224,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let p = Penalized1::new(2);
+        let p = Penalized1::new(2).expect("dim >= 1");
         let plain_no_trailing: String = p.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(p.render_styled().plain_text(), plain_no_trailing);
     }
@@ -177,7 +234,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let p = Penalized1::new(2);
+        let p = Penalized1::new(2).expect("dim >= 1");
         let styled = p.render_styled();
         let label = styled.lines[0]
             .spans
@@ -192,7 +249,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let p = Penalized1::new(2);
+        let p = Penalized1::new(2).expect("dim >= 1");
         for line in p.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/rastrigin.rs
+++ b/crates/rlevo-environments/src/landscapes/rastrigin.rs
@@ -5,20 +5,35 @@
 
 use std::f64::consts::PI;
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Rastrigin function evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Rastrigin {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
     /// Amplitude constant (canonical: `10.0`).
     pub a: f64,
 }
 
 impl Rastrigin {
     /// Creates a `dim`-dimensional Rastrigin evaluator with `A = 10`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: the `A·n` offset collapses to `0`
+    /// and the per-coordinate sum is empty, so `f` is identically `0` — the
+    /// Rastrigin's global optimum — for every input.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Rastrigin";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim, a: 10.0 })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim, a: 10.0 }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Rastrigin function at `x`.
@@ -87,14 +102,24 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Rastrigin::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Rastrigin::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_origin() {
-        let r = Rastrigin::new(5);
+        let r = Rastrigin::new(5).expect("dim >= 1");
         assert_relative_eq!(r.evaluate(&[0.0; 5]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_elsewhere() {
-        let r = Rastrigin::new(3);
+        let r = Rastrigin::new(3).expect("dim >= 1");
         assert!(r.evaluate(&[1.0, 2.0, 3.0]) > 0.0);
     }
 
@@ -102,7 +127,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let r = Rastrigin::new(2);
+        let r = Rastrigin::new(2).expect("dim >= 1");
         let plain_no_trailing: String = r.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(r.render_styled().plain_text(), plain_no_trailing);
     }
@@ -112,7 +137,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let r = Rastrigin::new(2);
+        let r = Rastrigin::new(2).expect("dim >= 1");
         let styled = r.render_styled();
         let label = styled.lines[0]
             .spans
@@ -127,7 +152,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let r = Rastrigin::new(2);
+        let r = Rastrigin::new(2).expect("dim >= 1");
         for line in r.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/rosenbrock.rs
+++ b/crates/rlevo-environments/src/landscapes/rosenbrock.rs
@@ -13,35 +13,47 @@
 //!
 //! Requires `n ≥ 2`; the sum is empty for `n = 1`.
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Rosenbrock function evaluator with configurable dimensionality.
 ///
 /// The `100` and `1` coefficients are fixed per the canonical definition, so the
 /// struct carries no tunable constants.
 #[derive(Debug, Clone, Copy)]
 pub struct Rosenbrock {
-    /// Number of input dimensions. Must be `≥ 2`.
-    pub dim: usize,
+    /// Number of input dimensions. Always `≥ 2` — enforced by [`Rosenbrock::new`].
+    dim: usize,
 }
 
 impl Rosenbrock {
     /// Creates a `dim`-dimensional Rosenbrock evaluator.
     ///
-    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim < 2`. The chained sum runs over adjacent
+    /// coordinate pairs (`i = 1..n−1`) and is empty for a single coordinate, so
+    /// `f` would be identically `0` everywhere — a constant "landscape" whose
+    /// every point is a global optimum.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Rosenbrock";
+        config::at_least(C, "dim", dim, 2)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Rosenbrock function at `x`.
     ///
     /// # Panics
     ///
-    /// Panics if `x.len() != self.dim`, or if `self.dim < 2` (the pairwise sum is
-    /// undefined for a single coordinate).
+    /// Panics if `x.len() != self.dim`.
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");
-        assert!(self.dim >= 2, "Rosenbrock requires dim >= 2");
         x.windows(2)
             .map(|w| {
                 let (xi, xn) = (w[0], w[1]);
@@ -102,13 +114,13 @@ mod tests {
 
     #[test]
     fn global_minimum_at_known_location() {
-        let r = Rosenbrock::new(4);
+        let r = Rosenbrock::new(4).expect("dim >= 2");
         assert_relative_eq!(r.evaluate(&[1.0; 4]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let r = Rosenbrock::new(3);
+        let r = Rosenbrock::new(3).expect("dim >= 2");
         assert!(
             r.evaluate(&[0.0, 0.0, 0.0]) > 0.0,
             "Rosenbrock must be positive away from (1,…,1)"
@@ -118,29 +130,40 @@ mod tests {
     #[test]
     fn minimum_at_ones() {
         // Every term vanishes: 100·(1−1)² + (1−1)² = 0.
-        let r = Rosenbrock::new(5);
+        let r = Rosenbrock::new(5).expect("dim >= 2");
         assert_relative_eq!(r.evaluate(&[1.0; 5]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn known_value_at_origin() {
         // Each of the n−1 terms contributes 100·0 + 1 = 1, so f(0) = n−1.
-        let r = Rosenbrock::new(4);
+        let r = Rosenbrock::new(4).expect("dim >= 2");
         assert_relative_eq!(r.evaluate(&[0.0; 4]), 3.0, epsilon = 1e-12);
     }
 
     #[test]
-    #[should_panic(expected = "requires dim >= 2")]
-    fn panics_on_dim_one() {
-        let r = Rosenbrock::new(1);
-        let _ = r.evaluate(&[0.5]);
+    fn new_rejects_dim_one() {
+        assert!(
+            Rosenbrock::new(1).is_err(),
+            "dim = 1 leaves the pairwise sum empty"
+        );
+    }
+
+    #[test]
+    fn new_rejects_dim_zero() {
+        assert!(Rosenbrock::new(0).is_err(), "dim = 0 has no coordinates");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Rosenbrock::new(7).expect("dim >= 2").dim(), 7);
     }
 
     #[test]
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let r = Rosenbrock::new(2);
+        let r = Rosenbrock::new(2).expect("dim >= 2");
         let plain_no_trailing: String = r.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(r.render_styled().plain_text(), plain_no_trailing);
     }
@@ -150,7 +173,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let r = Rosenbrock::new(2);
+        let r = Rosenbrock::new(2).expect("dim >= 2");
         let styled = r.render_styled();
         let label = styled.lines[0]
             .spans
@@ -165,7 +188,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let r = Rosenbrock::new(2);
+        let r = Rosenbrock::new(2).expect("dim >= 2");
         for line in r.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/rosenbrock_flat.rs
+++ b/crates/rlevo-environments/src/landscapes/rosenbrock_flat.rs
@@ -10,31 +10,44 @@
 //! The true domain is `[-2000, 2000]^n`; [`bounds`](RosenbrockFlat::bounds)
 //! returns the reduced `(-30, 30)` window for meaningful renders. Requires `n ≥ 2`.
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Generalized Modified Rosenbrock No.01 evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct RosenbrockFlat {
-    /// Number of input dimensions. Must be `≥ 2`.
-    pub dim: usize,
+    /// Number of input dimensions. Always `≥ 2` — enforced by [`RosenbrockFlat::new`].
+    dim: usize,
 }
 
 impl RosenbrockFlat {
     /// Creates a `dim`-dimensional Modified Rosenbrock No.01 evaluator.
     ///
-    /// `dim` should be `≥ 2`; [`evaluate`](Self::evaluate) panics otherwise.
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim < 2`. Both the knife-edge term
+    /// `100·|x_{i+1} − x_i²|` and the `(1 − x_i)²` pull term are defined only on
+    /// adjacent coordinate pairs (`i = 1..n−1`); with a single coordinate the sum
+    /// is empty, erasing the ridge the benchmark exists to test.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "RosenbrockFlat";
+        config::at_least(C, "dim", dim, 2)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Modified Rosenbrock No.01 function at `x`.
     ///
     /// # Panics
     ///
-    /// Panics if `x.len() != self.dim`, or if `self.dim < 2`.
+    /// Panics if `x.len() != self.dim`.
     #[must_use]
     pub fn evaluate(&self, x: &[f64]) -> f64 {
         assert_eq!(x.len(), self.dim, "input dimension mismatch");
-        assert!(self.dim >= 2, "RosenbrockFlat requires dim >= 2");
         x.windows(2)
             .map(|w| {
                 let (xi, xn) = (w[0], w[1]);
@@ -95,13 +108,13 @@ mod tests {
 
     #[test]
     fn global_minimum_at_known_location() {
-        let r = RosenbrockFlat::new(4);
+        let r = RosenbrockFlat::new(4).expect("dim >= 2");
         assert_relative_eq!(r.evaluate(&[1.0; 4]), 0.0, epsilon = 1e-10);
     }
 
     #[test]
     fn positive_or_greater_elsewhere() {
-        let r = RosenbrockFlat::new(3);
+        let r = RosenbrockFlat::new(3).expect("dim >= 2");
         assert!(
             r.evaluate(&[0.0; 3]) > 0.0,
             "value away from (1,…,1) must exceed the minimum 0"
@@ -110,30 +123,45 @@ mod tests {
 
     #[test]
     fn minimum_at_ones() {
-        let r = RosenbrockFlat::new(5);
+        let r = RosenbrockFlat::new(5).expect("dim >= 2");
         assert_relative_eq!(r.evaluate(&[1.0; 5]), 0.0, epsilon = 1e-10);
     }
 
     #[test]
     fn flat_on_ridge() {
         // On the ridge x_{i+1} = x_i² (but not at x = 1) only the (1 − x_i)² term remains.
-        let r = RosenbrockFlat::new(2);
+        let r = RosenbrockFlat::new(2).expect("dim >= 2");
         let x = [2.0_f64, 4.0]; // x2 = x1² = 4 ⇒ abs term is 0
         let expected = (1.0 - 2.0_f64).powi(2); // 1.0
         assert_relative_eq!(r.evaluate(&x), expected, epsilon = 1e-10);
     }
 
     #[test]
-    #[should_panic(expected = "requires dim >= 2")]
-    fn panics_on_dim_one() {
-        let _ = RosenbrockFlat::new(1).evaluate(&[1.0]);
+    fn new_rejects_dim_one() {
+        assert!(
+            RosenbrockFlat::new(1).is_err(),
+            "dim = 1 leaves the pairwise sum empty"
+        );
+    }
+
+    #[test]
+    fn new_rejects_dim_zero() {
+        assert!(
+            RosenbrockFlat::new(0).is_err(),
+            "dim = 0 has no coordinates"
+        );
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(RosenbrockFlat::new(7).expect("dim >= 2").dim(), 7);
     }
 
     #[test]
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let r = RosenbrockFlat::new(2);
+        let r = RosenbrockFlat::new(2).expect("dim >= 2");
         let plain_no_trailing: String = r.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(r.render_styled().plain_text(), plain_no_trailing);
     }
@@ -143,7 +171,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let r = RosenbrockFlat::new(2);
+        let r = RosenbrockFlat::new(2).expect("dim >= 2");
         let styled = r.render_styled();
         let label = styled.lines[0]
             .spans
@@ -158,7 +186,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let r = RosenbrockFlat::new(2);
+        let r = RosenbrockFlat::new(2).expect("dim >= 2");
         for line in r.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/schwefel.rs
+++ b/crates/rlevo-environments/src/landscapes/schwefel.rs
@@ -26,18 +26,34 @@ const X_OPT: f64 = 420.968_746_359_982_025;
 #[cfg(test)]
 const F_PER_DIM: f64 = 418.982_887_274_338;
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Schwefel function evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Schwefel {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Schwefel {
     /// Creates a `dim`-dimensional Schwefel evaluator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: the coordinate sum is empty, so
+    /// `f = 0`, which is also the certified optimum `−418.9829·n` evaluated at
+    /// `n = 0` — the landscape would report itself solved before the search
+    /// starts.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Schwefel";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Schwefel function at `x`.
@@ -103,10 +119,20 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Schwefel::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Schwefel::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_known_location() {
         // Numerically certified optimum; relative tolerance per the literature floor.
         let n = 4;
-        let s = Schwefel::new(n);
+        let s = Schwefel::new(n).expect("dim >= 1");
         assert_relative_eq!(
             s.evaluate(&[X_OPT; 4]),
             -F_PER_DIM * n as f64,
@@ -117,7 +143,7 @@ mod tests {
     #[test]
     fn positive_or_greater_elsewhere() {
         // f(0) = 0, which exceeds the true minimum −418.98·n for any n ≥ 1.
-        let s = Schwefel::new(3);
+        let s = Schwefel::new(3).expect("dim >= 1");
         assert!(
             s.evaluate(&[0.0; 3]) > s.evaluate(&[X_OPT; 3]),
             "origin must score worse than the global optimum"
@@ -126,7 +152,7 @@ mod tests {
 
     #[test]
     fn origin_is_not_minimum() {
-        let s = Schwefel::new(2);
+        let s = Schwefel::new(2).expect("dim >= 1");
         assert_relative_eq!(s.evaluate(&[0.0, 0.0]), 0.0, epsilon = 1e-12);
         assert!(s.evaluate(&[0.0, 0.0]) > s.evaluate(&[X_OPT, X_OPT]));
     }
@@ -135,7 +161,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let s = Schwefel::new(2);
+        let s = Schwefel::new(2).expect("dim >= 1");
         let plain_no_trailing: String = s.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(s.render_styled().plain_text(), plain_no_trailing);
     }
@@ -145,7 +171,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let s = Schwefel::new(2);
+        let s = Schwefel::new(2).expect("dim >= 1");
         let styled = s.render_styled();
         let label = styled.lines[0]
             .spans
@@ -160,7 +186,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let s = Schwefel::new(2);
+        let s = Schwefel::new(2).expect("dim >= 1");
         for line in s.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/src/landscapes/sphere.rs
+++ b/crates/rlevo-environments/src/landscapes/sphere.rs
@@ -4,18 +4,34 @@
 //! Commonly evaluated over `[-5.12, 5.12]^n` for comparability with
 //! Rastrigin / Ackley, though any symmetric domain works.
 
+use rlevo_core::config::{self, ConfigError};
+
 /// Sphere function evaluator with configurable dimensionality.
 #[derive(Debug, Clone, Copy)]
 pub struct Sphere {
     /// Number of input dimensions.
-    pub dim: usize,
+    dim: usize,
 }
 
 impl Sphere {
     /// Creates a `dim`-dimensional Sphere evaluator.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `dim == 0`: `f(x) = Σ x_i²` over an empty
+    /// coordinate set is the empty sum `0`, which is exactly the Sphere's
+    /// global optimum — a zero-dimensional instance would report itself solved
+    /// on every evaluation.
+    pub fn new(dim: usize) -> Result<Self, ConfigError> {
+        const C: &str = "Sphere";
+        config::nonzero(C, "dim", dim)?;
+        Ok(Self { dim })
+    }
+
+    /// Number of input dimensions.
     #[must_use]
-    pub const fn new(dim: usize) -> Self {
-        Self { dim }
+    pub const fn dim(&self) -> usize {
+        self.dim
     }
 
     /// Evaluate the Sphere function at `x`.
@@ -82,14 +98,24 @@ mod tests {
     use approx::assert_relative_eq;
 
     #[test]
+    fn dim_zero_is_rejected() {
+        assert!(Sphere::new(0).is_err(), "dim = 0 must not construct");
+    }
+
+    #[test]
+    fn dim_accessor_reports_configured_dim() {
+        assert_eq!(Sphere::new(7).expect("dim >= 1").dim(), 7);
+    }
+
+    #[test]
     fn global_minimum_at_origin() {
-        let s = Sphere::new(4);
+        let s = Sphere::new(4).expect("dim >= 1");
         assert_relative_eq!(s.evaluate(&[0.0; 4]), 0.0, epsilon = 1e-12);
     }
 
     #[test]
     fn positive_elsewhere() {
-        let s = Sphere::new(3);
+        let s = Sphere::new(3).expect("dim >= 1");
         assert_relative_eq!(s.evaluate(&[1.0, 2.0, 3.0]), 14.0, epsilon = 1e-12);
     }
 
@@ -97,7 +123,7 @@ mod tests {
     fn render_styled_matches_ascii() {
         use crate::render::AsciiRenderable;
 
-        let s = Sphere::new(2);
+        let s = Sphere::new(2).expect("dim >= 1");
         let plain_no_trailing: String = s.render_ascii().lines().collect::<Vec<_>>().join("\n");
         assert_eq!(s.render_styled().plain_text(), plain_no_trailing);
     }
@@ -107,7 +133,7 @@ mod tests {
         use crate::render::AsciiRenderable;
         use crate::render::palette::{BEST_FG, BEST_MODIFIER};
 
-        let s = Sphere::new(2);
+        let s = Sphere::new(2).expect("dim >= 1");
         let styled = s.render_styled();
         let label = styled.lines[0]
             .spans
@@ -122,7 +148,7 @@ mod tests {
     fn render_ascii_within_width_budget() {
         use crate::render::AsciiRenderable;
 
-        let s = Sphere::new(2);
+        let s = Sphere::new(2).expect("dim >= 1");
         for line in s.render_ascii().lines() {
             assert!(
                 line.chars().count() <= 80,

--- a/crates/rlevo-environments/tests/landscape_dim_guards.rs
+++ b/crates/rlevo-environments/tests/landscape_dim_guards.rs
@@ -1,0 +1,299 @@
+//! Cross-landscape regression net for issue #110 — an unguarded `dim` on an
+//! n-dimensional landscape silently produces `NaN` or a wrong optimum
+//! (`Sphere::new(0)` evaluates the empty sum `0`, i.e. reports itself solved on
+//! every call; `Ackley::new(0)` divides by zero).
+//!
+//! Every landscape carries its own `new_rejects_*` unit test, but per-file tests
+//! do nothing to stop the *next* landscape from landing unguarded. This file is
+//! the single place that enumerates all of them and — critically — checks that
+//! enumeration against the crate source tree itself:
+//! [`table_covers_every_landscape_module`] reads `src/landscapes/` from disk at
+//! test time and fails unless every module there is classified into exactly one
+//! of
+//!
+//! - [`DIM_GUARDS`] — n-D landscapes with a `new(dim)` constructor, whose guard
+//!   is then exercised by the other tests in this file;
+//! - [`MULTI_FACTOR_LANDSCAPES`] — n-D landscapes whose dimension is a product of
+//!   several constructor arguments, covered by a bespoke test
+//!   ([`concatenated_trap_rejects_zero_factors`]);
+//! - [`FIXED_2D_LANDSCAPES`] — landscapes defined only on 2-D inputs, which take
+//!   no `dim` at all and so have nothing to guard;
+//! - [`NON_LANDSCAPE_MODULES`] — support modules that are not landscapes.
+//!
+//! **Adding a landscape? You must classify it in one of those lists** — a new
+//! `src/landscapes/*.rs` file that appears in none of them fails the test with
+//! instructions. The check also runs in reverse: a listed module that no longer
+//! exists on disk is a stale row and fails too.
+
+use std::fs;
+use std::path::Path;
+
+use rlevo_core::config::ConfigError;
+
+use rlevo_environments::landscapes::{
+    ackley::Ackley, alpine1::Alpine1, concatenated_trap::ConcatenatedTrap, deb1::Deb1,
+    eggholder::Eggholder, griewank::Griewank, lunacek_bi_rastrigin::LunacekBiRastrigin,
+    michalewicz::Michalewicz, needle_eye::Needle, penalized1::Penalized1, rastrigin::Rastrigin,
+    rosenbrock::Rosenbrock, rosenbrock_flat::RosenbrockFlat, schwefel::Schwefel, sphere::Sphere,
+};
+
+/// The landscape module directory, resolved from the crate root at compile time.
+/// Cargo sets `CARGO_MANIFEST_DIR` for integration tests, so this points at the
+/// real source tree the test binary was built from.
+const LANDSCAPE_SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/landscapes");
+
+/// One landscape's dimension guard, type-erased so landscapes with different
+/// concrete types share a table.
+///
+/// `ctor` runs the real `new(dim)` and, on success, projects through the
+/// `dim()` accessor — so the row exercises the constructor *and* asserts the
+/// accessor round-trips the value that was accepted.
+struct DimGuard {
+    /// Landscape type name, for assertion messages.
+    name: &'static str,
+    /// The `landscapes::<module>` this row covers, cross-checked against disk by
+    /// [`table_covers_every_landscape_module`].
+    module: &'static str,
+    /// `new(dim)` mapped to the constructed instance's reported `dim()`.
+    ctor: fn(usize) -> Result<usize, ConfigError>,
+    /// Smallest `dim` the landscape is well-defined at.
+    min_dim: usize,
+}
+
+/// Builds a [`DimGuard`] row per `module: Type => min_dim` triple.
+///
+/// The module is spelled out rather than derived from the type name: the two do
+/// not always agree (`Needle` lives in `needle_eye`), and a wrong guess would
+/// weaken the disk cross-check into a rubber stamp.
+macro_rules! dim_guards {
+    ($($module:ident: $ty:ty => $min_dim:expr),+ $(,)?) => {
+        &[$(DimGuard {
+            name: stringify!($ty),
+            module: stringify!($module),
+            ctor: |dim| <$ty>::new(dim).map(|l| l.dim()),
+            min_dim: $min_dim,
+        }),+]
+    };
+}
+
+/// Every n-D landscape with a `new(dim)` constructor, paired with the smallest
+/// dimension at which its objective is well-defined.
+///
+/// `min_dim == 2` for the landscapes whose sum runs over *adjacent pairs*
+/// (`Rosenbrock`, `RosenbrockFlat`) or is defined on 2-D coordinate pairs
+/// (`Eggholder`), and for `LunacekBiRastrigin` whose depth term degenerates in
+/// one dimension. Everything else is a separable per-coordinate sum and is
+/// meaningful from `dim == 1`.
+static DIM_GUARDS: &[DimGuard] = dim_guards![
+    sphere: Sphere => 1,
+    rastrigin: Rastrigin => 1,
+    ackley: Ackley => 1,
+    griewank: Griewank => 1,
+    schwefel: Schwefel => 1,
+    alpine1: Alpine1 => 1,
+    deb1: Deb1 => 1,
+    needle_eye: Needle => 1,
+    michalewicz: Michalewicz => 1,
+    penalized1: Penalized1 => 1,
+    rosenbrock: Rosenbrock => 2,
+    rosenbrock_flat: RosenbrockFlat => 2,
+    eggholder: Eggholder => 2,
+    lunacek_bi_rastrigin: LunacekBiRastrigin => 2,
+];
+
+/// n-D landscapes whose dimension is a *product* of several constructor
+/// arguments, so they do not fit the `new(dim)` shape of [`DIM_GUARDS`] and get
+/// a bespoke test instead — see [`concatenated_trap_rejects_zero_factors`].
+static MULTI_FACTOR_LANDSCAPES: &[&str] = &["concatenated_trap"];
+
+/// Landscapes defined *only* on 2-D inputs: their `new()` takes no arguments,
+/// there is no `dim` to validate, and issue #110 cannot apply to them.
+///
+/// A landscape belongs here **only if it has no dimension parameter at all**. If
+/// it takes a `dim`, it needs a [`DIM_GUARDS`] row instead.
+static FIXED_2D_LANDSCAPES: &[&str] = &[
+    "branin",
+    "bukin6",
+    "cross_in_tray",
+    "easom",
+    "goldstein_price",
+    "himmelblau",
+    "six_hump_camel",
+    "trefethen",
+];
+
+/// Modules under `src/landscapes/` that do not define a landscape.
+static NON_LANDSCAPE_MODULES: &[&str] = &["render"];
+
+/// The heart of #110: `dim == 0` is never a legal landscape.
+#[test]
+fn every_landscape_rejects_zero_dim() {
+    for guard in DIM_GUARDS {
+        assert!(
+            (guard.ctor)(0).is_err(),
+            "{}::new(0) must be rejected (issue #110)",
+            guard.name,
+        );
+    }
+}
+
+/// `dim == 1` is the boundary case: legal for the separable landscapes,
+/// rejected by the four that need at least a coordinate pair.
+#[test]
+fn one_dim_is_accepted_exactly_by_the_separable_landscapes() {
+    for guard in DIM_GUARDS {
+        let got = (guard.ctor)(1);
+        if guard.min_dim >= 2 {
+            assert!(
+                got.is_err(),
+                "{} needs dim >= {} — new(1) must be rejected",
+                guard.name,
+                guard.min_dim,
+            );
+        } else {
+            assert_eq!(
+                got,
+                Ok(1),
+                "{} is well-defined at dim == 1 — new(1) must be accepted",
+                guard.name,
+            );
+        }
+    }
+}
+
+/// Each landscape accepts its own declared minimum, and `dim()` round-trips the
+/// accepted value (guarding against a private-field/accessor mismatch).
+#[test]
+fn every_landscape_accepts_its_minimum_and_reports_it() {
+    for guard in DIM_GUARDS {
+        assert_eq!(
+            (guard.ctor)(guard.min_dim),
+            Ok(guard.min_dim),
+            "{}::new({}) must be accepted and report dim() == {}",
+            guard.name,
+            guard.min_dim,
+            guard.min_dim,
+        );
+        assert_eq!(
+            (guard.ctor)(10),
+            Ok(10),
+            "{}::new(10) must be accepted and report dim() == 10",
+            guard.name,
+        );
+    }
+}
+
+/// [`ConcatenatedTrap`] is the one landscape whose dimension is a *product*, so
+/// either factor going to zero yields a zero-length genome.
+#[test]
+fn concatenated_trap_rejects_zero_factors() {
+    assert!(
+        ConcatenatedTrap::new(0, 5).is_err(),
+        "ConcatenatedTrap::new(0, 5) must be rejected: num_blocks == 0 (issue #110)",
+    );
+    assert!(
+        ConcatenatedTrap::new(4, 0).is_err(),
+        "ConcatenatedTrap::new(4, 0) must be rejected: block_size == 0 (issue #110)",
+    );
+    let trap = ConcatenatedTrap::new(4, 5).expect("num_blocks >= 1 && block_size >= 1");
+    assert_eq!(trap.dim(), 20, "dim() must be num_blocks * block_size");
+}
+
+/// Tripwire: every module in `src/landscapes/` must be classified, and every
+/// classification must name a module that exists.
+///
+/// This reads the crate's own source directory, so it bites on a landscape that
+/// is *added* without a guard — which no table-internal count can do.
+#[test]
+fn table_covers_every_landscape_module() {
+    let on_disk = landscape_modules_on_disk();
+    let registered = registered_modules();
+
+    let unregistered: Vec<&String> = on_disk
+        .iter()
+        .filter(|module| !registered.contains(&module.as_str()))
+        .collect();
+    assert!(
+        unregistered.is_empty(),
+        "unclassified landscape module(s) in src/landscapes/: {unregistered:?}\n\
+         Every landscape must be accounted for by this regression net (issue #110). \
+         Classify each one in tests/landscape_dim_guards.rs:\n\
+         - takes a `dim`: add a DIM_GUARDS row (`module: Type => min_dim`);\n\
+         - dimension is a product of several args: add it to MULTI_FACTOR_LANDSCAPES \
+         and cover it like concatenated_trap_rejects_zero_factors;\n\
+         - genuinely 2-D with a no-argument `new()`: add it to FIXED_2D_LANDSCAPES;\n\
+         - not a landscape at all: add it to NON_LANDSCAPE_MODULES.\n\
+         Do not delete this assertion.",
+    );
+
+    let stale: Vec<&&str> = registered
+        .iter()
+        .filter(|module| !on_disk.iter().any(|found| found == *module))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "stale row(s) in tests/landscape_dim_guards.rs: {stale:?} — \
+         no such module in src/landscapes/. Was it renamed or removed?",
+    );
+}
+
+/// Every module name this file claims to cover, across all four lists.
+///
+/// Panics if a module is classified twice: overlapping lists would make the
+/// coverage check ambiguous (and one of the two classifications is necessarily
+/// wrong).
+fn registered_modules() -> Vec<&'static str> {
+    let mut modules: Vec<&'static str> = DIM_GUARDS
+        .iter()
+        .map(|guard| guard.module)
+        .chain(MULTI_FACTOR_LANDSCAPES.iter().copied())
+        .chain(FIXED_2D_LANDSCAPES.iter().copied())
+        .chain(NON_LANDSCAPE_MODULES.iter().copied())
+        .collect();
+    modules.sort_unstable();
+
+    let mut deduped = modules.clone();
+    deduped.dedup();
+    assert_eq!(
+        modules, deduped,
+        "a landscape module is classified in more than one list — each belongs to \
+         exactly one of DIM_GUARDS / MULTI_FACTOR_LANDSCAPES / FIXED_2D_LANDSCAPES / \
+         NON_LANDSCAPE_MODULES",
+    );
+
+    modules
+}
+
+/// The landscape modules that actually exist in the crate source tree.
+///
+/// Both module layouts are picked up: `foo.rs` and `foo/mod.rs`. `mod.rs` itself
+/// only declares a module tree, so it is not a landscape module and is skipped;
+/// non-Rust files (editor scratch, etc.) are ignored.
+fn landscape_modules_on_disk() -> Vec<String> {
+    let dir = Path::new(LANDSCAPE_SRC_DIR);
+    let entries =
+        fs::read_dir(dir).unwrap_or_else(|err| panic!("cannot read {}: {err}", dir.display()));
+
+    let mut modules: Vec<String> = entries
+        .map(|entry| entry.expect("readable directory entry").path())
+        .filter_map(|path| {
+            if path.is_dir() {
+                return path.file_name()?.to_str().map(String::from);
+            }
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                return None;
+            }
+            let stem = path.file_stem()?.to_str()?;
+            (stem != "mod").then(|| stem.to_owned())
+        })
+        .collect();
+    modules.sort();
+
+    assert!(
+        !modules.is_empty(),
+        "found no landscape modules under {} — the path this test walks is wrong, \
+         which would silently disarm the coverage check",
+        dir.display(),
+    );
+    modules
+}

--- a/crates/rlevo-environments/tests/render_coverage.rs
+++ b/crates/rlevo-environments/tests/render_coverage.rs
@@ -197,21 +197,21 @@ fn toy_text_blackjack() {
 #[test]
 fn landscapes_sphere() {
     use rlevo_environments::landscapes::sphere::Sphere;
-    let env = Sphere::new(2);
+    let env = Sphere::new(2).expect("dim >= 1");
     assert_render_invariants(&env, "Sphere");
 }
 
 #[test]
 fn landscapes_rastrigin() {
     use rlevo_environments::landscapes::rastrigin::Rastrigin;
-    let env = Rastrigin::new(2);
+    let env = Rastrigin::new(2).expect("dim >= 1");
     assert_render_invariants(&env, "Rastrigin");
 }
 
 #[test]
 fn landscapes_ackley() {
     use rlevo_environments::landscapes::ackley::Ackley;
-    let env = Ackley::new(2);
+    let env = Ackley::new(2).expect("dim >= 1");
     assert_render_invariants(&env, "Ackley");
 }
 

--- a/crates/rlevo-examples/examples/book/ch01_sphere_ga.rs
+++ b/crates/rlevo-examples/examples/book/ch01_sphere_ga.rs
@@ -45,7 +45,10 @@ fn main() {
         },
         replacement: GaReplacement::Elitist { elitism_k: 2 },
     };
-    let fitness_fn = FromLandscape::with_sense(Sphere::new(DIM), ObjectiveSense::Minimize);
+    let fitness_fn = FromLandscape::with_sense(
+        Sphere::new(DIM).expect("dim >= 1"),
+        ObjectiveSense::Minimize,
+    );
 
     let mut harness =
         EvolutionaryHarness::<B, _, _>::new(strategy, config, fitness_fn, SEED, device, GENS)
@@ -92,7 +95,10 @@ mod tests {
                 },
                 replacement: GaReplacement::Elitist { elitism_k: 2 },
             },
-            FromLandscape::with_sense(Sphere::new(DIM), ObjectiveSense::Minimize),
+            FromLandscape::with_sense(
+                Sphere::new(DIM).expect("dim >= 1"),
+                ObjectiveSense::Minimize,
+            ),
             SEED,
             device,
             GENS,

--- a/crates/rlevo-examples/examples/evolution/eda_showcase.rs
+++ b/crates/rlevo-examples/examples/evolution/eda_showcase.rs
@@ -214,7 +214,7 @@ fn rosenbrock_demo() {
          strongest captured link correlation grow while UMDA has no such notion.\n"
     );
 
-    let landscape = Rosenbrock::new(ROSEN_DIM);
+    let landscape = Rosenbrock::new(ROSEN_DIM).expect("dim >= 2");
     let trace_seed = ROSEN_SEEDS[0];
 
     // Verbose single-seed run: UMDA. Print mean position magnitude + mean σ.
@@ -572,7 +572,8 @@ fn trap_demo() {
          full-refit models, where the structural story is clean.\n"
     );
 
-    let trap = ConcatenatedTrap::new(TRAP_BLOCKS, TRAP_K);
+    let trap =
+        ConcatenatedTrap::new(TRAP_BLOCKS, TRAP_K).expect("num_blocks >= 1 && block_size >= 1");
 
     // UMDA trace: per-gene Gaussian means collapse toward 0 (deceived).
     println!("UMDA (seed {TRAP_TRACE_SEED}) — independent per-dimension Gaussian:");

--- a/crates/rlevo-examples/examples/evolution/report_sphere_landscape_with_client.rs
+++ b/crates/rlevo-examples/examples/evolution/report_sphere_landscape_with_client.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_build_provenance();
     let sink: Arc<Mutex<dyn RecordSink>> = Arc::new(Mutex::new(writer));
 
-    let sphere = Sphere::new(2);
+    let sphere = Sphere::new(2).expect("dim >= 1");
     let (lo, hi) = sphere.bounds();
     let bounds_f32 = (lo as f32, hi as f32);
 

--- a/crates/rlevo-examples/examples/harness/ga_rastrigin.rs
+++ b/crates/rlevo-examples/examples/harness/ga_rastrigin.rs
@@ -76,7 +76,7 @@ struct GaEnv {
 
 impl GaEnv {
     fn new(seed: u64, dim: usize, pop_size: usize, max_generations: usize) -> Self {
-        let landscape = Rastrigin::new(dim);
+        let landscape = Rastrigin::new(dim).expect("dim >= 1");
         let mut rng = StdRng::seed_from_u64(seed);
         let population = sample_population(&mut rng, &landscape, pop_size);
         Self {
@@ -130,7 +130,7 @@ fn sample_population(rng: &mut StdRng, landscape: &Rastrigin, pop_size: usize) -
     let (lo, hi) = landscape.bounds();
     let unit = Uniform::new(lo, hi).unwrap();
     (0..pop_size)
-        .map(|_| (0..landscape.dim).map(|_| unit.sample(rng)).collect())
+        .map(|_| (0..landscape.dim()).map(|_| unit.sample(rng)).collect())
         .collect()
 }
 

--- a/crates/rlevo/examples/evo/ackley_showcase.rs
+++ b/crates/rlevo/examples/evo/ackley_showcase.rs
@@ -33,6 +33,6 @@ means a run never crossed into the central funnel.\n\n\
         "",
     );
     let dim = 10;
-    let landscape = Ackley::new(dim);
+    let landscape = Ackley::new(dim).expect("dim >= 1");
     common::showcase("Ackley", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/alpine1_showcase.rs
+++ b/crates/rlevo/examples/evo/alpine1_showcase.rs
@@ -23,6 +23,6 @@ the output\" section for the full column legend.\n\
         "",
     );
     let dim = 10;
-    let landscape = Alpine1::new(dim);
+    let landscape = Alpine1::new(dim).expect("dim >= 1");
     common::showcase("Alpine1", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/deb1_showcase.rs
+++ b/crates/rlevo/examples/evo/deb1_showcase.rs
@@ -23,6 +23,6 @@ near-flat — so reaching `−1` is about landing on the regular grid, and a
         "",
     );
     let dim = 10;
-    let landscape = Deb1::new(dim);
+    let landscape = Deb1::new(dim).expect("dim >= 1");
     common::showcase("Deb1", dim, landscape.bounds(), 0.05, landscape);
 }

--- a/crates/rlevo/examples/evo/eggholder_showcase.rs
+++ b/crates/rlevo/examples/evo/eggholder_showcase.rs
@@ -24,6 +24,6 @@ scattered across competing wells. \n\
         "",
     );
     let dim = 10;
-    let landscape = Eggholder::new(dim);
+    let landscape = Eggholder::new(dim).expect("dim >= 2");
     common::showcase("Eggholder", dim, landscape.bounds(), 20.0, landscape);
 }

--- a/crates/rlevo/examples/evo/griewank_showcase.rs
+++ b/crates/rlevo/examples/evo/griewank_showcase.rs
@@ -22,6 +22,6 @@ than settling in the central bowl.\n\
         "",
     );
     let dim = 10;
-    let landscape = Griewank::new(dim);
+    let landscape = Griewank::new(dim).expect("dim >= 1");
     common::showcase("Griewank", dim, landscape.bounds(), 20.0, landscape);
 }

--- a/crates/rlevo/examples/evo/lunacek_showcase.rs
+++ b/crates/rlevo/examples/evo/lunacek_showcase.rs
@@ -22,6 +22,6 @@ difficulty this benchmark is designed to expose.\n\
         "",
     );
     let dim = 10;
-    let landscape = LunacekBiRastrigin::new(dim);
+    let landscape = LunacekBiRastrigin::new(dim).expect("dim >= 2");
     common::showcase("Lunacek", dim, landscape.bounds(), 0.2, landscape);
 }

--- a/crates/rlevo/examples/evo/memetic_showcase.rs
+++ b/crates/rlevo/examples/evo/memetic_showcase.rs
@@ -129,7 +129,7 @@ where
 {
     let device: <B as BackendTypes>::Device = Default::default();
     let fitness: CountingRastrigin = CountingRastrigin {
-        landscape: Rastrigin::new(DIM),
+        landscape: Rastrigin::new(DIM).expect("dim >= 1"),
         evals: evals.clone(),
     };
     let mut harness = EvolutionaryHarness::<B, S, CountingRastrigin>::new(
@@ -176,7 +176,7 @@ fn run_memetic_row(
 ) {
     let evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
     let wrapper_fitness: CountingRastrigin = CountingRastrigin {
-        landscape: Rastrigin::new(DIM),
+        landscape: Rastrigin::new(DIM).expect("dim >= 1"),
         evals: evals.clone(),
     };
     let strategy: MemeticWrapper<B, _, _, _> = MemeticWrapper::<B, _, _, _>::new(

--- a/crates/rlevo/examples/evo/michalewicz_showcase.rs
+++ b/crates/rlevo/examples/evo/michalewicz_showcase.rs
@@ -23,6 +23,6 @@ that explored poorly.\n\
         "",
     );
     let dim = 10;
-    let landscape = Michalewicz::new(dim);
+    let landscape = Michalewicz::new(dim).expect("dim >= 1");
     common::showcase("Michalewicz", dim, landscape.bounds(), 0.1, landscape);
 }

--- a/crates/rlevo/examples/evo/needle_eye_showcase.rs
+++ b/crates/rlevo/examples/evo/needle_eye_showcase.rs
@@ -23,6 +23,6 @@ luck-of-sampling test.\n\
         "",
     );
     let dim = 10;
-    let landscape = Needle::new(dim);
+    let landscape = Needle::new(dim).expect("dim >= 1");
     common::showcase("NeedleEye", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/penalized1_showcase.rs
+++ b/crates/rlevo/examples/evo/penalized1_showcase.rs
@@ -23,6 +23,6 @@ penalized region.\n\
         "",
     );
     let dim = 10;
-    let landscape = Penalized1::new(dim);
+    let landscape = Penalized1::new(dim).expect("dim >= 1");
     common::showcase("Penalized1", dim, landscape.bounds(), 2.0, landscape);
 }

--- a/crates/rlevo/examples/evo/rastrigin_showcase.rs
+++ b/crates/rlevo/examples/evo/rastrigin_showcase.rs
@@ -35,6 +35,6 @@ run settled into one of the off-origin minima.\n\n\
         "",
     );
     let dim = 10;
-    let landscape = Rastrigin::new(dim);
+    let landscape = Rastrigin::new(dim).expect("dim >= 1");
     common::showcase("Rastrigin", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/examples/evo/rosenbrock_flat_showcase.rs
+++ b/crates/rlevo/examples/evo/rosenbrock_flat_showcase.rs
@@ -23,6 +23,6 @@ valley.\n\
         "",
     );
     let dim = 10;
-    let landscape = RosenbrockFlat::new(dim);
+    let landscape = RosenbrockFlat::new(dim).expect("dim >= 2");
     common::showcase("RosenbrockFlat", dim, landscape.bounds(), 1.0, landscape);
 }

--- a/crates/rlevo/examples/evo/rosenbrock_showcase.rs
+++ b/crates/rlevo/examples/evo/rosenbrock_showcase.rs
@@ -22,6 +22,6 @@ for `n ≥ 4`.\n\
         "",
     );
     let dim = 10;
-    let landscape = Rosenbrock::new(dim);
+    let landscape = Rosenbrock::new(dim).expect("dim >= 2");
     common::showcase("Rosenbrock", dim, landscape.bounds(), 1.0, landscape);
 }

--- a/crates/rlevo/examples/evo/schwefel_showcase.rs
+++ b/crates/rlevo/examples/evo/schwefel_showcase.rs
@@ -24,6 +24,6 @@ the wrong basins.\n\
         "",
     );
     let dim = 10;
-    let landscape = Schwefel::new(dim);
+    let landscape = Schwefel::new(dim).expect("dim >= 1");
     common::showcase("Schwefel", dim, landscape.bounds(), 20.0, landscape);
 }

--- a/crates/rlevo/examples/evo/sphere_showcase.rs
+++ b/crates/rlevo/examples/evo/sphere_showcase.rs
@@ -30,6 +30,6 @@ whether they find the optimum at all.\n\n\
         "",
     );
     let dim = 10;
-    let landscape = Rastrigin::new(dim);
+    let landscape = Rastrigin::new(dim).expect("dim >= 1");
     common::showcase("Rastrigin", dim, landscape.bounds(), 0.4, landscape);
 }

--- a/crates/rlevo/tests/determinism.rs
+++ b/crates/rlevo/tests/determinism.rs
@@ -48,7 +48,10 @@ where
     let mut harness = EvolutionaryHarness::<B, EdaStrategy<B, M>, _>::new(
         EdaStrategy::new(model),
         params,
-        FromLandscape::with_sense(Sphere::new(DIM), ObjectiveSense::Minimize),
+        FromLandscape::with_sense(
+            Sphere::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         SEED,
         device,
         GENS,

--- a/crates/rlevo/tests/eda_convergence.rs
+++ b/crates/rlevo/tests/eda_convergence.rs
@@ -132,7 +132,7 @@ fn all_five_models_reach_sphere_threshold() {
         UnivariateGaussianParams::default_for(DIM),
         SELECTION_RATIO,
         bounds,
-        Sphere::new(DIM),
+        Sphere::new(DIM).expect("dim >= 1"),
         SEED,
     );
     assert!(
@@ -147,7 +147,7 @@ fn all_five_models_reach_sphere_threshold() {
         UnivariateBernoulliParams::default_for(DIM),
         SELECTION_RATIO,
         None,
-        Sphere::new(DIM),
+        Sphere::new(DIM).expect("dim >= 1"),
         SEED,
     );
     assert!(
@@ -160,7 +160,7 @@ fn all_five_models_reach_sphere_threshold() {
         CompactGeneticParams::default_for(DIM),
         SELECTION_RATIO,
         None,
-        Sphere::new(DIM),
+        Sphere::new(DIM).expect("dim >= 1"),
         SEED,
     );
     assert!(
@@ -173,7 +173,7 @@ fn all_five_models_reach_sphere_threshold() {
         DependencyChainParams::default_for(DIM),
         SELECTION_RATIO,
         bounds,
-        Sphere::new(DIM),
+        Sphere::new(DIM).expect("dim >= 1"),
         SEED,
     );
     assert!(
@@ -188,7 +188,7 @@ fn all_five_models_reach_sphere_threshold() {
         BayesianNetworkParams::default_for(DIM),
         SELECTION_RATIO,
         None,
-        Sphere::new(DIM),
+        Sphere::new(DIM).expect("dim >= 1"),
         SEED,
     );
     assert!(
@@ -224,7 +224,8 @@ fn boa_solves_trap_where_umda_and_mimic_stall() {
     const TRAP_POP: usize = 2000;
     const TRAP_RATIO: f32 = 0.3;
     const TRAP_GENS: usize = 60;
-    let trap = ConcatenatedTrap::new(4, 5); // trap-5 × 4 blocks, dim 20
+    // trap-5 × 4 blocks, dim 20
+    let trap = ConcatenatedTrap::new(4, 5).expect("num_blocks >= 1 && block_size >= 1");
 
     let mut boa: Vec<f32> = SEEDS
         .iter()
@@ -344,7 +345,7 @@ fn mimic_beats_umda_median_on_rosenbrock() {
                 p,
                 RATIO,
                 bounds,
-                Rosenbrock::new(DIM),
+                Rosenbrock::new(DIM).expect("dim >= 2"),
                 seed,
             )
         })
@@ -361,7 +362,7 @@ fn mimic_beats_umda_median_on_rosenbrock() {
                 p,
                 RATIO,
                 bounds,
-                Rosenbrock::new(DIM),
+                Rosenbrock::new(DIM).expect("dim >= 2"),
                 seed,
             )
         })

--- a/crates/rlevo/tests/memetic_rastrigin.rs
+++ b/crates/rlevo/tests/memetic_rastrigin.rs
@@ -110,7 +110,8 @@ struct RunResult {
 fn de_evals_to_target(seed: u64, de: &DeConfig, target: f32, max_gens: usize) -> RunResult {
     let device: <B as BackendTypes>::Device = Default::default();
     let evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    let fitness: CountingRastrigin = CountingRastrigin::new(Rastrigin::new(DIM), evals.clone());
+    let fitness: CountingRastrigin =
+        CountingRastrigin::new(Rastrigin::new(DIM).expect("dim >= 1"), evals.clone());
     let strategy: DifferentialEvolution<B> = DifferentialEvolution::<B>::new();
     let mut harness =
         EvolutionaryHarness::<B, _, _>::new(strategy, de.clone(), fitness, seed, device, max_gens)
@@ -151,9 +152,9 @@ fn memetic_evals_to_target(
     // scoring) and the wrapper's (local-search probes).
     let evals: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
     let harness_fitness: CountingRastrigin =
-        CountingRastrigin::new(Rastrigin::new(DIM), evals.clone());
+        CountingRastrigin::new(Rastrigin::new(DIM).expect("dim >= 1"), evals.clone());
     let wrapper_fitness: CountingRastrigin =
-        CountingRastrigin::new(Rastrigin::new(DIM), evals.clone());
+        CountingRastrigin::new(Rastrigin::new(DIM).expect("dim >= 1"), evals.clone());
 
     let strategy: MemeticWrapper<B, _, _, _> = MemeticWrapper::<B, _, _, _>::new(
         DifferentialEvolution::<B>::new(),

--- a/crates/rlevo/tests/objective_sense_baseline.rs
+++ b/crates/rlevo/tests/objective_sense_baseline.rs
@@ -97,12 +97,20 @@ fn de_config() -> DeConfig {
 fn sphere_strategies_reach_near_optimum() {
     // Sphere is convex/unimodal with optimum 0; every real-valued strategy
     // should drive best_fitness_ever well below 1.0 in user space.
-    let ga = run_to_best(GeneticAlgorithm::<B>::new(), ga_config(), Sphere::new(DIM));
-    let es = run_to_best(EvolutionStrategy::<B>::new(), es_config(), Sphere::new(DIM));
+    let ga = run_to_best(
+        GeneticAlgorithm::<B>::new(),
+        ga_config(),
+        Sphere::new(DIM).expect("dim >= 1"),
+    );
+    let es = run_to_best(
+        EvolutionStrategy::<B>::new(),
+        es_config(),
+        Sphere::new(DIM).expect("dim >= 1"),
+    );
     let de = run_to_best(
         DifferentialEvolution::<B>::new(),
         de_config(),
-        Sphere::new(DIM),
+        Sphere::new(DIM).expect("dim >= 1"),
     );
 
     for (name, best) in [("GA", ga), ("ES", es), ("DE", de)] {
@@ -125,17 +133,17 @@ fn rastrigin_strategies_improve_on_random_search() {
     let ga = run_to_best(
         GeneticAlgorithm::<B>::new(),
         ga_config(),
-        Rastrigin::new(DIM),
+        Rastrigin::new(DIM).expect("dim >= 1"),
     );
     let es = run_to_best(
         EvolutionStrategy::<B>::new(),
         es_config(),
-        Rastrigin::new(DIM),
+        Rastrigin::new(DIM).expect("dim >= 1"),
     );
     let de = run_to_best(
         DifferentialEvolution::<B>::new(),
         de_config(),
-        Rastrigin::new(DIM),
+        Rastrigin::new(DIM).expect("dim >= 1"),
     );
 
     for (name, best) in [("GA", ga), ("ES", es), ("DE", de)] {
@@ -156,7 +164,7 @@ fn ackley_de_reaches_near_optimum() {
     let de = run_to_best(
         DifferentialEvolution::<B>::new(),
         de_config(),
-        Ackley::new(DIM),
+        Ackley::new(DIM).expect("dim >= 1"),
     );
     assert!(
         de.is_finite() && de >= 0.0,

--- a/crates/rlevo/tests/rastrigin_run_suite.rs
+++ b/crates/rlevo/tests/rastrigin_run_suite.rs
@@ -67,7 +67,11 @@ fn ga_factory(
     EvolutionaryHarness::new(
         GeneticAlgorithm::<B>::new(),
         params,
-        FromFitnessEvaluable::with_sense(Minimizer, Rastrigin::new(DIM), ObjectiveSense::Minimize),
+        FromFitnessEvaluable::with_sense(
+            Minimizer,
+            Rastrigin::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         seed,
         device,
         MAX_GENS,
@@ -84,7 +88,11 @@ fn es_factory(
     EvolutionaryHarness::new(
         EvolutionStrategy::<B>::new(),
         params,
-        FromFitnessEvaluable::with_sense(Minimizer, Rastrigin::new(DIM), ObjectiveSense::Minimize),
+        FromFitnessEvaluable::with_sense(
+            Minimizer,
+            Rastrigin::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         seed,
         device,
         MAX_GENS,
@@ -102,7 +110,11 @@ fn ep_factory(
     EvolutionaryHarness::new(
         EvolutionaryProgramming::<B>::new(),
         params,
-        FromFitnessEvaluable::with_sense(Minimizer, Rastrigin::new(DIM), ObjectiveSense::Minimize),
+        FromFitnessEvaluable::with_sense(
+            Minimizer,
+            Rastrigin::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         seed,
         device,
         MAX_GENS,
@@ -122,7 +134,11 @@ fn de_factory(
     EvolutionaryHarness::new(
         DifferentialEvolution::<B>::new(),
         params,
-        FromFitnessEvaluable::with_sense(Minimizer, Rastrigin::new(DIM), ObjectiveSense::Minimize),
+        FromFitnessEvaluable::with_sense(
+            Minimizer,
+            Rastrigin::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         seed,
         device,
         MAX_GENS,

--- a/crates/rlevo/tests/swarm_rastrigin_suite.rs
+++ b/crates/rlevo/tests/swarm_rastrigin_suite.rs
@@ -142,7 +142,7 @@ where
         PsoConfig::default_for(32, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -160,7 +160,7 @@ fn gwo_ra(
         GwoConfig::default_for(32, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -178,7 +178,7 @@ fn woa_ra(
         WoaConfig::default_for(32, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -196,7 +196,7 @@ fn salp_ra(
         SalpConfig::default_for(32, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -214,7 +214,7 @@ fn abc_ra(
         AbcConfig::default_for(30, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -232,7 +232,7 @@ fn bat_ra(
         BatConfig::default_for(30, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -250,7 +250,7 @@ fn aco_r_ra(
         AcoRConfig::default_for(30, 15, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -270,7 +270,7 @@ fn cuckoo_ra(
         cfg,
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -288,7 +288,7 @@ fn firefly_ra(
         FireflyConfig::default_for(24, DIM),
         FromFitnessEvaluable::with_sense(
             RastriginFit,
-            Rastrigin::new(DIM),
+            Rastrigin::new(DIM).expect("dim >= 1"),
             ObjectiveSense::Minimize,
         ),
         seed,
@@ -308,7 +308,11 @@ fn pso_ak(
     EvolutionaryHarness::new(
         ParticleSwarm::<B>::new(),
         PsoConfig::default_for(32, DIM),
-        FromFitnessEvaluable::with_sense(AckleyFit, Ackley::new(DIM), ObjectiveSense::Minimize),
+        FromFitnessEvaluable::with_sense(
+            AckleyFit,
+            Ackley::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         seed,
         Default::default(),
         MAX_GENS,
@@ -329,7 +333,11 @@ fn de_rand1_ak(
     EvolutionaryHarness::new(
         DifferentialEvolution::<B>::new(),
         params,
-        FromFitnessEvaluable::with_sense(AckleyFit, Ackley::new(DIM), ObjectiveSense::Minimize),
+        FromFitnessEvaluable::with_sense(
+            AckleyFit,
+            Ackley::new(DIM).expect("dim >= 1"),
+            ObjectiveSense::Minimize,
+        ),
         seed,
         Default::default(),
         MAX_GENS,

--- a/docs/user-book/src/appendix-a-ec-algorithms/estimation-of-distribution.md
+++ b/docs/user-book/src/appendix-a-ec-algorithms/estimation-of-distribution.md
@@ -69,7 +69,7 @@ model and every page below:
   seeded through process-global state, which interleaves across parallel
   strategy calls and breaks the per-stream determinism the crate guarantees.
   Models sample on the host and upload with `Tensor::from_data`
-  (the [evolution host-RNG convention](../part-3-evolution/index.md)).
+  (the [evolution host-RNG convention](../appendix-d-suppl/ask-tell-contract.md#the-seed_stream-and-reproducibility)).
 - **Selection order is a convenience, not a contract.** The rows handed to
   `fit` arrive in descending-fitness order (best = highest first), deterministically.
   Models that need the best or worst row (PBIL, cGA) still compute

--- a/docs/user-book/src/appendix-d-suppl/ask-tell-contract.md
+++ b/docs/user-book/src/appendix-d-suppl/ask-tell-contract.md
@@ -144,7 +144,7 @@ fn main() {
     let strategy = GeneticAlgorithm::<B>::new();
     let params = GaConfig::default_for(/* pop = */ 64, /* dim = */ 8);
     let mut rng = StdRng::seed_from_u64(42);
-    let mut fitness_fn = FromLandscape::new(Sphere::new(8));
+    let mut fitness_fn = FromLandscape::new(Sphere::new(8).expect("dim >= 1"));
 
     // init builds the first state and samples the initial population.
     let mut state = strategy.init(&params, &mut rng, &device);

--- a/docs/user-book/src/appendix-d-suppl/fitness-landscape.md
+++ b/docs/user-book/src/appendix-d-suppl/fitness-landscape.md
@@ -78,7 +78,7 @@ and weaknesses in isolation:
   Cross-in-Tray, Bukin N.6, and Trefethen.
 
 The continuous ones implement the `Landscape` trait from
-[Optimising a Function](../part-2-guided-tour/01-optimizing-a-function.md), so
+[Optimising a Function](../part-2-guided-tour/10-optimizing-a-function.md), so
 you can drop any of them into the harness in place of `Sphere`.
 
 ## The hiker analogy

--- a/docs/user-book/src/appendix-d-suppl/tensor-rank-vs-matrix-rank.md
+++ b/docs/user-book/src/appendix-d-suppl/tensor-rank-vs-matrix-rank.md
@@ -124,7 +124,7 @@ The three senses map onto three different mechanisms:
   [`Observable<OR>`](https://docs.rs/rlevo-core/latest/rlevo_core/state/trait.Observable.html)
   projection trait is for: it lets a state `project()` into an observation of a
   *different* tensor order $OR \neq SR$. The
-  [Environments chapter](../part-1-foundations/34-environment.md) walks through how
+  [Environments chapter](../part-1-foundations/reinforcement-learning/34-environment.md) walks through how
   an environment wires this up.
 
 The one-line takeaway: **partial observability is almost always a dimensionality or

--- a/docs/user-book/src/part-1-foundations/evolutionary-computation/23-fitness.md
+++ b/docs/user-book/src/part-1-foundations/evolutionary-computation/23-fitness.md
@@ -148,10 +148,14 @@ construction site so intent is visible:
 
 ```rust,ignore
 use rlevo_core::objective::ObjectiveSense;
+use rlevo_environments::landscapes::sphere::Sphere;
 use rlevo_evolution::fitness::FromLandscape;
 
 // A cost surface: declare Minimize explicitly (the adapter would default to it).
-let fitness = FromLandscape::with_sense(SphereLandscape::new(dim), ObjectiveSense::Minimize);
+let fitness = FromLandscape::with_sense(
+    Sphere::new(dim).expect("dim >= 1"),
+    ObjectiveSense::Minimize,
+);
 // ... run the harness ...
 // best_fitness_ever reads in your declared sense — the natural cost.
 assert!(harness.latest_metrics().unwrap().best_fitness_ever < 1e-3); // Sphere → 0
@@ -233,7 +237,7 @@ impl FitnessEvaluable for Minimizer {
 }
 
 // 10-dimensional Rastrigin, ready to hand to an EvolutionaryHarness.
-let fitness_fn = FromFitnessEvaluable::new(Minimizer, Rastrigin::new(DIM));
+let fitness_fn = FromFitnessEvaluable::new(Minimizer, Rastrigin::new(DIM).expect("dim >= 1"));
 ```
 
 **Evaluator carries the scoring; the landscape is a marker.** The per-strategy
@@ -263,7 +267,8 @@ defined right next to the test or experiment, fold it into the evaluator and let
 the landscape collapse to a marker. When the landscape *is* the whole objective
 and no scoring shim adds anything, skip `FromFitnessEvaluable` and reach for
 `FromLandscape` instead — `crates/rlevo-examples/examples/book/ch01_sphere_ga.rs`
-does exactly that with `FromLandscape::new(Sphere::new(DIM))`.
+does exactly that with
+`FromLandscape::with_sense(Sphere::new(DIM).expect("dim >= 1"), ObjectiveSense::Minimize)`.
 
 Both adapters follow the same recipe per generation: pull each population row to
 host as `f32`, widen to `f64`, evaluate on the CPU row-by-row, and re-upload the

--- a/docs/user-book/src/part-2-guided-tour/10-optimizing-a-function.md
+++ b/docs/user-book/src/part-2-guided-tour/10-optimizing-a-function.md
@@ -28,9 +28,16 @@ The sphere is built in:
 ```rust,no_run
 use rlevo::envs::landscapes::sphere::Sphere;
 
-let problem = Sphere::new(/* dim = */ 8);
+let problem = Sphere::new(/* dim = */ 8).expect("dim >= 1");
 assert_eq!(problem.evaluate(&[0.0; 8]), 0.0);   // the global minimum
 ```
+
+Construction is fallible on purpose: at `dim == 0`, \\(\sum_i x_i^2\\) is an empty
+sum, which evaluates to exactly `0.0` — the sphere's own global optimum — so an
+unguarded zero-dimensional instance would silently report every run "solved"
+rather than fail loudly at setup. Every landscape in `rlevo::envs::landscapes`
+rejects its degenerate dimensionality this way; we `.expect` here because `8` is
+a compile-time constant we control, not a value read from user input.
 
 `Sphere` also tells you a sensible search box via `problem.bounds()`, which
 returns `(-5.12, 5.12)` — the conventional range for this benchmark.
@@ -159,7 +166,7 @@ You optimised a *function*. But the candidates were just vectors — nothing sai
 they couldn't be the **weights of a neural network**, or that the score had to
 come from a formula instead of an **agent acting in a world**.
 
-The [next section](03-classic-control.md) brings in a real `Environment`, a
+The [next section](20-classic-control.md) brings in a real `Environment`, a
 reward signal, and a gradient-based RL agent. If you first want to see exactly
 how the harness drove the strategy here — and how to write that ask/tell loop by
 hand when the harness doesn't fit — read


### PR DESCRIPTION
## Summary

Every n-dimensional landscape in `rlevo-environments` accepted `dim == 0` through an unvalidated `pub const fn new(dim) -> Self`, and the resulting evaluator did not fail — it lied. `Sphere`, `Rastrigin`, `Alpine1`, `Schwefel`, `Needle` and `Griewank` evaluated over an empty slice and returned **their own global optimum**, so a misconfigured run read as *solved*. `Ackley` and `Deb1` returned `NaN`; `Penalized1` indexed an empty `Vec` and underflowed `usize`; `ConcatenatedTrap` accepted a zero `block_size` and panicked inside `chunks_exact(0)`. This PR makes all 15 constructors fallible (`-> Result<Self, ConfigError>`) and privatizes `dim`, so a degenerate dimension is rejected at construction rather than silently producing a wrong answer.

The issue proposed `assert!(dim >= 1)` in `new`. **That was deliberately not what shipped** — see Notes.

## Change Type

- [x] Bug fix (includes regression test) — **but note this is a breaking API change**, not the non-breaking bug fix the template anticipates; see Notes for the migration.
- [x] Documentation correction (typo, broken link, misleading doc comment) — a user-book snippet documented `SphereLandscape::new(dim)`, a type that has never existed.

## Linked Issue

Closes #110

## What Was Changed

- **`crates/rlevo-environments/src/landscapes/` (15 files)** — `pub const fn new(dim) -> Self` → `pub fn new(dim) -> Result<Self, ConfigError>`, validating via the existing `rlevo_core::config::nonzero` / `config::at_least` helpers. `new` is no longer `const`.
  - `dim >= 1`: `sphere`, `rastrigin`, `ackley`, `griewank`, `schwefel`, `alpine1`, `deb1`, `needle_eye`, `michalewicz`, `penalized1`
  - `dim >= 2`: `rosenbrock`, `rosenbrock_flat`, `eggholder`, `lunacek_bi_rastrigin` (their sum runs over adjacent coordinate pairs and is empty at n = 1)
  - `concatenated_trap`: both `num_blocks` and `block_size` non-zero, and their product must not overflow `usize`
- **Encapsulation** — the `dim` field (and `ConcatenatedTrap`'s `num_blocks`/`block_size`) is now private, behind `#[must_use] pub const fn dim(&self) -> usize`. Without this the guard is bypassable by a struct literal, so it would not be an invariant.
- **Removed the four now-dead `assert!(self.dim >= 2)` from `evaluate`** in `rosenbrock`, `rosenbrock_flat`, `eggholder`, `lunacek_bi_rastrigin` — unreachable once `new` is the sole construction path. The `assert_eq!(x.len(), self.dim, "input dimension mismatch")` checks are **kept** in all 15: that is a different invariant (slice length vs configured dim), and `Landscape::evaluate(&self, &[f64]) -> f64` has no error channel.
- **`# Errors` docs** on every fallible constructor, written per-landscape against the actual formula (`docs/rules.md` §6 is zero-exception).
- **New: `crates/rlevo-environments/tests/landscape_dim_guards.rs`** — the regression net. It `read_dir`s `src/landscapes/` at test time and requires every module on disk to be classified into exactly one of `DIM_GUARDS` / `MULTI_FACTOR_LANDSCAPES` / `FIXED_2D_LANDSCAPES` / `NON_LANDSCAPE_MODULES`, so a *new* landscape cannot land unguarded and a stale row (renamed/removed module) also fails.
- **Call sites retrofitted** — 15 `crates/rlevo/examples/evo/*_showcase.rs`, 4 `crates/rlevo-examples/examples/`, 6 `crates/rlevo/tests/` suites. All are `main`/test bodies, so they use `.expect("dim >= 1")` / `.expect("dim >= 2")`; no `Result` plumbing was forced upward.
- **`CHANGELOG.md`** — `### Breaking changes` entry with the migration, plus a `**Fixed**` entry under `rlevo-environments` describing the defect.
- **`docs/user-book/`** — landscape snippets updated for the fallible constructor; replaced `SphereLandscape::new(dim)` (a type that does not exist) with the real `Sphere`; fixed 4 pre-existing broken intra-book links found while sweeping.

## How It Was Tested

```
cargo build --workspace --all-targets      # clean
cargo test --workspace                     # 2388 passed, 0 failed
cargo clippy --workspace --all-targets --all-features   # zero warnings, no #[allow] added
cargo fmt --all --check                    # clean
cd docs/user-book && mdbook build          # clean; anchors + links verified in generated HTML
```

Regression tests (fail on the previous code, pass on this PR):

- `tests/landscape_dim_guards.rs` — `every_landscape_rejects_zero_dim` (all 15), `one_dim_is_accepted_exactly_by_the_separable_landscapes` (pins `>= 2` for exactly the four adjacent-pair landscapes), `every_landscape_accepts_its_minimum_and_reports_it`, `concatenated_trap_rejects_zero_factors`, `table_covers_every_landscape_module`.
- Per-file: `dim_zero_is_rejected` on each landscape; `lunacek_bi_rastrigin::funnel_parameters_finite_at_minimum_dim` pins `s() > 0` and `mu2().is_finite()` at the boundary `dim = 2`; `penalized1::dim_one_is_well_defined_and_attains_optimum` pins that `n = 1` is valid.
- Boundary: `ConcatenatedTrap::new(usize::MAX, 1)` is **accepted** (largest representable dim) while `new(usize::MAX, 2)` is rejected on overflow.

The net was verified by mutation, not just by passing: adding an unguarded landscape without a table row **fails** `table_covers_every_landscape_module`; removing a guard **fails** `every_landscape_rejects_zero_dim`.

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`)
- Burn backend tested: CPU (`ndarray`)
- OS: macOS 26.5.2 (Darwin, arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 4.8)**. Scope: **the whole change** — triage against the code reviews, the design decision, the implementation across all 15 landscapes, the call-site retrofit, the regression net, the literature validation, and the docs. Reviewed and verified by the maintainer before merge.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Why not `assert!`, as the issue proposed.** ADR 0030 had already refused a panic for this exact defect class — a zero-size dimension accepted at a construction boundary, yielding a degenerate-but-inhabitable object — and resolved it with `Result<_, ConfigError>` via `config::nonzero`, explicitly listing `assert!` as the rejected alternative ("inconsistent with the ADR 0026 `Result<_, ConfigError>` convention... Rejected in favour of convention parity"). Its load-bearing test — "construction is a setup boundary, not a hot-path operator" — applies to `Landscape::new` verbatim, and fallible `new` is already the in-crate pattern (`box2d/.../terrain.rs`, `classic/bandit/contextual.rs`). Taking the `assert!` route would have required a new ADR explaining why 0030 does *not* generalize; taking this route required none. **No new ADR is needed for this PR.**

**Migration.** `Sphere::new(d)` → `Sphere::new(d).expect("dim >= 1")` at a setup boundary, or `?` where a `Result` is already threaded. Read `dim` through `landscape.dim()` rather than the field. Construct through `new`, not a struct literal. `new` is no longer `const` — no `const`/`static` landscape item existed in the workspace, so nothing else moves. No persisted data is affected (landscapes carry no serialized form).

**`LunacekBiRastrigin` was the sharp case.** Its `assert!(dim >= 2)` lived inside `evaluate`, but the *public* `s()` and `mu2()` accessors bypass `evaluate` entirely. Below n = 2 the depth-scaling parameter `s = 1 − 1/(2√(n+20) − 8.2)` goes non-positive (`s(1) ≈ −0.036`), making `mu2 = −√((μ₁² − d)/s)` a **silent `NaN`** that no `evaluate`-side assert could ever reach. This is the concrete reason the guard belongs at construction.

**Why the existing tests missed all of this.** They only ever constructed sensible dimensions. And per ADR 0034, the fitness-hygiene chokepoint maps `NaN → −inf` (worst), so even the NaN landscapes did not blow up — a `dim == 0` Ackley run produced a population where every member was worst-ranked, which reads as "the optimizer failed to converge", not "the landscape is misconfigured".

**Literature provenance.** `Penalized1` stays at `dim >= 1`, not 2: per Yao, Liu & Lin (1999) f12, the `Σ_{i=1}^{n-1}` term is empty at n = 1 but the `10sin²(πy₁)` and `(y_n − 1)²` terms sit outside it and survive, and the published optimum `f(−1) = 0` still holds — a test pins this so it is not "helpfully" tightened later. `LunacekBiRastrigin`'s `dim >= 2` is **derived by us** from the published parameterization; neither the 2008 PPSN paper nor the COCO/BBOB `f24` spec states it, and the doc says so rather than citing a section that does not exist. `Eggholder`'s n-D form traces only to Mishra (2006), a non-peer-reviewed working paper (reproduced as Jamil & Yang 2013 f53), and its module doc now flags that as a lower-confidence extension.

**Follow-ups found but deliberately not fixed here** (each wants its own issue, to keep this PR to a single concern):
1. `crates/rlevo/examples/evo/sphere_showcase.rs` constructs a **`Rastrigin`**, not a `Sphere`, then labels it `showcase("Sphere", ...)`. Real bug, unrelated to #110; behaviour preserved here.
2. `michalewicz.rs`'s `lower_m_produces_smoother_surface` test asserts nothing (evaluates both and discards). Pre-existing.
3. `Michalewicz::m`, `Ackley::a`/`b`/`c`, `Rastrigin::a` remain `pub` mutable fields — they do not gate construction validity, so they belong to the broader encapsulation sweep (cf. #141), not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
