### PR TITLE
fix(c51): Clamp projection atom index to support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   at the default bounds, which never bind on a healthy run (verified: the
   Pendulum end-to-end run passes unchanged at avg −1167.78).
 
+**Added**
+
+- **`algorithms::c51::projection::atom_spacing`** — the single source of truth
+  for the atom spacing `Δz = (v_max − v_min) / (N − 1)` (Bellemare et al. 2017,
+  §4.1). `C51TrainingConfig::delta_z()` now delegates to it, so the support
+  tensor built in `C51Agent` and the index scale used by the projection can no
+  longer drift apart. Exposed as a free function taking scalars rather than a
+  `C51TrainingConfig` method, so a future Rainbow agent can call
+  `project_distribution` without depending on C51's config type.
+
 **Changed**
+
+- **`C51TrainingConfig::delta_z()` returns `f32::NAN` for `num_atoms < 2`,
+  where it previously returned `±inf`.** The old body divided by
+  `num_atoms.saturating_sub(1)`, i.e. by zero. Both values are degenerate and
+  the builder's `validate()` rejects `num_atoms < 2` before either can be
+  observed, but `NaN` propagates visibly through downstream arithmetic whereas
+  `inf` silently yields a `b` coordinate of `0`. Reachable only by constructing
+  the config through a struct literal, which bypasses `validate()` — the
+  general problem tracked as #326. The signature and `#[must_use]` are
+  unchanged.
 
 - **`target_update_frequency` default raised from `100` to `10_000` for DQN,
   C51 and QR-DQN.** The old value had no basis in the literature or in any
@@ -242,6 +262,56 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   handful of times (see #337 for per-scale tuning guidance).
 
 **Fixed**
+
+- **C51 crashed on roughly 4% of valid atom supports — f32 rounding pushed the
+  projection's atom index one past the end of the support** (resolves #180).
+  `project_distribution` clamps the Bellman shift `Tz` to `[v_min, v_max]`, so
+  the continuous atom coordinate `b = (Tz − v_min) / Δz` is *mathematically*
+  confined to `[0, N−1]`. Bellemare et al. 2017 assert exactly that, as an
+  inline comment in Algorithm 1 — and it is exact in ℝ. It is not exact in
+  IEEE-754. When `Tz` saturates at `v_max`, the division can round `b` a few
+  ULPs **above** `N−1`, `ceil` then yields `N`, and the `scatter` indexes off
+  the end of a size-`N` axis and panics.
+
+  With `v_min = −10, v_max = 0.1, N = 8`, `b = 7.000000477` and any reward
+  `≥ 0.1` panics with `index 8 out of bounds for dimension of size 8`. A sweep
+  over `v_min ∈ [−20, 0)`, `v_max ∈ (v_min, 20]` and `N ∈ [2, 64]` found
+  **165,092 of 3,786,300 supports** affected. Every one of them passes
+  `validate()`; none is exotic. `b` is now clamped to `[0, N−1]` before
+  `floor`/`ceil` — a no-op in real arithmetic, and the same guard CleanRL's
+  `c51.py` carries.
+
+  **Why the tests missed it.** The default support `(−10, 10, 51)` lands on
+  `b = 50.0` exactly, and so do every unit test's `(−1, 1, 3)` and `(−2, 2, n)`
+  and every benchmark's `(−10, 10, {21, 51, 101})`. The suite contained a
+  `projection_clamps_above_support` test aimed squarely at this boundary, but on
+  an exactly-landing support it cannot observe the defect no matter how it is
+  written. The regression tests added here use non-default supports chosen
+  *because* they round badly.
+
+  Note this is distinct from the exact-atom-landing case (`l == u`, where both
+  distance weights are zero and mass would be dropped), which the existing
+  `l_eq_u_mask` already handled correctly and which is unchanged.
+
+- **`project_distribution` silently returned a corrupted target distribution
+  for a degenerate support, instead of failing** (found while fixing #180).
+  With `v_min == v_max` the spacing `Δz` is `0`, so `b = (Tz − v_min)/0` is
+  `NaN`. `f32::clamp` **propagates** `NaN` rather than rescuing it, and Rust's
+  saturating float→int cast maps `NaN` to `0` — so every index collapsed to
+  atom 0 and the function returned a plausible-looking distribution with all
+  mass on the bottom atom. No panic, and no `NaN` in the output to signal it.
+  Silent corruption is a worse failure than the out-of-bounds panic above.
+
+  The pre-existing `assert!(num_atoms >= 2)` does not cover this: `num_atoms`
+  can be perfectly valid while `v_max − v_min == 0`. `project_distribution` now
+  asserts that the spacing is finite and strictly positive, and documents both
+  panic conditions under `# Panics`.
+
+  This is guarded in the projection operator rather than only in config
+  validation because `project_distribution` is public, re-exported, and takes
+  **raw `f32` scalars** — it is reachable with no `C51TrainingConfig` involved,
+  so it has to defend its own contract. The related gap where a config struct
+  literal bypasses `validate()` entirely is tracked as #326.
 
 - **PPO's Gaussian `log_std` was unbounded, so a long continuous-control run
   could collapse it until `σ` underflowed to zero and NaN poisoned every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,8 +246,10 @@ Act as a Senior Software Engineer writing professional Git commits.
 2. Separate subject from body with a blank line
 3. Body (optional): explain *why*, not what; wrap at 72 characters; omit if not useful
 4. Append a `CRITICAL:` line flagging the most complex or risky part of the diff (e.g., a lifetime adjustment, unsafe block, lock ordering, or a subtle invariant)
-5. End with `Co-Authored-By: <model> <noreply@anthropic.com>`, where
-   `<model>` is the Claude model that authored the change — one of
-   `Claude Fable 5`, `Claude Opus 4.8`, or `Claude Sonnet 4.6`
+5. End with a `Claude-Session:` trailer linking the session that authored the
+   change — e.g. `Claude-Session: https://claude.ai/code/session_<id>`. The
+   session link is the useful provenance: it reaches the reasoning behind the
+   diff, which a model name alone does not. Omit the trailer entirely for
+   commits authored without Claude.
 
 **Output**: raw commit message text only — no markdown fences, no preamble, no meta-commentary.

--- a/crates/rlevo-evolution/src/algorithms/mod.rs
+++ b/crates/rlevo-evolution/src/algorithms/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! - [`eda`] — [`EdaStrategy`](eda::EdaStrategy) over a
 //!   [`ProbabilityModel`](crate::ProbabilityModel): UMDA, PBIL, compact-GA,
-//!   and a dependency-chain MIMIC model.
+//!   a dependency-chain MIMIC model, and a BIC-scored Bayesian network (BOA).
 //!
 //! # Hybrid / composite strategies
 //!

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs
@@ -9,6 +9,8 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use crate::algorithms::c51::projection::atom_spacing;
+
 /// Configuration for training a Categorical DQN (C51) agent.
 ///
 /// Holds all hyperparameters required to initialise and train a
@@ -92,9 +94,20 @@ pub struct C51TrainingConfig {
 
 impl C51TrainingConfig {
     /// Spacing between adjacent atoms: `(v_max − v_min) / (num_atoms − 1)`.
+    ///
+    /// Delegates to [`atom_spacing`] so the support this config builds and the
+    /// bin indices the categorical projection computes share one definition of
+    /// `Δz` — an ULP of disagreement between the two is enough to push a
+    /// scatter index off the end of the support.
+    ///
+    /// # Returns
+    /// The uniform atom spacing, or [`f32::NAN`] for a degenerate
+    /// `num_atoms < 2` (a spacing is undefined with fewer than two atoms).
+    /// [`Validate`] rejects such a config, but a struct literal can bypass the
+    /// builder, so this stays total rather than panicking (see issue #326).
     #[must_use]
     pub fn delta_z(&self) -> f32 {
-        (self.v_max - self.v_min) / (self.num_atoms.saturating_sub(1) as f32)
+        atom_spacing(self.v_min, self.v_max, self.num_atoms)
     }
 }
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/projection.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/projection.rs
@@ -25,6 +25,47 @@
 use burn::tensor::backend::Backend;
 use burn::tensor::{IndexingUpdateOp, Int, Tensor};
 
+/// Spacing `Δz` between adjacent atoms of a uniform categorical support.
+///
+/// `Δz = (v_max − v_min) / (num_atoms − 1)` — the single source of truth for
+/// the atom scale. Both the *construction* of the support tensor
+/// (`z_i = v_min + i · Δz`) and the *index* computation inside
+/// [`project_distribution`] must use this one function; two independent
+/// spellings of the same constant can disagree by an ULP and push a bin index
+/// off the end of the support.
+///
+/// Kept as a free function taking scalars (rather than a method on a config)
+/// so the projection operator stays usable by any distributional agent —
+/// C51 today, a future Rainbow tomorrow — without a config dependency.
+///
+/// # Arguments
+/// - `v_min`, `v_max`: support bounds `z_0` and `z_{N-1}`.
+/// - `num_atoms`: number of atoms `N`.
+///
+/// # Returns
+/// The uniform atom spacing. A support needs **at least two** atoms for a
+/// spacing to be defined; for `num_atoms < 2` this returns [`f32::NAN`] rather
+/// than panicking or dividing by zero, so the degeneracy propagates visibly
+/// instead of silently producing `±inf` coordinates. Callers that require a
+/// well-formed support validate `num_atoms >= 2` up front
+/// (`C51TrainingConfig::validate`, and the assertion in
+/// [`project_distribution`]).
+///
+/// # Examples
+/// ```
+/// use rlevo_reinforcement_learning::algorithms::c51::projection::atom_spacing;
+///
+/// assert!((atom_spacing(-10.0, 10.0, 51) - 0.4).abs() < 1e-6);
+/// assert!(atom_spacing(0.0, 1.0, 1).is_nan());
+/// ```
+#[must_use]
+pub fn atom_spacing(v_min: f32, v_max: f32, num_atoms: usize) -> f32 {
+    if num_atoms < 2 {
+        return f32::NAN;
+    }
+    (v_max - v_min) / (num_atoms as f32 - 1.0)
+}
+
 /// Projects the target distribution onto the fixed categorical support.
 ///
 /// # Parameters
@@ -41,6 +82,19 @@ use burn::tensor::{IndexingUpdateOp, Int, Tensor};
 ///
 /// # Returns
 /// A `(batch, num_atoms)` tensor of projected probabilities. Rows sum to ≈1.
+///
+/// # Panics
+/// - If `num_atoms < 2`. A categorical support needs at least two atoms for the
+///   `N-1` spacing denominator to be meaningful.
+/// - If the atom spacing `Δz = (v_max − v_min) / (N − 1)` is not finite and
+///   strictly positive — i.e. the support is degenerate (`v_max == v_min`) or
+///   inverted (`v_max < v_min`), or a bound is non-finite. This is *not*
+///   implied by `num_atoms >= 2`: a well-sized `num_atoms = 51` support with
+///   `v_min == v_max` gives `Δz = 0`, so `b = (Tz − v_min) / Δz` is `NaN`.
+///   `f32::clamp` propagates `NaN` rather than rescuing it, and `NaN as i32`
+///   saturates to `0`, which would collapse every atom index to zero and pile
+///   the whole distribution onto atom 0 — a silently corrupted target rather
+///   than an observable failure. The assertion converts that into a panic.
 #[allow(clippy::too_many_arguments)]
 pub fn project_distribution<B: Backend>(
     next_probs: Tensor<B, 2>,
@@ -59,7 +113,15 @@ pub fn project_distribution<B: Backend>(
     );
     assert!(num_atoms >= 2, "C51 requires at least two atoms");
     let device = next_probs.device();
-    let delta_z = (v_max - v_min) / (num_atoms as f32 - 1.0);
+    let delta_z = atom_spacing(v_min, v_max, num_atoms);
+    // A zero or non-finite spacing makes `b` NaN below; `clamp` propagates NaN
+    // and `NaN as i32` saturates to 0, so the projection would return a
+    // silently corrupted distribution with all mass on atom 0. Fail loudly.
+    assert!(
+        delta_z.is_finite() && delta_z > 0.0,
+        "C51 support must satisfy v_max > v_min with finite bounds \
+         (got v_min={v_min}, v_max={v_max}, num_atoms={num_atoms}, delta_z={delta_z})",
+    );
 
     // Broadcast each argument to (B, N).
     let rewards_bn: Tensor<B, 2> = rewards.unsqueeze_dim::<2>(1); // (B, 1)
@@ -72,7 +134,19 @@ pub fn project_distribution<B: Backend>(
     let tz = tz.clamp(v_min, v_max);
 
     // Continuous atom coordinate b ∈ [0, N-1], and its floor/ceil as Int.
+    //
+    // `tz` is already clamped to [v_min, v_max], so `b ∈ [0, N-1]` holds
+    // exactly in real arithmetic — Bellemare et al. 2017 Algorithm 1 states it
+    // as an inline assertion. It does *not* hold in IEEE-754: for many valid
+    // supports (e.g. v_min = -10, v_max = 0.1, N = 8) the f32 division rounds a
+    // few ULPs above N-1, so `ceil` yields index N and the scatter below
+    // indexes off the end of the support. Re-clamping `b` — not the derived
+    // indices — restores the invariant and keeps `u_f - b == 0` exact at the
+    // boundary, so the `l == u` mask below still carries the full mass. Same
+    // guard as CleanRL's `c51.py`. No-op for any support that does not round
+    // out of range.
     let b = (tz.sub_scalar(v_min)).div_scalar(delta_z);
+    let b = b.clamp(0.0, num_atoms as f32 - 1.0);
     let l_idx: Tensor<B, 2, Int> = b.clone().floor().int();
     let u_idx: Tensor<B, 2, Int> = b.clone().ceil().int();
 
@@ -106,7 +180,7 @@ mod tests {
         n: usize,
         device: &<B as burn::tensor::backend::BackendTypes>::Device,
     ) -> Tensor<B, 1> {
-        let delta = (v_max - v_min) / (n as f32 - 1.0);
+        let delta = atom_spacing(v_min, v_max, n);
         let data: Vec<f32> = (0..n).map(|i| v_min + (i as f32) * delta).collect();
         Tensor::from_data(TensorData::new(data, vec![n]), device)
     }
@@ -226,5 +300,155 @@ mod tests {
                 "row sum should be 1, got {s}: {row:?}"
             );
         }
+    }
+
+    /// Drives one clamped-to-`v_max` projection and returns the projected row.
+    ///
+    /// A reward far above `v_max` with `terminated = 1` forces `Tz ≡ v_max` for
+    /// every atom, which is exactly the `b == N-1` boundary where the f32
+    /// rounding defect bites.
+    fn project_saturated_row(v_min: f32, v_max: f32, n: usize, reward: f32) -> Vec<f32> {
+        assert!(
+            reward >= v_max,
+            "reward {reward} must saturate the support to force Tz = v_max",
+        );
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
+        let next_probs = Tensor::<B, 2>::from_data(
+            TensorData::new(vec![1.0_f32 / (n as f32); n], vec![1, n]),
+            &device,
+        );
+        let rewards = Tensor::<B, 1>::from_data(TensorData::new(vec![reward], vec![1]), &device);
+        let terminated =
+            Tensor::<B, 1>::from_data(TensorData::new(vec![1.0_f32], vec![1]), &device);
+        let support = make_support(v_min, v_max, n, &device);
+
+        let out = project_distribution(
+            next_probs, rewards, terminated, support, 0.99, v_min, v_max, n,
+        );
+        into_vec(out)
+    }
+
+    #[test]
+    fn projection_handles_f32_rounding_at_top_atom() {
+        // Regression, issue #180. On this *valid* support the continuous atom
+        // coordinate rounds to b = 7.000000477 > N-1 = 7, so `ceil(b) = 8`
+        // scattered off the end of a size-8 axis and panicked. Note the
+        // default support (-10, 10, 51) cannot catch this: it lands on 50.0
+        // exactly, which is why the bug survived.
+        let v = project_saturated_row(-10.0, 0.1, 8, 5.0);
+
+        let s: f32 = v.iter().sum();
+        assert!(
+            (s - 1.0).abs() < 1e-5,
+            "row sum should be 1, got {s}: {v:?}"
+        );
+        assert!(
+            (v[7] - 1.0).abs() < 1e-5,
+            "clamped Tz = v_max should put all mass on the top atom, got {}",
+            v[7]
+        );
+        for (i, p) in v.iter().enumerate().take(7) {
+            assert!(*p < 1e-6, "atom {i} should be empty, got {p}");
+        }
+    }
+
+    #[test]
+    fn projection_handles_f32_rounding_on_symmetric_support() {
+        // Second known overflow from the #180 sweep: (-13, 13, 12) yields
+        // b = 11.000000954 against a max valid index of 11.
+        let v = project_saturated_row(-13.0, 13.0, 12, 100.0);
+
+        let s: f32 = v.iter().sum();
+        assert!(
+            (s - 1.0).abs() < 1e-5,
+            "row sum should be 1, got {s}: {v:?}"
+        );
+        assert!(
+            (v[11] - 1.0).abs() < 1e-5,
+            "clamped Tz = v_max should put all mass on the top atom, got {}",
+            v[11]
+        );
+    }
+
+    #[test]
+    fn projection_preserves_mass_across_overflowing_supports() {
+        // A spread of (v_min, v_max, N) triples from the #180 sweep, every one
+        // of which passes `C51TrainingConfig::validate` and every one of which
+        // panicked before the clamp. Mass must land wholly on the top atom.
+        let supports = [
+            (-10.0_f32, 0.1_f32, 8_usize),
+            (-13.0, 13.0, 12),
+            (-10.0, 0.1, 15),
+            (-0.1, 0.1, 12),
+            (-0.1, 0.2, 20),
+        ];
+
+        for (v_min, v_max, n) in supports {
+            let v = project_saturated_row(v_min, v_max, n, v_max + 1000.0);
+            let s: f32 = v.iter().sum();
+            assert!(
+                (s - 1.0).abs() < 1e-5,
+                "row sum should be 1 for ({v_min}, {v_max}, {n}), got {s}"
+            );
+            assert!(
+                (v[n - 1] - 1.0).abs() < 1e-5,
+                "top atom should hold all mass for ({v_min}, {v_max}, {n}), got {}",
+                v[n - 1]
+            );
+        }
+    }
+
+    /// Drives one projection on an arbitrary (possibly degenerate) support.
+    ///
+    /// Deliberately does *not* pre-validate `v_min`/`v_max`: the point is to
+    /// reach [`project_distribution`]'s own guard. Note `make_support` calls
+    /// `atom_spacing` too, so for a degenerate support the support tensor
+    /// itself is degenerate — the tests below assert on the panic *message* to
+    /// confirm the guard fired rather than some incidental failure.
+    fn project_on_support(v_min: f32, v_max: f32, n: usize) -> Vec<f32> {
+        let device: <B as burn::tensor::backend::BackendTypes>::Device = Default::default();
+        let next_probs = Tensor::<B, 2>::from_data(
+            TensorData::new(vec![1.0_f32 / (n as f32); n], vec![1, n]),
+            &device,
+        );
+        let rewards = Tensor::<B, 1>::from_data(TensorData::new(vec![0.0_f32], vec![1]), &device);
+        let terminated =
+            Tensor::<B, 1>::from_data(TensorData::new(vec![0.0_f32], vec![1]), &device);
+        let support = make_support(v_min, v_max, n, &device);
+
+        let out = project_distribution(
+            next_probs, rewards, terminated, support, 0.99, v_min, v_max, n,
+        );
+        into_vec(out)
+    }
+
+    #[test]
+    #[should_panic(expected = "C51 support must satisfy v_max > v_min")]
+    fn projection_rejects_degenerate_support_v_min_equals_v_max() {
+        // Δz = 0 ⇒ b = NaN ⇒ every index collapses to 0 and the whole
+        // distribution silently lands on atom 0. Must panic instead.
+        let _ = project_on_support(5.0, 5.0, 51);
+    }
+
+    #[test]
+    #[should_panic(expected = "C51 support must satisfy v_max > v_min")]
+    fn projection_rejects_inverted_support_v_min_greater_than_v_max() {
+        // Δz < 0 ⇒ the atom coordinate runs backwards; the support is not a
+        // valid ordered categorical support at all.
+        let _ = project_on_support(1.0, -1.0, 51);
+    }
+
+    #[test]
+    fn atom_spacing_matches_uniform_support_and_is_nan_when_degenerate() {
+        assert!((atom_spacing(-10.0, 10.0, 51) - 0.4).abs() < 1e-6);
+        assert!((atom_spacing(-1.0, 1.0, 3) - 1.0).abs() < 1e-6);
+        assert!(
+            atom_spacing(0.0, 1.0, 1).is_nan(),
+            "spacing is undefined for a single atom"
+        );
+        assert!(
+            atom_spacing(0.0, 1.0, 0).is_nan(),
+            "spacing is undefined for an empty support"
+        );
     }
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -376,7 +376,7 @@ Supplementary rules:
 
 | Dependency | Approved Usage | Forbidden |
 |------------|---------------|-----------|
-| `burn` | `TensorConvertible`, neural network models, backends (`wgpu`, `ndarray`) | Importing Burn in `rlevo-core` beyond trait bounds |
+| `burn` | `TensorConvertible`, neural network models, backends (`wgpu`, `flex`) | Importing Burn in `rlevo-core` beyond trait bounds |
 | `rand` | `rand::rng()` for thread-local RNG; `rng.random_range(0..n)` | `rand::thread_rng()` (deprecated) |
 | `rand_distr` | Advanced sampling distributions | Inline manual rejection sampling when a distribution exists |
 | `serde` | Derive `Serialize + Deserialize` on all domain types | Manual `impl Serialize` unless unavoidable |

--- a/docs/user-book/src/appendix-a-ec-algorithms/cuckoo-search.md
+++ b/docs/user-book/src/appendix-a-ec-algorithms/cuckoo-search.md
@@ -192,7 +192,7 @@ range — more than enough, since \\(\sigma_u\\) only scales the step.
 
 **Backend-parity caveat.** The fractional power \\(\lvert v\rvert^{1/\beta}\\) is
 sensitive to FMA reordering: wgpu reductions can drift \\(\sim 10^{-3}\\) relative
-from the `Flex`/ndarray path on the *same seed*. CS trajectories are therefore
+from the `Flex` CPU path on the *same seed*. CS trajectories are therefore
 not bit-identical across backends, and the backend-parity test relaxes its
 tolerance for CS accordingly. Within a single backend, runs are fully
 reproducible.
@@ -231,7 +231,7 @@ identical trajectories on a fixed backend.
 | Rugged multimodal landscape, exploration over precision | CS's Lévy jumps plus abandonment resist sticking in one basin; pair with a local refiner if you need precision |
 | Need high-precision convergence on a smooth landscape | [CMA-ES](cma-es.md) or [DE](differential-evolution.md) — CS has no gradient-biased update and plateaus early |
 | Strong variable dependencies | [CMA-ES](cma-es.md) — CS perturbs each coordinate independently |
-| Reproducible results across wgpu and ndarray backends | Be aware CS is **not** bit-identical across backends (the fractional-power caveat); use a single backend if exact parity matters |
+| Reproducible results across the `wgpu` and `Flex` backends | Be aware CS is **not** bit-identical across backends (the fractional-power caveat); use a single backend if exact parity matters |
 | Binary / combinatorial search | [Binary GA](binary-encoded-genetic-algorithm.md) — CS is defined over continuous nests |
 
 ---

--- a/docs/user-book/src/appendix-d-suppl/index.md
+++ b/docs/user-book/src/appendix-d-suppl/index.md
@@ -18,8 +18,9 @@
 (`ask`) and receives their scores (`tell`), without owning the evaluation step.
 See [The Ask/Tell Contract](ask-tell-contract.md) for the full treatment.
 
-**Backend.** A Burn trait that abstracts over CPU (`ndarray`), GPU (`wgpu`), and
-other compute targets. Algorithm code is generic over `B: Backend`.
+**Backend.** A Burn trait that abstracts over CPU (`Flex`), GPU (`wgpu`), and
+other compute targets. Algorithm code is generic over `B: Backend`. `rlevo`
+enables `wgpu` and `flex`; other Burn backends exist but are not wired up here.
 
 **Elitism.** Carrying the best \\(k\\) individuals from one generation to the
 next unchanged, guaranteeing that the best fitness never regresses.

--- a/docs/user-book/src/grid-agent.md
+++ b/docs/user-book/src/grid-agent.md
@@ -81,9 +81,9 @@ inverse: it checks the shape is `[3]`, reads the three values back, and rejects
 any byte that does not name a valid direction. The example exercises this contract
 end to end — it encodes an observation, decodes it, and asserts the result is
 unchanged, the same round-trip a policy depends on every step. Because the trait
-is generic over `B`, that one implementation serves the CPU `ndarray` backend, the
-`wgpu` GPU backend, or the `Flex` backend the example uses, with no change to the
-conversion logic.
+is generic over `B`, that one implementation serves the `Flex` CPU backend the
+example uses, the `wgpu` GPU backend, or any other Burn backend you wire up,
+with no change to the conversion logic.
 
 ## State — the full world
 

--- a/docs/user-book/src/part-1-foundations/50-why-combine.md
+++ b/docs/user-book/src/part-1-foundations/50-why-combine.md
@@ -95,7 +95,7 @@ apart rather than separate codebases:
 - Reproducible randomness derives from a single root seed through `seed_stream`,
   making a hybrid run — with all its interacting stochastic parts — exactly
   replicable.
-- The same algorithm code runs on CPU (via `ndarray`) and GPU (via `wgpu`)
+- The same algorithm code runs on CPU (via `Flex`) and GPU (via `wgpu`)
   without change.
 
 Part II puts all of this to work, and shows what the combination looks like in

--- a/docs/user-book/src/part-4-open-problems/01-where-rlevo-stands.md
+++ b/docs/user-book/src/part-4-open-problems/01-where-rlevo-stands.md
@@ -4,6 +4,11 @@
 contract. "Stable" below means *implemented, exercised by tests, and used in at
 least one benchmark or example* — not *frozen API*. APIs are still moving.
 
+Where an algorithm is implemented and tested but not yet exercised by a
+benchmark or example, we mark it **Implemented** rather than Stable. The
+distinction matters to you: a Stable entry has been run end-to-end on a real
+problem, an Implemented one has only been run against its own tests.
+
 For the full algorithm catalogue with derivations and configuration knobs, see
 [Appendix A (EC)](../appendix-a-ec-algorithms/index.md),
 [Appendix B (RL)](../appendix-b-rl-algorithms/index.md), and
@@ -20,7 +25,7 @@ For the full algorithm catalogue with derivations and configuration knobs, see
 | Evolution Strategies | Stable | `(1+1)`, `(1+λ)`, `(μ,λ)`, `(μ+λ)`; 1/5th rule and log-normal σ adaptation |
 | Differential Evolution | Stable | `Rand1Bin/Exp`, `Rand2Bin`, `Best1Bin`, `CurrentToBest1Bin`; greedy per-slot replacement |
 | Evolutionary Programming | Stable | Fogel-style; per-individual log-normal σ, q-tournament survivor selection |
-| CMA-ES / CMSA-ES | Planned | Covariance-matrix adaptation; tracked in [issue #59](https://github.com/anthonytorlucci/rlevo/issues/59) |
+| CMA-ES / CMSA-ES | Implemented | Covariance-matrix adaptation with self-contained strategy state ([ADR 0021](https://github.com/anthonytorlucci/rlevo/blob/main/docs/adr/0021-cma-es-placement-and-self-contained-strategy.md)); 43 tests including Sphere-d10 and Rastrigin-d10 convergence. Not yet *Stable* by the definition above — no benchmark or example exercises it, and it is reachable only as `rlevo::evo::algorithms::cma_es::CmaEs`, not from the crate root |
 
 **Estimation-of-distribution algorithms.** All share the `EdaStrategy`
 `fit → sample` driver; only the `ProbabilityModel` changes.
@@ -49,6 +54,16 @@ For the full algorithm catalogue with derivations and configuration knobs, see
 | ABC, Cuckoo Search, Firefly | Stable | Nature-inspired continuous metaheuristics |
 | GWO, WOA, Bat, SSA | Stable (legacy comparator) | Retained for comparison; see Sörensen (2015), Camacho-Villalón et al. (2023) |
 
+**Co-evolution.** Where a fitness function is not fixed but depends on the rest
+of the population — predator against prey, or a solution assembled from
+sub-populations — we drive evaluation through `CoEvolutionaryHarness` rather
+than a plain fitness call.
+
+| Algorithm | Status | Notes |
+| --------- | ------ | ----- |
+| Competitive co-evolution | Stable | `CompetitiveCoEA`; `HallOfFameFitness` guards against cyclic forgetting |
+| Cooperative co-evolution | Stable | `CooperativeCoEA`; `CoupledFitness` composes a full solution from per-species partials |
+
 ### Reinforcement learning (`rlevo::rl`)
 
 All eight agents have integration tests and benchmark harnesses.
@@ -64,32 +79,51 @@ All eight agents have integration tests and benchmark harnesses.
 | TD3 | Stable | Off-policy, continuous; twin critics, target-policy smoothing, delayed updates |
 | SAC | Stable | Off-policy, continuous; squashed-Gaussian actor, twin critics, auto-tuned temperature α |
 
+### Hybrid strategies (`rlevo::hybrid`)
+
+Evolution and RL meet here and nowhere else. `rlevo-evolution` never depends on
+`rlevo-core`, so anything that couples a strategy to an
+[`Environment`](https://docs.rs/rlevo-core) rollout lives in this crate — the
+boundary is deliberate, and it is what keeps the pure-EC side usable without
+dragging in the RL stack.
+
+| Component | Status | Notes |
+| --------- | ------ | ----- |
+| `RolloutFitness` | Stable | Scores a population of flat policy parameters by running episodes against an `Environment` |
+| `PolicyNeuroevolution` | Stable | Pairs a `WeightOnly` strategy with `RolloutFitness` inside an `EvolutionaryHarness` |
+| `StatefulPolicy` / `ReactivePolicy` | Stable | The recurrent rollout contract, and its memoryless `Hidden = ()` convenience |
+
 ### Environments (`rlevo::envs`)
 
 | Family | Environments |
 | ------ | ------------ |
-| Classic control | CartPole, Acrobot, MountainCar, MountainCarContinuous, Pendulum |
+| Classic control | CartPole, Acrobot, MountainCar, MountainCarContinuous, Pendulum, Santa Fe Ant Trail |
 | Box2D | LunarLander, BipedalWalker, CarRacing |
+| Board games | Chess, Connect Four |
 | Locomotion (MuJoCo-style) | InvertedPendulum, InvertedDoublePendulum, Reacher, Swimmer |
 | Grid worlds | Empty, FourRooms, DoorKey, MultiRoom, LavaGap, Crossing, DynamicObstacles, Memory, Unlock(+Pickup), GoToDoor, DistShift |
 | Toy text | FrozenLake, CliffWalking, Taxi, Blackjack |
-| K-Armed Bandit | Stationary and non-stationary variants |
+| K-Armed Bandit | Stationary, non-stationary, adversarial, and contextual variants |
 | Landscapes | Sphere, Rastrigin, Rosenbrock, Ackley, Griewank, Schwefel, Michalewicz, Concatenated Trap, and ~15 more (see Appendix D) |
 
 ## Known gaps and limitations
 
 **DQN on LunarLander.** A DQN agent trained on LunarLander for 150,000 steps
-performed worse than random. The implementation is believed correct (it learns
-CartPole, Acrobot, and grid tasks); the root cause is insufficient
-hyperparameter tuning and training budget. This benchmark is deferred pending a
-proper tuning effort — DQN itself is not in question.
+settled into a degenerate hovering policy and scored worse than random. The
+implementation is believed correct — it learns CartPole, Acrobot, and the grid
+tasks — so DQN itself is not in question.
+
+We originally attributed this to insufficient tuning and training budget, and
+that attribution is no longer safe to state as fact: the measurement predates
+the fix to LunarLander's crash-termination reward
+([issue #122](https://github.com/anthonytorlucci/rlevo/issues/122)), where
+crashes failed to terminate the episode and could net positive reward. An agent
+that learned to hover is exactly what that reward signal would have selected
+for. The benchmark needs re-running against the corrected environment before
+any cause is assigned ([issue #270](https://github.com/anthonytorlucci/rlevo/issues/270)).
 
 **Multi-objective optimisation.** `rlevo` does not implement NSGA-II or any
 Pareto-based selection. Single-objective only.
-
-**Covariance-matrix adaptation.** CMA-ES / CMSA-ES are not yet implemented
-([issue #59](https://github.com/anthonytorlucci/rlevo/issues/59)). For problems
-with strong variable dependencies, this is the most-missed strategy.
 
 **Distributed evaluation.** Population evaluation is parallelised locally via
 `rayon`. There is no built-in support for distributing evaluation across
@@ -108,7 +142,14 @@ for where it is discussed alongside the fix it does not replace.
 **Reproducibility with GPU backends.** The `wgpu` backend uses GPU kernels whose
 non-determinism can break exact reproducibility even with a fixed seed.
 Deterministic runs require both a seeded backend RNG and pinning `rayon` to a
-single thread; the `ndarray` backend is fully deterministic.
+single thread — `rayon`'s work-stealing changes reduction order, and the CPU
+path (`burn-flex`) parallelises its GEMM through it. The examples do exactly
+this; see the note in `crates/rlevo-examples/Cargo.toml`.
+
+We enable the `wgpu` and `flex` Burn backends only. Burn's `ndarray` backend is
+*not* wired up in this workspace, so it is not an option you can reach for
+today — if you need a deterministic CPU run, pin `rayon` on `flex` rather than
+switching backend.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes a `scatter` panic in the C51 categorical projection caused by IEEE-754 rounding: for supports where `(v_max - v_min) / (num_atoms - 1)` is not exactly representable in `f32`, a `tz` value clamped to exactly `v_max` can compute `b = (tz - v_min) / delta_z` marginally above `num_atoms - 1`, so `ceil(b)` yields `num_atoms` and indexes one past the end of the distribution tensor. The fix clamps `b` to `[0, num_atoms - 1]` after the division — the same guard CleanRL carries, and consistent with Bellemare et al. (2017) Algorithm 1, which asserts `bj ∈ [0, N-1]` as an invariant that holds exactly in ℝ but not under floating-point arithmetic.

While verifying the fix, a second and more serious defect was found in the same function and is fixed here: a degenerate support (`v_min == v_max`) gives `delta_z == 0`, so `b` is `NaN`; `f32::clamp` propagates `NaN`, and Rust's saturating float→int cast makes `NaN as i32 == 0`. The projection would return a **silently corrupted** distribution with all probability mass on atom 0 — no panic, no `NaN` in the output, nothing to notice. `project_distribution` is `pub` and re-exported and takes raw `f32` scalars, so it is reachable without any config object; it now asserts on non-finite or non-positive spacing.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #180

## What Was Changed

- `crates/rlevo-reinforcement-learning/src/algorithms/c51/projection.rs`
  - Added `pub fn atom_spacing(v_min, v_max, num_atoms) -> f32` as the single source of truth for support spacing; returns `f32::NAN` for `num_atoms < 2`.
  - Clamped `b` to `[0.0, num_atoms as f32 - 1.0]` before `floor`/`ceil` — the actual defect fix.
  - Added an assertion that `delta_z` is finite and positive, with a message naming `v_min`, `v_max`, `num_atoms`, and `delta_z`.
  - Left the `l == u` mask logic byte-for-byte unchanged; it handles a different (already-correct) edge case.
- `crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs`
  - `delta_z()` now delegates to `atom_spacing`. This is load-bearing, not cosmetic: `c51_agent.rs:247` uses `delta_z()` to build the actual support tensor, so support construction and index scale were two independent sources of truth that could disagree.
- `CHANGELOG.md` — Added/Changed/Fixed entries under `[Unreleased]`, including the `delta_z()` behaviour change for `num_atoms < 2` (previously `±inf`, now `NaN`).
- `docs/user-book/` (7 files) and `docs/rules.md` — realigned the project-status page with the codebase and corrected stale `ndarray` backend references to `Flex`. See Notes.

## How It Was Tested

```
cargo build --workspace                      # clean
cargo test --workspace                       # 0 failed
cargo clippy --all-targets --all-features    # no warnings
```

Regression tests added in `projection.rs`:

| Test | Covers |
|---|---|
| `projection_handles_f32_rounding_at_top_atom` | The reported reproducer, `(v_min=-10.0, v_max=0.1, num_atoms=8)` |
| `projection_handles_f32_rounding_on_symmetric_support` | Symmetric support `(-13.0, 13.0, 12)` |
| `projection_preserves_mass_across_overflowing_supports` | Mass conservation over 5 sweep-verified overflowing supports |
| `projection_rejects_degenerate_support_v_min_equals_v_max` | The `NaN` corruption path |
| `projection_rejects_inverted_support_v_min_greater_than_v_max` | Negative spacing |
| `atom_spacing_matches_uniform_support_and_is_nan_when_degenerate` | The new helper, including the `num_atoms < 2` contract |

**Before/after.** On the previous code, `(-10.0, 0.1, 8)` panics in `burn-flex-0.21.0/src/ops/gather_scatter.rs:142` with `index 8 out of bounds for dimension of size 8`. All three rounding tests were mutation-checked: each fails with the clamp removed.

**Scope of the bug — the issue undercounts it.** A sweep over the config space found **165,092 of 3,786,300** valid supports trigger the overflow, not the 4,408 stated in the issue title.

**Why the existing tests missed it.** The suite used supports where `delta_z` happens to be exactly representable (e.g. `(-10, 10, 51)`), so `b` never overflowed.

**No lower-bound analogue exists.** A 321,300-combination sweep confirmed the `b < 0` case is structurally impossible: `tz` is clamped to `>= v_min` first, and `x - x == 0` is exact in IEEE-754. A test for it would be vacuous, so none was added.

**No sibling algorithm is affected.** There is no Rainbow or IQN in the workspace; QR-DQN has no projection step; these are the only two `scatter` calls in the workspace.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned via `rust-toolchain.toml`)
- Burn backend tested: `Flex` (CPU)
- OS: macOS 26.5.2 (aarch64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 4.8)**. Scope: **issue triage and literature reconciliation against Bellemare et al. (2017), the config-space sweep, the fix, the regression tests, and the documentation realignment. Every commit carries a `Claude-Session:` trailer linking the authoring session.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [ ] This PR addresses a single concern. — **see Notes**
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**The single-concern box is deliberately unchecked.** This branch carries two commits:

- `e9aae8c fix(c51): Clamp projection atom index to support` — the #180 fix.
- `8afe32b docs(user-book): Realign status page with the codebase` — unrelated documentation work done in the same session.

The docs commit is cleanly separable and touches no source outside one doc comment in `rlevo-evolution/src/algorithms/mod.rs`. Say the word and I will split it into its own PR so #180 lands as a single-concern bug fix.

**Follow-ups surfaced, not addressed here:**

- The user-book status page now distinguishes **Implemented** from **Stable**. CMA-ES/CMSA-ES are implemented (2,598 lines, 43 tests) but have no benchmark, no example, and no crate-root re-export, so they are listed as Implemented rather than Stable. Closing that gap is separate work.
- The DQN LunarLander result on the status page predates the #122 crash-termination fix, where crashes could net *positive* reward — plausibly the cause of the observed hovering policy. The page now states the cause as unknown pending a re-run rather than asserting it (#270). Settling that needs a benchmark run, not a docs edit.
- Issue #326 (config-struct encapsulation) was re-triaged during this work and retitled from `[rl]` to `[workspace]`: 19 of the 32 affected structs are in `rlevo-evolution`, which the old title hid. A separate claim in the linked review doc was **refuted** and annotated in place.
