### PR TITLE
test(rl-ppo): Pin GAE returns identity positionally

### DIFF
--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/rollout.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/rollout.rs
@@ -346,8 +346,14 @@ mod tests {
     #[test]
     fn gae_matches_reference_trajectory_no_termination() {
         // 5-step rollout, no mid-rollout episode boundary.
+        //
+        // `values` is deliberately non-constant: a flat critic makes both the
+        // advantage check and the `returns = A + V` check permutation-blind,
+        // since every index carries the same V and any misalignment still
+        // matches. Distinct per-step values let the positional assertions
+        // below actually pin the ordering.
         let rewards = vec![1.0, 1.0, 1.0, 1.0, 1.0];
-        let values = vec![0.5, 0.5, 0.5, 0.5, 0.5];
+        let values = vec![0.1, 0.4, 0.2, 0.7, 0.5];
         let term = vec![false; 5];
         let trunc = vec![None; 5];
         let last_value = 0.5_f32;
@@ -355,23 +361,42 @@ mod tests {
         let lam = 0.95_f32;
         let (advs, rets) = compute_gae(&rewards, &values, &term, &trunc, last_value, gamma, lam);
 
-        // Hand-compute: delta = r + γ · V' · nonterm − V = 1 + 0.99·0.5·1 − 0.5 = 0.995
-        // A[4] = delta[4] = 0.995
-        // A[3] = delta[3] + γλ·A[4]·1 = 0.995 + 0.99·0.95·0.995 = 0.995 + 0.9356..
-        let delta = 1.0 + gamma * 0.5 * 1.0 - 0.5;
+        // Independent reference recursion, general per-step form. With no
+        // termination and no truncation every mask is 1, so
+        //   δ[t] = r[t] + γ·V'[t] − V[t],  V'[t] = V[t+1] (V' = last_value at t = 4)
+        //   A[t] = δ[t] + γλ·A[t+1],       A[5] ≡ 0,  γλ = 0.9405
+        // Spot values for the tail:
+        //   t=4: δ = 1 + 0.99·0.5 − 0.5 = 0.995        → A[4] = 0.995
+        //   t=3: δ = 1 + 0.99·0.5 − 0.7 = 0.795        → A[3] = 0.795 + 0.9405·0.995
+        //                                                     = 1.730_797_5
+        let n = rewards.len();
         let mut expected = [0.0_f32; 5];
         let mut last = 0.0_f32;
-        for t in (0..5).rev() {
-            last = delta + gamma * lam * 1.0 * last;
+        for t in (0..n).rev() {
+            let next_value = if t == n - 1 {
+                last_value
+            } else {
+                values[t + 1]
+            };
+            let delta = rewards[t] + gamma * next_value - values[t];
+            last = delta + gamma * lam * last;
             expected[t] = last;
         }
         for (i, (a, e)) in advs.iter().zip(expected.iter()).enumerate() {
             assert!((a - e).abs() < 1e-6, "step {i}: {a} vs {e}");
         }
-        for (a, v) in advs.iter().zip(values.iter()) {
-            // returns = adv + V
-            let r = a + v;
-            assert!(rets.contains(&r) || (rets[0] - r).abs() < 1e-5);
+        // Positional — not set-membership — check of the returns identity.
+        // `rets[t]` must equal `advs[t] + values[t]` at the *same* index t, so
+        // a reversed or otherwise misaligned `returns` vector fails here.
+        for t in 0..n {
+            let want = advs[t] + values[t];
+            assert!(
+                (rets[t] - want).abs() < 1e-6,
+                "step {t}: returns {} != advantage {} + value {} = {want}",
+                rets[t],
+                advs[t],
+                values[t]
+            );
         }
     }
 


### PR DESCRIPTION
Resolves #189 §7.1. §3.3 of the same review is refuted and closed — no code change.

## The defect

`gae_matches_reference_trajectory_no_termination` checked the `returns = A + V` identity with `rets.contains(&r)` — **set membership** — against a constant `values = [0.5; 5]`. With a flat critic every index carries the same V, so any misalignment between `returns` and `advantages` still found a match: the assertion was permutation-blind. A trailing `|| (rets[0] - r).abs() < 1e-5` disjunct made it weaker still, admitting anything that matched element zero.

The original review called it "vacuously true regardless of computation correctness." That's overstated — it did catch a dropped `+V` and an off-by-one constant. The real defect is narrower and more precise: it was blind to *ordering*.

## The fix

- `values` is now non-constant (`[0.1, 0.4, 0.2, 0.7, 0.5]`). This is the load-bearing part — without it, even a positional check cannot detect misalignment.
- The reference advantage recursion is rewritten to the general per-step form. The old hardcoded `delta = 1.0 + gamma * 0.5 * 1.0 - 0.5` was only valid under a flat critic.
- Set membership is replaced by a positional assertion at the same index `t`. The escape-hatch disjunct is gone.

Test-only: `compute_gae` and `RolloutBuffer` are untouched, and the diff falls entirely inside `mod tests`.

## Verification

Mutation-tested against the real `compute_gae` — each applied and reverted individually, file verified diff-identical after each:

| Mutation | Result |
|---|---|
| `returns.reverse()` | **caught** — `step 0: returns 1.495 != advantage 4.807006 + value 0.1` |
| `returns[t] = advs[t] + values[0]` (constant-V misalignment) | **caught** — `step 1: returns 3.8331265 != advantage 3.7331266 + value 0.4` |
| `advantages.rotate_left(1)` | **caught** — `step 0: 3.7331266 vs 4.807006` |
| γ/λ swapped | **caught** — `step 0: 4.726428 vs 4.807006` |
| `unwrap_or(next_value)` → `unwrap_or(0.0)` in the boot mask | **caught** — `step 0: 2.812711 vs 4.807006` |

No survivors. `cargo test -p rlevo-reinforcement-learning`: 259 passed, 0 failed (plus 5 doctests). `cargo clippy -p rlevo-reinforcement-learning --all-targets --all-features` clean. `cargo fmt --all --check` clean.

## Reviewer note — what bounds this oracle

The reference recursion deliberately drops `compute_gae`'s mask machinery (`ended`, `boot`, truncation). That is valid **only** because this fixture never terminates or truncates, which makes both masks identity — confirmed live by the boot-mask mutation above, which the test still catches. **Adding a boundary to this fixture would silently turn the oracle into a wrong answer.** Masking and truncation stay covered by the sibling tests (`gae_handles_terminated_mid_rollout`, `gae_bootstraps_truncation_value_mid_rollout`, `gae_truncation_differs_from_termination`, `gae_terminal_final_step_zeros_bootstrap`, `gae_running_final_step_uses_last_value`).

Also worth knowing: a pure `advantages` shift is caught by the advantage-vs-reference loop, not by the new returns assertion — that assertion derives `want` from `advs[t]` itself. Its unique contribution is specifically returns/advantages *misalignment*.

## Why §3.3 got no code

Re-verified against the current tree; structure unchanged since the issue was rewritten. There is no `gather` method — `rollout.rs:230` is `gather_f32(&self, data: &[f32], …)`, which never reads `self.advantages`/`self.returns`. Those vectors are `Vec::new()` at `:94-95` and emptied by `clear()` at `:262-263`, so unfinalized means *empty*, never stale, and the failure is a loud index-OOB panic, not a silent wrong gradient. `AuxRolloutBuffer` does not depend on `RolloutBuffer` (`aux_buffer.rs:32-44`), so the "shared buffer" coupling that justified the remedy isn't real. Every call site finalizes first (`ppo_agent.rs:452,514,517,595`, `ppg_agent.rs:490,512,575,578`) and the buffer is private.

The `finalized: bool` remedy was considered and declined: it changes `advantages()`/`returns()` from returning an empty slice to panicking — a downstream-visible break to a `pub` accessor — in exchange for a better-worded panic rather than a correctness fix.

**The type-state remedy would violate ADR 0046** and should not be proposed a fourth time; the reasoning is now recorded in the review document, not just in issue text.

No `CHANGELOG.md` or user-book entry — test-only, no user-observable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls3XzbLsSmSrh12FdMqfBR
