### PR TITLE
perf(rl): Stage minibatch observations host-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -758,6 +758,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   size. The device→host→device round-trip in `polyak_update` is where the
   real per-step cost lives; that is tracked separately as #322.
 
+- **Every agent's minibatch staging round-tripped each observation through the
+  device before ever using it** (resolves #362, completing the #187 sweep).
+  `stack_to_tensor` was added in #195 as the single batched host→device upload
+  path, nominally consumed by `memory.rs::sample_batch` — but no agent ever
+  called `sample_batch` (the dead-`PrioritizedExperienceReplay` defect tracked
+  as #188), so the helper had no live caller from the day it landed. ADR 0050
+  retired that consumer deliberately, leaving staging to each agent because
+  "each agent stages differently". Eight agents — `dqn`, `c51`, `qrdqn`,
+  `ddpg`, `td3`, `sac`, `ppo`, and `ppg` — had always kept a hand-rolled
+  staging loop that called
+  `TensorConvertible::to_tensor` on one sampled transition, immediately called
+  `.into_data()` on the result, and copied the floats back into a host `Vec`.
+  The observation was already on the host: the loop uploaded it to the
+  accelerator and downloaded it unchanged, then dropped the tensor without a
+  single operation ever running on it. The staging loops now write straight
+  into the preallocated flat buffer with `write_host_row` — the same primitive
+  `to_tensor` and `stack_to_tensor` are both built on — and the one batched
+  `Tensor::from_data` upload per minibatch is unchanged.
+
+  The cost is worst on `wgpu`, where `into_data()` is a synchronization point:
+  a `learn_step` at `batch_size = 64` stalled the pipeline 128 times (state and
+  next-state) before any real work began, on top of 128 discarded buffer
+  allocations. The `.expect("float data")` panic each read carried is gone from
+  the hot loop with it.
+
+  No test caught this because there was nothing to catch: `write_host_row` is
+  the primitive `to_tensor` itself uses, so the staged bytes are bit-identical
+  either way. The defect was pure throughput, invisible to any correctness
+  assertion, and the existing tests pass unmodified — which is the acceptance
+  criterion here rather than evidence of a gap.
+
 **Added**
 
 - **`PpoUpdateStats::min_log_std` and a one-shot warning when the `log_std`

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
@@ -464,12 +464,14 @@ where
 
         for &id in batch.ids() {
             let t = self.buffer.get(id).expect("a freshly sampled id is live");
-            let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&self.device);
-            let next_tensor: Tensor<B::InnerBackend, DO> = t.next_obs.to_tensor(&self.device);
-            let obs_data = obs_tensor.into_data().convert::<f32>();
-            let next_data = next_tensor.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
-            next_flat.extend_from_slice(next_data.as_slice::<f32>().expect("float data"));
+            // Stage host-side: `to_tensor` would upload each row only to read it
+            // straight back -- one wgpu sync point per row, no op in between. The
+            // turbofish is required: `O`'s dual `TensorConvertible` bound is ambiguous.
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(&t.obs, &mut obs_flat);
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(
+                &t.next_obs,
+                &mut next_flat,
+            );
             action_idxs.push(t.action as i64);
             rewards.push(t.reward);
             terminated.push(if t.terminated { 1.0 } else { 0.0 });

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
@@ -437,12 +437,14 @@ where
 
         for &id in batch.ids() {
             let t = self.buffer.get(id).expect("a freshly sampled id is live");
-            let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&device);
-            let next_tensor: Tensor<B::InnerBackend, DO> = t.next_obs.to_tensor(&device);
-            let obs_data = obs_tensor.into_data().convert::<f32>();
-            let next_data = next_tensor.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
-            next_flat.extend_from_slice(next_data.as_slice::<f32>().expect("float data"));
+            // Stage host-side: `to_tensor` would upload each row only to read it
+            // straight back -- one wgpu sync point per row, no op in between. The
+            // turbofish is required: `O`'s dual `TensorConvertible` bound is ambiguous.
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(&t.obs, &mut obs_flat);
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(
+                &t.next_obs,
+                &mut next_flat,
+            );
             action_flat.extend_from_slice(&t.action);
             rewards.push(t.reward);
             terminated.push(if t.terminated { 1.0 } else { 0.0 });

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
@@ -414,12 +414,14 @@ where
 
         for &id in batch.ids() {
             let t = self.buffer.get(id).expect("a freshly sampled id is live");
-            let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&self.device);
-            let next_tensor: Tensor<B::InnerBackend, DO> = t.next_obs.to_tensor(&self.device);
-            let obs_data = obs_tensor.into_data().convert::<f32>();
-            let next_data = next_tensor.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
-            next_flat.extend_from_slice(next_data.as_slice::<f32>().expect("float data"));
+            // Stage host-side: `to_tensor` would upload each row only to read it
+            // straight back -- one wgpu sync point per row, no op in between. The
+            // turbofish is required: `O`'s dual `TensorConvertible` bound is ambiguous.
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(&t.obs, &mut obs_flat);
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(
+                &t.next_obs,
+                &mut next_flat,
+            );
             action_idxs.push(t.action as i64);
             rewards.push(t.reward);
             terminated.push(if t.terminated { 1.0 } else { 0.0 });

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/aux_buffer.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/aux_buffer.rs
@@ -1,7 +1,16 @@
 //! Auxiliary-phase replay buffer for PPG.
 //!
-//! Accumulates the last `n_iteration` policy-phase rollouts so the auxiliary
-//! phase can train over the combined pool. Each slice stores:
+//! Accumulates policy-phase rollouts until drained by the auxiliary phase, so
+//! that phase can train over the combined pool. The pool is **unbounded**:
+//! [`AuxRolloutBuffer::push_slice`] never evicts, and [`AuxRolloutBuffer::is_ready`]
+//! only *reports* that `n_iteration` rollouts have accumulated — it does not cap
+//! them. Under the normal PPG loop the auxiliary phase calls
+//! [`AuxRolloutBuffer::clear`] every `n_iteration` rollouts, which bounds the
+//! pool in practice. A caller that drives the `pub`
+//! `PpgAgent::snapshot_into_aux_buffer` seam directly without ever running the
+//! auxiliary phase will grow the pool without limit.
+//!
+//! Each slice stores:
 //!
 //! - `obs` — the rollout's observations (CPU-resident, cloned at push time)
 //! - `returns` — GAE target returns `advantages + values`, used as the
@@ -140,9 +149,7 @@ impl<B: Backend, O: Clone> AuxRolloutBuffer<B, O> {
         for &global in indices {
             let (si, ii) = self.locate(global);
             let slice = &self.slices[si];
-            let t: Tensor<B, DO> = slice.obs[ii].to_tensor(device);
-            let data = t.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(data.as_slice::<f32>().expect("f32 obs"));
+            slice.obs[ii].write_host_row(&mut obs_flat);
             returns.push(slice.returns[ii]);
         }
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
@@ -550,9 +550,7 @@ where
 
                 let mut obs_flat: Vec<f32> = Vec::with_capacity(n * numel_per_obs);
                 for &i in chunk {
-                    let t: Tensor<B, DO> = self.buffer.obs()[i].to_tensor(&self.device);
-                    let data = t.into_data().convert::<f32>();
-                    obs_flat.extend_from_slice(data.as_slice::<f32>().expect("f32 obs"));
+                    self.buffer.obs()[i].write_host_row(&mut obs_flat);
                 }
                 let mut batched_shape: Vec<usize> = Vec::with_capacity(DB);
                 batched_shape.push(n);
@@ -784,9 +782,7 @@ where
             let n = end - start;
             let mut obs_flat: Vec<f32> = Vec::with_capacity(n * numel_per_obs);
             for g in start..end {
-                let t: Tensor<B, DO> = self.aux_buffer.obs_at(g).to_tensor(&self.device);
-                let data = t.into_data().convert::<f32>();
-                obs_flat.extend_from_slice(data.as_slice::<f32>().expect("f32 obs"));
+                self.aux_buffer.obs_at(g).write_host_row(&mut obs_flat);
             }
             let mut batched_shape: Vec<usize> = Vec::with_capacity(DB);
             batched_shape.push(n);

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_agent.rs
@@ -484,12 +484,12 @@ where
                 }
                 let n = chunk.len();
 
-                // Materialise minibatch observations on device.
+                // Stage minibatch observations host-side, then upload once
+                // below: `to_tensor` here would push each row to the device
+                // only to read it straight back, with no op in between.
                 let mut obs_flat: Vec<f32> = Vec::with_capacity(n * numel_per_obs);
                 for &i in chunk {
-                    let t: Tensor<B, DO> = self.buffer.obs()[i].to_tensor(&self.device);
-                    let data = t.into_data().convert::<f32>();
-                    obs_flat.extend_from_slice(data.as_slice::<f32>().expect("f32 obs"));
+                    self.buffer.obs()[i].write_host_row(&mut obs_flat);
                 }
                 let mut batched_shape: Vec<usize> = Vec::with_capacity(DB);
                 batched_shape.push(n);

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
@@ -419,12 +419,14 @@ where
 
         for &id in batch.ids() {
             let t = self.buffer.get(id).expect("a freshly sampled id is live");
-            let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&self.device);
-            let next_tensor: Tensor<B::InnerBackend, DO> = t.next_obs.to_tensor(&self.device);
-            let obs_data = obs_tensor.into_data().convert::<f32>();
-            let next_data = next_tensor.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
-            next_flat.extend_from_slice(next_data.as_slice::<f32>().expect("float data"));
+            // Stage host-side: `to_tensor` would upload each row only to read it
+            // straight back -- one wgpu sync point per row, no op in between. The
+            // turbofish is required: `O`'s dual `TensorConvertible` bound is ambiguous.
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(&t.obs, &mut obs_flat);
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(
+                &t.next_obs,
+                &mut next_flat,
+            );
             action_idxs.push(t.action as i64);
             rewards.push(t.reward);
             terminated.push(if t.terminated { 1.0 } else { 0.0 });

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
@@ -504,12 +504,14 @@ where
 
         for &id in batch.ids() {
             let t = self.buffer.get(id).expect("a freshly sampled id is live");
-            let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&device);
-            let next_tensor: Tensor<B::InnerBackend, DO> = t.next_obs.to_tensor(&device);
-            let obs_data = obs_tensor.into_data().convert::<f32>();
-            let next_data = next_tensor.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
-            next_flat.extend_from_slice(next_data.as_slice::<f32>().expect("float data"));
+            // Stage host-side: `to_tensor` would upload each row only to read it
+            // straight back -- one wgpu sync point per row, no op in between. The
+            // turbofish is required: `O`'s dual `TensorConvertible` bound is ambiguous.
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(&t.obs, &mut obs_flat);
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(
+                &t.next_obs,
+                &mut next_flat,
+            );
             action_flat.extend_from_slice(&t.action);
             rewards.push(t.reward);
             terminated.push(if t.terminated { 1.0 } else { 0.0 });

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
@@ -486,12 +486,14 @@ where
 
         for &id in batch.ids() {
             let t = self.buffer.get(id).expect("a freshly sampled id is live");
-            let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&device);
-            let next_tensor: Tensor<B::InnerBackend, DO> = t.next_obs.to_tensor(&device);
-            let obs_data = obs_tensor.into_data().convert::<f32>();
-            let next_data = next_tensor.into_data().convert::<f32>();
-            obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
-            next_flat.extend_from_slice(next_data.as_slice::<f32>().expect("float data"));
+            // Stage host-side: `to_tensor` would upload each row only to read it
+            // straight back -- one wgpu sync point per row, no op in between. The
+            // turbofish is required: `O`'s dual `TensorConvertible` bound is ambiguous.
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(&t.obs, &mut obs_flat);
+            <O as TensorConvertible<DO, B::InnerBackend>>::write_host_row(
+                &t.next_obs,
+                &mut next_flat,
+            );
             action_flat.extend_from_slice(&t.action);
             rewards.push(t.reward);
             terminated.push(if t.terminated { 1.0 } else { 0.0 });


### PR DESCRIPTION
**Stack 2 of 4** — based on #366. Resolves #187 and #362.

## The defect

Nine staging loops across eight agents uploaded each sampled observation to the device and immediately downloaded it, purely to obtain a host `Vec<f32>`:

```rust
let obs_tensor: Tensor<B::InnerBackend, DO> = t.obs.to_tensor(&self.device);  // upload
let obs_data = obs_tensor.into_data().convert::<f32>();                       // download
obs_flat.extend_from_slice(obs_data.as_slice::<f32>().expect("float data"));
```

The tensors were dropped **without a single operation ever running on them**. On wgpu each `into_data()` is a synchronization point, so a `learn_step` at batch 64 stalled the pipeline 128 times before any real work began.

The loops now write straight into the preallocated flat buffer via `TensorConvertible::write_host_row` — the primitive `to_tensor` is itself derived from — leaving the single batched `Tensor::from_data` upload unchanged.

## Sites

`aux_buffer.rs:152`, `ppg_agent.rs:553,785`, `ppo_agent.rs:490`, and the six off-policy `learn_step` loops (`dqn`, `c51`, `qrdqn`, `ddpg`, `td3`, `sac`).

**#362 listed the PPG/PPO sites as "secondary, unanalyzed."** They are analyzed here, and the list was half false positive: `ppo_agent.rs:686`, `ppg_agent.rs:872`, and `aux_buffer.rs:239` are **legitimate** — test-module `from_tensor` impls, or reads of computed forward-pass output. Only three of the six were defects. The tell is whether the tensor was built from host data the caller already had, versus computed on device; `into_data()` alone does not indicate the defect.

## Why no test changed

Staging is **bit-identical** — `write_host_row` is the primitive `to_tensor` calls internally, and `base.rs:899` pins the layout equivalence. No correctness test could distinguish old from new. Existing tests passing **unmodified** is the acceptance criterion here, not evidence of a coverage gap. The defect was pure throughput.

## What #366 measures about this

On wgpu/Metal (Apple M2 Pro) the removed path costs ~1.5 ms per row. Stack 4 measures the end-to-end consequence: **staging was 88–98% of `learn_step`**.

**On Flex/CPU the effect is 0–2%** for any network with real compute. This fix is enormous on Metal and irrelevant on CPU; both halves matter.

## Review notes

The `CRITICAL:` line in the commit is the load-bearing part: the six off-policy agents bind `O` as both `TensorConvertible<DO, B>` and `TensorConvertible<DO, B::InnerBackend>`, so the plain method call is ambiguous (`E0284`) — `write_host_row`'s signature mentions neither `R` nor `B`. **The old round-trip's type ascription was what disambiguated it**, so the turbofish introduced here is load-bearing, not stylistic. PPO and PPG sit under a single bound and need none.

That awkwardness is what #367 (stack 3) removes properly.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features` (0 issues), `cargo test --workspace` (2616 passed, 0 failed, zero test files modified). QA reviewed: no crossed `obs`/`next_obs` assignment, no `act()` path converted, all legitimate `into_data()` reads left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDX6bXaa6vcBjCR4arxP3P