### PR TITLE
fix(rl): Gate target hard sync on tau in DQN/C51/QR-DQN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,78 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### `rlevo-reinforcement-learning`
 
+**Changed**
+
+- **`target_update_frequency` default raised from `100` to `10_000` for DQN,
+  C51 and QR-DQN.** The old value had no basis in the literature or in any
+  reference implementation. The new one matches Stable-Baselines3's
+  `target_update_interval`, which — like our `step` counter — is measured in
+  **environment steps**, so the two are directly comparable.
+
+  This is deliberately *not* a literal match to Nature DQN, and the field docs
+  now say so. Mnih et al. 2015 specify `C = 10,000` measured in **parameter
+  updates** (Extended Data Table 1); at our `train_frequency: 4` that would be
+  ≈40,000 env steps. Our 10,000 env steps is ≈2,500 parameter updates — 4×
+  more frequent than Nature, and exactly SB3's convention. The field rustdocs
+  now state the unit explicitly, since "target update frequency" is measured
+  differently by different sources and the ambiguity is a live trap.
+
+  **No behavioral change under the shipped defaults**, which keep `tau = 0.005`
+  — after the #182 fix below, `target_update_frequency` is inert whenever
+  `tau > 0.0`. This affects only runs that explicitly opt into hard-sync mode
+  with `tau = 0.0`. Such runs will now sync the target 100× less often; if you
+  had been relying on the old `100` implicitly, set it explicitly. Note the new
+  default is Atari-scaled: on a short classic-control run it may sync only a
+  handful of times (see #337 for per-scale tuning guidance).
+
 **Fixed**
 
+- **The default DQN, C51 and QR-DQN config ran two target-update mechanisms at
+  once, and the hard one erased the soft one** (resolves #182) — `sync_target`
+  gated its full `target ← policy` copy on `target_update_frequency` alone and
+  never read `tau`, despite every config doc promising the opposite ("When
+  `tau > 0.0` … this field is ignored"). Because the `Default` shipped at the
+  time set **both** `tau = 0.005` and `target_update_frequency = 100` (that
+  frequency is now `10_000`, see **Changed** above), and each `train`
+  loop calls `sync_target()` unconditionally, a default run performed a Polyak
+  soft update every learn step *and* slammed the target onto the policy every
+  100 steps — destroying the target lag that Polyak exists to provide, which is
+  the whole mechanism these algorithms rely on for bootstrap stability. This
+  was not a config-exotic edge case; it was the default path for all three
+  agents. `sync_target` now returns early whenever `tau > 0.0`, so the hard
+  sync fires only under `tau == 0.0`, exactly as documented.
+
+  No published algorithm runs both schemes on one target network: Mnih et al.
+  2015 (DQN), Bellemare et al. 2017 (C51) and Dabney et al. 2018 (QR-DQN) all
+  specify a *pure* periodic hard copy, while Lillicrap et al. 2015 (DDPG)
+  specifies pure Polyak explicitly as a **replacement** for it — the point of
+  soft updates being that targets are "constrained to change slowly". Stable-
+  Baselines3 and CleanRL expose both knobs but as a *single* gated mechanism
+  (frequency says when, `tau` says how far), never as two independent schedules.
+
+  The tests could not catch it, for a sharper reason than #167/#168: nothing in
+  the workspace ever reads `target_net` — there is no accessor and never was
+  one. The three integration tests set **both** knobs (e.g. `.tau(0.005)` with
+  `.target_update_frequency(500)`), thereby *encoding the defective config*,
+  then assert only that rewards are finite and that two seeded runs agree. A
+  scheduled hard copy is both finite and perfectly deterministic, so those
+  assertions hold identically under either regime. Each agent now carries two
+  in-source unit tests asserting on the target's **parameter tensors** — one
+  pinning that `sync_target` is a no-op under `tau > 0.0`, one covering the
+  `tau == 0.0` hard-sync branch, which the fix would otherwise leave entirely
+  untested since no in-tree config sets it. Assertions deliberately avoid
+  Q-values and greedy actions: argmax is a lossy hash of the weights, so a
+  0.005 Polyak step and a full hard copy frequently yield the same action, and
+  such a test would have passed against the unfixed code.
+
+  Also fixed: `tau == 0.0` together with `target_update_frequency == 0` meant
+  the target network never updated at all — silently trainable against a frozen
+  random bootstrap. All three configs now reject it in `validate()`. The
+  converse (both set) remains legal, since the library `Default` relies on it.
+
+  Note that `target_update_frequency` still means *soft* cadence in SAC and
+  *hard* cadence in these three; that cross-family divergence is tracked
+  separately as #334.
 - **A panic inside a learn step could permanently brick an agent** (ADR 0046,
   resolves #167) — all eight gradient-based agents (`dqn`, `c51`, `qrdqn`,
   `ddpg`, `td3`, `sac`, `ppo`, `ppg`) stored their trainable networks as
@@ -134,6 +204,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   backend primitives), so its cost scales with `Param` count, not network
   size. The device→host→device round-trip in `polyak_update` is where the
   real per-step cost lives; that is tracked separately as #322.
+
+  A second qualification, added when #182 landed: the phrase "the exact
+  failure mode τ exists to avoid" above overstates the practical exposure on
+  `dqn`, `c51` and `qrdqn` specifically. Until #182, those three hard-synced
+  the target on schedule anyway under any `target_update_frequency > 0`, so
+  under the shipped `Default` the panic-path residue was byte-identical to
+  what `sync_target` was about to do regardless, and was re-applied within at
+  most `target_update_frequency` env steps. The fix was nonetheless fully
+  load-bearing on `ddpg`, `sac` and `td3` — which have no hard-sync path at
+  all, so nothing would ever have overwritten the residue — and on
+  pure-Polyak configs (`target_update_frequency == 0`) of all six agents.
 
 ---
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
@@ -350,15 +350,31 @@ where
 
     /// Synchronises the target network with the current policy network.
     ///
-    /// When [`C51TrainingConfig::tau`] is greater than zero, a per-call
-    /// Polyak soft update `target ← (1 − τ) · target + τ · policy` is
-    /// performed inside [`learn_step`](Self::learn_step) and this method is a
-    /// no-op unless `target_update_frequency` is also set.
+    /// This method is **only ever the hard-sync path**: a full copy of the
+    /// policy weights into the target. The soft (Polyak) path lives inside
+    /// [`learn_step`](Self::learn_step), not here.
     ///
-    /// When `tau` is zero, this method performs a hard sync — a full copy of
-    /// the policy weights into the target — every `target_update_frequency`
-    /// steps. If `target_update_frequency` is `0`, hard sync is disabled.
+    /// The two mechanisms are mutually exclusive and selected by
+    /// [`C51TrainingConfig::tau`]:
+    ///
+    /// - `tau > 0` — Polyak soft updates `target ← (1 − τ) · target + τ ·
+    ///   policy` run per learn step inside [`learn_step`](Self::learn_step),
+    ///   and this method is a **no-op**, whatever `target_update_frequency`
+    ///   says. A hard copy here would erase the very lag `tau` exists to
+    ///   maintain.
+    /// - `tau == 0` — soft updates are disabled and this method performs the
+    ///   hard sync every `target_update_frequency` steps. If
+    ///   `target_update_frequency` is `0`, hard sync is disabled too; that
+    ///   combination leaves the target frozen forever and is rejected by
+    ///   [`C51TrainingConfig::validate`](rlevo_core::config::Validate::validate).
+    ///
+    /// Safe to call unconditionally once per env step — the gating lives here.
     pub fn sync_target(&mut self) {
+        // `tau > 0` means the soft update in `learn_step` owns the target;
+        // `target_update_frequency` is an inert fallback in that mode.
+        if self.config.tau > 0.0 {
+            return;
+        }
         if self.config.target_update_frequency == 0 {
             return;
         }
@@ -550,6 +566,254 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use burn::backend::{Autodiff, Flex};
+    use burn::module::{AutodiffModule, Module};
+    use burn::nn::{Linear, LinearConfig};
+    use burn::tensor::backend::Backend;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use serde::{Deserialize, Serialize};
+
+    use crate::algorithms::c51::c51_config::C51TrainingConfigBuilder;
+    use crate::utils::polyak_update;
+    use rlevo_core::base::{Action as ActionTrait, TensorConversionError};
+
+    type Be = Autodiff<Flex>;
+
+    const TEST_ACTIONS: usize = 2;
+    const TEST_ATOMS: usize = 5;
+
+    /// Two-feature observation — the smallest thing the agent will accept.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestObs([f32; 2]);
+
+    impl Observation<1> for TestObs {
+        fn shape() -> [usize; 1] {
+            [2]
+        }
+    }
+
+    impl<B: Backend> TensorConvertible<1, B> for TestObs {
+        fn row_shape() -> [usize; 1] {
+            [2]
+        }
+        fn write_host_row(&self, buf: &mut Vec<f32>) {
+            buf.extend_from_slice(&self.0);
+        }
+        fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
+            let v = tensor
+                .into_data()
+                .convert::<f32>()
+                .to_vec::<f32>()
+                .map_err(|e| TensorConversionError {
+                    message: format!("host read failed: {e:?}"),
+                })?;
+            Ok(Self([v[0], v[1]]))
+        }
+    }
+
+    /// Binary discrete action.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestAction(usize);
+
+    impl ActionTrait<1> for TestAction {
+        fn shape() -> [usize; 1] {
+            [TEST_ACTIONS]
+        }
+        fn is_valid(&self) -> bool {
+            self.0 < TEST_ACTIONS
+        }
+    }
+
+    impl DiscreteAction<1> for TestAction {
+        const ACTION_COUNT: usize = TEST_ACTIONS;
+        fn from_index(index: usize) -> Self {
+            assert!(index < TEST_ACTIONS, "action index out of bounds");
+            Self(index)
+        }
+        fn to_index(&self) -> usize {
+            self.0
+        }
+    }
+
+    /// Minimal trainable C51 network.
+    ///
+    /// The backend generic **must** be named `B`: Burn's `Module` derive keys
+    /// off the identifier, and any other name makes the derive treat the struct
+    /// as parameter-free — the optimizer would then step nothing and every
+    /// "weights moved" assertion below would pass vacuously.
+    #[derive(Module, Debug)]
+    struct TestNet<B: Backend> {
+        linear: Linear<B>,
+    }
+
+    impl<B: Backend> TestNet<B> {
+        fn init(device: &B::Device) -> Self {
+            Self {
+                linear: LinearConfig::new(2, TEST_ACTIONS * TEST_ATOMS).init(device),
+            }
+        }
+
+        fn forward_impl(&self, observations: Tensor<B, 2>) -> Tensor<B, 3> {
+            let [batch, _] = observations.dims();
+            self.linear
+                .forward(observations)
+                .reshape([batch, TEST_ACTIONS, TEST_ATOMS])
+        }
+    }
+
+    impl<B: AutodiffBackend> C51Model<B, 2> for TestNet<B> {
+        fn forward(&self, observations: Tensor<B, 2>) -> Tensor<B, 3> {
+            self.forward_impl(observations)
+        }
+        fn forward_inner(
+            inner: &Self::InnerModule,
+            observations: Tensor<B::InnerBackend, 2>,
+        ) -> Tensor<B::InnerBackend, 3> {
+            inner.forward_impl(observations)
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+            polyak_update::<B::InnerBackend, TestNet<B::InnerBackend>>(
+                &active.valid(),
+                target,
+                tau as f32,
+            )
+        }
+    }
+
+    type TestAgent = C51Agent<Be, TestNet<Be>, TestObs, TestAction, 1, 2>;
+
+    /// Reads the linear layer's weights back to the host, element-wise.
+    ///
+    /// Deliberately not a `sum()` proxy: per-element optimizer steps very
+    /// nearly cancel in a sum, which would make "did the target change" a
+    /// coin flip rather than a measurement.
+    fn weights(net: &TestNet<Flex>) -> Vec<f32> {
+        net.linear
+            .weight
+            .val()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .expect("weight tensor host read")
+    }
+
+    fn policy_weights(agent: &TestAgent) -> Vec<f32> {
+        weights(&agent.policy().valid())
+    }
+
+    fn target_weights(agent: &TestAgent) -> Vec<f32> {
+        weights(&agent.target_net)
+    }
+
+    fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+        assert_eq!(a.len(), b.len(), "weight snapshots must have equal length");
+        a.iter()
+            .zip(b)
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0_f32, f32::max)
+    }
+
+    /// Builds an agent whose buffer is primed and whose `learning_starts` is
+    /// `0`, so a single [`C51Agent::learn_step`] can be driven directly
+    /// without a training loop (and thus without coupling to ε decay or the
+    /// buffer-fill schedule).
+    fn primed_agent(tau: f64, target_update_frequency: usize) -> TestAgent {
+        let device = <Flex as burn::tensor::backend::BackendTypes>::Device::default();
+        let config = C51TrainingConfigBuilder::new()
+            .tau(tau)
+            .target_update_frequency(target_update_frequency)
+            .batch_size(2)
+            .learning_starts(0)
+            .learning_rate(0.01)
+            .num_atoms(TEST_ATOMS)
+            .v_min(-1.0)
+            .v_max(1.0)
+            .build()
+            .expect("valid test config");
+
+        let mut agent: TestAgent =
+            C51Agent::new(TestNet::<Be>::init(&device), config, device).expect("agent constructs");
+        for i in 0..4 {
+            let x = i as f32;
+            agent.remember(
+                TestObs([x, -x]),
+                &TestAction(i % TEST_ACTIONS),
+                1.0,
+                TestObs([x + 1.0, -x]),
+                false,
+            );
+        }
+        agent
+    }
+
+    /// Regression for #182: with `tau > 0` the Polyak-lagged target must
+    /// survive a `sync_target()` landing on a multiple of
+    /// `target_update_frequency`. The old code hard-copied the policy here,
+    /// erasing the lag every 100 steps under the *default* config.
+    #[test]
+    fn sync_target_is_noop_when_tau_is_positive() {
+        let mut agent = primed_agent(0.005, 100);
+        let mut rng = StdRng::seed_from_u64(42);
+        agent
+            .learn_step(&mut rng)
+            .expect("learn_step runs with a primed buffer and learning_starts = 0");
+
+        // Precondition: without divergence the assertion below is vacuous.
+        let diverged = max_abs_diff(&policy_weights(&agent), &target_weights(&agent));
+        assert!(
+            diverged > 1e-5,
+            "precondition failed: policy and target must differ before sync_target \
+             (max |Δw| = {diverged:e}); the regression assertion would be vacuous"
+        );
+
+        // Land exactly on a hard-sync boundary.
+        agent.step = 100;
+        agent.sync_target();
+
+        let after = max_abs_diff(&policy_weights(&agent), &target_weights(&agent));
+        assert!(
+            after > 1e-5,
+            "tau = 0.005 must leave the target Polyak-lagged, but sync_target \
+             hard-copied the policy onto it (max |Δw| = {after:e})"
+        );
+        assert!(
+            (after - diverged).abs() < 1e-9,
+            "sync_target must be a pure no-op when tau > 0: max |Δw| moved from \
+             {diverged:e} to {after:e}"
+        );
+    }
+
+    /// The other branch of the gate: with `tau == 0` the hard sync is the only
+    /// target-update mechanism, and must still fire on a multiple of
+    /// `target_update_frequency`.
+    #[test]
+    fn sync_target_hard_copies_when_tau_is_zero() {
+        let mut agent = primed_agent(0.0, 100);
+        let mut rng = StdRng::seed_from_u64(42);
+        agent
+            .learn_step(&mut rng)
+            .expect("learn_step runs with a primed buffer and learning_starts = 0");
+
+        let diverged = max_abs_diff(&policy_weights(&agent), &target_weights(&agent));
+        assert!(
+            diverged > 1e-5,
+            "precondition failed: policy and target must differ before sync_target \
+             (max |Δw| = {diverged:e})"
+        );
+
+        agent.step = 100;
+        agent.sync_target();
+
+        let after = max_abs_diff(&policy_weights(&agent), &target_weights(&agent));
+        assert!(
+            after < 1e-9,
+            "tau = 0 must hard-sync the target onto the policy at a multiple of \
+             target_update_frequency (max |Δw| = {after:e})"
+        );
+    }
 
     #[test]
     fn metrics_performance_record_returns_reward_and_steps() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs
@@ -7,7 +7,7 @@
 
 use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
-use rlevo_core::config::{self, ConfigError, Validate};
+use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
 /// Configuration for training a Categorical DQN (C51) agent.
 ///
@@ -44,7 +44,18 @@ pub struct C51TrainingConfig {
 
     /// Period, in env steps, between hard syncs of the target network.
     ///
-    /// Only meaningful when [`tau`](Self::tau) is `0`.
+    /// Only meaningful when [`tau`](Self::tau) is `0`; while `tau > 0` the
+    /// Polyak soft update is the live mechanism and this field is inert.
+    ///
+    /// The unit is **environment steps** — not parameter updates and not
+    /// gradient updates. The default of `10_000` matches
+    /// Stable-Baselines3's `target_update_interval`, which is counted in the
+    /// same unit. It is *not* the Nature-DQN figure: Mnih et al. (2015)
+    /// specify `C = 10,000` **parameter updates** (Extended Data Table 1),
+    /// which under the default [`train_frequency`](Self::train_frequency) of
+    /// `4` would be 40,000 environment steps. So 10,000 env steps is roughly
+    /// 2,500 parameter updates — four times more frequent than Nature's `C`,
+    /// and an exact match to the SB3 convention.
     pub target_update_frequency: usize,
 
     /// Upper bound on steps allowed per episode (for bookkeeping only —
@@ -89,6 +100,11 @@ impl C51TrainingConfig {
 
 impl Default for C51TrainingConfig {
     /// Returns defaults consistent with CleanRL's reference C51 hyperparameters.
+    ///
+    /// [`target_update_frequency`](Self::target_update_frequency) is
+    /// `10_000` environment steps, matching Stable-Baselines3's
+    /// `target_update_interval`. It is inert under these defaults because
+    /// `tau = 0.005 > 0` selects the Polyak soft update.
     fn default() -> Self {
         Self {
             batch_size: 32,
@@ -98,7 +114,7 @@ impl Default for C51TrainingConfig {
             epsilon_start: 1.0,
             epsilon_end: 0.01,
             epsilon_decay: 0.995,
-            target_update_frequency: 100,
+            target_update_frequency: 10_000,
             steps_per_episode: 1000,
             replay_buffer_capacity: 10_000,
             learning_starts: 1_000,
@@ -128,6 +144,22 @@ impl Validate for C51TrainingConfig {
         config::at_least(C, "num_atoms", self.num_atoms, 2)?;
         config::distinct(C, "v_max", f64::from(self.v_min), f64::from(self.v_max))?;
         config::ordered(C, "v_max", f64::from(self.v_min), f64::from(self.v_max))?;
+        // The target network has exactly two update mechanisms — Polyak soft
+        // updates (`tau > 0`) and periodic hard syncs
+        // (`target_update_frequency > 0`). Disabling both leaves the target
+        // frozen at its initial weights for the whole run, which silently
+        // trains against a random bootstrap. `tau` is already range-checked
+        // to `[0, 1]` above, so `<= 0.0` here is exactly "τ is zero".
+        if self.tau <= 0.0 && self.target_update_frequency == 0 {
+            return Err(ConfigError {
+                config: C,
+                field: "target_update_frequency",
+                kind: ConstraintKind::Custom(
+                    "target network would never update: set tau > 0 for Polyak \
+                     soft updates, or target_update_frequency > 0 for hard syncs",
+                ),
+            });
+        }
         Ok(())
     }
 }
@@ -320,6 +352,47 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         assert!(C51TrainingConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_config_where_target_never_updates() {
+        let err = C51TrainingConfigBuilder::new()
+            .tau(0.0)
+            .target_update_frequency(0)
+            .build()
+            .unwrap_err();
+        assert_eq!(
+            err.field, "target_update_frequency",
+            "tau == 0 with no hard-sync period must be rejected: the target would never update"
+        );
+    }
+
+    #[test]
+    fn accepts_either_target_update_mechanism_alone() {
+        assert!(
+            C51TrainingConfigBuilder::new()
+                .tau(0.0)
+                .target_update_frequency(100)
+                .build()
+                .is_ok(),
+            "hard sync alone is a valid target-update mechanism"
+        );
+        assert!(
+            C51TrainingConfigBuilder::new()
+                .tau(0.005)
+                .target_update_frequency(0)
+                .build()
+                .is_ok(),
+            "Polyak soft update alone is a valid target-update mechanism"
+        );
+        assert!(
+            C51TrainingConfigBuilder::new()
+                .tau(0.005)
+                .target_update_frequency(100)
+                .build()
+                .is_ok(),
+            "both set is legal: tau wins and the frequency is an inert fallback (this is Default)"
+        );
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/train.rs
@@ -25,12 +25,16 @@ use crate::algorithms::c51::c51_model::C51Model;
 ///
 /// The loop runs one environment step per iteration. After collecting each
 /// transition, it calls [`C51Agent::learn_step`] whenever
-/// [`C51Agent::should_train`] returns `true`, synchronises the target network
-/// via [`C51Agent::sync_target`], and decays ε via
-/// [`C51Agent::decay_exploration`]. On episode termination the loop records
+/// [`C51Agent::should_train`] returns `true`, calls [`C51Agent::sync_target`],
+/// and decays ε via [`C51Agent::decay_exploration`]. On episode termination the loop records
 /// per-episode [`C51Metrics`] into the agent's rolling statistics window and
 /// calls [`Environment::reset`] to begin a new episode, except on the very
 /// last step (to avoid recording a phantom episode in recording environments).
+///
+/// `sync_target` is called unconditionally and self-gates: it is the **hard
+/// sync only**, and does nothing unless `tau == 0`. With the default `tau =
+/// 0.005` the target is maintained solely by the Polyak update inside
+/// [`C51Agent::learn_step`].
 ///
 /// # Const generics
 ///

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
@@ -337,9 +337,33 @@ where
         self.config.train_frequency > 0 && self.step.is_multiple_of(self.config.train_frequency)
     }
 
-    /// Hard-syncs the target network with the policy network when
-    /// `self.step` is a multiple of `config.target_update_frequency`.
+    /// Periodically hard-syncs the target network with the policy network.
+    ///
+    /// This method is **only ever the hard path** — a wholesale copy of the
+    /// policy weights into the target. The soft (Polyak) path lives inside
+    /// [`learn_step`](Self::learn_step), not here.
+    ///
+    /// When [`DqnTrainingConfig::tau`] is greater than zero this method is a
+    /// **no-op**: the target is maintained exclusively by the per-learn-step
+    /// Polyak update `target ← (1 − τ) · target + τ · policy`, and a hard copy
+    /// would erase precisely the target lag that soft updates exist to
+    /// create. Because the default config sets `tau = 0.005`, the hard path is
+    /// unreachable for a default agent regardless of
+    /// `target_update_frequency`.
+    ///
+    /// When `tau` is zero, a hard sync is performed every
+    /// `target_update_frequency` steps. If `target_update_frequency` is `0`,
+    /// hard syncing is disabled entirely — a combination rejected by
+    /// [`DqnTrainingConfig::validate`](rlevo_core::config::Validate::validate)
+    /// when `tau` is also zero, since the target would then never update.
+    ///
+    /// [`DqnTrainingConfig::tau`]: crate::algorithms::dqn::dqn_config::DqnTrainingConfig::tau
     pub fn sync_target(&mut self) {
+        // Soft updates own the target network when tau > 0; hard-copying here
+        // would wipe out the Polyak lag every `target_update_frequency` steps.
+        if self.config.tau > 0.0 {
+            return;
+        }
         if self.config.target_update_frequency == 0 {
             return;
         }
@@ -473,6 +497,145 @@ where
 mod tests {
     use super::*;
 
+    use burn::backend::{Autodiff, Flex};
+    use burn::module::{AutodiffModule, Module, Param};
+    use burn::nn::{Linear, LinearConfig};
+    use burn::tensor::backend::Backend;
+    use rlevo_core::base::Action;
+    use rlevo_core::base::TensorConversionError;
+    use serde::{Deserialize, Serialize};
+
+    use crate::algorithms::dqn::dqn_config::DqnTrainingConfigBuilder;
+    use crate::utils::polyak_update;
+
+    type TestBackend = Autodiff<Flex>;
+    type TestInner = <TestBackend as AutodiffBackend>::InnerBackend;
+    type TestAgent = DqnAgent<TestBackend, TestNet<TestBackend>, TestObs, TestAction, 1, 2>;
+
+    /// Minimal two-in/two-out linear Q-network used by the target-sync tests.
+    ///
+    /// Weights are set to a caller-chosen constant so "policy differs from
+    /// target" is provable by inspection rather than by luck of the seed.
+    #[derive(Module, Debug)]
+    struct TestNet<B: Backend> {
+        linear: Linear<B>,
+    }
+
+    impl<B: Backend> TestNet<B> {
+        /// Builds a bias-free 2x2 linear layer whose every weight equals `value`.
+        fn constant(
+            device: &<B as burn::tensor::backend::BackendTypes>::Device,
+            value: f32,
+        ) -> Self {
+            let linear: Linear<B> = LinearConfig::new(2, 2).with_bias(false).init(device);
+            let weight: Tensor<B, 2> =
+                Tensor::from_data(TensorData::new(vec![value; 4], vec![2, 2]), device);
+            Self {
+                linear: Linear {
+                    weight: Param::from_tensor(weight),
+                    ..linear
+                },
+            }
+        }
+    }
+
+    /// Reads a network's weight tensor back to the host for exact comparison.
+    fn weights<B: Backend>(net: &TestNet<B>) -> Vec<f32> {
+        net.linear
+            .weight
+            .val()
+            .into_data()
+            .convert::<f32>()
+            .into_vec::<f32>()
+            .expect("weight tensor is float data")
+    }
+
+    impl<B: AutodiffBackend> DqnModel<B, 2> for TestNet<B> {
+        fn forward(&self, observations: Tensor<B, 2>) -> Tensor<B, 2> {
+            self.linear.forward(observations)
+        }
+
+        fn forward_inner(
+            inner: &Self::InnerModule,
+            observations: Tensor<B::InnerBackend, 2>,
+        ) -> Tensor<B::InnerBackend, 2> {
+            inner.linear.forward(observations)
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+            polyak_update::<B::InnerBackend, TestNet<B::InnerBackend>>(
+                &active.valid(),
+                target,
+                tau as f32,
+            )
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestObs([f32; 2]);
+
+    impl Observation<1> for TestObs {
+        fn shape() -> [usize; 1] {
+            [2]
+        }
+    }
+
+    impl<B: Backend> TensorConvertible<1, B> for TestObs {
+        fn row_shape() -> [usize; 1] {
+            [2]
+        }
+
+        fn write_host_row(&self, buf: &mut Vec<f32>) {
+            buf.extend_from_slice(&self.0);
+        }
+
+        fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
+            let data = tensor.into_data().convert::<f32>();
+            let v = data.as_slice::<f32>().map_err(|_| TensorConversionError {
+                message: "non-float tensor".into(),
+            })?;
+            Ok(Self([v[0], v[1]]))
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestAction(usize);
+
+    impl Action<1> for TestAction {
+        fn shape() -> [usize; 1] {
+            [2]
+        }
+
+        fn is_valid(&self) -> bool {
+            self.0 < 2
+        }
+    }
+
+    impl DiscreteAction<1> for TestAction {
+        const ACTION_COUNT: usize = 2;
+
+        fn from_index(index: usize) -> Self {
+            assert!(index < Self::ACTION_COUNT, "action index out of range");
+            Self(index)
+        }
+
+        fn to_index(&self) -> usize {
+            self.0
+        }
+    }
+
+    /// Builds an agent whose policy weights are all `1.0` and whose target
+    /// weights are all `2.0`, i.e. provably diverged before any sync.
+    fn diverged_agent(config: DqnTrainingConfig) -> TestAgent {
+        let device = <TestInner as burn::tensor::backend::BackendTypes>::Device::default();
+        let policy: TestNet<TestBackend> = TestNet::constant(&device, 1.0);
+        let target: TestNet<TestInner> = TestNet::constant(&device, 2.0);
+        let mut agent = TestAgent::new(policy, config, device).expect("valid config");
+        agent.target_net = target;
+        agent
+    }
+
     #[test]
     fn metrics_performance_record_returns_reward_and_steps() {
         let m = DqnMetrics {
@@ -491,5 +654,72 @@ mod tests {
     fn error_display_uses_thiserror_messages() {
         let err = DqnAgentError::InvalidAction("bad index".into());
         assert_eq!(err.to_string(), "Invalid action: bad index");
+    }
+
+    /// Regression (issue #182): with soft updates enabled, `sync_target` must
+    /// not hard-copy the policy over the target — doing so erases the Polyak
+    /// lag every `target_update_frequency` steps.
+    ///
+    /// Asserts on parameter tensors, not Q-values: a greedy action is a lossy
+    /// argmax of the weights and would agree under both behaviours.
+    #[test]
+    fn test_dqn_agent_sync_target_is_noop_when_tau_positive() {
+        let config = DqnTrainingConfig::default();
+        assert!(config.tau > 0.0, "default config must enable soft updates");
+        let freq = config.target_update_frequency;
+        assert!(freq > 0, "default config must set a hard-sync frequency");
+
+        let mut agent = diverged_agent(config);
+        // Precondition: without this, the test below would be vacuous.
+        let policy_w = weights(agent.policy());
+        let target_w = weights(&agent.target_net);
+        assert_ne!(
+            policy_w, target_w,
+            "precondition: policy and target must differ before the sync"
+        );
+
+        // Land exactly on a hard-sync boundary — the branch the bug fired on.
+        agent.step = freq;
+        agent.sync_target();
+
+        let after = weights(&agent.target_net);
+        assert_ne!(
+            after,
+            weights(agent.policy()),
+            "sync_target must not hard-copy the policy while tau > 0"
+        );
+        assert_eq!(
+            after, target_w,
+            "target weights must be left completely untouched when tau > 0"
+        );
+    }
+
+    /// Mirror of the regression test: with `tau == 0.0` the hard path is the
+    /// only target-update mechanism, so it must still fire on a boundary step.
+    #[test]
+    fn test_dqn_agent_sync_target_hard_copies_when_tau_zero() {
+        let config = DqnTrainingConfigBuilder::new()
+            .tau(0.0)
+            .target_update_frequency(100)
+            .build()
+            .expect("valid config");
+
+        let mut agent = diverged_agent(config);
+        let policy_w = weights(agent.policy());
+        assert_ne!(
+            policy_w,
+            weights(&agent.target_net),
+            "precondition: policy and target must differ before the sync"
+        );
+
+        agent.step = 100;
+        agent.sync_target();
+
+        assert_eq!(
+            weights(&agent.target_net),
+            policy_w,
+            "with tau == 0 the target must be hard-copied from the policy at a \
+             multiple of target_update_frequency"
+        );
     }
 }

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_config.rs
@@ -2,7 +2,7 @@
 
 use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
-use rlevo_core::config::{self, ConfigError, Validate};
+use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
 /// Configuration structure for training a Deep Q-Network (DQN).
 ///
@@ -51,7 +51,20 @@ pub struct DqnTrainingConfig {
     /// copying the policy network weights wholesale every
     /// `target_update_frequency` steps. When `tau > 0.0`, soft Polyak
     /// averaging is used inside every [`DqnAgent::learn_step`] call and this
-    /// field is ignored. Set to `0` to disable hard syncing entirely.
+    /// field is ignored. Set to `0` to disable hard syncing entirely — but note
+    /// that `tau == 0.0` together with `target_update_frequency == 0` is
+    /// rejected by [`validate`](Validate::validate), since the target network
+    /// would then never update at all.
+    ///
+    /// The unit is **environment steps** — not parameter updates and not
+    /// gradient updates. The default of `10_000` matches Stable-Baselines3's
+    /// `target_update_interval`, which is counted in the same unit. It is
+    /// deliberately *not* the Nature-DQN figure: Mnih et al. (2015) specify
+    /// `C = 10,000` **parameter updates** (Extended Data Table 1), which under
+    /// the default [`train_frequency`](Self::train_frequency) of `4` would be
+    /// 40,000 environment steps. So 10,000 env steps is roughly 2,500
+    /// parameter updates — four times more frequent than Nature's `C`, and an
+    /// exact match to the SB3 convention.
     ///
     /// [`DqnAgent::learn_step`]: crate::algorithms::dqn::dqn_agent::DqnAgent::learn_step
     pub target_update_frequency: usize,
@@ -99,8 +112,10 @@ impl Default for DqnTrainingConfig {
     /// Key values: `batch_size = 32`, `gamma = 0.99`, `tau = 0.005`
     /// (soft updates active), `learning_rate = 1e-3`, `epsilon_start = 1.0`
     /// decaying to `0.01` at rate `0.995`, `replay_buffer_capacity = 10_000`,
-    /// `learning_starts = 1_000`, `train_frequency = 4`, `double_q = false`,
-    /// gradient clipping at norm 100.
+    /// `learning_starts = 1_000`, `train_frequency = 4`,
+    /// `target_update_frequency = 10_000` env steps (SB3's
+    /// `target_update_interval`), `double_q = false`, gradient clipping at
+    /// norm 100.
     ///
     /// Because `tau > 0.0`, `target_update_frequency` is ignored by the
     /// default configuration — soft updates run every learn step.
@@ -113,7 +128,7 @@ impl Default for DqnTrainingConfig {
             epsilon_start: 1.0,
             epsilon_end: 0.01,
             epsilon_decay: 0.995,
-            target_update_frequency: 100,
+            target_update_frequency: 10_000,
             steps_per_episode: 1000,
             replay_buffer_capacity: 10000,
             learning_starts: 1000,
@@ -138,6 +153,21 @@ impl Validate for DqnTrainingConfig {
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
         config::nonzero(C, "train_frequency", self.train_frequency)?;
         config::nonzero(C, "steps_per_episode", self.steps_per_episode)?;
+        // Cross-field: `tau == 0.0` disables the Polyak soft update and
+        // `target_update_frequency == 0` disables the periodic hard sync, so
+        // together they freeze the target network for the whole run. Note the
+        // converse (both set) is legal: `tau` is then the live mechanism and
+        // the frequency is inert — the library `Default` relies on this.
+        if self.tau <= 0.0 && self.target_update_frequency == 0 {
+            return Err(ConfigError {
+                config: C,
+                field: "target_update_frequency",
+                kind: ConstraintKind::Custom(
+                    "target network would never update: set tau > 0.0 for soft \
+                     updates, or target_update_frequency > 0 for hard syncs",
+                ),
+            });
+        }
         Ok(())
     }
 }
@@ -290,6 +320,32 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         assert!(DqnTrainingConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_frozen_target_network() {
+        let err = DqnTrainingConfigBuilder::new()
+            .tau(0.0)
+            .target_update_frequency(0)
+            .build()
+            .unwrap_err();
+        assert_eq!(
+            err.field, "target_update_frequency",
+            "tau == 0 with no hard sync leaves the target network frozen forever"
+        );
+    }
+
+    #[test]
+    fn accepts_soft_updates_with_inert_hard_sync_frequency() {
+        let cfg = DqnTrainingConfigBuilder::new()
+            .tau(0.005)
+            .target_update_frequency(100)
+            .build();
+        assert!(
+            cfg.is_ok(),
+            "tau > 0 alongside a non-zero frequency is legal: tau is the live \
+             mechanism and the frequency is an inert fallback (this is Default)"
+        );
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/train.rs
@@ -27,8 +27,11 @@ use crate::algorithms::dqn::dqn_model::DqnModel;
 ///    replay buffer with [`DqnAgent::remember`].
 /// 3. Calls [`DqnAgent::learn_step`] when `agent.should_train()` returns
 ///    `true` (controlled by [`DqnTrainingConfig::train_frequency`]).
-/// 4. Syncs the target network with [`DqnAgent::sync_target`] (hard or soft
-///    depending on [`DqnTrainingConfig::tau`]).
+/// 4. Calls [`DqnAgent::sync_target`], which performs a **hard** target-network
+///    copy every [`DqnTrainingConfig::target_update_frequency`] steps — and
+///    only when [`DqnTrainingConfig::tau`] is `0.0`. With `tau > 0.0` (the
+///    default) this call is a no-op: the target is instead maintained by the
+///    Polyak soft update inside [`DqnAgent::learn_step`].
 /// 5. Decays ε with [`DqnAgent::decay_exploration`].
 ///
 /// When an episode ends the collected [`DqnMetrics`] are recorded via
@@ -61,6 +64,7 @@ use crate::algorithms::dqn::dqn_model::DqnModel;
 ///
 /// [`DqnTrainingConfig::train_frequency`]: crate::algorithms::dqn::dqn_config::DqnTrainingConfig::train_frequency
 /// [`DqnTrainingConfig::tau`]: crate::algorithms::dqn::dqn_config::DqnTrainingConfig::tau
+/// [`DqnTrainingConfig::target_update_frequency`]: crate::algorithms::dqn::dqn_config::DqnTrainingConfig::target_update_frequency
 /// [`EnvironmentError`]: rlevo_core::environment::EnvironmentError
 pub fn train<B, M, E, O, A, R, const DO: usize, const SD: usize, const DB: usize>(
     agent: &mut DqnAgent<B, M, O, A, DO, DB>,

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
@@ -315,9 +315,38 @@ where
         self.config.train_frequency > 0 && self.step.is_multiple_of(self.config.train_frequency)
     }
 
-    /// Hard-syncs the target network with the policy network when
-    /// `self.step` is a multiple of `config.target_update_frequency`.
+    /// Periodically **hard**-syncs the target network with the policy network.
+    ///
+    /// This method only ever performs the hard path — a full copy of the policy
+    /// weights into the target. The Polyak soft update
+    /// `target ← (1 − τ) · target + τ · policy` is *not* performed here; it runs
+    /// once per gradient update inside [`learn_step`](Self::learn_step).
+    ///
+    /// The two mechanisms are mutually exclusive:
+    ///
+    /// - When [`QrDqnTrainingConfig::tau`] is greater than zero, soft updates
+    ///   are the live mechanism and **this method is a no-op**, regardless of
+    ///   `target_update_frequency`. A hard copy here would discard the
+    ///   deliberate lag the soft update maintains, which is exactly what
+    ///   `tau` exists to create. Because the shipped
+    ///   [`Default`](QrDqnTrainingConfig::default) sets `tau = 0.005`, the hard
+    ///   path is unreachable for the default configuration.
+    /// - When `tau` is zero, this method copies the policy weights into the
+    ///   target on every step that is a positive multiple of
+    ///   `config.target_update_frequency`. A `target_update_frequency` of `0`
+    ///   disables hard syncs entirely.
+    ///
+    /// Setting both `tau` and `target_update_frequency` to zero would freeze the
+    /// target network forever and is rejected by
+    /// [`QrDqnTrainingConfig::validate`](rlevo_core::config::Validate::validate),
+    /// so this method can never be a silent no-op on both paths.
     pub fn sync_target(&mut self) {
+        // Soft updates own the target network; the hard copy would erase the
+        // Polyak lag. `tau` is validated into `[0, 1]`, so `> 0.0` is exactly
+        // "soft updates enabled".
+        if self.config.tau > 0.0 {
+            return;
+        }
         if self.config.target_update_frequency == 0 {
             return;
         }
@@ -480,6 +509,195 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use burn::backend::{Autodiff, Flex};
+    use burn::module::{AutodiffModule, Module, Param};
+    use burn::tensor::backend::Backend;
+
+    use rlevo_environments::classic::cartpole::{CartPoleAction, CartPoleObservation};
+
+    use crate::algorithms::qrdqn::qrdqn_config::QrDqnTrainingConfigBuilder;
+    use crate::utils::polyak_update;
+
+    type TestBackend = Autodiff<Flex>;
+    type TestInnerBackend = <TestBackend as AutodiffBackend>::InnerBackend;
+
+    const TEST_OBS_FEATURES: usize = 4; // CartPoleObservation is [4].
+    const TEST_ACTIONS: usize = 2;
+    const TEST_QUANTILES: usize = 4;
+
+    /// Minimal QR-DQN network: one weight matrix, no RNG.
+    ///
+    /// Every parameter is built from explicit [`TensorData`], so two nets with
+    /// different `fill` values are guaranteed to differ elementwise — the
+    /// target-sync tests below need a deterministic, backend-RNG-free way to
+    /// put the policy and target networks provably out of sync.
+    #[derive(Module, Debug)]
+    struct TestQrDqnNet<B: Backend> {
+        w: Param<Tensor<B, 2>>,
+    }
+
+    impl<B: Backend> TestQrDqnNet<B> {
+        fn new(fill: f32, device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
+            let cols = TEST_ACTIONS * TEST_QUANTILES;
+            let data = vec![fill; TEST_OBS_FEATURES * cols];
+            let w: Tensor<B, 2> =
+                Tensor::from_data(TensorData::new(data, vec![TEST_OBS_FEATURES, cols]), device);
+            Self {
+                w: Param::from_tensor(w),
+            }
+        }
+
+        fn forward_impl(&self, observations: Tensor<B, 2>) -> Tensor<B, 3> {
+            let [batch_size, _] = observations.dims();
+            observations
+                .matmul(self.w.val())
+                .reshape([batch_size, TEST_ACTIONS, TEST_QUANTILES])
+        }
+    }
+
+    impl<B: AutodiffBackend> QrDqnModel<B, 2> for TestQrDqnNet<B> {
+        fn forward(&self, observations: Tensor<B, 2>) -> Tensor<B, 3> {
+            self.forward_impl(observations)
+        }
+        fn forward_inner(
+            inner: &Self::InnerModule,
+            observations: Tensor<B::InnerBackend, 2>,
+        ) -> Tensor<B::InnerBackend, 3> {
+            inner.forward_impl(observations)
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+            polyak_update::<B::InnerBackend, TestQrDqnNet<B::InnerBackend>>(
+                &active.valid(),
+                target,
+                tau as f32,
+            )
+        }
+    }
+
+    type TestAgent = QrDqnAgent<
+        TestBackend,
+        TestQrDqnNet<TestBackend>,
+        CartPoleObservation,
+        CartPoleAction,
+        1,
+        2,
+    >;
+
+    /// Reads a network's single parameter matrix back to the host.
+    fn weights_of<B: Backend>(net: &TestQrDqnNet<B>) -> Vec<f32> {
+        net.w
+            .val()
+            .into_data()
+            .convert::<f32>()
+            .into_vec::<f32>()
+            .expect("f32 host read of a parameter this test just built")
+    }
+
+    fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+        assert_eq!(
+            a.len(),
+            b.len(),
+            "parameter vectors must be the same length"
+        );
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0_f32, f32::max)
+    }
+
+    /// Builds an agent whose policy and target networks are *deliberately* out
+    /// of sync: the policy is filled with `1.0`, the target with `2.0`.
+    ///
+    /// This stands in for "the policy has drifted away from the target during
+    /// training" without running a training loop — driving real gradient steps
+    /// would couple the test to `learning_starts`, buffer fill and the ε
+    /// schedule, none of which the target-sync gate depends on.
+    fn diverged_agent(tau: f64, target_update_frequency: usize) -> TestAgent {
+        let device: <TestBackend as burn::tensor::backend::BackendTypes>::Device =
+            Default::default();
+        let config = QrDqnTrainingConfigBuilder::new()
+            .tau(tau)
+            .target_update_frequency(target_update_frequency)
+            .num_quantiles(TEST_QUANTILES)
+            .build()
+            .expect("valid config");
+        let policy: TestQrDqnNet<TestBackend> = TestQrDqnNet::new(1.0, &device);
+        let mut agent = TestAgent::new(policy, config, device).expect("valid config");
+        // In-source unit tests may touch private fields (rules.md §5); this is
+        // the seam that makes the gate testable without a public accessor.
+        agent.target_net = TestQrDqnNet::<TestInnerBackend>::new(2.0, &device);
+        agent
+    }
+
+    #[test]
+    fn test_qrdqn_agent_sync_target_is_noop_when_tau_is_positive() {
+        // Regression test for #182: with the default `tau = 0.005`, the
+        // periodic hard copy used to fire anyway and erase the Polyak lag.
+        let mut agent = diverged_agent(0.005, 100);
+
+        let policy_before = weights_of(&agent.policy().valid());
+        let target_before = weights_of(&agent.target_net);
+        // Precondition — without this the assertion below would be vacuous.
+        assert!(
+            max_abs_diff(&policy_before, &target_before) > 1e-3,
+            "precondition: policy and target must already differ before sync_target"
+        );
+
+        // Land exactly on a hard-sync boundary.
+        agent.step = 100;
+        agent.sync_target();
+
+        let target_after = weights_of(&agent.target_net);
+        assert!(
+            max_abs_diff(&target_after, &target_before) < 1e-6,
+            "target network must be untouched by sync_target when tau > 0"
+        );
+        assert!(
+            max_abs_diff(&target_after, &policy_before) > 1e-3,
+            "sync_target must not hard-copy the policy into the target while \
+             Polyak soft updates (tau > 0) own the target network"
+        );
+    }
+
+    #[test]
+    fn test_qrdqn_agent_sync_target_hard_copies_when_tau_is_zero() {
+        // Mirror of the regression test: with soft updates disabled, the hard
+        // sync is the only mechanism and must still fire on schedule.
+        let mut agent = diverged_agent(0.0, 100);
+
+        let policy_before = weights_of(&agent.policy().valid());
+        let target_before = weights_of(&agent.target_net);
+        assert!(
+            max_abs_diff(&policy_before, &target_before) > 1e-3,
+            "precondition: policy and target must already differ before sync_target"
+        );
+
+        agent.step = 100;
+        agent.sync_target();
+
+        let target_after = weights_of(&agent.target_net);
+        assert!(
+            max_abs_diff(&target_after, &policy_before) < 1e-6,
+            "with tau = 0 the target must become an exact copy of the policy at \
+             a multiple of target_update_frequency"
+        );
+    }
+
+    #[test]
+    fn test_qrdqn_agent_sync_target_skips_non_multiple_steps_when_tau_is_zero() {
+        let mut agent = diverged_agent(0.0, 100);
+        let target_before = weights_of(&agent.target_net);
+
+        agent.step = 99;
+        agent.sync_target();
+
+        assert!(
+            max_abs_diff(&weights_of(&agent.target_net), &target_before) < 1e-6,
+            "hard sync must only fire on multiples of target_update_frequency"
+        );
+    }
 
     #[test]
     fn metrics_performance_record_returns_reward_and_steps() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
@@ -14,7 +14,7 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use burn::tensor::backend::Backend;
 use burn::tensor::{Tensor, TensorData};
-use rlevo_core::config::{self, ConfigError, Validate};
+use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
 /// Configuration for training a Quantile Regression DQN (QR-DQN) agent.
 ///
@@ -51,7 +51,25 @@ pub struct QrDqnTrainingConfig {
 
     /// Period, in env steps, between hard syncs of the target network.
     ///
-    /// Only meaningful when [`tau`](Self::tau) is `0`.
+    /// Only meaningful when [`tau`](Self::tau) is `0`. When `tau > 0` the
+    /// Polyak soft update is the live mechanism and this field is an inert
+    /// fallback —
+    /// [`QrDqnAgent::sync_target`](crate::algorithms::qrdqn::qrdqn_agent::QrDqnAgent::sync_target)
+    /// is a no-op, so the hard copy can never erase the soft-update lag.
+    ///
+    /// Setting both this field and `tau` to `0` is rejected by
+    /// [`validate`](Validate::validate): the target network would never update
+    /// at all.
+    ///
+    /// The unit is **environment steps** — not parameter updates and not
+    /// gradient updates. The default of `10_000` matches
+    /// Stable-Baselines3's `target_update_interval`, which is counted in the
+    /// same unit. It is *not* the Nature-DQN figure: Mnih et al. (2015)
+    /// specify `C = 10,000` **parameter updates** (Extended Data Table 1),
+    /// which under the default [`train_frequency`](Self::train_frequency) of
+    /// `4` would be 40,000 environment steps. So 10,000 env steps is roughly
+    /// 2,500 parameter updates — four times more frequent than Nature's `C`,
+    /// and an exact match to the SB3 convention.
     pub target_update_frequency: usize,
 
     /// Upper bound on steps allowed per episode (for bookkeeping only —
@@ -100,6 +118,11 @@ impl QrDqnTrainingConfig {
 impl Default for QrDqnTrainingConfig {
     /// Returns defaults consistent with Dabney et al. 2018 QR-DQN
     /// reference hyperparameters.
+    ///
+    /// [`target_update_frequency`](Self::target_update_frequency) is
+    /// `10_000` environment steps, matching Stable-Baselines3's
+    /// `target_update_interval`. It is inert under these defaults because
+    /// `tau = 0.005 > 0` selects the Polyak soft update.
     fn default() -> Self {
         Self {
             batch_size: 32,
@@ -109,7 +132,7 @@ impl Default for QrDqnTrainingConfig {
             epsilon_start: 1.0,
             epsilon_end: 0.01,
             epsilon_decay: 0.995,
-            target_update_frequency: 100,
+            target_update_frequency: 10_000,
             steps_per_episode: 1000,
             replay_buffer_capacity: 10_000,
             learning_starts: 1_000,
@@ -137,6 +160,18 @@ impl Validate for QrDqnTrainingConfig {
         config::nonzero(C, "steps_per_episode", self.steps_per_episode)?;
         config::nonzero(C, "num_quantiles", self.num_quantiles)?;
         config::in_range(C, "kappa", 0.0, f64::INFINITY, f64::from(self.kappa))?;
+        // `tau` is already range-checked to `[0, 1]` above, so `<= 0.0` is
+        // exactly "soft updates disabled" (and avoids a float `==`).
+        if self.tau <= 0.0 && self.target_update_frequency == 0 {
+            return Err(ConfigError {
+                config: C,
+                field: "target_update_frequency",
+                kind: ConstraintKind::Custom(
+                    "target network would never update: set tau > 0 for Polyak soft updates, \
+                     or target_update_frequency > 0 for periodic hard syncs",
+                ),
+            });
+        }
         Ok(())
     }
 }
@@ -212,6 +247,11 @@ impl QrDqnTrainingConfigBuilder {
     /// Sets [`QrDqnTrainingConfig::target_update_frequency`].
     ///
     /// Only meaningful when [`tau`](Self::tau) is `0.0`; ignored otherwise.
+    ///
+    /// # Errors
+    ///
+    /// [`build`](Self::build) rejects `frequency == 0` combined with
+    /// `tau == 0.0`, since that leaves the target network frozen forever.
     pub fn target_update_frequency(mut self, frequency: usize) -> Self {
         self.config.target_update_frequency = frequency;
         self
@@ -319,6 +359,52 @@ mod tests {
             .build()
             .unwrap_err();
         assert_eq!(err.field, "num_quantiles");
+    }
+
+    #[test]
+    fn rejects_frozen_target_when_tau_and_frequency_are_both_zero() {
+        let err = QrDqnTrainingConfigBuilder::new()
+            .tau(0.0)
+            .target_update_frequency(0)
+            .build()
+            .unwrap_err();
+        assert_eq!(
+            err.field, "target_update_frequency",
+            "a config in which the target network never updates must be rejected"
+        );
+    }
+
+    #[test]
+    fn accepts_soft_updates_with_an_inert_hard_sync_frequency() {
+        // The workspace default sets both; under the `sync_target` gate the
+        // frequency is simply inert, so this must stay a legal config
+        // (ADR 0026: a library default must pass its own `validate`).
+        let cfg = QrDqnTrainingConfigBuilder::new()
+            .tau(0.005)
+            .target_update_frequency(100)
+            .build();
+        assert!(
+            cfg.is_ok(),
+            "tau > 0 alongside a nonzero target_update_frequency is legal"
+        );
+    }
+
+    #[test]
+    fn accepts_hard_sync_only_configuration() {
+        let cfg = QrDqnTrainingConfigBuilder::new()
+            .tau(0.0)
+            .target_update_frequency(500)
+            .build();
+        assert!(cfg.is_ok(), "tau = 0 with periodic hard syncs is legal");
+    }
+
+    #[test]
+    fn accepts_soft_update_only_configuration() {
+        let cfg = QrDqnTrainingConfigBuilder::new()
+            .tau(0.01)
+            .target_update_frequency(0)
+            .build();
+        assert!(cfg.is_ok(), "tau > 0 with hard sync disabled is legal");
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/train.rs
@@ -7,8 +7,13 @@
 //! 1. Select an action with ε-greedy exploration ([`QrDqnAgent::act`]).
 //! 2. Step the environment and store the transition in the replay buffer.
 //! 3. Every `train_frequency` steps, run one gradient update
-//!    ([`QrDqnAgent::learn_step`]) and optionally sync the target network.
-//! 4. On episode termination, record [`QrDqnMetrics`] (including
+//!    ([`QrDqnAgent::learn_step`]).
+//! 4. Call [`QrDqnAgent::sync_target`] every step. This is the **hard**-sync
+//!    path only, and it is gated internally: it is a no-op unless
+//!    `tau == 0.0`. When `tau > 0` the target network is instead maintained by
+//!    the Polyak soft update inside `learn_step`, so calling `sync_target`
+//!    unconditionally here cannot clobber that lag.
+//! 5. On episode termination, record [`QrDqnMetrics`] (including
 //!    `quantile_spread`) and reset the environment.
 //!
 //! The only behavioural difference from [`crate::algorithms::c51::train`] is


### PR DESCRIPTION
Resolves #182.

## The bug

`sync_target` gated its full `target ← policy` copy on `target_update_frequency` alone and **never read `tau`**, despite every config doc promising the opposite — *"When `tau > 0.0` … this field is ignored"*.

Because the shipped `Default` set **both** `tau = 0.005` and `target_update_frequency = 100`, and each `train` loop calls `sync_target()` unconditionally, a default run did a Polyak soft update every learn step **and** slammed the target onto the policy every 100 steps — destroying the target lag that Polyak exists to provide. That is the mechanism these algorithms depend on for bootstrap stability.

This was the **default path** for DQN, C51 and QR-DQN, not a config-exotic edge case.

## Literature basis

No published algorithm runs both schemes on one target network:

- **Mnih et al. 2015** (DQN), **Bellemare et al. 2017** (C51), **Dabney et al. 2018** (QR-DQN) — pure periodic hard copy. C51 and QR-DQN explicitly inherit Nature DQN's protocol.
- **Lillicrap et al. 2015** (DDPG) — pure Polyak, `τ = 0.001`, stated explicitly as a *replacement*: targets "constrained to change slowly, greatly improving the stability of learning."
- **SB3 / CleanRL** — expose both knobs, but as a *single gated mechanism* (frequency says when, `tau` says how far). **Dopamine** — hard copy only, no `tau` parameter at all.

Searched arXiv, Semantic Scholar and Consensus; nothing combines two independently-scheduled rules on one target network.

## The fix

`sync_target` now early-returns whenever `tau > 0.0`, so the hard sync fires only under `tau == 0.0` — exactly as the docs already claimed. Applied identically to all three agents.

Also in this PR:

- **`validate()` now rejects `tau == 0.0 && target_update_frequency == 0`** — that combination left the target network frozen for the entire run, silently training against a random bootstrap. Both-set remains legal; the shipped `Default` relies on it (ADR 0026).
- **`target_update_frequency` default raised `100` → `10_000`.** The old value had no basis in any paper or reference implementation. The new one matches **SB3's `target_update_interval`**, which — like our `step` counter — is measured in **env steps**. Deliberately *not* a literal Nature match: Mnih's `C = 10,000` counts **parameter updates**, ≈40,000 env steps at `train_frequency: 4`. The field rustdocs now state the unit explicitly, since the ambiguity is a live trap. Inert under the shipped defaults.
- Corrected `sync_target` rustdocs and `train.rs` module docs, which described it as "hard or soft depending on `tau`" — it is only ever the hard path.

## Why the tests missed it

Nothing in the workspace reads `target_net`; there is no accessor. The three integration tests set **both** knobs — e.g. `.tau(0.005)` with `.target_update_frequency(500)` — thereby *encoding the broken config* — then assert only that rewards are finite and two seeded runs agree. A scheduled hard copy is finite and perfectly deterministic, so those assertions hold identically under either regime.

## Test design (the load-bearing part)

7 new in-source unit tests, reading the private `target_net` field per `rules.md §5`. No public accessor added.

**Assertions are on parameter tensors, never on Q-values or greedy actions.** Argmax is a lossy hash of the weights — a 0.005 Polyak step and a full hard copy usually select the same action, so an argmax-based test **passes against the unfixed code**. That would have re-created the exact blind spot that let this ship.

Each regression test asserts its own divergence precondition first, so it cannot go vacuous. The `tau == 0.0` mirror branch is covered in all three because the fix otherwise makes it unreachable in-tree — without it, this PR would have *removed* coverage.

**Sanity-checked by reverting the gate**, per agent: DQN failed with target `2.0 → 1.0`; C51 with `max |Δw| = 0e0`; QR-DQN with "target must be untouched when tau > 0".

## Verification

| Check | Result |
|---|---|
| `cargo test -p rlevo-reinforcement-learning` | 179 passed, 0 failed |
| `cargo clippy --all-targets --all-features` | clean |
| `cargo fmt --all --check` | clean |
| Ignored convergence + 500k acceptance runs | **10 passed, 0 failed** |

The convergence runs matter: the integration fixtures set `tau=0.005` with `target_update_frequency=500`, so their targets are now genuinely Polyak-lagged and **the learning trajectory changed**. All assertions still hold, including `qrdqn_cartpole_acceptance` (500k steps, avg reward ≥ 195). Independently re-run by the QA reviewer.

## Not in scope

- **#334** — `target_update_frequency` means *soft* cadence in SAC, *hard* cadence here. Deferred deliberately: unifying by reinterpreting the fields in place would leave existing configs deserializing cleanly into a near-frozen target, silently. Should land as a `TargetUpdate` sum type that fails loudly.
- **#335** — `config::in_range`'s NaN-rejection branch is untested, and three agents' τ control flow now rests on it.
- **#336** — `polyak_update` has no tests at all, despite underpinning all six off-policy agents.
- **#337** — the new default is Atari-scaled while `steps_per_episode`/`learning_starts` are classic-control scaled.

No ADR for this change: it makes the code do what its own rustdoc already said. The ADR belongs to #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxTgFWEfDobTRTBsiGuqA5