### PR TITLE
fix(rl-utils): Mask bootstrap term on terminal transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **A non-finite `next_q_max` survived terminal transitions in
+  `compute_target_q_values`, defeating the terminal-bootstrap convention**
+  (resolves #192). The target was computed by *scaling* the bootstrap term,
+  `rewards + gamma * next_q_max * (1.0 - terminated)`, and because
+  `NaN * 0.0 == NaN` (as does `Inf * 0.0`), a poisoned `next_q_max` propagated
+  into the target on exactly the samples where the convention says the
+  bootstrap must vanish. The term is now genuinely masked to `0` wherever
+  `terminated == 1.0`, so a terminal target is the reward regardless of what
+  the next-state estimate holds.
+
+  This is hardening, not a repair of live divergence: the expression cannot
+  *originate* a NaN, and for all-finite inputs the new form is numerically
+  identical, so no algorithm's behaviour changes. It amplified a defect whose
+  only known trigger — SAC's alpha optimizer poisoning itself on a single
+  non-finite gradient — was fixed in #184. The existing tests missed it because
+  they only ever fed finite Q-values, where the two formulations agree
+  exactly. The four affected call sites are DQN, DDPG, TD3, and SAC; C51 and
+  QR-DQN never used this helper (they mask in their own projection step).
+
 - **PPO/PPG progress logging fired at `lcm(num_steps, log_every)`, not
   `log_every` — and not at all for plausible configs** (resolves #321). Both
   loops gated on `global_step.is_multiple_of(log_every)`, but the check sits

--- a/crates/rlevo-reinforcement-learning/src/utils.rs
+++ b/crates/rlevo-reinforcement-learning/src/utils.rs
@@ -26,13 +26,27 @@ use burn::tensor::{Tensor, TensorData};
 ///   in Reinforcement Learning", ICML 2018, Eq. 6 (partial-episode
 ///   bootstrapping), and Gymnasium's
 ///   `Q(s,a) = r + γ · ¬terminated · max_a' Q(s′,a')`.
+///
+/// # Non-finite hardening
+///
+/// The bootstrap term is **masked**, not scaled by `(1 − terminated)`. The two
+/// agree exactly for finite inputs, but scaling propagates poison: IEEE-754
+/// gives `NaN · 0.0 == NaN` and `inf · 0.0 == NaN`, so a single non-finite
+/// entry in `next_q_max` would survive a terminal transition and contaminate
+/// the target — the one place the algorithm has a guaranteed-correct value
+/// (the reward alone). Selecting on the terminal mask forces the bootstrap to
+/// be exactly `0` wherever `terminated == 1.0`, whatever `next_q_max` holds
+/// there. This is defensive only; it does not alter any target computed from
+/// finite inputs.
 pub fn compute_target_q_values<B: Backend>(
     rewards: Tensor<B, 1>,
     next_q_max: Tensor<B, 1>,
     terminated: Tensor<B, 1>,
     gamma: f32,
 ) -> Tensor<B, 1> {
-    rewards.clone() + gamma * next_q_max * (1.0 - terminated)
+    let is_terminal = terminated.equal_elem(1.0);
+    let bootstrap = next_q_max.mul_scalar(gamma).mask_fill(is_terminal, 0.0);
+    rewards + bootstrap
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +90,20 @@ impl<B: Backend> ModuleMapper<B> for PolyakMapper<B> {
 ///
 /// Used by every off-policy algorithm that maintains a target network (DQN,
 /// C51, QR-DQN, DDPG, TD3, SAC). Pass `tau = 1.0` for a hard copy.
+///
+/// Parameters are paired by [`ParamId`], not by position or name, so `target`
+/// must carry the *same* `ParamId`s as `active`.
+///
+/// # Panics
+///
+/// Panics if `target` holds a parameter whose [`ParamId`] is absent from
+/// `active` — that is, if the two modules were built independently rather than
+/// `target` being derived from `active`.
+///
+/// A fresh `init` mints new `ParamId`s, so two separately initialised networks
+/// never match even when their architecture and weights are identical. Build
+/// the target network by cloning the active one (`let target = active.clone();`)
+/// and it holds by construction; every in-tree agent does this.
 pub fn polyak_update<B: Backend, M: Module<B>>(active: &M, target: M, tau: f32) -> M {
     let mut collector = ParamCollector::<B> {
         tensors: HashMap::new(),
@@ -107,6 +135,120 @@ mod tests {
     /// this module is representable in binary floating point (the taus are
     /// dyadic), so this only absorbs backend reduction noise.
     const EPS: f32 = 1e-6;
+
+    // -----------------------------------------------------------------------
+    // compute_target_q_values
+    // -----------------------------------------------------------------------
+
+    /// Builds a rank-1 `f32` tensor on the default test device.
+    fn floats(values: &[f32]) -> Tensor<TestBackend, 1> {
+        Tensor::from_floats(values, &TestDevice::default())
+    }
+
+    /// Reads a rank-1 tensor back to host floats.
+    fn host(tensor: Tensor<TestBackend, 1>) -> Vec<f32> {
+        tensor
+            .to_data()
+            .to_vec::<f32>()
+            .expect("target tensor is f32 by construction")
+    }
+
+    /// The pre-hardening formula, kept verbatim as the reference oracle for
+    /// the "finite inputs are unchanged" test.
+    fn scaled_reference(
+        rewards: Tensor<TestBackend, 1>,
+        next_q_max: Tensor<TestBackend, 1>,
+        terminated: Tensor<TestBackend, 1>,
+        gamma: f32,
+    ) -> Tensor<TestBackend, 1> {
+        rewards + gamma * next_q_max * (1.0 - terminated)
+    }
+
+    #[test]
+    fn test_compute_target_q_values_masks_non_finite_bootstrap_on_terminal() {
+        // Sample 0 is terminal with a NaN continuation value, sample 1 is
+        // terminal with +inf, sample 2 with -inf. Under the old
+        // `* (1.0 - terminated)` scaling all three produced NaN, because
+        // `NaN * 0.0` and `inf * 0.0` are both NaN.
+        let rewards = floats(&[1.5, -2.0, 0.25]);
+        let next_q_max = floats(&[f32::NAN, f32::INFINITY, f32::NEG_INFINITY]);
+        let terminated = floats(&[1.0, 1.0, 1.0]);
+
+        let got = host(compute_target_q_values(
+            rewards, next_q_max, terminated, 0.99,
+        ));
+        let want = [1.5_f32, -2.0, 0.25];
+
+        for (i, (&g, &w)) in got.iter().zip(want.iter()).enumerate() {
+            assert!(
+                g.is_finite(),
+                "a terminal transition must never inherit a non-finite bootstrap; \
+                 sample {i} got {g}"
+            );
+            assert_abs_diff_eq!(g, w, epsilon = EPS);
+        }
+    }
+
+    #[test]
+    fn test_compute_target_q_values_bootstraps_when_not_terminated() {
+        // Masking must not disturb the non-terminal path: every sample here
+        // keeps the full `reward + gamma * next_q_max` target.
+        let gamma = 0.9_f32;
+        const REWARDS: [f32; 3] = [1.0, -0.5, 0.0];
+        // 1.0 + 0.9*2.0 = 2.8 ; -0.5 + 0.9*4.0 = 3.1 ; 0.0 + 0.9*(-3.0) = -2.7
+        const WANT: [f32; 3] = [2.8, 3.1, -2.7];
+
+        let got = host(compute_target_q_values(
+            floats(&REWARDS),
+            floats(&[2.0, 4.0, -3.0]),
+            floats(&[0.0, 0.0, 0.0]),
+            gamma,
+        ));
+
+        for (i, (&g, &w)) in got.iter().zip(WANT.iter()).enumerate() {
+            assert_abs_diff_eq!(g, w, epsilon = EPS);
+            assert!(
+                (g - REWARDS[i]).abs() > EPS,
+                "sample {i} must actually bootstrap, not collapse to the reward; got {g}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_target_q_values_matches_scaled_formula_on_finite_inputs() {
+        // Mixed terminal / non-terminal batch, all finite: the masked form must
+        // reproduce the old `* (1.0 - terminated)` result exactly.
+        let gamma = 0.97_f32;
+        let rewards = [0.0_f32, 1.25, -3.5, 2.0, -0.75, 10.0];
+        let next_q_max = [5.0_f32, -5.0, 0.0, 123.5, -0.125, 1.0];
+        let terminated = [0.0_f32, 1.0, 0.0, 1.0, 0.0, 1.0];
+
+        let want = host(scaled_reference(
+            floats(&rewards),
+            floats(&next_q_max),
+            floats(&terminated),
+            gamma,
+        ));
+        let got = host(compute_target_q_values(
+            floats(&rewards),
+            floats(&next_q_max),
+            floats(&terminated),
+            gamma,
+        ));
+
+        assert_eq!(
+            got.len(),
+            want.len(),
+            "masking must preserve the batch length"
+        );
+        for (i, (&g, &w)) in got.iter().zip(want.iter()).enumerate() {
+            assert_abs_diff_eq!(g, w, epsilon = EPS);
+            assert!(
+                g.is_finite(),
+                "finite inputs must give a finite target; sample {i} got {g}"
+            );
+        }
+    }
 
     // Hand-set constant weights. `active` and `target` differ in *every*
     // element, which is what lets the tau = 0 and tau = 0.25 tests distinguish


### PR DESCRIPTION
## Summary

`compute_target_q_values` built the Bellman target by *scaling* the bootstrap term, `rewards + gamma * next_q_max * (1.0 - terminated)`. Because `NaN * 0.0 == NaN` (as does `Inf * 0.0`), an already-poisoned `next_q_max` propagated into the target on exactly the samples where the terminal convention says the bootstrap must vanish. The term is now genuinely masked to `0` wherever `terminated == 1.0`, so a terminal target is the reward regardless of what the next-state estimate holds. This is defensive hardening, not a repair of live divergence — the expression cannot *originate* a non-finite value, and for all-finite inputs the new form is numerically identical, so no algorithm's behaviour changes.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #192

## What Was Changed

`crates/rlevo-reinforcement-learning/src/utils.rs`:

- `compute_target_q_values` — replaced `rewards.clone() + gamma * next_q_max * (1.0 - terminated)` with `terminated.equal_elem(1.0)` + `mask_fill(is_terminal, 0.0)` on the `gamma`-scaled bootstrap.
- Dropped the redundant `rewards.clone()` — `rewards` is an owned parameter used exactly once.
- Added a `# Panics` section to the **public** `polyak_update`, documenting that it panics when `active` and `target` carry divergent `ParamId`s (i.e. `target` was built by an independent `init` rather than cloned from `active`), and giving the remedy. It deliberately did **not** go on `PolyakMapper::map_float`, where the `.expect()` actually lives — `PolyakMapper` is a private struct, so rustdoc would never render it.
- Three new unit tests in the in-source `#[cfg(test)] mod tests`.

`CHANGELOG.md` — entry under `[Unreleased]` → `### rlevo-reinforcement-learning` → `**Fixed**`.

## How It Was Tested

```
cargo build --workspace                        # Finished, no errors
cargo test --workspace                         # all green
cargo clippy --all-targets --all-features      # 0 warnings
cargo fmt --all --check                        # clean
```

Regression test: `test_compute_target_q_values_masks_non_finite_bootstrap_on_terminal` — feeds `NaN`, `+inf`, and `-inf` in `next_q_max` on terminated samples and asserts each target `is_finite()` and equals the reward. **Verified non-vacuous by execution**: the function was temporarily reverted to the old formula, and this test fails against it (NaN leaks through) and passes on this PR. The other two new tests (`..._bootstraps_when_not_terminated`, `..._matches_scaled_formula_on_finite_inputs`) pass under *both* formulations by design — they are equivalence guards asserting this change is behaviour-preserving, not regression tests for the defect.

Equivalence was also checked by executing both formulations against live Burn tensors rather than by reading: bitwise identical on all finite inputs tried. The one divergence is `-0.0` → `+0.0` on terminal rows where the reward is exactly negative zero and `next_q_max` is negative; all four call sites (`dqn_agent.rs:500`, `ddpg_agent.rs:508`, `td3_agent.rs:585`, `sac_agent.rs:609`) feed `target` into a squared-error or Huber loss, which erases the sign.

- Rust toolchain: `stable 1.94.1 (e408947bf 2026-03-25)`
- Burn backend tested: `Flex` (CPU) — the backend every in-tree RL path uses
- OS: macOS 26.5.2 (arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): __Claude Code (Opus 4.8)__. Scope: __full authorship of the diff, tests, and changelog entry, plus the pre-merge verification described above; reviewed and accepted by the maintainer__.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**`equal_elem(1.0)` is an exact float comparison, not a threshold — this is the load-bearing assumption.** It is safe today because `terminated` originates as `if t.terminated { 1.0 } else { 0.0 }` from a `bool` at all four call sites and undergoes no arithmetic en route (verified by tracing each site back to `memory.rs:394`). Exact equality was chosen over a `> 0.5` threshold deliberately: it gives the smallest behavioural footprint, diverging from the old code *only* on exact terminals. A future n-step-return or GAE-style path that interpolates the terminal mask would silently bypass this guard and should revisit the comparison.

**Follow-up, filed separately:** #357 — QR-DQN hand-rolls the same target computation at `qrdqn_agent.rs:477-480` and carries the identical defect, unfixed. C51 was checked and is **not** affected despite near-identical syntax (its `keep` multiplies the fixed atom support, not a network output), so `c51/projection.rs` should be left alone.

Two stale cross-references in #192's body were corrected in a comment there rather than in this diff: #173 is closed (resolved by #349), and #322's stated mechanism is refuted (the GPU sync stall does not exist in this tree — all RL paths run on CPU `Flex`; the real cost is a host memcpy per parameter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01128d2B9qyUmwHCjz9Uw5ay
