### PR TITLE
fix(ppo): Remove dead max_grad_norm config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,42 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Breaking changes**
 
+- **`PpoTrainingConfig::max_grad_norm` removed — it was dead state advertising a
+  feature the crate does not have** (resolves #183). The field defaulted to
+  `0.5`, was validated as positive, and had a public builder setter, but nothing
+  in the workspace ever read it: `PpoAgent::update` and `PpgAgent` build their
+  optimizers from `clip_grad` alone. A user reading `max_grad_norm: 0.5` in the
+  default config reasonably concluded gradient clipping was on. It never was —
+  `clip_grad` is the only functional knob and it defaults to `None`, so **stock
+  PPO and PPG perform no gradient clipping whatsoever**.
+
+  PPG inherited the defect verbatim through `PpgConfig::ppo`, and the deletion
+  propagates to it automatically.
+
+  Setting `clip_grad` is *not* an equivalent substitute for what the field
+  claimed. Burn's `GradientClipping::Norm` rescales **each parameter tensor
+  independently** (`burn-optim`'s `clip_by_norm` takes the L2 norm of one
+  tensor; `SimpleOptimizerMapper` applies it per-parameter), whereas Huang et
+  al. detail #10 clips the **global** norm across the whole flattened parameter
+  vector. The per-tensor form neither bounds the global norm nor preserves the
+  gradient's direction, so wiring the old field into the optimizer would have
+  been a different algorithm wearing the documented name. True global-norm
+  clipping needs a reduction over `GradientsParams` before `step_with` and is
+  tracked separately in #328.
+
+  *Migration.* Delete any `.max_grad_norm(..)` builder call or struct-literal
+  field — the call sites fail to compile, which is the point, since they were
+  silently no-ops. To opt into per-tensor clipping, set `clip_grad`, but do not
+  record it as detail #10. No persisted data is affected.
+
+  Four doc sites that asserted the missing behavior were corrected: the crate
+  README's defaults table (which also miscited the detail as #11), both
+  `max_grad_norm` and `clip_grad` doc-comments in `ppo_config.rs`, and the
+  `ppo/README.md` implementation-details table, where #10 moves from
+  "Implemented" to the documented-gaps list. The tests missed this because no
+  test asserted that a configured clip actually changes a gradient — the field
+  was only ever exercised through its own validator.
+
 - **GAE read episode done-ness one step late, mis-timing the bootstrap cut for
   *every* PPO/PPG run** (resolves #170, part 1). `RolloutBuffer::push_step`
   stores `obs[t]` alongside the status of the transition *out of* `obs[t]`, so

--- a/crates/rlevo-examples/examples/classic/report_ppo_cartpole_with_client.rs
+++ b/crates/rlevo-examples/examples/classic/report_ppo_cartpole_with_client.rs
@@ -259,10 +259,11 @@ pub fn build_agent(total_timesteps: usize) -> CartPoleAgent {
         .value_coef(0.5)
         .gamma(0.99)
         .gae_lambda(0.95)
-        // Global grad-norm clip of 0.5 (CleanRL default). The optimizer wraps
-        // both policy and value grads with this; without it, PPO can take
-        // destabilizing steps. NOTE: `max_grad_norm` is a separate, currently
-        // inert config field — `clip_grad` is the knob that actually clips.
+        // Gradient-norm clip at 0.5. `clip_grad` is the only clipping knob and
+        // is `None` (off) by default; without it PPO can take destabilizing
+        // steps. NOTE: Burn clips this **per tensor**, not across the global
+        // flattened parameter vector, so it is not CleanRL's detail #10
+        // global-norm clip. See issue #328.
         .clip_grad(Some(GradientClippingConfig::Norm(0.5)))
         .build()
         .expect("valid config");

--- a/crates/rlevo-reinforcement-learning/README.md
+++ b/crates/rlevo-reinforcement-learning/README.md
@@ -149,10 +149,15 @@ Default hyperparameters follow CleanRL's `ppo.py`:
 | `clip_value_loss` | true | Huang et al. #9 |
 | `entropy_coef` | 0.01 | CleanRL |
 | `value_coef` | 0.5 | CleanRL |
-| `max_grad_norm` | 0.5 | Huang et al. #11 |
+| `clip_grad` | `None` (no clipping) | — |
 | Adam `epsilon` | 1e-5 | Huang et al. #3 |
 
 `num_envs` is currently fixed at `1`; vectorised rollout is deferred.
+
+`clip_grad` is the only gradient-clipping knob and is **off by default**. Burn's
+`GradientClippingConfig::Norm` clips per tensor, not across the global flattened
+parameter vector, so setting it does not reproduce Huang et al. #10
+(global-norm clipping). True global-norm clipping is tracked in issue #328.
 
 **References**
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
@@ -801,3 +801,129 @@ where
         out
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::{Autodiff, Flex};
+    use burn::grad_clipping::GradientClippingConfig;
+    use burn::module::Module;
+    use burn::nn::{Linear, LinearConfig};
+    use burn::tensor::backend::Backend;
+    use rlevo_core::base::TensorConversionError;
+    use serde::{Deserialize, Serialize};
+
+    use crate::algorithms::ppg::policies::{
+        PpgCategoricalPolicyHead, PpgCategoricalPolicyHeadConfig,
+    };
+    use crate::algorithms::ppg::ppg_config::PpgConfigBuilder;
+    use crate::algorithms::ppo::ppo_config::PpoTrainingConfig;
+
+    type TestBackend = Autodiff<Flex>;
+    type TestAgent = PpgAgent<
+        TestBackend,
+        PpgCategoricalPolicyHead<TestBackend>,
+        TestValue<TestBackend>,
+        TestObs,
+        1,
+        2,
+    >;
+
+    /// Minimal scalar main-value head: `PpgAgent` requires a `PpoValue`
+    /// implementation and the crate ships no built-in one.
+    #[derive(Module, Debug)]
+    struct TestValue<B: Backend> {
+        head: Linear<B>,
+    }
+
+    impl<B: Backend> TestValue<B> {
+        fn init(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
+            Self {
+                head: LinearConfig::new(2, 1).init(device),
+            }
+        }
+    }
+
+    impl<B: AutodiffBackend> PpoValue<B, 2> for TestValue<B> {
+        fn forward(&self, obs: Tensor<B, 2>) -> Tensor<B, 1> {
+            self.head.forward(obs).squeeze_dim(1)
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestObs([f32; 2]);
+
+    impl Observation<1> for TestObs {
+        fn shape() -> [usize; 1] {
+            [2]
+        }
+    }
+
+    impl<B: Backend> TensorConvertible<1, B> for TestObs {
+        fn row_shape() -> [usize; 1] {
+            [2]
+        }
+
+        fn write_host_row(&self, buf: &mut Vec<f32>) {
+            buf.extend_from_slice(&self.0);
+        }
+
+        fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
+            let data = tensor.into_data().convert::<f32>();
+            let v = data.as_slice::<f32>().map_err(|_| TensorConversionError {
+                message: "non-float tensor".into(),
+            })?;
+            Ok(Self([v[0], v[1]]))
+        }
+    }
+
+    /// Builds an agent whose `config.ppo.clip_grad` is exactly `clip_grad`,
+    /// leaving every other knob at its default.
+    fn agent_with_clip_grad(clip_grad: Option<GradientClippingConfig>) -> TestAgent {
+        let device = Default::default();
+        let policy: PpgCategoricalPolicyHead<TestBackend> = PpgCategoricalPolicyHeadConfig {
+            obs_dim: 2,
+            hidden: 4,
+            num_actions: 2,
+        }
+        .init::<TestBackend>(&device);
+        let value = TestValue::<TestBackend>::init(&device);
+        let config = PpgConfigBuilder::new()
+            .with_ppo(|p| PpoTrainingConfig {
+                clip_grad: clip_grad.clone(),
+                ..p
+            })
+            .build()
+            .expect("valid config");
+        TestAgent::new(policy, value, config, device, 1).expect("valid config")
+    }
+
+    /// Regression (issue #183): PPG builds its optimizers from
+    /// `config.ppo.clip_grad` itself rather than delegating to `PpoAgent`, so
+    /// this wiring can rot independently of the PPO copy — assert it here too.
+    #[test]
+    fn clip_grad_none_leaves_both_optimizers_unclipped() {
+        let agent = agent_with_clip_grad(None);
+        assert!(
+            !agent.policy_optim.has_gradient_clipping(),
+            "clip_grad: None must leave the policy optimizer unclipped"
+        );
+        assert!(
+            !agent.value_optim.has_gradient_clipping(),
+            "clip_grad: None must leave the value optimizer unclipped"
+        );
+    }
+
+    #[test]
+    fn clip_grad_some_reaches_both_optimizers() {
+        let agent = agent_with_clip_grad(Some(GradientClippingConfig::Norm(0.5)));
+        assert!(
+            agent.policy_optim.has_gradient_clipping(),
+            "clip_grad: Some(..) must configure the policy optimizer"
+        );
+        assert!(
+            agent.value_optim.has_gradient_clipping(),
+            "clip_grad: Some(..) must configure the value optimizer"
+        );
+    }
+}

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/README.md
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/README.md
@@ -41,7 +41,6 @@ critical subset):
 | 7 | Clipped surrogate objective | `losses::clipped_surrogate` |
 | 8 | Clipped value loss | `losses::clipped_value_loss` |
 | 9 | Entropy bonus | `ppo_agent::PpoAgent::update` |
-| 10 | Global grad clip via optimizer | `PpoTrainingConfig::clip_grad` (optional) |
 | 12 | Separate policy / value networks | `PpoAgent` fields |
 | — | Early stop on target_kl | `PpoAgent::update` (threshold `1.5 · target_kl`) |
 | — | Gaussian log-prob summed across action dims | `gaussian::log_prob_entropy` |
@@ -51,6 +50,12 @@ critical subset):
 
 - #1 Vectorised architecture — sequential `num_envs = 1` in v1; vec-envs are
   a follow-up.
+- #10 Global gradient-norm clipping — **not implemented**.
+  `PpoTrainingConfig::clip_grad` is `None` by default (no clipping at all), and
+  when set, Burn's `GradientClippingConfig::Norm` rescales each parameter
+  tensor against its *own* L2 norm. Detail #10 requires rescaling against the
+  norm of the entire flattened parameter vector, which Burn's optimizer hook
+  cannot express. Tracked in issue #328.
 - #11 Vectorised reset handling — N/A while sequential.
 - Running observation normalization / returns-based reward scaling — a
   follow-up. Pendulum reward targets note the expected gap.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_agent.rs
@@ -617,3 +617,127 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::{Autodiff, Flex};
+    use burn::grad_clipping::GradientClippingConfig;
+    use burn::module::Module;
+    use burn::nn::{Linear, LinearConfig};
+    use burn::tensor::backend::Backend;
+    use rlevo_core::base::TensorConversionError;
+    use serde::{Deserialize, Serialize};
+
+    use crate::algorithms::ppo::policies::CategoricalPolicyHeadConfig;
+    use crate::algorithms::ppo::policies::categorical::CategoricalPolicyHead;
+    use crate::algorithms::ppo::ppo_config::PpoTrainingConfigBuilder;
+
+    type TestBackend = Autodiff<Flex>;
+    type TestAgent = PpoAgent<
+        TestBackend,
+        CategoricalPolicyHead<TestBackend>,
+        TestValue<TestBackend>,
+        TestObs,
+        1,
+        2,
+    >;
+
+    /// Minimal scalar value head: `PpoAgent` requires a `PpoValue`
+    /// implementation and the crate ships no built-in one.
+    #[derive(Module, Debug)]
+    struct TestValue<B: Backend> {
+        head: Linear<B>,
+    }
+
+    impl<B: Backend> TestValue<B> {
+        fn init(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
+            Self {
+                head: LinearConfig::new(2, 1).init(device),
+            }
+        }
+    }
+
+    impl<B: AutodiffBackend> PpoValue<B, 2> for TestValue<B> {
+        fn forward(&self, obs: Tensor<B, 2>) -> Tensor<B, 1> {
+            self.head.forward(obs).squeeze_dim(1)
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestObs([f32; 2]);
+
+    impl Observation<1> for TestObs {
+        fn shape() -> [usize; 1] {
+            [2]
+        }
+    }
+
+    impl<B: Backend> TensorConvertible<1, B> for TestObs {
+        fn row_shape() -> [usize; 1] {
+            [2]
+        }
+
+        fn write_host_row(&self, buf: &mut Vec<f32>) {
+            buf.extend_from_slice(&self.0);
+        }
+
+        fn from_tensor(tensor: Tensor<B, 1>) -> Result<Self, TensorConversionError> {
+            let data = tensor.into_data().convert::<f32>();
+            let v = data.as_slice::<f32>().map_err(|_| TensorConversionError {
+                message: "non-float tensor".into(),
+            })?;
+            Ok(Self([v[0], v[1]]))
+        }
+    }
+
+    /// Builds an agent whose `clip_grad` is exactly `clip_grad`, leaving every
+    /// other knob at its default.
+    fn agent_with_clip_grad(clip_grad: Option<GradientClippingConfig>) -> TestAgent {
+        let device = Default::default();
+        let policy: CategoricalPolicyHead<TestBackend> = CategoricalPolicyHeadConfig {
+            obs_dim: 2,
+            hidden: 4,
+            num_actions: 2,
+        }
+        .init::<TestBackend>(&device);
+        let value = TestValue::<TestBackend>::init(&device);
+        let config = PpoTrainingConfigBuilder::new()
+            .clip_grad(clip_grad)
+            .build()
+            .expect("valid config");
+        TestAgent::new(policy, value, config, device, 1).expect("valid config")
+    }
+
+    /// Regression (issue #183): `clip_grad` must reach *both* optimizers.
+    ///
+    /// The sibling field `max_grad_norm` was dead `pub` state that no lint
+    /// could catch — clippy's `dead_code` does not fire on unread `pub` fields
+    /// of `pub` types. Only a wiring assertion like this one closes that gap,
+    /// so assert the plumbing rather than Burn's `clip_by_norm` arithmetic.
+    #[test]
+    fn clip_grad_none_leaves_both_optimizers_unclipped() {
+        let agent = agent_with_clip_grad(None);
+        assert!(
+            !agent.policy_optim.has_gradient_clipping(),
+            "clip_grad: None must leave the policy optimizer unclipped"
+        );
+        assert!(
+            !agent.value_optim.has_gradient_clipping(),
+            "clip_grad: None must leave the value optimizer unclipped"
+        );
+    }
+
+    #[test]
+    fn clip_grad_some_reaches_both_optimizers() {
+        let agent = agent_with_clip_grad(Some(GradientClippingConfig::Norm(0.5)));
+        assert!(
+            agent.policy_optim.has_gradient_clipping(),
+            "clip_grad: Some(..) must configure the policy optimizer"
+        );
+        assert!(
+            agent.value_optim.has_gradient_clipping(),
+            "clip_grad: Some(..) must configure the value optimizer"
+        );
+    }
+}

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
@@ -46,18 +46,21 @@ pub struct PpoTrainingConfig {
     /// number of iterations.
     pub anneal_lr: bool,
 
-    /// Global gradient-norm clip applied to each loss.backward() result.
-    ///
-    /// CleanRL uses `0.5`.
-    pub max_grad_norm: f32,
-
     /// Underlying optimizer config. Adam epsilon defaults to `1e-5` when the
     /// agent is constructed.
     pub optimizer: AdamConfig,
 
-    /// Optional gradient-clipping config. When set, the Burn optimizer wraps
-    /// the grads with this clip. Independent of `max_grad_norm`, which is
-    /// applied manually in the agent loop.
+    /// Optional gradient-clipping config — the *only* gradient-clipping knob
+    /// on this config. Defaults to `None`, so **no clipping is applied unless
+    /// you set it**.
+    ///
+    /// When set, the Burn optimizer applies the clip during its update step.
+    /// Note that Burn's [`GradientClippingConfig::Norm`] clips **per tensor**:
+    /// each parameter's gradient is rescaled against its own L2 norm. It does
+    /// *not* rescale against the global norm of the flattened parameter
+    /// vector, so it does **not** reproduce Huang et al. detail #10
+    /// (global-norm clipping at `0.5`, as in CleanRL). True global-norm
+    /// clipping is tracked in issue #328.
     pub clip_grad: Option<GradientClippingConfig>,
 
     // ----- objective -----
@@ -128,7 +131,6 @@ impl Default for PpoTrainingConfig {
             update_epochs: 4,
             learning_rate: 2.5e-4,
             anneal_lr: true,
-            max_grad_norm: 0.5,
             optimizer: adam,
             clip_grad: None,
             gamma: 0.99,
@@ -159,7 +161,6 @@ impl Validate for PpoTrainingConfig {
         config::nonzero(C, "num_minibatches", self.num_minibatches)?;
         config::nonzero(C, "update_epochs", self.update_epochs)?;
         config::positive(C, "learning_rate", self.learning_rate)?;
-        config::positive(C, "max_grad_norm", f64::from(self.max_grad_norm))?;
         config::in_range(C, "gamma", 0.0, 1.0, f64::from(self.gamma))?;
         config::in_range(C, "gae_lambda", 0.0, 1.0, f64::from(self.gae_lambda))?;
         config::positive(C, "clip_coef", f64::from(self.clip_coef))?;
@@ -240,12 +241,6 @@ impl PpoTrainingConfigBuilder {
     /// Enables or disables linear learning-rate annealing to zero.
     pub fn anneal_lr(mut self, anneal_lr: bool) -> Self {
         self.config.anneal_lr = anneal_lr;
-        self
-    }
-
-    /// Sets [`PpoTrainingConfig::max_grad_norm`] (global gradient-norm clip).
-    pub fn max_grad_norm(mut self, max_grad_norm: f32) -> Self {
-        self.config.max_grad_norm = max_grad_norm;
         self
     }
 
@@ -367,6 +362,11 @@ mod tests {
         assert_eq!(cfg.clip_coef, 0.2);
         assert_eq!(cfg.gae_lambda, 0.95);
         assert_eq!(cfg.gamma, 0.99);
+        // CleanRL clips at norm 0.5, but rlevo ships clipping *off* by
+        // default; the docs must keep saying so. Asserted because the
+        // neighbouring dead `max_grad_norm` field (issue #183) made the
+        // default look like it was 0.5.
+        assert!(cfg.clip_grad.is_none());
     }
 
     #[test]
@@ -401,12 +401,18 @@ mod tests {
             .clip_coef(0.1)
             .entropy_coef(0.0)
             .action_scale(2.0)
+            .clip_grad(Some(GradientClippingConfig::Norm(0.5)))
             .build()
             .expect("valid config");
         assert_eq!(cfg.num_steps, 256);
         assert_eq!(cfg.clip_coef, 0.1);
         assert_eq!(cfg.entropy_coef, 0.0);
         assert_eq!(cfg.action_scale, 2.0);
+        // `GradientClippingConfig` is not `PartialEq`, so match on the variant.
+        match cfg.clip_grad {
+            Some(GradientClippingConfig::Norm(n)) => assert!((n - 0.5).abs() < 1e-6),
+            other => panic!("clip_grad did not round-trip through the builder: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`PpoTrainingConfig::max_grad_norm` defaulted to `0.5`, was validated as positive, and had a public builder setter — but nothing in the workspace ever read it. A user reading the default config reasonably concluded gradient clipping was on; it was not. The only functional knob is `clip_grad`, which defaults to `None`, so **stock PPO and PPG perform no gradient clipping at all**. This removes the dead field and corrects five doc sites that asserted the missing behaviour. It does not implement clipping — see Notes.

## Change Type

- [x] Bug fix (non-breaking, includes regression test) — *see caveat in Notes: this is API-breaking, and the regression test is class-preventive rather than literal*
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #183

Related: #328 (implement true global-norm clipping, or decide not to)

## What Was Changed

- `ppo/ppo_config.rs` — deleted the `max_grad_norm` field, its `Default` entry, its `config::positive` validator call, and the public `PpoTrainingConfigBuilder::max_grad_norm` setter. Rewrote the `clip_grad` doc-comment to state that it is the only clipping knob, defaults to `None` (no clipping), and clips **per tensor** rather than reproducing Huang et al. detail #10.
- `ppo/ppo_agent.rs` — added `#[cfg(test)] mod tests` (the file previously had none): `clip_grad_none_leaves_both_optimizers_unclipped` and `clip_grad_some_reaches_both_optimizers`, asserting via Burn's public `OptimizerAdaptor::has_gradient_clipping()` that a configured clip reaches both `policy_optim` and `value_optim`.
- `ppg/ppg_agent.rs` — the same two tests against PPG's own construction path.
- `ppo/ppo_config.rs` (tests) — extended `defaults_match_cleanrl` with `assert!(cfg.clip_grad.is_none())`; extended `builder_round_trips_fields` to set and assert `clip_grad` through the builder.
- `rlevo-reinforcement-learning/README.md` — removed the `| max_grad_norm | 0.5 | Huang et al. #11 |` defaults row, which advertised a nonexistent default *and* miscited the detail number (#11 is vectorised reset handling; grad clip is #10). Replaced with `clip_grad = None (no clipping)` plus a note on per-tensor semantics.
- `ppo/README.md` — moved detail #10 out of the implemented table into the "Deferred (documented gaps, not bugs)" list.
- `rlevo-examples/.../report_ppo_cartpole_with_client.rs` — corrected the comment at `:262`, which called Burn's per-tensor clip a "Global grad-norm clip".
- `CHANGELOG.md` — entry under `[Unreleased]` → `rlevo-reinforcement-learning` → **Breaking changes**, with migration.

**PPG required no config changes** — `PpgConfig` embeds `PpoTrainingConfig`, so the deletion propagated automatically.

## How It Was Tested

```
cargo build --workspace                      # clean
cargo test --workspace                       # 0 failures across all crates
cargo clippy --all-targets --all-features    # 0 warnings
cargo fmt --all --check                      # no drift
```

Also verified: a workspace-wide search for `max_grad_norm` across `*.rs`/`*.md`/`*.toml` returns only the CHANGELOG lines describing the removal.

**The new tests were mutation-checked, not assumed to bite.** Deleting the clip from PPO's `value_optim` fails `clip_grad_some_reaches_both_optimizers` with "must configure the value optimizer" while PPG stays green; deleting it from PPG's `policy_optim` fails only the PPG test. That asymmetry is the evidence that **PPG's optimizer construction is a genuinely separate code path, not a delegation** — the two can rot independently.

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`)
- Burn backend tested: `Autodiff<Flex>` (the crate's existing test-backend convention, matching `dqn_agent.rs` / `qrdqn_agent.rs`)
- OS: macOS 26.5.2 (Darwin, arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 4.8)**. Scope: **the entire change** — triage against the codebase, the deletion and doc corrections, the added tests, the CHANGELOG entry, and this PR description. Human-directed throughout; the Burn per-tensor finding was independently verified against vendored source before it was relied on.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. — **not literally satisfiable here; see Notes.**
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**This is an API-breaking change.** `PpoTrainingConfigBuilder::max_grad_norm` was `pub`. Any downstream `.max_grad_norm(..)` call or struct-literal field now fails to compile — loudly, which is the desired outcome given it was silently a no-op. *Migration:* delete the call. To opt into per-tensor clipping, set `clip_grad`, but do not record it as detail #10. No persisted data is affected. The `[Unreleased]` entry is filed under **Breaking changes** accordingly.

**On the unticked checklist item.** A literal regression test is not possible: the defect was a field that did *nothing*, and the fix *deletes* it, so there is no behaviour to pin. The tests added instead cover `clip_grad` — the field that does work and had **zero** test coverage — so the same class of bug cannot recur silently on the knob that remains.

**Why this survived two review passes, which is the more useful finding.** Clippy's `dead_code` lint does not fire on unread `pub` fields of `pub` types; they are presumed downstream API surface. No compiler or lint gate would have caught this, and none will catch the next one. Worth considering as a standing review rule for this crate: any new `pub` field on a `*TrainingConfig` should ship with a test exercising its *effect* on agent construction or behaviour, not merely a default-value or round-trip assertion.

**"Just wire `max_grad_norm` into the optimizer" was considered and rejected.** Burn's `GradientClipping::Norm` is per-tensor: `burn-optim-0.21.0/src/grad_clipping/base.rs` `clip_by_norm` takes the L2 norm of a single tensor, and `SimpleOptimizerMapper` (`optim/simple/adaptor.rs:83-85`) applies it per-parameter. Huang et al. detail #10 clips the **global** norm across the whole flattened parameter vector. The per-tensor form neither bounds the global norm nor preserves the gradient's direction, so wiring the field up would have traded a lying doc for a lying implementation.

**Follow-up: #328 owns the remaining gap.** Default PPO/PPG still perform no gradient clipping. Whether rlevo wants detail #10 parity is a product decision, not a bug, and is deliberately out of scope here — the docs needed to stop claiming the feature regardless of whether it is ever built. Note that defaulting `clip_grad` to `Some(Norm(0.5))` is *not* a safe stopgap: per-tensor semantics would make it look like #10 parity while behaving differently, recreating this defect with real training consequences.
