### PR TITLE
bench(rl): Add backend-parametric staging A/B micro-bench

### DIFF
--- a/crates/rlevo-reinforcement-learning/Cargo.toml
+++ b/crates/rlevo-reinforcement-learning/Cargo.toml
@@ -72,3 +72,8 @@ harness = false
 name = "sac_bench"
 path = "benches/sac_bench.rs"
 harness = false
+
+[[bench]]
+name = "staging_bench"
+path = "benches/staging_bench.rs"
+harness = false

--- a/crates/rlevo-reinforcement-learning/benches/staging_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/staging_bench.rs
@@ -1,0 +1,273 @@
+//! A/B micro-bench of the minibatch observation-staging seam: the device
+//! round trip (`obs.to_tensor(device)` then immediately `.into_data()`,
+//! upload-then-download-unchanged) vs. `TensorConvertible::write_host_row`
+//! (pure host staging, one batched upload). Answers #187 / #362's open
+//! measurement question (issue #365 step 1): both strategies are implemented
+//! **inline, in this file**, so a single `cargo bench` run yields the delta.
+//!
+//! # A note on this checkout's actual state
+//!
+//! Commit `797d18c` ("Stage minibatch observations host-side") is *not* an
+//! ancestor of this worktree's HEAD — `git merge-base --is-ancestor 797d18c
+//! HEAD` returns false, and `797d18c`'s parent is this same HEAD commit. It
+//! sits on a sibling branch reachable in the shared object store, not in this
+//! branch's history. Concretely: `dqn_agent.rs::learn_step` in *this*
+//! checkout still round-trips (`t.obs.to_tensor(&self.device)` then
+//! `.into_data().convert::<f32>()`, lines ~417-422) — the fix has not been
+//! wired into any agent here. What *does* already exist here is the
+//! `TensorConvertible::write_host_row` primitive itself (`rlevo-core`), which
+//! is enough to build this A/B independently of whether any agent calls it
+//! yet. Treat this bench as answering "is the not-yet-applied fix worth
+//! applying", not "did the applied fix help".
+//!
+//! # Design
+//!
+//! - `stage_roundtrip` — the round-trip path, reproduced verbatim from the
+//!   minibatch loop live in this checkout's `dqn_agent.rs::learn_step`: per
+//!   row, `to_tensor(device)`, then `.into_data().convert::<f32>()`, then
+//!   `extend_from_slice` into the flat host buffer; one batched
+//!   `Tensor::from_data` at the end.
+//! - `stage_host_row` — the candidate replacement: per row,
+//!   `TensorConvertible::write_host_row(&mut flat)` (no device touched), then
+//!   the same batched `Tensor::from_data`.
+//!
+//! Both are generic over the row type `T: TensorConvertible<R, B>` and the
+//! backend `B`, so one implementation covers `CartPoleObservation` (`R = 1`,
+//! 4 floats/row) and `PixelObservation` (`R = 3`, 1200 floats/row) and both
+//! `Flex` and `Wgpu`, per the #365 sweep requirement (sync count is invariant
+//! to row size; bytes moved are not).
+//!
+//! # Methodology — forcing completion inside the timed region
+//!
+//! wgpu is asynchronous: `Tensor::from_data` and friends *submit* work and
+//! return immediately. A timer that stops there measures submission, not
+//! execution — and would make `stage_roundtrip` look artificially fast,
+//! because its per-row `into_data()` calls are precisely what forces
+//! synchronization (confirmed by reading `Tensor::into_data` →
+//! `try_into_data` → `crate::try_read_sync(self.into_data_async())`, which
+//! blocks the calling thread until the device queue drains up to that
+//! tensor). `stage_host_row` has no such call anywhere in its loop.
+//!
+//! So **both** timed closures below end with an explicit
+//! `black_box(tensor.into_data())` on the *final batched* tensor — applied
+//! identically to both strategies — guaranteeing every timed iteration
+//! includes full device completion, not just command submission. This is the
+//! only correctness-relevant addition to the "obvious" A/B: without it the
+//! result direction inverts.
+//!
+//! # Correctness gate
+//!
+//! [`assert_bit_identical`] runs once per (observation, backend) group,
+//! outside the timed region, before any `bench_with_input` call. If the two
+//! strategies ever disagree, the timing comparison is meaningless.
+//!
+//! # Run with
+//!
+//! ```bash
+//! cargo bench -p rlevo-reinforcement-learning --bench staging_bench
+//! ```
+//!
+//! # Reporting
+//!
+//! Results are backend- and hardware-scoped by construction: every criterion
+//! group name carries the backend label (`flex` / `wgpu`), and `wgpu` on this
+//! development machine is Metal on an Apple M2 Pro (verified independently —
+//! see the step-0 smoke test in the #365 session notes). A `wgpu` number here
+//! does not transfer to CUDA or any other machine.
+
+#[path = "support/bench_backend.rs"]
+mod bench_backend;
+
+use std::hint::black_box;
+
+use burn::backend::{Flex, Wgpu};
+use burn::tensor::backend::{Backend, BackendTypes};
+use burn::tensor::{Tensor, TensorData};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_core::base::TensorConvertible;
+use rlevo_core::state::Observable;
+use rlevo_environments::classic::cartpole::CartPoleObservation;
+use rlevo_environments::pixel_grid::{CELL_COUNT, PixelGridState, PixelObservation};
+
+use bench_backend::BenchBackend;
+
+/// Device type alias so generic signatures below don't repeat the projection.
+type DeviceOf<B> = <B as BackendTypes>::Device;
+
+/// Batch sizes swept per (observation, backend) combination — at least
+/// 32/64/256 per the #365 request; 64 matches the existing `dqn_bench.rs`
+/// `dqn_learn_step_batch64`.
+const BATCH_SIZES: [usize; 3] = [32, 64, 256];
+
+// ---------------------------------------------------------------------------
+// The two staging strategies under test
+// ---------------------------------------------------------------------------
+
+/// The round-trip path: per row, upload then immediately read back, purely
+/// to obtain a host `f32` slice to append. Reproduced verbatim from the
+/// minibatch loop currently live in this checkout's
+/// `dqn_agent.rs::learn_step` (`obs_tensor.into_data().convert::<f32>()` +
+/// `extend_from_slice(..as_slice::<f32>()..)`).
+fn stage_roundtrip<const R: usize, const BR: usize, T, B>(
+    items: &[T],
+    device: &DeviceOf<B>,
+) -> Tensor<B, BR>
+where
+    T: TensorConvertible<R, B>,
+    B: Backend,
+{
+    debug_assert_eq!(BR, R + 1, "batched rank BR must equal row rank R + 1");
+    let row_shape = T::row_shape();
+    let row_len: usize = row_shape.iter().product();
+    let mut flat: Vec<f32> = Vec::with_capacity(items.len() * row_len);
+    for item in items {
+        let row_tensor: Tensor<B, R> = item.to_tensor(device);
+        let row_data = row_tensor.into_data().convert::<f32>();
+        flat.extend_from_slice(row_data.as_slice::<f32>().expect("float data"));
+    }
+    let mut shape = [0usize; BR];
+    shape[0] = items.len();
+    shape[1..].copy_from_slice(&row_shape);
+    Tensor::from_data(TensorData::new(flat, shape), device)
+}
+
+/// The candidate replacement: write straight into the host buffer, one
+/// batched upload, zero per-row device round trips. Uses the
+/// `TensorConvertible::write_host_row` primitive that already exists in
+/// `rlevo-core` but is not yet wired into any agent's minibatch loop in this
+/// checkout (see the module-level note on `797d18c`).
+fn stage_host_row<const R: usize, const BR: usize, T, B>(
+    items: &[T],
+    device: &DeviceOf<B>,
+) -> Tensor<B, BR>
+where
+    T: TensorConvertible<R, B>,
+    B: Backend,
+{
+    debug_assert_eq!(BR, R + 1, "batched rank BR must equal row rank R + 1");
+    let row_shape = T::row_shape();
+    let row_len: usize = row_shape.iter().product();
+    let mut flat: Vec<f32> = Vec::with_capacity(items.len() * row_len);
+    for item in items {
+        item.write_host_row(&mut flat);
+    }
+    let mut shape = [0usize; BR];
+    shape[0] = items.len();
+    shape[1..].copy_from_slice(&row_shape);
+    Tensor::from_data(TensorData::new(flat, shape), device)
+}
+
+/// Runs both strategies on the same batch and asserts the resulting tensors
+/// are bit-identical. Call **once**, outside any timed region.
+fn assert_bit_identical<const R: usize, const BR: usize, T, B>(items: &[T], device: &DeviceOf<B>)
+where
+    T: TensorConvertible<R, B>,
+    B: Backend,
+{
+    let rt: Tensor<B, BR> = stage_roundtrip::<R, BR, T, B>(items, device);
+    let hr: Tensor<B, BR> = stage_host_row::<R, BR, T, B>(items, device);
+    let rt_v: Vec<f32> = rt.into_data().into_vec().expect("host read (roundtrip)");
+    let hr_v: Vec<f32> = hr.into_data().into_vec().expect("host read (host_row)");
+    assert_eq!(
+        rt_v, hr_v,
+        "stage_roundtrip and stage_host_row diverged -- staging is not bit-identical; \
+         the timing comparison below would be meaningless"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic batch data
+// ---------------------------------------------------------------------------
+
+fn cartpole_batch(n: usize, rng: &mut StdRng) -> Vec<CartPoleObservation> {
+    (0..n)
+        .map(|_| CartPoleObservation {
+            cart_pos: rng.random_range(-2.4_f32..2.4_f32),
+            cart_vel: rng.random_range(-3.0_f32..3.0_f32),
+            pole_angle: rng.random_range(-0.2_f32..0.2_f32),
+            pole_ang_vel: rng.random_range(-3.0_f32..3.0_f32),
+        })
+        .collect()
+}
+
+fn pixel_batch(n: usize, rng: &mut StdRng) -> Vec<PixelObservation> {
+    (0..n)
+        .map(|_| {
+            let agent = rng.random_range(0..CELL_COUNT as u32);
+            let goal = rng.random_range(0..CELL_COUNT as u32);
+            PixelGridState::new(agent, goal).project()
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Bench driver
+// ---------------------------------------------------------------------------
+
+/// Runs the `roundtrip` vs. `host_row` A/B for one (observation type,
+/// backend) combination across [`BATCH_SIZES`], inside criterion group
+/// `group_name`.
+fn bench_stage<const R: usize, const BR: usize, T, B>(
+    c: &mut Criterion,
+    group_name: &str,
+    make_batch: impl Fn(usize, &mut StdRng) -> Vec<T>,
+) where
+    T: TensorConvertible<R, B>,
+    B: BenchBackend,
+{
+    let device = B::device();
+    let mut rng = StdRng::seed_from_u64(365);
+
+    // Correctness gate: once, outside the timed region (see module doc).
+    let check_batch = make_batch(*BATCH_SIZES.last().expect("non-empty"), &mut rng);
+    assert_bit_identical::<R, BR, T, B>(&check_batch, &device);
+
+    let mut group = c.benchmark_group(group_name);
+    // 20 samples (vs. criterion's default 100): `stage_roundtrip` on wgpu at
+    // batch 256 costs ~1.5 ms/row * 256 rows ~= 384 ms/iteration purely from
+    // per-row synchronization, so 100 iterations is ~38 s for that one cell
+    // alone. Cut 5x here to keep the full 24-benchmark sweep tractable while
+    // still reporting a real confidence interval (criterion's minimum is 10).
+    group.sample_size(20);
+    for &batch_size in &BATCH_SIZES {
+        let items = make_batch(batch_size, &mut rng);
+        group.bench_with_input(
+            BenchmarkId::new("roundtrip", batch_size),
+            &items,
+            |b, items| {
+                b.iter(|| {
+                    let t = stage_roundtrip::<R, BR, T, B>(black_box(items), &device);
+                    // Force completion inside the timed region -- see module doc.
+                    black_box(t.into_data());
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("host_row", batch_size),
+            &items,
+            |b, items| {
+                b.iter(|| {
+                    let t = stage_host_row::<R, BR, T, B>(black_box(items), &device);
+                    black_box(t.into_data());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_staging(c: &mut Criterion) {
+    bench_stage::<1, 2, CartPoleObservation, Flex>(c, "stage_cartpole_flex", cartpole_batch);
+    bench_stage::<1, 2, CartPoleObservation, Wgpu>(c, "stage_cartpole_wgpu", cartpole_batch);
+    bench_stage::<3, 4, PixelObservation, Flex>(c, "stage_pixel_flex", pixel_batch);
+    bench_stage::<3, 4, PixelObservation, Wgpu>(c, "stage_pixel_wgpu", pixel_batch);
+}
+
+criterion_group!(benches, bench_staging);
+criterion_main!(benches);

--- a/crates/rlevo-reinforcement-learning/benches/support/bench_backend.rs
+++ b/crates/rlevo-reinforcement-learning/benches/support/bench_backend.rs
@@ -1,0 +1,63 @@
+//! Backend-parametric scaffolding shared by benches that need to sweep the
+//! same workload across more than one Burn backend.
+//!
+//! Every `[[bench]]` is its own compilation unit, so this module is pulled in
+//! per-file via `#[path = "support/bench_backend.rs"] mod bench_backend;`; it
+//! sits in a subdirectory so Cargo's bench autodiscovery does not treat it as
+//! a standalone target (mirrors `crates/rlevo/benches/support/`).
+//!
+//! [`BenchBackend`] exists so a bench body is written once, generic over
+//! `B: BenchBackend`, and instantiated per backend at the call site — adding a
+//! backend later (CUDA, ROCm, ...) is one new `impl` block here, not a
+//! rewrite of every bench that sweeps backends. See `staging_bench.rs` for
+//! the reference usage.
+
+#![allow(dead_code)]
+
+use burn::backend::{Flex, Wgpu};
+use burn::tensor::backend::{Backend, BackendTypes};
+
+/// A `Backend` benches can select by a stable, printable label.
+///
+/// This is deliberately *not* a blanket impl over `Backend` — only backends a
+/// bench author has actually validated on the target hardware (see the wgpu
+/// smoke test in the #365 step-1 session) get an `impl` here, so a typo'd or
+/// unavailable backend fails at the `impl` site, not at bench-report time.
+pub trait BenchBackend: Backend {
+    /// Short, lowercase, filesystem/CLI-safe label used in criterion group
+    /// names and in this bench's own report table (e.g. `"flex"`, `"wgpu"`).
+    /// Report text must pair this label with the concrete hardware/adapter it
+    /// ran on — the label alone does not carry that (a `"wgpu"` number on
+    /// this machine is Metal on an Apple M2 Pro; it says nothing about CUDA).
+    const NAME: &'static str;
+
+    /// Constructs the device this backend benches against.
+    ///
+    /// `Default` is sufficient for every backend implemented today: `Flex`
+    /// has exactly one (CPU) device, and wgpu's `WgpuDevice::DefaultDevice`
+    /// selects the highest-priority GPU adapter present. On this machine
+    /// (Apple M2 Pro) that resolves to Metal — confirmed independently by
+    /// forcing `cubecl::wgpu::init_setup::<Metal>` in the step-0 smoke test,
+    /// which reported `backend: Metal` in the resulting `WgpuSetup`.
+    fn device() -> <Self as BackendTypes>::Device {
+        Default::default()
+    }
+}
+
+impl BenchBackend for Flex {
+    const NAME: &'static str = "flex";
+}
+
+impl BenchBackend for Wgpu {
+    const NAME: &'static str = "wgpu";
+}
+
+// Adding CUDA later is exactly this shape, gated behind the `cuda` feature:
+//
+// #[cfg(feature = "cuda")]
+// impl BenchBackend for burn::backend::Cuda {
+//     const NAME: &'static str = "cuda";
+// }
+//
+// No existing bench body changes — callers add one more monomorphized call
+// (`bench_stage::<_, _, _, Cuda>(...)`) alongside the Flex/Wgpu ones.


### PR DESCRIPTION
**Stack 1 of 4** — base for the round-trip fix that follows. Addresses part of #365.

## Why this lands first

The suite had **no GPU coverage**: all 14 benches ran on `Flex`, which is a CPU backend (`burn-flex-0.21.0/src/backend.rs:34,98` — `FlexDevice` displays `"Cpu"`). `dqn_learn_step_batch64` exercises exactly the minibatch staging path at exactly batch 64, and would have reported no difference however bad that path got.

This PR is the measurement capability. The next PR is the fix it justifies.

## What it does

`staging_bench.rs` implements **both** staging strategies inline — per-row `to_tensor`/`into_data` versus `write_host_row` — so one criterion run yields the delta without checking out a prior commit. Generic over backend and observation type, so CUDA is a type parameter rather than a rewrite. `benches/support/bench_backend.rs` carries the shared scaffolding.

24 cells: `{CartPoleObservation [4], PixelObservation [20,20,3]} × {Flex, Wgpu} × {32, 64, 256}`.

`assert_bit_identical` runs once per group **outside** the timed region — independent corroboration that both strategies produce identical data.

## Results — wgpu/Metal, Apple M2 Pro, criterion n=20

Scoped to this hardware and backend. **These do not transfer to CUDA.**

| Observation | Backend | Batch | roundtrip | host_row | ratio |
|---|---|---|---|---|---|
| CartPole `[4]` | Wgpu/Metal | 64 | 96.7–97.1 ms | 1.49 ms | ~65× |
| CartPole `[4]` | Wgpu/Metal | 256 | 383.7–385.0 ms | 1.49 ms | ~257× |
| Pixel `[20,20,3]` | Wgpu/Metal | 64 | 97.2–97.6 ms | 1.57 ms | ~62× |
| CartPole `[4]` | Flex (CPU) | 64 | 10.80 µs | 0.225 µs | ~48× |
| Pixel `[20,20,3]` | Flex (CPU) | 64 | ~25.5 µs | ~7.6 µs | ~3.4× |

Cost is **~1.5 ms per row**, consistent within 3% across every batch size *and* both observation sizes — a fixed per-sync cost invariant to row size.

The two-axis sweep earned its keep: Flex/Pixel is ~3.4× while Flex/CartPole is ~48×. A single-configuration benchmark would have produced a number both true and misleading.

## Review notes

- **The forced read at the end of each timed closure is load-bearing, not redundant.** wgpu is asynchronous; without it the timer measures command submission rather than execution, and the round-trip arm — whose `into_data()` calls are the very thing forcing synchronization — would appear artificially *fast*, inverting the result.
- That forced read puts a ~1.49 ms floor under the `host_row` arm which is **measurement artifact, not intrinsic cost**. Real `learn_step` never syncs the staged tensor. The reported ratios therefore *understate* the real-world gap.
- **Unresolved:** at criterion's default `sample_size = 100`, `stage_cartpole_wgpu/roundtrip/256` did not complete. Worked around at n=20, which matched an independent non-criterion measurement to 0.4%. Could not be separated from a possible sandbox clock artifact. Stack 4 probes this further and does not reproduce it.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features` (0 issues), `cargo test --workspace` (2616 passed, 0 failed). No `src/` file touched; new bench files and one `Cargo.toml` entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDX6bXaa6vcBjCR4arxP3P