### PR TITLE
fix: pre-release v0.3.0 publish blockers and docs.rs KaTeX build

### DIFF
--- a/crates/rlevo-benchmarks/Cargo.toml
+++ b/crates/rlevo-benchmarks/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "Benchmarking harness for rlevo (internal crate — use `rlevo` for the full API)"
 license.workspace = true
 edition.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo-core/Cargo.toml
+++ b/crates/rlevo-core/Cargo.toml
@@ -19,3 +19,10 @@ rand_distr = {workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+
+# Render LaTeX in docs (e.g. TransitionDynamics) via KaTeX on docs.rs.
+# The header must live inside this crate's own directory — docs.rs builds
+# from the packaged tarball, which cannot contain files outside the crate
+# root, so a `../../` path here silently works locally but 404s on docs.rs.
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "katex-header.html"]

--- a/crates/rlevo-core/Cargo.toml
+++ b/crates/rlevo-core/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "Core traits and types for rlevo (internal crate — use `rlevo` for the full API)"
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo-core/katex-header.html
+++ b/crates/rlevo-core/katex-header.html
@@ -1,3 +1,8 @@
+<!-- Synced copy of the canonical file at the repo root (`katex-header.html`).
+     Cargo can only package files inside a crate's own directory, so every
+     crate using `[package.metadata.docs.rs] rustdoc-args` for KaTeX needs its
+     own copy here. Edit the root file, then copy it into every crate that
+     references it (currently: rlevo-core, rlevo-environments). -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>

--- a/crates/rlevo-core/src/base.rs
+++ b/crates/rlevo-core/src/base.rs
@@ -148,7 +148,11 @@ pub trait Action<const R: usize>: Debug + Clone + Sized {
     fn is_valid(&self) -> bool;
 }
 
-/// Deterministic environment transition dynamics: s_{t+1} = f(s_t, a_t).
+/// Deterministic environment transition dynamics.
+///
+/// ```math
+/// s_{t+1} = f(s_t, a_t)
+/// ```
 ///
 /// This trait covers only **deterministic** transitions. Stochastic dynamics
 /// (where the successor state is drawn from a distribution) are not modeled

--- a/crates/rlevo-environments/Cargo.toml
+++ b/crates/rlevo-environments/Cargo.toml
@@ -25,9 +25,12 @@ approx = { workspace = true }
 bincode = { version = "2", features = ["serde"] }
 
 # Render LaTeX in docs (e.g. the cartpole physics) via KaTeX on docs.rs.
+# The header must live inside this crate's own directory — docs.rs builds
+# from the packaged tarball, which cannot contain files outside the crate
+# root, so a `../../` path here silently works locally but 404s on docs.rs.
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--html-in-header", "../../katex-header.html"]
+rustdoc-args = ["--html-in-header", "katex-header.html"]
 
 [features]
 default = ["box2d", "locomotion"]

--- a/crates/rlevo-environments/Cargo.toml
+++ b/crates/rlevo-environments/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "RL benchmark environments and landscapes for rlevo (internal crate — use `rlevo` for the full API)"
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo-environments/katex-header.html
+++ b/crates/rlevo-environments/katex-header.html
@@ -1,0 +1,38 @@
+<!-- Synced copy of the canonical file at the repo root (`katex-header.html`).
+     Cargo can only package files inside a crate's own directory, so every
+     crate using `[package.metadata.docs.rs] rustdoc-args` for KaTeX needs its
+     own copy here. Edit the root file, then copy it into every crate that
+     references it (currently: rlevo-core, rlevo-environments). -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    // Render fenced ```math blocks (verbatim, so markdown never mangles `_`/`\`).
+    document
+      .querySelectorAll("pre code.language-math, code.language-math")
+      .forEach(function (el) {
+        var pre = el.closest("pre") || el;
+        var span = document.createElement("span");
+        try {
+          katex.render(el.textContent, span, {
+            displayMode: true,
+            throwOnError: false,
+          });
+          pre.replaceWith(span);
+        } catch (e) {
+          /* leave the raw block in place on failure */
+        }
+      });
+    // Render inline $...$ / \(...\) in prose.
+    renderMathInElement(document.body, {
+      delimiters: [
+        { left: "$$", right: "$$", display: true },
+        { left: "\\[", right: "\\]", display: true },
+        { left: "$", right: "$", display: false },
+        { left: "\\(", right: "\\)", display: false },
+      ],
+      ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"],
+    });
+  });
+</script>

--- a/crates/rlevo-evolution/Cargo.toml
+++ b/crates/rlevo-evolution/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "Evolutionary algorithms for rlevo (internal crate — use `rlevo` for the full API)"
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo-examples/Cargo.toml
+++ b/crates/rlevo-examples/Cargo.toml
@@ -129,6 +129,6 @@ path = "examples/evolution/santa_fe_ant_stochastic.rs"
 [dev-dependencies]
 # `rlevo-test-support` (ADR 0024) provides the random baseline + `flex_guard`
 # single-thread determinism preamble for the cross-crate neuroevolution test.
-rlevo-test-support = { path = "../rlevo-test-support", version = "0.2.0" }
+rlevo-test-support = { path = "../rlevo-test-support" }
 # Pin rayon to one thread in the examples/test for reproducible Burn RNG.
 rayon = { workspace = true }

--- a/crates/rlevo-hybrid/Cargo.toml
+++ b/crates/rlevo-hybrid/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "Hybrid evolutionary + RL strategies for rlevo (internal crate — use `rlevo` for the full API)"
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo-metrics-registry/Cargo.toml
+++ b/crates/rlevo-metrics-registry/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "Single-source-of-truth typed registry of canonical rlevo training metrics, shared by the benchmarks recorder and the WASM report client (ADR-0015)"
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo-reinforcement-learning/Cargo.toml
+++ b/crates/rlevo-reinforcement-learning/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 description = "Deep reinforcement learning algorithms for rlevo (internal crate — use `rlevo` for the full API)"
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/rlevo/Cargo.toml
+++ b/crates/rlevo/Cargo.toml
@@ -21,7 +21,7 @@ rlevo-hybrid = { path = "../rlevo-hybrid", version = "0.2.0" }
 [dev-dependencies]
 rlevo-benchmarks = { path = "../rlevo-benchmarks", version = "0.2.0" }
 rlevo-environments = { path = "../rlevo-environments", version = "0.2.0", features = ["bench"] }
-rlevo-test-support = { path = "../rlevo-test-support", version = "0.2.0" }
+rlevo-test-support = { path = "../rlevo-test-support" }
 approx = { workspace = true }
 burn = { workspace = true }
 criterion = { workspace = true }


### PR DESCRIPTION
## Summary
- Fixes the docs.rs KaTeX build regression from 0.2.0 by pointing `rustdoc-args` at a same-directory `katex-header.html` copy for `rlevo-core` and `rlevo-environments` (Cargo can only package files inside a crate's own directory; the old `../../katex-header.html` reference resolved locally but was absent from the packaged tarball).
- Removes a permanent crates.io publish blocker: `rlevo-test-support` (new, internal-only, `publish = false`) was pinned with a `version` requirement in `rlevo`'s and `rlevo-examples`'s dev-dependencies, which cargo tries to resolve against the registry during packaging — a crate that will never be published can never satisfy that lookup. Now path-only.
- Adds the missing `readme.workspace = true` to all seven publishable sub-crates, which had their own `README.md` but no `readme` field, so crates.io/docs.rs would have rendered nothing.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo publish --dry-run -p rlevo` — confirmed the `rlevo-test-support` resolution error is gone, packaging/verification proceeds to the upload step
- [x] Rebuilt `rlevo-core`'s packaged tarball and generated docs with the exact docs.rs `rustdoc-args`, confirmed KaTeX assets/auto-render script are correctly injected
- [x] Manually reviewed all math snippets in `rlevo-core::base` and the flagged `rlevo-environments` files for valid KaTeX syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)