### PR TITLE
refactor(rl): Drop the throwaway .valid() at the 6 target soft-update call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,29 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   even exist on PPO or PPG (theirs are `update()` and
   `policy_phase_update()`). `ppg` was not named in issue #167 but carried
   the identical defect at 5 call sites and is fixed under the same change.
+- **A panic during a target soft update silently hard-synced the target onto
+  its live network** (resolves #168) — the six off-policy agents (`dqn`,
+  `c51`, `qrdqn`, `ddpg`, `sac`, `td3`) built a throwaway `.valid()` snapshot
+  of the *active* network and `std::mem::replace`d it into the target field
+  purely to keep the field populated while `soft_update` consumed the target
+  by value. On the happy path the placeholder was overwritten on the very next
+  line and cost nothing observable. On a panic inside `soft_update` it was
+  never overwritten, so the agent unwound with the target field holding a full
+  copy of the policy — a hard sync the caller never asked for, and the exact
+  failure mode τ exists to avoid. On TD3 the window spanned three fields, so
+  one fault could corrupt the target actor and both target critics. The tests
+  could not catch it for the same reason they missed #167: nothing in the
+  suite drives a panic through a learn step. `M::InnerModule` is `Clone`
+  (`Module<B>: Clone` is a supertrait in Burn 0.21), so all 10 call sites now
+  pass `self.<target>.clone()` and leave the field untouched until
+  `soft_update` returns. Numerics are unchanged — the discarded snapshot never
+  reached the Polyak average.
+
+  Note that the *performance* premise in the original text of #168 was wrong
+  and has been retracted: `.valid()` is not a deep copy (it moves refcounted
+  backend primitives), so its cost scales with `Param` count, not network
+  size. The device→host→device round-trip in `polyak_update` is where the
+  real per-step cost lives; that is tracked separately as #322.
 
 ---
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
@@ -532,9 +532,11 @@ where
             .step_with(&mut self.optimizer, self.config.learning_rate, grads);
 
         if self.config.tau > 0.0 {
-            let fresh_valid = self.policy().valid();
-            let target = std::mem::replace(&mut self.target_net, fresh_valid);
-            self.target_net = M::soft_update(self.policy(), target, self.config.tau);
+            // Clone rather than move out: the field stays intact if
+            // `soft_update` panics, so a failure can't silently hard-sync
+            // the target onto the policy.
+            self.target_net =
+                M::soft_update(self.policy(), self.target_net.clone(), self.config.tau);
         }
 
         Some(LearnOutcome {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
@@ -501,14 +501,14 @@ where
             self.actor
                 .step_with(&mut self.actor_opt, self.config.actor_lr, actor_grads);
 
+            // Clone rather than move out: each target field stays intact if
+            // `soft_update` panics, so a failure can't silently hard-sync the
+            // target onto its live network.
             let tau = self.config.tau as f64;
-            let fresh_target_actor = self.actor.get().valid();
-            let target_actor = std::mem::replace(&mut self.target_actor, fresh_target_actor);
-            self.target_actor = Actor::soft_update(self.actor.get(), target_actor, tau);
-
-            let fresh_target_critic = self.critic.get().valid();
-            let target_critic = std::mem::replace(&mut self.target_critic, fresh_target_critic);
-            self.target_critic = Critic::soft_update(self.critic.get(), target_critic, tau);
+            self.target_actor =
+                Actor::soft_update(self.actor.get(), self.target_actor.clone(), tau);
+            self.target_critic =
+                Critic::soft_update(self.critic.get(), self.target_critic.clone(), tau);
 
             self.last_actor_loss = actor_loss_value;
             actor_loss_opt = Some(actor_loss_value);

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
@@ -455,9 +455,11 @@ where
 
         // Soft update when tau > 0; otherwise rely on hard sync_target().
         if self.config.tau > 0.0 {
-            let fresh_valid = self.policy().valid();
-            let target = std::mem::replace(&mut self.target_net, fresh_valid);
-            self.target_net = M::soft_update(self.policy(), target, self.config.tau);
+            // Clone rather than move out: the field stays intact if
+            // `soft_update` panics, so a failure can't silently hard-sync
+            // the target onto the policy.
+            self.target_net =
+                M::soft_update(self.policy(), self.target_net.clone(), self.config.tau);
         }
 
         Some(LearnOutcome {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
@@ -462,9 +462,11 @@ where
             .step_with(&mut self.optimizer, self.config.learning_rate, grads);
 
         if self.config.tau > 0.0 {
-            let fresh_valid = self.policy().valid();
-            let target = std::mem::replace(&mut self.target_net, fresh_valid);
-            self.target_net = M::soft_update(self.policy(), target, self.config.tau);
+            // Clone rather than move out: the field stays intact if
+            // `soft_update` panics, so a failure can't silently hard-sync
+            // the target onto the policy.
+            self.target_net =
+                M::soft_update(self.policy(), self.target_net.clone(), self.config.tau);
         }
 
         Some(LearnOutcome {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
@@ -669,16 +669,14 @@ where
             .critic_updates
             .is_multiple_of(self.config.target_update_frequency)
         {
+            // Clone rather than move out: each target field stays intact if
+            // `soft_update` panics, so a failure can't silently hard-sync the
+            // target onto its live critic.
             let tau = self.config.tau as f64;
-            let fresh_target_critic_1 = self.critic_1.get().valid();
-            let target_critic_1 =
-                std::mem::replace(&mut self.target_critic_1, fresh_target_critic_1);
-            self.target_critic_1 = Critic::soft_update(self.critic_1.get(), target_critic_1, tau);
-
-            let fresh_target_critic_2 = self.critic_2.get().valid();
-            let target_critic_2 =
-                std::mem::replace(&mut self.target_critic_2, fresh_target_critic_2);
-            self.target_critic_2 = Critic::soft_update(self.critic_2.get(), target_critic_2, tau);
+            self.target_critic_1 =
+                Critic::soft_update(self.critic_1.get(), self.target_critic_1.clone(), tau);
+            self.target_critic_2 =
+                Critic::soft_update(self.critic_2.get(), self.target_critic_2.clone(), tau);
         }
 
         Some(LearnOutcome {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
@@ -595,21 +595,16 @@ where
             self.actor
                 .step_with(&mut self.actor_opt, self.config.actor_lr, actor_grads);
 
+            // Clone rather than move out: each target field stays intact if
+            // `soft_update` panics, so a failure can't silently hard-sync the
+            // target onto its live network.
             let tau = self.config.tau as f64;
-
-            let fresh_target_actor = self.actor.get().valid();
-            let target_actor = std::mem::replace(&mut self.target_actor, fresh_target_actor);
-            self.target_actor = Actor::soft_update(self.actor.get(), target_actor, tau);
-
-            let fresh_target_critic_1 = self.critic_1.get().valid();
-            let target_critic_1 =
-                std::mem::replace(&mut self.target_critic_1, fresh_target_critic_1);
-            self.target_critic_1 = Critic::soft_update(self.critic_1.get(), target_critic_1, tau);
-
-            let fresh_target_critic_2 = self.critic_2.get().valid();
-            let target_critic_2 =
-                std::mem::replace(&mut self.target_critic_2, fresh_target_critic_2);
-            self.target_critic_2 = Critic::soft_update(self.critic_2.get(), target_critic_2, tau);
+            self.target_actor =
+                Actor::soft_update(self.actor.get(), self.target_actor.clone(), tau);
+            self.target_critic_1 =
+                Critic::soft_update(self.critic_1.get(), self.target_critic_1.clone(), tau);
+            self.target_critic_2 =
+                Critic::soft_update(self.critic_2.get(), self.target_critic_2.clone(), tau);
 
             self.last_actor_loss = actor_loss_value;
             actor_loss_opt = Some(actor_loss_value);


### PR DESCRIPTION
Resolves #168.

## What was wrong

Every target soft-update path in the six off-policy agents built a `.valid()` snapshot of the **active** network, `mem::replace`d it into the target field, and overwrote it on the very next line:

```rust
let fresh = self.policy().valid();                    // written, then immediately discarded
let target = std::mem::replace(&mut self.target_net, fresh);
self.target_net = M::soft_update(self.policy(), target, tau);
```

The dance existed only to keep the field populated while `soft_update` consumes the target by value.

On the happy path the placeholder cost nothing observable. **On a panic inside `soft_update` it was never overwritten**, so the agent unwound with the target field holding a full copy of the policy — a hard sync the caller never asked for, and precisely the failure mode τ exists to avoid. On TD3 the window spanned three fields, so one fault could corrupt the target actor and both target critics.

## The fix

`Module<B>: Clone` is a supertrait (`burn-core-0.21.0/src/module/base.rs:84`) and `type InnerModule: Module<B::InnerBackend>`, so the target field is `Clone`. All 10 blocks become:

```rust
self.target_net = M::soft_update(self.policy(), self.target_net.clone(), self.config.tau);
```

No trait signature changes. `ddpg_model.rs` / `td3_model.rs` needed no change.

| File | Fields |
|---|---|
| `dqn/dqn_agent.rs` | `target_net` |
| `c51/c51_agent.rs` | `target_net` |
| `qrdqn/qrdqn_agent.rs` | `target_net` |
| `ddpg/ddpg_agent.rs` | `target_actor`, `target_critic` |
| `sac/sac_agent.rs` | `target_critic_1`, `target_critic_2` |
| `td3/td3_agent.rs` | `target_actor`, `target_critic_1`, `target_critic_2` |

## Why this is semantically identical on the happy path

A QA pass specifically tried to refute this and failed. `soft_update` is declared on the **model** trait (`fn soft_update(active: &Self, target: Self::InnerModule, tau: f64)`) with no agent receiver, so it cannot observe a sibling target field. The `self.actor`/`self.critic_*` and `self.target_actor`/`self.target_critic_*` namespaces are disjoint by construction, so no `mem::replace` write was ever read by a later site's `active` argument in the multi-field DDPG/SAC/TD3 blocks. Old and new read bit-identical inputs at all 10 sites.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy -p rlevo-reinforcement-learning --all-targets --all-features` — 0 warnings
- `cargo test -p rlevo-reinforcement-learning` — 164 passed, 0 failed
- `cargo test -p rlevo --tests` — 0 failed across 19 binaries; `sac_linear_flex_reproducibility` and `td3_linear_flex_reproducibility` pass, empirically confirming numerics are unchanged
- `grep mem::replace crates/rlevo-reinforcement-learning/src/` — zero hits
- The hard `sync_target()` paths still use `.valid()` legitimately and are byte-for-byte untouched

## The performance premise was wrong — retracted

The original issue framed this as a perf bug. That is refuted and the CHANGELOG says so: `.valid()` is not a deep copy. Traced through Burn 0.21, it resolves to `Tensor::new(K::inner(primitive))` → a **field move** of refcounted backend primitives. Cost scales with `Param` count (~6 for an MLP), not bytes.

The real network-size-scaling cost is one layer down — `utils.rs:38,58` round-trips every parameter device→host→device via `to_data()`/`from_data()` on each soft update. That is confirmed and tracked as #322, not fixed here.

## Known gap

No test asserts the panic-safety property this change buys. Filed as #332 with a concrete reproducer and the reusable `shared.rs:421` test shape. QA recommended it as a fast-follow rather than a merge gate: the fix is mechanical and its correctness rests on a static-typing argument, not on runtime behavior.

## Related

- #322 — the real soft-update perf bug
- #167 / ADR 0046 — same batch, same failure family. Verified complementary, not contradictory: target fields are `InnerModule`, never handed to an optimizer, so they have no ownership window for `Slot` to close. ADR 0046 needs no amendment.
- #332 — the missing regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S22cyyZRE8Y4D5avsrXnYn