### PR TITLE
fix(ppo): Fire PPO/PPG progress logs on a step watermark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,48 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **PPO/PPG progress logging fired at `lcm(num_steps, log_every)`, not
+  `log_every` — and not at all for plausible configs** (resolves #321). Both
+  loops gated on `global_step.is_multiple_of(log_every)`, but the check sits
+  *after* the inner rollout `for` loop, so `global_step` was only ever observed
+  at multiples of `num_steps` (default `128`). Logging therefore required
+  `log_every` to divide the rollout stride. With `log_every = 100` the first
+  line landed at step 3200 instead of 100 — 32× too sparse — and with
+  `log_every = 500` at step 16000, so any run shorter than that emitted
+  **nothing at all**, silently, while the rustdoc promised "a progress line
+  every this many global steps". The six off-policy loops were never affected:
+  they check `(step + 1) % log_every == 0` *inside* the step loop.
+
+  The trigger is now a last-logged watermark
+  (`global_step − last ≥ log_every`), which is robust to the stride instead of
+  depending on divisibility. It stays at the rollout boundary by necessity —
+  the log payload reports `PpoUpdateStats` from `update()`, which does not
+  exist mid-rollout — so the realised cadence is bounded by
+  `[log_every, log_every + num_steps)` rather than being exactly `log_every`.
+  Rounding *up* to the next boundary is the deliberate choice: advancing the
+  watermark by `log_every` instead of to `global_step` would let it fall behind
+  and then fire on consecutive boundaries to catch up, which is burstier.
+
+  A second defect surfaced while fixing the first: because the final rollout is
+  usually partial, the terminal boundary can sit less than `log_every` past the
+  watermark and never fire, dropping the last `update()`'s statistics
+  (`total_timesteps = 10000, log_every = 500` logged last at 9728 and reported
+  nothing for 10000). Both loops now emit a final progress line when the run
+  ends, unless the boundary already logged it.
+
+  Existing tests missed all of this because nothing anywhere observed a log
+  line: there was no log-capture test in the workspace, and every integration
+  call site passed `log_every = 0`, so the trigger was pure control flow that
+  no assertion touched. Both halves are now closed. The decision itself moved
+  into a `LogWatermark` helper in `algorithms::shared` with direct unit tests,
+  and `crates/rlevo/tests/` gained `tracing`-subscriber capture tests for PPO
+  and PPG that run the real training loops with logging on and assert a line is
+  emitted, that the last one reports `total_timesteps`, and that spacing stays
+  within `[log_every, log_every + num_steps)`. Those tests were verified to
+  fail against the old gate — the first draft used a 700-step budget, which the
+  old divisibility check satisfied by coincidence at the terminal boundary, so
+  the run length is deliberately 650 (no boundary of which is a multiple of
+  `log_every = 100`). `log_every == 0` still disables logging.
 - **One non-finite gradient permanently bricked SAC's temperature controller for
   the rest of the run** (resolves #184). `LogAlpha::adam_step` folded
   `g = −(log π̄ + H̄)` straight into its hand-rolled Adam moments with no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6382,7 +6382,6 @@ dependencies = [
  "rlevo-test-support",
  "serde",
  "tempfile",
- "tracing",
  "tracing-subscriber",
 ]
 
@@ -6543,6 +6542,8 @@ dependencies = [
  "rlevo-core",
  "rlevo-environments",
  "serde",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6382,6 +6382,7 @@ dependencies = [
  "rlevo-test-support",
  "serde",
  "tempfile",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/train.rs
@@ -19,11 +19,12 @@ use rlevo_core::action::DiscreteAction;
 use rlevo_core::base::{Observation, Reward, TensorConvertible};
 use rlevo_core::environment::{Environment, Snapshot};
 
-use crate::algorithms::ppg::ppg_agent::{PpgAgent, PpgAgentError, PpgMetrics};
+use crate::algorithms::ppg::ppg_agent::{AuxPhaseStats, PpgAgent, PpgAgentError, PpgMetrics};
 use crate::algorithms::ppg::ppg_policy::PpgAuxValueHead;
 use crate::algorithms::ppo::ppo_agent::PpoUpdateStats;
 use crate::algorithms::ppo::ppo_policy::PpoPolicy;
 use crate::algorithms::ppo::ppo_value::PpoValue;
+use crate::algorithms::shared::LogWatermark;
 
 /// Run the PPG training loop against a **discrete** action environment.
 ///
@@ -45,7 +46,11 @@ use crate::algorithms::ppo::ppo_value::PpoValue;
 ///   shuffling.
 /// - `total_timesteps` — total environment steps to collect before returning.
 /// - `log_every` — emit a `tracing::info!` log line every this many global
-///   steps; pass `0` to disable logging.
+///   steps; pass `0` to disable logging. Progress can only be emitted at a
+///   rollout boundary (the payload reads the policy-phase and auxiliary-phase
+///   statistics), so a line lands at the first boundary at or after each
+///   `log_every` steps have elapsed — never less often, and at most once per
+///   rollout.
 ///
 /// # Errors
 ///
@@ -99,6 +104,16 @@ where
         min_log_std: None,
     };
     let mut global_step = 0_usize;
+    // Hoisted out of the loop so the terminal progress line can report the
+    // final iteration's auxiliary phase. Left loop-local it would be out of
+    // scope after the loop, and the closing line would claim `aux_ran = false`
+    // for a rollout that may well have run one.
+    let mut last_aux: Option<AuxPhaseStats> = None;
+    // Watermark, not `global_step % log_every`: the step counter is only
+    // sampled at rollout boundaries (multiples of `num_steps`), so a
+    // divisibility test would fire on `lcm(num_steps, log_every)` — see
+    // `LogWatermark` and issue #321.
+    let mut log_watermark = LogWatermark::new(log_every);
 
     while global_step < total_timesteps {
         for _ in 0..rollout_len {
@@ -168,33 +183,78 @@ where
         agent.finalize_rollout(snapshot.observation());
         agent.snapshot_into_aux_buffer();
         last_update_stats = agent.policy_phase_update(rng);
-        let aux = agent.maybe_aux_phase(rng);
+        last_aux = agent.maybe_aux_phase(rng);
 
-        if log_every > 0 && global_step.is_multiple_of(log_every) {
-            let avg = agent
-                .stats()
-                .avg_score()
-                .map(|v| format!("{v:.2}"))
-                .unwrap_or_else(|| "n/a".to_string());
-            tracing::info!(
-                step = global_step,
-                total_steps = total_timesteps,
-                iteration = agent.iteration(),
-                avg_reward = %avg,
-                policy_loss = last_update_stats.policy_loss,
-                value_loss = last_update_stats.value_loss,
-                entropy = last_update_stats.entropy,
-                approx_kl = last_update_stats.approx_kl,
-                clip_frac = last_update_stats.clip_frac,
-                aux_ran = aux.is_some(),
-                aux_value_loss = aux.map(|a| a.aux_value_loss).unwrap_or(0.0),
-                aux_policy_kl = aux.map(|a| a.policy_kl).unwrap_or(0.0),
-                "ppg training progress"
+        if log_watermark.should_log(global_step) {
+            emit_progress(
+                agent,
+                &last_update_stats,
+                last_aux,
+                global_step,
+                total_timesteps,
             );
         }
     }
 
+    // The final rollout is usually partial, so the last boundary can fall short
+    // of `log_every` past the watermark and never fire — which would drop the
+    // run's final policy- and auxiliary-phase stats. Report the terminal step
+    // unless it was already logged above.
+    if log_watermark.should_log_final(global_step) {
+        emit_progress(
+            agent,
+            &last_update_stats,
+            last_aux,
+            global_step,
+            total_timesteps,
+        );
+    }
+
     Ok(())
+}
+
+/// Emits one PPG progress event.
+///
+/// Factored out so the periodic in-loop line and the terminal line are
+/// literally the same event rather than two copies that drift apart. Kept as a
+/// free function rather than a closure because the loop needs `agent` mutably
+/// between calls, which an `agent`-capturing closure would forbid.
+///
+/// `aux` is the *most recent* iteration's auxiliary-phase result: `None` means
+/// the auxiliary buffer was not yet full on that iteration, which is the normal
+/// case for `n_iteration - 1` out of every `n_iteration` rollouts.
+fn emit_progress<B, P, V, O, const DO: usize, const DB: usize>(
+    agent: &PpgAgent<B, P, V, O, DO, DB>,
+    stats: &PpoUpdateStats,
+    aux: Option<AuxPhaseStats>,
+    global_step: usize,
+    total_timesteps: usize,
+) where
+    B: AutodiffBackend,
+    P: PpoPolicy<B, DB> + PpgAuxValueHead<B, DB>,
+    V: PpoValue<B, DB>,
+    O: Observation<DO> + TensorConvertible<DO, B>,
+{
+    let avg = agent
+        .stats()
+        .avg_score()
+        .map(|v| format!("{v:.2}"))
+        .unwrap_or_else(|| "n/a".to_string());
+    tracing::info!(
+        step = global_step,
+        total_steps = total_timesteps,
+        iteration = agent.iteration(),
+        avg_reward = %avg,
+        policy_loss = stats.policy_loss,
+        value_loss = stats.value_loss,
+        entropy = stats.entropy,
+        approx_kl = stats.approx_kl,
+        clip_frac = stats.clip_frac,
+        aux_ran = aux.is_some(),
+        aux_value_loss = aux.map_or(0.0, |a| a.aux_value_loss),
+        aux_policy_kl = aux.map_or(0.0, |a| a.policy_kl),
+        "ppg training progress"
+    );
 }
 
 /// Maps an [`EnvironmentError`](rlevo_core::environment::EnvironmentError)

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs
@@ -26,11 +26,15 @@ use rlevo_core::environment::{Environment, Snapshot};
 use crate::algorithms::ppo::ppo_agent::{PpoAgent, PpoAgentError, PpoMetrics, PpoUpdateStats};
 use crate::algorithms::ppo::ppo_policy::PpoPolicy;
 use crate::algorithms::ppo::ppo_value::PpoValue;
+use crate::algorithms::shared::LogWatermark;
 
 /// PPO training loop against a **discrete** action environment.
 ///
 /// Pass `log_every > 0` to enable periodic `tracing::info!` progress; set
-/// `log_every == 0` to suppress logging.
+/// `log_every == 0` to suppress logging. Progress can only be emitted at a
+/// rollout boundary (the payload reads the update statistics), so a line lands
+/// at the first boundary at or after each `log_every` steps have elapsed —
+/// never less often, and at most once per rollout.
 pub fn train_discrete<B, P, V, E, O, A, R, const DO: usize, const SD: usize, const DB: usize>(
     agent: &mut PpoAgent<B, P, V, O, DO, DB>,
     env: &mut E,
@@ -61,7 +65,8 @@ where
 /// [`PpoPolicy::raw_to_env_row`]) via [`ContinuousAction::from_slice`].
 ///
 /// Pass `log_every > 0` to enable periodic `tracing::info!` progress; set
-/// `log_every == 0` to suppress logging.
+/// `log_every == 0` to suppress logging. The cadence is the rollout-boundary
+/// one described on [`train_discrete`].
 pub fn train_continuous<
     B,
     P,
@@ -141,6 +146,11 @@ where
         min_log_std: None,
     };
     let mut global_step = 0_usize;
+    // Watermark, not `global_step % log_every`: the step counter is only
+    // sampled at rollout boundaries (multiples of `num_steps`), so a
+    // divisibility test would fire on `lcm(num_steps, log_every)` — see
+    // `LogWatermark` and issue #321.
+    let mut log_watermark = LogWatermark::new(log_every);
     let loop_start = Instant::now();
 
     while global_step < total_timesteps {
@@ -211,48 +221,90 @@ where
         agent.finalize_rollout(snapshot.observation());
         last_update_stats = agent.update(rng);
 
-        if log_every > 0 && global_step.is_multiple_of(log_every) {
-            let avg = agent
-                .stats()
-                .avg_score()
-                .map(|v| format!("{v:.2}"))
-                .unwrap_or_else(|| "n/a".to_string());
-            // Per-iteration episode-return statistics over the recent-episode
-            // window. Cheap: a handful of arithmetic ops on a bounded VecDeque,
-            // gated behind the periodic-log guard so the hot path is untouched.
-            let ret_stats = EpisodeReturnStats::from_window(&agent.stats().recent_history);
-            let elapsed = loop_start.elapsed().as_secs_f64();
-            let steps_per_sec = if elapsed > 0.0 {
-                global_step as f64 / elapsed
-            } else {
-                0.0
-            };
-            tracing::info!(
-                step = global_step,
-                total_steps = total_timesteps,
-                iteration = agent.iteration(),
-                avg_reward = %avg,
-                policy_loss = last_update_stats.policy_loss,
-                value_loss = last_update_stats.value_loss,
-                entropy = last_update_stats.entropy,
-                approx_kl = last_update_stats.approx_kl,
-                old_approx_kl = last_update_stats.old_approx_kl,
-                clip_frac = last_update_stats.clip_frac,
-                explained_variance = last_update_stats.explained_variance,
-                episode_return_mean = ret_stats.mean,
-                episode_return_std = ret_stats.std,
-                episode_return_min = ret_stats.min,
-                episode_return_max = ret_stats.max,
-                episode_length_mean = ret_stats.length_mean,
-                env_steps_sampled = global_step,
-                steps_per_sec = steps_per_sec,
-                learning_rate = agent.current_learning_rate(),
-                "ppo training progress"
+        if log_watermark.should_log(global_step) {
+            emit_progress(
+                agent,
+                &last_update_stats,
+                global_step,
+                total_timesteps,
+                loop_start,
             );
         }
     }
 
+    // The final rollout is usually partial, so the last boundary can fall short
+    // of `log_every` past the watermark and never fire — which would drop the
+    // run's final update stats. Report the terminal step unless it was already
+    // logged above.
+    if log_watermark.should_log_final(global_step) {
+        emit_progress(
+            agent,
+            &last_update_stats,
+            global_step,
+            total_timesteps,
+            loop_start,
+        );
+    }
+
     Ok(())
+}
+
+/// Emits one PPO progress event.
+///
+/// Factored out so the periodic in-loop line and the terminal line are
+/// literally the same event: with ~18 fields, two copies of the
+/// `tracing::info!` would drift the moment either is edited. Kept as a free
+/// function rather than a closure because the loop needs `agent` mutably
+/// between calls, which an `agent`-capturing closure would forbid.
+fn emit_progress<B, P, V, O, const DO: usize, const DB: usize>(
+    agent: &PpoAgent<B, P, V, O, DO, DB>,
+    stats: &PpoUpdateStats,
+    global_step: usize,
+    total_timesteps: usize,
+    loop_start: Instant,
+) where
+    B: AutodiffBackend,
+    P: PpoPolicy<B, DB>,
+    V: PpoValue<B, DB>,
+    O: Observation<DO> + TensorConvertible<DO, B>,
+{
+    let avg = agent
+        .stats()
+        .avg_score()
+        .map(|v| format!("{v:.2}"))
+        .unwrap_or_else(|| "n/a".to_string());
+    // Per-iteration episode-return statistics over the recent-episode window.
+    // Cheap: a handful of arithmetic ops on a bounded VecDeque, and only ever
+    // reached behind the periodic-log guard so the hot path is untouched.
+    let ret_stats = EpisodeReturnStats::from_window(&agent.stats().recent_history);
+    let elapsed = loop_start.elapsed().as_secs_f64();
+    let steps_per_sec = if elapsed > 0.0 {
+        global_step as f64 / elapsed
+    } else {
+        0.0
+    };
+    tracing::info!(
+        step = global_step,
+        total_steps = total_timesteps,
+        iteration = agent.iteration(),
+        avg_reward = %avg,
+        policy_loss = stats.policy_loss,
+        value_loss = stats.value_loss,
+        entropy = stats.entropy,
+        approx_kl = stats.approx_kl,
+        old_approx_kl = stats.old_approx_kl,
+        clip_frac = stats.clip_frac,
+        explained_variance = stats.explained_variance,
+        episode_return_mean = ret_stats.mean,
+        episode_return_std = ret_stats.std,
+        episode_return_min = ret_stats.min,
+        episode_return_max = ret_stats.max,
+        episode_length_mean = ret_stats.length_mean,
+        env_steps_sampled = global_step,
+        steps_per_sec = steps_per_sec,
+        learning_rate = agent.current_learning_rate(),
+        "ppo training progress"
+    );
 }
 
 /// Summary statistics over a window of recently completed episodes.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
@@ -1,7 +1,8 @@
 //! Shared infrastructure for the algorithm implementations in this module.
 //!
-//! Currently hosts [`Slot`], the network-ownership newtype every agent uses to
-//! hold a trainable network across a Burn optimizer step.
+//! Hosts [`Slot`], the network-ownership newtype every agent uses to hold a
+//! trainable network across a Burn optimizer step, and [`LogWatermark`], the
+//! progress-logging trigger shared by the on-policy training loops.
 //!
 //! # Why a `Slot` exists
 //!
@@ -217,6 +218,101 @@ impl<M> Slot<M> {
     {
         let module = self.0.take().expect(POISONED);
         self.0 = Some(opt.step(lr, module, grads));
+    }
+}
+
+/// Periodic progress-logging trigger for a loop that advances in strides.
+///
+/// Decides whether a training loop should emit its periodic `tracing` progress
+/// event at the current `global_step`, using a **last-logged watermark** rather
+/// than a divisibility test.
+///
+/// # Why a watermark and not `global_step % log_every == 0`
+///
+/// The on-policy loops (PPO, PPG) can only log at a **rollout boundary**: the
+/// payload reads the update statistics, which do not exist until after
+/// `update` / `policy_phase_update` has run at the end of an iteration. So the
+/// step counter is never observed at every value — it is only ever observed at
+/// multiples of `num_steps` (128 by default).
+///
+/// A divisibility test against a counter sampled on a stride fires on the
+/// *intersection* of the two schedules, i.e. every `lcm(num_steps, log_every)`
+/// steps — not every `log_every` steps. With `num_steps = 128` that silently
+/// turned `log_every = 100` into an effective cadence of 3200 (32× too sparse)
+/// and `log_every = 500` into 16 000 — so a 10 000-step run emitted **zero**
+/// progress lines despite asking for 20 (issue #321).
+///
+/// The watermark form has no such coupling: it fires as soon as at least
+/// `log_every` steps have elapsed since the previous log, whatever the stride,
+/// and then re-anchors on the step it actually fired at. The cadence degrades
+/// gracefully to "once per rollout" when `log_every` is smaller than the
+/// stride, which is the best any boundary-gated logger can do.
+///
+/// # Contract
+///
+/// - `every == 0` disables logging entirely — [`should_log`](Self::should_log)
+///   always returns `false`. This is documented public API on the `log_every`
+///   parameter of the training entry points (issue #174).
+/// - The watermark is monotonic: a given `global_step` fires at most once, so
+///   re-querying the same step (or a step that went backwards) cannot produce a
+///   duplicate log line.
+#[derive(Debug)]
+pub(crate) struct LogWatermark {
+    /// Requested cadence in global steps; `0` disables logging.
+    every: usize,
+    /// Global step at which the last log fired (`0` before the first).
+    last: usize,
+}
+
+impl LogWatermark {
+    /// Creates a watermark for a cadence of `every` global steps.
+    ///
+    /// Pass `0` to disable logging; see the type-level contract.
+    pub(crate) const fn new(every: usize) -> Self {
+        Self { every, last: 0 }
+    }
+
+    /// Returns `true` if a progress line is due at `global_step`, and if so
+    /// re-anchors the watermark on that step.
+    ///
+    /// Fires when at least `every` steps have elapsed since the previous log
+    /// (or since the start of the run). Uses a saturating difference so a
+    /// non-monotonic `global_step` can only under-fire, never panic.
+    pub(crate) fn should_log(&mut self, global_step: usize) -> bool {
+        if self.every == 0 {
+            return false;
+        }
+        if global_step.saturating_sub(self.last) >= self.every {
+            self.last = global_step;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns `true` if the run's terminal step still owes a progress line,
+    /// and if so re-anchors the watermark so it cannot fire again.
+    ///
+    /// The final rollout is usually **partial** — the collection loop breaks as
+    /// soon as `global_step >= total_timesteps`, so the last boundary lands on
+    /// an arbitrary step rather than a multiple of the stride. That boundary
+    /// can therefore sit less than `every` past the watermark and never trigger
+    /// [`should_log`](Self::should_log), silently dropping the final update's
+    /// statistics — the most interesting line of the run.
+    ///
+    /// Concretely, with `num_steps = 128` and `log_every = 500`, a
+    /// 10 000-step run logs at 9728 and then finishes at 10 000 with nothing
+    /// reported. Call this once after the loop to close that gap.
+    ///
+    /// Returns `false` when logging is disabled (`every == 0`) and when
+    /// `global_step` was already logged by the in-loop trigger, so the terminal
+    /// line is never a duplicate.
+    pub(crate) fn should_log_final(&mut self, global_step: usize) -> bool {
+        if self.every == 0 || global_step == self.last {
+            return false;
+        }
+        self.last = global_step;
+        true
     }
 }
 
@@ -504,6 +600,217 @@ mod tests {
         assert!(
             rendered.contains("TestNet"),
             "Debug must name the module type, got: {rendered}"
+        );
+    }
+
+    // -------- LogWatermark --------
+
+    /// Global steps a PPO/PPG loop actually observes: one sample per rollout
+    /// boundary, i.e. multiples of `stride`, up to and including `total`.
+    fn boundaries(stride: usize, total: usize) -> impl Iterator<Item = usize> {
+        (stride..=total).step_by(stride)
+    }
+
+    /// Global steps at which `watermark` fires over a strided run.
+    fn fire_steps(log_every: usize, stride: usize, total: usize) -> Vec<usize> {
+        let mut wm = LogWatermark::new(log_every);
+        boundaries(stride, total)
+            .filter(|&step| wm.should_log(step))
+            .collect()
+    }
+
+    #[test]
+    fn test_log_watermark_zero_never_fires() {
+        let fired = fire_steps(0, 128, 10_000);
+        assert!(
+            fired.is_empty(),
+            "log_every == 0 must disable logging entirely, but fired at {fired:?}"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_fires_when_every_is_coprime_with_stride() {
+        // Regression for #321: with the old `global_step % log_every == 0`
+        // test this fired only at lcm(128, 100) = 3200, 6400, ... — 32x too
+        // sparse. The watermark must fire at the first boundary at or past
+        // each 100-step mark.
+        let fired = fire_steps(100, 128, 1000);
+        assert_eq!(
+            fired,
+            vec![128, 256, 384, 512, 640, 768, 896],
+            "log_every = 100 on a 128 stride must fire once per rollout boundary"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_fires_within_ten_thousand_steps() {
+        // Regression for #321: log_every = 500 with a 128 stride produced ZERO
+        // lines in a 10k run under divisibility (first hit at lcm = 16 000).
+        let fired = fire_steps(500, 128, 10_000);
+        assert_eq!(
+            fired.first().copied(),
+            Some(512),
+            "the first log must land at the first boundary at or past step 500"
+        );
+        // 500 rounds up to the next boundary, so the realised spacing is 512
+        // and a 10 000-step run yields floor(10_000 / 512) = 19 lines — the
+        // requested ~20, versus zero before the fix.
+        assert_eq!(
+            fired.len(),
+            19,
+            "a 10k-step run at log_every = 500 must emit ~20 lines, got {fired:?}"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_smaller_than_stride_fires_once_per_boundary() {
+        // `log_every` below the rollout length cannot log more often than the
+        // loop reaches a boundary; it must not fire twice for one boundary.
+        let fired = fire_steps(10, 128, 640);
+        assert_eq!(
+            fired,
+            vec![128, 256, 384, 512, 640],
+            "a sub-stride cadence must saturate at one line per rollout boundary"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_divisor_of_stride_preserves_old_cadence() {
+        // `log_every` dividing the stride is the one case the old divisibility
+        // test got right; the watermark must not change it.
+        let fired = fire_steps(64, 128, 640);
+        let old_behaviour: Vec<usize> = boundaries(128, 640)
+            .filter(|step| step.is_multiple_of(64))
+            .collect();
+        assert_eq!(
+            fired, old_behaviour,
+            "an exact divisor of the stride must keep its pre-fix cadence"
+        );
+    }
+
+    /// Boundaries a loop actually reaches, including the **partial** final
+    /// rollout: collection breaks at `global_step >= total`, so the run always
+    /// ends exactly on `total`.
+    fn boundaries_with_partial_tail(stride: usize, total: usize) -> Vec<usize> {
+        let mut steps: Vec<usize> = boundaries(stride, total).collect();
+        if steps.last() != Some(&total) {
+            steps.push(total);
+        }
+        steps
+    }
+
+    /// Replays a whole run — in-loop triggers plus the one terminal check —
+    /// and returns every step that emitted a line.
+    fn fire_steps_full_run(log_every: usize, stride: usize, total: usize) -> Vec<usize> {
+        let mut wm = LogWatermark::new(log_every);
+        let steps = boundaries_with_partial_tail(stride, total);
+        let mut fired: Vec<usize> = steps
+            .iter()
+            .copied()
+            .filter(|&step| wm.should_log(step))
+            .collect();
+        if wm.should_log_final(total) {
+            fired.push(total);
+        }
+        fired
+    }
+
+    #[test]
+    fn test_log_watermark_final_zero_never_fires() {
+        let mut wm = LogWatermark::new(0);
+        assert!(
+            !wm.should_log_final(10_000),
+            "log_every == 0 must disable the terminal line too"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_final_skips_already_logged_terminal_step() {
+        let mut wm = LogWatermark::new(100);
+        assert!(wm.should_log(128), "the in-loop trigger must fire first");
+        assert!(
+            !wm.should_log_final(128),
+            "a terminal step the loop already logged must not be logged twice"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_final_recovers_dropped_terminal_line() {
+        // Both regressions from the follow-up review: the partial final
+        // rollout lands short of `every` past the watermark, so `should_log`
+        // declines and the run's last update stats would vanish.
+        let mut wm = LogWatermark::new(500);
+        for step in boundaries_with_partial_tail(128, 10_000) {
+            wm.should_log(step);
+        }
+        assert!(
+            wm.should_log_final(10_000),
+            "tt=10000 / le=500 must still report the terminal step (last in-loop line was 9728)"
+        );
+
+        let mut wm = LogWatermark::new(100);
+        for step in boundaries_with_partial_tail(128, 300) {
+            wm.should_log(step);
+        }
+        assert!(
+            wm.should_log_final(300),
+            "tt=300 / le=100 must still report the terminal step (last in-loop line was 256)"
+        );
+    }
+
+    #[test]
+    fn test_log_watermark_full_run_adds_at_most_one_final_line() {
+        // A full run emits floor(total / realised_spacing) in-loop lines plus
+        // at most one terminal line — never two for the same step.
+        for &(log_every, stride, total) in &[
+            (500_usize, 128_usize, 10_000_usize),
+            (100, 128, 300),
+            (128, 128, 1024), // `every` == stride: terminal step already logged
+            (64, 128, 640),   // exact divisor of the stride
+            (10, 128, 1000),  // sub-stride cadence
+        ] {
+            let fired = fire_steps_full_run(log_every, stride, total);
+            let mut deduped = fired.clone();
+            deduped.dedup();
+            assert_eq!(
+                fired, deduped,
+                "no step may be logged twice (le={log_every}, stride={stride}, tt={total})"
+            );
+            assert_eq!(
+                fired.last().copied(),
+                Some(total),
+                "every run must report its terminal step \
+                 (le={log_every}, stride={stride}, tt={total}), got {fired:?}"
+            );
+
+            let in_loop_only = fire_steps(log_every, stride, total).len();
+            assert!(
+                fired.len() <= in_loop_only + 1,
+                "the terminal line may add at most one entry \
+                 (le={log_every}, stride={stride}, tt={total}), got {fired:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_log_watermark_never_fires_twice_for_same_step() {
+        // `every` deliberately *divides* the boundary so this test isolates the
+        // dedup/monotonicity property. With a non-dividing `every` the opening
+        // `should_log` would already be exercising the #321 cadence bug, and a
+        // failure here would not tell us which property broke.
+        let mut wm = LogWatermark::new(64);
+        assert!(wm.should_log(128), "the first qualifying step must fire");
+        assert!(
+            !wm.should_log(128),
+            "re-querying the same global step must not emit a duplicate line"
+        );
+        assert!(
+            !wm.should_log(64),
+            "a step behind the watermark must not fire"
+        );
+        assert!(
+            wm.should_log(192),
+            "the watermark must re-arm once `every` steps have elapsed"
         );
     }
 }

--- a/crates/rlevo-test-support/Cargo.toml
+++ b/crates/rlevo-test-support/Cargo.toml
@@ -13,6 +13,11 @@ burn = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+# Backing for the `capture` module, which lets integration tests assert on the
+# `tracing` events a training loop emits (issue #321). Dev-only reach: this
+# crate is `publish = false` and consumed solely through `[dev-dependencies]`.
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 rlevo-core = { path = "../rlevo-core", version = "0.3.1" }
 rlevo-environments = { path = "../rlevo-environments", version = "0.3.1", default-features = false }
 

--- a/crates/rlevo-test-support/src/capture.rs
+++ b/crates/rlevo-test-support/src/capture.rs
@@ -1,0 +1,242 @@
+//! `tracing` event capture for tests that assert on *logging behaviour*.
+//!
+//! Most assertions in this workspace are about values an algorithm returns.
+//! A few are about what it **emits**: a training loop's periodic progress line
+//! is a documented part of its contract (`log_every`), and a loop can satisfy
+//! every numeric assertion while silently logging nothing at all. That is not
+//! hypothetical — issue #321 was exactly this failure: PPO/PPG gated progress
+//! on `global_step % log_every == 0` at a rollout boundary, so any `log_every`
+//! that did not divide `num_steps` fired on `lcm(num_steps, log_every)` and a
+//! short run emitted zero lines. Nothing panicked, no metric moved, and every
+//! existing test passed, because every call site passed `log_every = 0`.
+//!
+//! [`FieldCapture`] closes that class of gap: install it around a run, then
+//! assert on the field values the run actually emitted.
+//!
+//! # Scope
+//!
+//! This is a **test assertion tool**, not a logging framework. It collects one
+//! named integer field and nothing else — no span tracking, no formatting, no
+//! filtering DSL. If a test needs more than "which values of field `X` did this
+//! code emit, in order", it wants a real subscriber, not this.
+
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+
+/// Collects the values of one named integer field across every `tracing` event
+/// emitted while installed.
+///
+/// The captured values arrive in emission order, so a test can assert on both
+/// *whether* something was logged and the *cadence* it was logged at (the gap
+/// between consecutive values).
+///
+/// # Which fields are captured
+///
+/// Any event carrying a field with the configured name, recorded as an integer.
+/// `usize` and `u64` both arrive through `tracing`'s `record_u64`; every other
+/// field on the event is ignored, as are events without the named field.
+///
+/// Capture is deliberately **not** filtered by target or level. A test installs
+/// this around a specific call — the scope is the closure, not the process — so
+/// a target filter would add configuration without excluding anything the test
+/// did not already choose to run. Add one only if a test appears that genuinely
+/// needs to disambiguate two emitters.
+///
+/// # Examples
+///
+/// ```
+/// use rlevo_test_support::capture::FieldCapture;
+///
+/// let capture = FieldCapture::new("step");
+/// capture.record(|| {
+///     tracing::info!(step = 128_usize, "progress");
+///     tracing::info!(step = 256_usize, "progress");
+/// });
+/// assert_eq!(capture.values(), vec![128, 256]);
+/// ```
+///
+/// Asserting that a training loop logs at all, and that its final line reports
+/// the terminal step:
+///
+/// ```ignore
+/// let capture = FieldCapture::new("step");
+/// capture.record(|| {
+///     train_discrete(&mut agent, &mut env, &mut rng, TOTAL, LOG_EVERY).expect("training");
+/// });
+/// let steps = capture.values();
+/// assert!(!steps.is_empty(), "the run must emit at least one progress line");
+/// assert_eq!(steps.last().copied(), Some(TOTAL as u64));
+/// ```
+#[derive(Debug, Clone)]
+pub struct FieldCapture {
+    /// Name of the event field to collect.
+    field: &'static str,
+    /// Values seen so far, in emission order.
+    ///
+    /// Shared with the installed [`Layer`], which `tracing` requires to be
+    /// `Send + Sync`, hence the `Arc<Mutex<_>>` rather than a plain `Vec`.
+    values: Arc<Mutex<Vec<u64>>>,
+}
+
+impl FieldCapture {
+    /// Creates a capture for the event field named `field`.
+    ///
+    /// The capture starts empty and collects nothing until
+    /// [`record`](Self::record) installs it.
+    #[must_use]
+    pub fn new(field: &'static str) -> Self {
+        Self {
+            field,
+            values: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Runs `closure` with this capture installed as the default `tracing`
+    /// subscriber, returning the closure's value.
+    ///
+    /// Installation is scoped to the closure (`tracing::subscriber::with_default`)
+    /// and thread-local, so it neither leaks into later tests nor races other
+    /// tests in the same binary. Values accumulate across repeated calls; build
+    /// a fresh [`FieldCapture`] per assertion rather than clearing.
+    ///
+    /// Note that a `tracing` subscriber only observes events emitted on **this**
+    /// thread. Code under test that logs from a spawned thread will not be
+    /// captured.
+    pub fn record<T>(&self, closure: impl FnOnce() -> T) -> T {
+        let layer = CaptureLayer {
+            field: self.field,
+            values: Arc::clone(&self.values),
+        };
+        tracing::subscriber::with_default(tracing_subscriber::registry().with(layer), closure)
+    }
+
+    /// Returns the captured values, in emission order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock was poisoned by a panic inside a previous
+    /// [`record`](Self::record) call while the lock was held.
+    #[must_use]
+    pub fn values(&self) -> Vec<u64> {
+        self.values.lock().expect("capture lock poisoned").clone()
+    }
+}
+
+/// The [`Layer`] installed by [`FieldCapture::record`].
+///
+/// Separate from [`FieldCapture`] because `tracing` consumes the layer by value
+/// on install, while the test keeps the handle it reads results from.
+struct CaptureLayer {
+    field: &'static str,
+    values: Arc<Mutex<Vec<u64>>>,
+}
+
+impl<S: Subscriber> Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor {
+            field: self.field,
+            value: None,
+        };
+        event.record(&mut visitor);
+        if let Some(value) = visitor.value {
+            self.values
+                .lock()
+                .expect("capture lock poisoned")
+                .push(value);
+        }
+    }
+}
+
+/// Extracts a single named integer field from one event.
+///
+/// [`Visit`] requires `record_debug`, and every other `record_*` method
+/// defaults to delegating to it; overriding only `record_u64` therefore
+/// discards all non-integer fields, which is exactly the intent.
+struct FieldVisitor {
+    field: &'static str,
+    value: Option<u64>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == self.field {
+            self.value = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_capture_collects_named_field_in_emission_order() {
+        let capture = FieldCapture::new("step");
+        capture.record(|| {
+            tracing::info!(step = 128_usize, "first");
+            tracing::info!(step = 256_usize, "second");
+        });
+        assert_eq!(
+            capture.values(),
+            vec![128, 256],
+            "values must be collected in emission order"
+        );
+    }
+
+    #[test]
+    fn test_field_capture_ignores_events_without_the_field() {
+        let capture = FieldCapture::new("step");
+        capture.record(|| {
+            tracing::info!(step = 42_usize, "matching");
+            tracing::info!(other = 99_usize, "non-matching field");
+            tracing::info!("no fields at all");
+        });
+        assert_eq!(
+            capture.values(),
+            vec![42],
+            "only events carrying the named field may be captured"
+        );
+    }
+
+    #[test]
+    fn test_field_capture_ignores_non_integer_values() {
+        let capture = FieldCapture::new("step");
+        capture.record(|| {
+            tracing::info!(step = "not an integer", "string-valued");
+            tracing::info!(step = 7_usize, "integer-valued");
+        });
+        assert_eq!(
+            capture.values(),
+            vec![7],
+            "a same-named non-integer field must not be captured"
+        );
+    }
+
+    #[test]
+    fn test_field_capture_is_empty_when_nothing_is_emitted() {
+        let capture = FieldCapture::new("step");
+        capture.record(|| {});
+        assert!(
+            capture.values().is_empty(),
+            "a run that emits nothing must capture nothing"
+        );
+    }
+
+    #[test]
+    fn test_field_capture_does_not_observe_events_outside_record() {
+        let capture = FieldCapture::new("step");
+        tracing::info!(step = 1_usize, "before install");
+        capture.record(|| tracing::info!(step = 2_usize, "during"));
+        tracing::info!(step = 3_usize, "after install");
+        assert_eq!(
+            capture.values(),
+            vec![2],
+            "installation must be scoped to the `record` closure"
+        );
+    }
+}

--- a/crates/rlevo-test-support/src/lib.rs
+++ b/crates/rlevo-test-support/src/lib.rs
@@ -27,9 +27,13 @@
 //!   baseline a learning test must beat, instead of hard-coding it.
 //! - [`mod@assert`] — reward-finiteness, baseline, and reproducibility assertions
 //!   that standardise the per-algorithm acceptance checks.
+//! - [`capture`] — [`FieldCapture`](capture::FieldCapture), for tests that
+//!   assert on the `tracing` events a training loop emits rather than on the
+//!   values it returns.
 
 pub mod assert;
 pub mod baseline;
+pub mod capture;
 pub mod env;
 pub mod flex;
 mod macros;

--- a/crates/rlevo/Cargo.toml
+++ b/crates/rlevo/Cargo.toml
@@ -31,10 +31,6 @@ rand_distr = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 tempfile = "3"
-# `tracing` is needed alongside the subscriber for the PPO/PPG progress-logging
-# capture tests (issue #321), which implement a minimal `Layer` over the crate's
-# own event types. Dev-only: no shipped crate here logs.
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]

--- a/crates/rlevo/Cargo.toml
+++ b/crates/rlevo/Cargo.toml
@@ -31,6 +31,10 @@ rand_distr = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 tempfile = "3"
+# `tracing` is needed alongside the subscriber for the PPO/PPG progress-logging
+# capture tests (issue #321), which implement a minimal `Layer` over the crate's
+# own event types. Dev-only: no shipped crate here logs.
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -279,3 +279,127 @@ rl_learning_test! {
     run = run_cartpole,
     random = random_cartpole,
 }
+
+// ---------------------------------------------------------------------------
+// Progress-logging cadence (issue #321)
+// ---------------------------------------------------------------------------
+//
+// PPG shares the PPO watermark, so this is the twin of
+// `ppo_progress_logs_when_log_every_does_not_divide_num_steps` in
+// `ppo_integration.rs`. It is duplicated rather than shared because the two
+// live in separate test binaries and the capture layer is ~30 lines of
+// single-purpose scaffolding; promoting it to `rlevo-test-support` would mean
+// adding `tracing` deps there for two call sites.
+//
+// PPG is worth covering separately: its progress payload also reads the
+// auxiliary-phase result, which is loop-local and had to be hoisted so the
+// terminal line reports it rather than claiming `aux_ran = false`.
+
+/// Collects the `step` field of every captured `tracing` event.
+#[derive(Default)]
+struct StepVisitor {
+    step: Option<u64>,
+}
+
+impl tracing::field::Visit for StepVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "step" {
+            self.step = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+/// `tracing` layer that appends each event's `step` to a shared vector.
+struct StepCapture {
+    steps: std::sync::Arc<std::sync::Mutex<Vec<u64>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for StepCapture {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = StepVisitor::default();
+        event.record(&mut visitor);
+        if let Some(step) = visitor.step {
+            self.steps.lock().expect("capture mutex").push(step);
+        }
+    }
+}
+
+#[test]
+fn ppg_progress_logs_when_log_every_does_not_divide_num_steps() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // The canonical #321 configuration: `lcm(128, 100) = 3200`, so the old
+    // divisibility gate emitted ZERO lines for a run this short.
+    const NUM_STEPS: usize = 128;
+    const LOG_EVERY: usize = 100;
+    // Chosen so that no boundary of the run -- 128, 256, 384, 512, 640, 650 --
+    // is a multiple of `LOG_EVERY`. A total that happened to be a multiple of
+    // 100 would let the old gate fire on the terminal boundary by coincidence,
+    // making this test pass against the bug it exists to catch.
+    const TOTAL: usize = 650;
+    const SEED: u64 = 7;
+    // Small enough that the auxiliary phase actually fires during the run, so
+    // the hoisted `aux` is exercised rather than being `None` throughout.
+    const N_ITERATION: usize = 2;
+
+    let _guard = flex_guard();
+
+    let steps = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    let subscriber = tracing_subscriber::registry().with(StepCapture {
+        steps: std::sync::Arc::clone(&steps),
+    });
+
+    tracing::subscriber::with_default(subscriber, || {
+        let mut env = TimeLimit::new(cartpole_seeded(SEED), 500);
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let mut agent = make_cart_pole_agent(SEED, NUM_STEPS, TOTAL, N_ITERATION);
+        train_discrete::<Be, _, _, _, _, CartPoleAction, _, 1, 1, 2>(
+            &mut agent, &mut env, &mut rng, TOTAL, LOG_EVERY,
+        )
+        .expect("training");
+    });
+
+    let steps = steps.lock().expect("capture mutex").clone();
+
+    // (1) The literal #321 regression: zero lines under the old gate.
+    assert!(
+        !steps.is_empty(),
+        "a {TOTAL}-step PPG run with log_every = {LOG_EVERY} must emit at least one progress \
+         line, but emitted none (the old divisibility gate fired only on multiples of \
+         lcm({NUM_STEPS}, {LOG_EVERY}) = 3200)"
+    );
+
+    // (2) The terminal line: the run's final policy-phase stats must be
+    // reported even though the closing rollout is partial.
+    assert_eq!(
+        steps.last().copied(),
+        Some(TOTAL as u64),
+        "the final progress line must report the terminal step {TOTAL}, got {steps:?}"
+    );
+
+    // (3) Cadence: a boundary-gated logger cannot hit `log_every` exactly, but
+    // it must never fall a whole extra rollout behind it. The terminal line is
+    // exempt — it is deliberately early, by design.
+    let mut previous = 0_u64;
+    for &step in &steps[..steps.len() - 1] {
+        let gap = step - previous;
+        assert!(
+            gap >= LOG_EVERY as u64,
+            "progress lines must be at least log_every = {LOG_EVERY} steps apart, \
+             got a gap of {gap} at step {step} in {steps:?}"
+        );
+        assert!(
+            gap < (LOG_EVERY + NUM_STEPS) as u64,
+            "progress lines must never lag more than one rollout past log_every \
+             (< {}), got a gap of {gap} at step {step} in {steps:?}",
+            LOG_EVERY + NUM_STEPS
+        );
+        previous = step;
+    }
+}

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -31,6 +31,7 @@ use rlevo_reinforcement_learning::algorithms::ppo::ppo_value::PpoValue;
 
 use rlevo_test_support::assert::assert_all_finite;
 use rlevo_test_support::baseline::{random_return, uniform_discrete};
+use rlevo_test_support::capture::FieldCapture;
 use rlevo_test_support::env::cartpole_seeded;
 use rlevo_test_support::flex::{FlexAutodiff as Be, flex_guard, seeded_device};
 use rlevo_test_support::{TrainOutcome, rl_learning_test, rl_reproducibility_test};
@@ -286,54 +287,15 @@ rl_learning_test! {
 //
 // PPG shares the PPO watermark, so this is the twin of
 // `ppo_progress_logs_when_log_every_does_not_divide_num_steps` in
-// `ppo_integration.rs`. It is duplicated rather than shared because the two
-// live in separate test binaries and the capture layer is ~30 lines of
-// single-purpose scaffolding; promoting it to `rlevo-test-support` would mean
-// adding `tracing` deps there for two call sites.
+// `ppo_integration.rs`. The event-capture plumbing is shared via
+// `rlevo_test_support::capture::FieldCapture`.
 //
 // PPG is worth covering separately: its progress payload also reads the
 // auxiliary-phase result, which is loop-local and had to be hoisted so the
 // terminal line reports it rather than claiming `aux_ran = false`.
 
-/// Collects the `step` field of every captured `tracing` event.
-#[derive(Default)]
-struct StepVisitor {
-    step: Option<u64>,
-}
-
-impl tracing::field::Visit for StepVisitor {
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        if field.name() == "step" {
-            self.step = Some(value);
-        }
-    }
-
-    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
-}
-
-/// `tracing` layer that appends each event's `step` to a shared vector.
-struct StepCapture {
-    steps: std::sync::Arc<std::sync::Mutex<Vec<u64>>>,
-}
-
-impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for StepCapture {
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
-        let mut visitor = StepVisitor::default();
-        event.record(&mut visitor);
-        if let Some(step) = visitor.step {
-            self.steps.lock().expect("capture mutex").push(step);
-        }
-    }
-}
-
 #[test]
 fn ppg_progress_logs_when_log_every_does_not_divide_num_steps() {
-    use tracing_subscriber::layer::SubscriberExt;
-
     // The canonical #321 configuration: `lcm(128, 100) = 3200`, so the old
     // divisibility gate emitted ZERO lines for a run this short.
     const NUM_STEPS: usize = 128;
@@ -350,12 +312,8 @@ fn ppg_progress_logs_when_log_every_does_not_divide_num_steps() {
 
     let _guard = flex_guard();
 
-    let steps = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
-    let subscriber = tracing_subscriber::registry().with(StepCapture {
-        steps: std::sync::Arc::clone(&steps),
-    });
-
-    tracing::subscriber::with_default(subscriber, || {
+    let capture = FieldCapture::new("step");
+    capture.record(|| {
         let mut env = TimeLimit::new(cartpole_seeded(SEED), 500);
         let mut rng = StdRng::seed_from_u64(SEED);
         let mut agent = make_cart_pole_agent(SEED, NUM_STEPS, TOTAL, N_ITERATION);
@@ -365,7 +323,7 @@ fn ppg_progress_logs_when_log_every_does_not_divide_num_steps() {
         .expect("training");
     });
 
-    let steps = steps.lock().expect("capture mutex").clone();
+    let steps = capture.values();
 
     // (1) The literal #321 regression: zero lines under the old gate.
     assert!(

--- a/crates/rlevo/tests/ppo_integration.rs
+++ b/crates/rlevo/tests/ppo_integration.rs
@@ -443,3 +443,134 @@ rl_learning_test! {
     run = run_pendulum,
     random = random_pendulum,
 }
+
+// ---------------------------------------------------------------------------
+// Progress-logging cadence (issue #321)
+// ---------------------------------------------------------------------------
+//
+// The PPO loop can only log at a rollout boundary, so `global_step` is sampled
+// on a `num_steps` stride. The original gate was
+// `global_step % log_every == 0`, which fires on the *intersection* of the two
+// schedules — `lcm(num_steps, log_every)` — so any `log_every` that does not
+// divide `num_steps` silently logged far too rarely or (for a short run) never
+// at all. The fix is a last-logged watermark plus a terminal line.
+//
+// This test pins the wiring, not just the helper: that the watermark is
+// constructed from `log_every`, consulted at the rollout boundary, that
+// `emit_progress` is actually reached, and that the run's final step is
+// reported. Everything else in this suite passes `log_every = 0`, so without
+// it the whole logging path is unexercised.
+
+/// Collects the `step` field of every captured `tracing` event.
+///
+/// Deliberately minimal — not a general capture harness. `usize` fields arrive
+/// through `record_u64`; the other visit methods are no-ops because the ~18
+/// remaining fields of the progress event are irrelevant here.
+#[derive(Default)]
+struct StepVisitor {
+    step: Option<u64>,
+}
+
+impl tracing::field::Visit for StepVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "step" {
+            self.step = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+/// `tracing` layer that appends each event's `step` to a shared vector.
+struct StepCapture {
+    steps: std::sync::Arc<std::sync::Mutex<Vec<u64>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for StepCapture {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = StepVisitor::default();
+        event.record(&mut visitor);
+        if let Some(step) = visitor.step {
+            self.steps.lock().expect("capture mutex").push(step);
+        }
+    }
+}
+
+#[test]
+fn ppo_progress_logs_when_log_every_does_not_divide_num_steps() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // The canonical #321 configuration: a 128-step rollout stride with
+    // `log_every = 100`, which shares no useful factor with it. `lcm(128, 100)`
+    // is 3200, so the old gate emitted ZERO lines for this run.
+    const NUM_STEPS: usize = 128;
+    const LOG_EVERY: usize = 100;
+    // Not a multiple of the stride, so the final rollout is partial (boundaries
+    // at 128..640, then a 10-step tail) — which is exactly the case where the
+    // watermark alone would drop the closing line.
+    //
+    // It must also not be a multiple of `LOG_EVERY`: at 700 the old gate would
+    // fire on the terminal boundary by coincidence and this test would pass
+    // against the very bug it exists to catch. No boundary of this run --
+    // 128, 256, 384, 512, 640, 650 -- is a multiple of 100.
+    const TOTAL: usize = 650;
+    const SEED: u64 = 7;
+
+    let _guard = flex_guard();
+
+    let steps = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    let subscriber = tracing_subscriber::registry().with(StepCapture {
+        steps: std::sync::Arc::clone(&steps),
+    });
+
+    tracing::subscriber::with_default(subscriber, || {
+        let mut env = TimeLimit::new(cartpole_seeded(SEED), 500);
+        let mut rng = StdRng::seed_from_u64(SEED);
+        let mut agent = make_cart_pole_agent(SEED, NUM_STEPS, TOTAL);
+        train_discrete::<Be, _, _, _, _, CartPoleAction, _, 1, 1, 2>(
+            &mut agent, &mut env, &mut rng, TOTAL, LOG_EVERY,
+        )
+        .expect("training");
+    });
+
+    let steps = steps.lock().expect("capture mutex").clone();
+
+    // (1) The literal #321 regression: zero lines under the old gate.
+    assert!(
+        !steps.is_empty(),
+        "a {TOTAL}-step run with log_every = {LOG_EVERY} must emit at least one progress line, \
+         but emitted none (this is the #321 regression: the old divisibility gate fired only on \
+         multiples of lcm({NUM_STEPS}, {LOG_EVERY}) = 3200)"
+    );
+
+    // (2) The terminal line: the run's final update stats must be reported.
+    assert_eq!(
+        steps.last().copied(),
+        Some(TOTAL as u64),
+        "the final progress line must report the terminal step {TOTAL}, got {steps:?}"
+    );
+
+    // (3) Cadence: a boundary-gated logger cannot hit `log_every` exactly, but
+    // it must never fall a whole extra rollout behind it. The terminal line is
+    // exempt — it is deliberately early, by design.
+    let mut previous = 0_u64;
+    for &step in &steps[..steps.len() - 1] {
+        let gap = step - previous;
+        assert!(
+            gap >= LOG_EVERY as u64,
+            "progress lines must be at least log_every = {LOG_EVERY} steps apart, \
+             got a gap of {gap} at step {step} in {steps:?}"
+        );
+        assert!(
+            gap < (LOG_EVERY + NUM_STEPS) as u64,
+            "progress lines must never lag more than one rollout past log_every \
+             (< {}), got a gap of {gap} at step {step} in {steps:?}",
+            LOG_EVERY + NUM_STEPS
+        );
+        previous = step;
+    }
+}

--- a/crates/rlevo/tests/ppo_integration.rs
+++ b/crates/rlevo/tests/ppo_integration.rs
@@ -38,6 +38,7 @@ use rlevo_reinforcement_learning::algorithms::ppo::train::{train_continuous, tra
 
 use rlevo_test_support::assert::assert_all_finite;
 use rlevo_test_support::baseline::{random_return, uniform_bounded};
+use rlevo_test_support::capture::FieldCapture;
 use rlevo_test_support::env::cartpole_seeded;
 use rlevo_test_support::flex::{FlexAutodiff as Be, flex_guard, seeded_device};
 use rlevo_test_support::{TrainOutcome, rl_learning_test, rl_reproducibility_test};
@@ -461,49 +462,8 @@ rl_learning_test! {
 // reported. Everything else in this suite passes `log_every = 0`, so without
 // it the whole logging path is unexercised.
 
-/// Collects the `step` field of every captured `tracing` event.
-///
-/// Deliberately minimal — not a general capture harness. `usize` fields arrive
-/// through `record_u64`; the other visit methods are no-ops because the ~18
-/// remaining fields of the progress event are irrelevant here.
-#[derive(Default)]
-struct StepVisitor {
-    step: Option<u64>,
-}
-
-impl tracing::field::Visit for StepVisitor {
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        if field.name() == "step" {
-            self.step = Some(value);
-        }
-    }
-
-    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
-}
-
-/// `tracing` layer that appends each event's `step` to a shared vector.
-struct StepCapture {
-    steps: std::sync::Arc<std::sync::Mutex<Vec<u64>>>,
-}
-
-impl<S: tracing::Subscriber> tracing_subscriber::layer::Layer<S> for StepCapture {
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
-        let mut visitor = StepVisitor::default();
-        event.record(&mut visitor);
-        if let Some(step) = visitor.step {
-            self.steps.lock().expect("capture mutex").push(step);
-        }
-    }
-}
-
 #[test]
 fn ppo_progress_logs_when_log_every_does_not_divide_num_steps() {
-    use tracing_subscriber::layer::SubscriberExt;
-
     // The canonical #321 configuration: a 128-step rollout stride with
     // `log_every = 100`, which shares no useful factor with it. `lcm(128, 100)`
     // is 3200, so the old gate emitted ZERO lines for this run.
@@ -522,12 +482,8 @@ fn ppo_progress_logs_when_log_every_does_not_divide_num_steps() {
 
     let _guard = flex_guard();
 
-    let steps = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
-    let subscriber = tracing_subscriber::registry().with(StepCapture {
-        steps: std::sync::Arc::clone(&steps),
-    });
-
-    tracing::subscriber::with_default(subscriber, || {
+    let capture = FieldCapture::new("step");
+    capture.record(|| {
         let mut env = TimeLimit::new(cartpole_seeded(SEED), 500);
         let mut rng = StdRng::seed_from_u64(SEED);
         let mut agent = make_cart_pole_agent(SEED, NUM_STEPS, TOTAL);
@@ -537,7 +493,7 @@ fn ppo_progress_logs_when_log_every_does_not_divide_num_steps() {
         .expect("training");
     });
 
-    let steps = steps.lock().expect("capture mutex").clone();
+    let steps = capture.values();
 
     // (1) The literal #321 regression: zero lines under the old gate.
     assert!(


### PR DESCRIPTION
## Summary

PPO and PPG gated progress logging on `global_step.is_multiple_of(log_every)`, but the check sits *after* the inner rollout loop, so `global_step` was only ever observed at multiples of `num_steps`. The realised cadence was therefore `lcm(num_steps, log_every)`, not `log_every`: at the 128-step default, `log_every = 100` first logged at step **3200** and `log_every = 500` at **16000**, so any run shorter than that emitted **nothing at all** — silently, with no error, while the rustdoc promised "a progress line every this many global steps". This replaces the divisibility gate with a last-logged watermark that is robust to the rollout stride. The six off-policy loops check inside the step loop and were never affected.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #321

## What Was Changed

- `crates/rlevo-reinforcement-learning/src/algorithms/shared.rs` — added `pub(crate) struct LogWatermark` with `new`, `should_log`, and `should_log_final`, plus 10 unit tests. Fires when `global_step − last ≥ every`; `every == 0` still disables logging on both methods, preserving the documented public contract.
- `crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs` — swapped the gate for the watermark; extracted the 19-field `tracing::info!` payload into `fn emit_progress` so the in-loop and terminal call sites cannot drift; added the terminal call after the loop.
- `crates/rlevo-reinforcement-learning/src/algorithms/ppg/train.rs` — same, with `AuxPhaseStats` hoisted to a `last_aux` binding above the loop so the closing line reports the final iteration's aux phase rather than a stale one.
- `crates/rlevo/tests/ppo_integration.rs`, `crates/rlevo/tests/ppg_integration.rs` — added `tracing`-subscriber capture tests driving the real training loops with logging enabled.
- `crates/rlevo-test-support/src/capture.rs` — **new module** holding the capture layer, shared by both test binaries (5 unit tests + 1 doctest). Public surface is one type:

  ```rust
  pub struct FieldCapture;
  impl FieldCapture {
      pub fn new(field: &'static str) -> Self;
      pub fn record<T>(&self, closure: impl FnOnce() -> T) -> T;
      pub fn values(&self) -> Vec<u64>;
  }
  ```

  `record` scopes subscriber installation to a closure, so the plumbing the earlier copies leaked into each test body (`Arc<Mutex<Vec<u64>>>`, `registry()`, `SubscriberExt`, `with_default`) is now private and a caller cannot forget to bound it. `CaptureLayer` is a separate private type because `tracing` consumes the layer by value on install while the test keeps the handle it reads from.
- `crates/rlevo-test-support/Cargo.toml` — `tracing` + `tracing-subscriber` added. Nothing added to `rlevo-reinforcement-learning`.
- `CHANGELOG.md` — entry under `[Unreleased]` → `rlevo-reinforcement-learning` → **Fixed**.

### Two design points worth reviewer attention

**The watermark stays at the rollout boundary rather than moving inside the loop.** The issue suggested either; only one is possible. The log payload reports `PpoUpdateStats` from `update()`, which does not exist mid-rollout. Consequence: the realised cadence is bounded by `[log_every, log_every + num_steps)` rather than being exactly `log_every`. Rounding *up* to the next boundary is deliberate — advancing the watermark by `log_every` instead of to `global_step` would let it fall behind and then fire on consecutive boundaries to catch up, which is burstier.

**A second defect surfaced while fixing the first.** Because the final rollout is usually partial, the terminal boundary can sit less than `log_every` past the watermark and never fire, dropping the last `update()`'s statistics — `total_timesteps = 10000, log_every = 500` logged last at 9728 and reported nothing for 10000. Both loops now emit a closing line unless the boundary already logged it.

## How It Was Tested

```
cargo build --workspace          # Finished in 41.84s, no errors
cargo test --workspace           # all suites pass, 0 failed
cargo clippy --all-targets --all-features   # zero warnings
```

**Regression test (the before/after):** `ppo_progress_logs_when_log_every_does_not_divide_num_steps` and its PPG twin run a 650-step training run with `log_every = 100` against the 128-step stride, and assert (1) at least one line is emitted, (2) the last event's `step` equals `total_timesteps`, (3) spacing stays within `[log_every, log_every + num_steps)`. Both were verified **failing** against a reverted `should_log` (`global_step % every == 0`, terminal line disabled), on assertion (1) — "must emit at least one progress line, but emitted none", which is the literal #321 symptom.

The revert-verification was **re-run after** the capture layer moved to `rlevo-test-support` — moving assertion machinery is exactly when a test can quietly stop observing the thing it names. Both still fail on "emitted none", and the reinforcement-learning crate is byte-identical between the two commits.

⚠️ **The 650-step budget is load-bearing, not arbitrary.** The first draft used 700, which the *old* gate satisfied by coincidence at the terminal boundary (700 % 100 == 0) — so the test passed against the very bug it names. No boundary of a 650-step run (128, 256, 384, 512, 640, 650) is a multiple of 100. The constant carries a comment; please don't tidy it to a round number.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: CPU (default workspace test backend)
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): __Claude Code (Opus 4.8)__. Scope: __full diff — implementation, tests, and CHANGELOG entry — authored via delegated agents under maintainer direction, with the watermark-vs-in-loop design decision, the terminal-line defect, and the vacuous-test catch reviewed and verified by the maintainer. Workspace build/test/clippy run and confirmed locally.__

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

No public API change: `log_every: usize` and the `0`-disables contract are untouched, so this is behaviour-only for existing callers.

## Notes

- **On the two new dependencies.** The template flags new dependencies as out of scope during alpha, so calling this out explicitly: `tracing` and `tracing-subscriber` are existing `[workspace.dependencies]` entries, added by inheritance to `rlevo-test-support`, which is `publish = false` and consumed only by `rlevo` and `rlevo-examples`. Nothing reaches a published crate, and `rlevo-reinforcement-learning` is untouched. The capture layer was initially duplicated across the two test binaries; it was centralized on maintainer request (commit `8355a16`), which is what pulled the deps into the shared crate.
- **Pre-existing, not addressed here:** `tracing-subscriber` in `crates/rlevo/Cargo.toml:34` appears to be unused — nothing under `crates/rlevo/{src,tests,benches,examples}` references `tracing` at all, and that was true before this branch. It is left alone rather than folded into this diff, which is a behaviour fix and should not also be deleting deps from an unrelated crate. Filed separately as #356, where it is confirmed dead by building all targets under all features with the line removed (`--all-features` covers `viz-tui`/`viz-report`, ruling out the feature-gated path).
- **#174 is still blocked, and got worse.** Its item (c) (`log_every` 0-sentinel → `Option<NonZeroUsize>`) now has to change `LogWatermark`'s constructor and tests as well as the 8 public signatures. Triage comment posted there, along with corrections: the `0` sentinel is documented in **all 8** `train.rs` files rather than the 3 it cites, and all its line numbers are stale from pre-existing drift.
- **#325's headline claim is refuted** and it has been retitled and relabelled `bug` → `enhancement`. Empty minibatches are impossible (`mb_size` carries an outer `.max(1)`, `chunks()` never yields an empty slice, and explicit `is_empty` guards already exist at three sites) — verified across a 1000-config sweep. Its premise holds but the harm does not. Note for whoever picks it up: the log line lives in the same rollout-boundary block as `update()`, so naively skipping the partial-rollout update would also skip the closing line added here.
