### PR TITLE
fix(rl): report DQN TD loss once in DqnMetrics

### DIFF
--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
@@ -57,10 +57,11 @@ pub struct DqnMetrics {
     pub reward: f32,
     /// Number of environment steps taken.
     pub steps: usize,
-    /// Most recent policy (Q-network) loss value.
+    /// Most recent TD (Q-network) loss value.
+    ///
+    /// DQN has a single TD loss — unlike actor-critic algorithms there is no
+    /// separate policy/value pair, so only this field is reported.
     pub policy_loss: f32,
-    /// Mirror of `policy_loss` kept for parity with actor-critic algorithms.
-    pub value_loss: f32,
     /// Exploration rate at the end of the episode.
     pub epsilon: f32,
     /// Mean predicted Q-value across the most recent learn step.
@@ -479,7 +480,6 @@ mod tests {
             reward: 42.0,
             steps: 7,
             policy_loss: 0.5,
-            value_loss: 0.5,
             epsilon: 0.1,
             q_mean: 1.0,
         };

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/train.rs
@@ -114,7 +114,6 @@ where
                 reward: episode_reward,
                 steps: episode_steps,
                 policy_loss: last_loss,
-                value_loss: last_loss,
                 epsilon: agent.epsilon() as f32,
                 q_mean: last_q_mean,
             };


### PR DESCRIPTION
## Summary
- Remove the duplicated `value_loss` field from `DqnMetrics`.
- DQN only has a single TD loss; keep it under `policy_loss` (same pattern as C51 / QR-DQN metrics).
- Stops the TUI/report layer from drawing one curve twice as if policy and value losses were independent.

## Test plan
- [ ] `cargo test -p rlevo-reinforcement-learning --lib algorithms::dqn`
- [ ] Confirm no remaining `DqnMetrics { … value_loss … }` constructors

Fixes #327