### PR TITLE
chore(release): Bump workspace version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.3.1] – 2026-07-17
+
+Patch release: no breaking changes since 0.3.0.
+
+### `rlevo-metrics-registry`
+
+**Added**
+
+- `Trend` reading (`HigherIsBetter` / `LowerIsBetter` / `Diagnostic`) and a
+  one-line interpretation hint per canonical metric (`trend_for`, `hint_for`),
+  surfaced above each plot in the benchmarks TUI's Separate layout so a
+  reader can tell whether a rising sparkline is good news without leaving the
+  dashboard. `MetricDescriptor` gains two fields with const-default
+  constructors; existing consumers stay source-compatible.
+
+### `rlevo-benchmarks`
+
+**Added**
+
+- Combined-layout TUI metric labels are now prefixed with a trend glyph
+  (↑ / ↓ / •), matching the Separate layout's enriched titles.
+
+### `rlevo-reinforcement-learning`
+
+**Fixed**
+
+- `SacAgent`'s default target entropy now uses `COMPONENTS` instead of
+  `RANK` — the Haarnoja et al. (2018b) heuristic it cites is
+  `-dim(action_space)`, not `-rank`. Behavior-identical today, since every
+  existing `BoundedAction` impl has `RANK == COMPONENTS`; this closes a
+  latent bug for any future multi-component bounded action type (part of
+  the ADR 0038 RANK/COMPONENTS blast radius).
+
+### Docs
+
+**Fixed**
+
+- KaTeX now renders backtick-wrapped inline `` $...$ `` math and fenced
+  ` ```math ` blocks correctly on docs.rs; both forms previously rendered as
+  raw, unprocessed LaTeX text (rustdoc emits them as `<code>` /
+  `<pre class="language-math"><code>`, which the header's original selectors
+  missed).
+- Sub-crate `readme` fields now resolve to each crate's own `README.md`
+  instead of all inheriting the workspace-root `README.md` via
+  `readme.workspace = true` (which does not re-relativize per member).
+- Over 20 misattributed or inaccurate citations corrected across crate
+  READMEs, ADRs 0043 and 0045, and the user-book (reference-verification
+  audit, issue #313).
+
+### Examples & user-book
+
+**Added**
+
+- `backend_sweep_neuroevolution` example and a "Choosing a Backend"
+  user-book chapter, illustrating CPU-vs-GPU backend selection via Burn's
+  backend genericity on a batched neuroevolution fitness function.
+
+### Infrastructure
+
+- Project logo migrated from SVG to PNG for consistent rendering on GitHub
+  and crates.io.
+- `justfile`'s report-client build recipe self-heals a missing
+  `wasm32-unknown-unknown` target after toolchain updates.
+
+---
+
 ## [0.3.0] – 2026-07-13
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6364,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "burn",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-benchmarks"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "base64 0.22.1",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-benchmarks-report-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6432,7 +6432,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "burn",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-environments"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "bincode",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-evolution"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "burn",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-examples"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "burn",
  "parking_lot",
@@ -6500,7 +6500,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-hybrid"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "burn",
@@ -6514,11 +6514,11 @@ dependencies = [
 
 [[package]]
 name = "rlevo-metrics-registry"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "rlevo-reinforcement-learning"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "burn",
@@ -6534,7 +6534,7 @@ dependencies = [
 
 [[package]]
 name = "rlevo-test-support"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "burn",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Anthony Torlucci"]
 description = "Deep Reinforcement Learning with Evolutionary Optimization"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps `workspace.package.version` to `0.3.1` (patch release, no breaking changes since 0.3.0)
- Drafts the `[0.3.1]` `CHANGELOG.md` section covering the 23 commits since the `v0.3.0` tag: metrics-registry `Trend` reading/hints + TUI trend glyph, SAC target-entropy fix (`COMPONENTS` vs `RANK`), docs.rs KaTeX inline/block rendering fix, sub-crate readme-path fix, reference-citation audit (issue #313), backend-sweep neuroevolution example
- Internal `path + version` pins are intentionally left at `"0.3.0"` — verified this is safe for a patch bump since Cargo's caret requirement semantics (`^0.3.0`) already admit `0.3.1`

This is the output of a full pre-release audit (crate inventory/dependency-graph check, manifest metadata audit, `cargo publish --dry-run` for all 8 publishable crates, a re-verified docs.rs/KaTeX rendering check against the actual packaged tarball with a real browser confirmation, and a release-hygiene pass). `docs/.private/publishing.md` (gitignored) was updated in place with the full findings and the exact remaining publish sequence.

## Test plan
- [x] `cargo build --workspace` compiles cleanly at 0.3.1
- [x] `cargo publish --dry-run` for all 8 publishable crates (7 clean; 1 documented false-positive explained in `publishing.md`)
- [x] `cargo doc --workspace --no-deps` — zero warnings
- [x] KaTeX rendering re-verified against packaged tarball + real browser check for `rlevo-core` and `rlevo-environments`
- [ ] Maintainer review of the drafted CHANGELOG section
- [ ] Remaining publish sequence (tag, `cargo publish` in dependency order, GitHub release) — not run by this PR, see `docs/.private/publishing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU8sRfuoMjc2PY64hhxpi1