### PR TITLE
docs(rl-benches, core): Correct staging-fix provenance left stale by the stack merge order

### DIFF
--- a/crates/rlevo-core/src/base.rs
+++ b/crates/rlevo-core/src/base.rs
@@ -326,6 +326,18 @@ pub trait TensorConvertible<const R: usize, B: Backend>: HostRow<R> + Sized {
 /// `shape[1..].copy_from_slice(&row)` sound (it would panic on a length
 /// mismatch otherwise).
 ///
+/// # Note
+///
+/// That this helper has no in-tree call sites is deliberate, not neglect. The
+/// six off-policy agents (`dqn`, `c51`, `qrdqn`, `ddpg`, `td3`, `sac`) fill five
+/// buffers — observations, next-observations, actions, rewards, terminated
+/// flags — in a *single* pass over the sampled ids; routing observations through
+/// this function would first require materializing an intermediate `Vec` of
+/// those rows, splitting that pass in two. They call [`write_host_row`] directly
+/// instead — the same primitive used here — and keep the one batched upload.
+/// This remains the recommended primitive for the common case: batching a
+/// homogeneous slice of [`HostRow`] rows into a single upload.
+///
 /// # Panics
 ///
 /// Panics if `BR != R + 1`.

--- a/crates/rlevo-reinforcement-learning/benches/learn_step_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/learn_step_bench.rs
@@ -20,7 +20,7 @@
 //! # This checkout's actual state
 //!
 //! `dqn_agent.rs::learn_step` in this checkout already uses
-//! `write_host_row` (commit `797d18c`, resolving #187/#362) -- see the
+//! `write_host_row` (commit `57dd565`, resolving #187/#362) -- see the
 //! [`Staging::HostRow`] arm below, which reproduces that production code
 //! path. [`Staging::Roundtrip`] reintroduces the pre-fix per-row
 //! `to_tensor` + `into_data()` round trip **inside this bench only**, for
@@ -179,9 +179,9 @@ const PIXEL_ACTIONS: usize = 4;
 enum Staging {
     /// Per-row `to_tensor(device)` then `.into_data()` -- upload-then-
     /// download-unchanged, one wgpu sync point per row. The pre-#187/#362
-    /// behaviour, reproduced verbatim from `797d18c`'s parent.
+    /// behaviour, reproduced verbatim from `57dd565`'s parent.
     Roundtrip,
-    /// `TensorConvertible::write_host_row` -- pure host staging, one batched
+    /// `HostRow::write_host_row` -- pure host staging, one batched
     /// upload. The strategy `dqn_agent.rs::learn_step` uses today.
     HostRow,
 }

--- a/crates/rlevo-reinforcement-learning/benches/staging_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/staging_bench.rs
@@ -1,35 +1,35 @@
 //! A/B micro-bench of the minibatch observation-staging seam: the device
 //! round trip (`obs.to_tensor(device)` then immediately `.into_data()`,
-//! upload-then-download-unchanged) vs. `TensorConvertible::write_host_row`
+//! upload-then-download-unchanged) vs. `HostRow::write_host_row`
 //! (pure host staging, one batched upload). Answers #187 / #362's open
 //! measurement question (issue #365 step 1): both strategies are implemented
 //! **inline, in this file**, so a single `cargo bench` run yields the delta.
 //!
-//! # A note on this checkout's actual state
+//! # This checkout's actual state
 //!
-//! Commit `797d18c` ("Stage minibatch observations host-side") is *not* an
-//! ancestor of this worktree's HEAD — `git merge-base --is-ancestor 797d18c
-//! HEAD` returns false, and `797d18c`'s parent is this same HEAD commit. It
-//! sits on a sibling branch reachable in the shared object store, not in this
-//! branch's history. Concretely: `dqn_agent.rs::learn_step` in *this*
-//! checkout still round-trips (`t.obs.to_tensor(&self.device)` then
-//! `.into_data().convert::<f32>()`, lines ~417-422) — the fix has not been
-//! wired into any agent here. What *does* already exist here is the
-//! `TensorConvertible::write_host_row` primitive itself (`rlevo-core`), which
-//! is enough to build this A/B independently of whether any agent calls it
-//! yet. Treat this bench as answering "is the not-yet-applied fix worth
-//! applying", not "did the applied fix help".
+//! The fix is applied. Commit `57dd565` ("Stage minibatch observations
+//! host-side") is an ancestor of HEAD, and all nine minibatch staging sites
+//! use the host-side path: the six off-policy agents (`dqn`, `c51`, `qrdqn`,
+//! `ddpg`, `td3`, `sac`) plus `ppo_agent.rs:492`, `ppg_agent.rs:553,785`, and
+//! `ppg/aux_buffer.rs:152`. Concretely, `dqn_agent.rs:419-420` now calls
+//! `t.obs.write_host_row(&mut obs_flat)` / `t.next_obs.write_host_row(&mut
+//! next_flat)` where it previously round-tripped through the device.
+//!
+//! So this bench answers "did the applied fix help", and going forward "what
+//! is the standing cost of the strategy the agents use" — [`stage_roundtrip`]
+//! survives here as the retired baseline, kept so the delta stays measurable
+//! and regressions in [`stage_host_row`] stay visible.
 //!
 //! # Design
 //!
-//! - `stage_roundtrip` — the round-trip path, reproduced verbatim from the
-//!   minibatch loop live in this checkout's `dqn_agent.rs::learn_step`: per
-//!   row, `to_tensor(device)`, then `.into_data().convert::<f32>()`, then
-//!   `extend_from_slice` into the flat host buffer; one batched
-//!   `Tensor::from_data` at the end.
-//! - `stage_host_row` — the candidate replacement: per row,
-//!   `TensorConvertible::write_host_row(&mut flat)` (no device touched), then
-//!   the same batched `Tensor::from_data`.
+//! - `stage_roundtrip` — the retired round-trip path, reproduced verbatim from
+//!   the minibatch loop in `57dd565`'s parent `dqn_agent.rs::learn_step`
+//!   (lines ~417-422 there): per row, `to_tensor(device)`, then
+//!   `.into_data().convert::<f32>()`, then `extend_from_slice` into the flat
+//!   host buffer; one batched `Tensor::from_data` at the end.
+//! - `stage_host_row` — the strategy the agents use today: per row,
+//!   `HostRow::write_host_row(&mut flat)` (no device touched), then the same
+//!   batched `Tensor::from_data`.
 //!
 //! Both are generic over the row type `T: TensorConvertible<R, B>` and the
 //! backend `B`, so one implementation covers `CartPoleObservation` (`R = 1`,
@@ -109,11 +109,11 @@ const BATCH_SIZES: [usize; 3] = [32, 64, 256];
 // The two staging strategies under test
 // ---------------------------------------------------------------------------
 
-/// The round-trip path: per row, upload then immediately read back, purely
-/// to obtain a host `f32` slice to append. Reproduced verbatim from the
-/// minibatch loop currently live in this checkout's
-/// `dqn_agent.rs::learn_step` (`obs_tensor.into_data().convert::<f32>()` +
-/// `extend_from_slice(..as_slice::<f32>()..)`).
+/// The retired round-trip path: per row, upload then immediately read back,
+/// purely to obtain a host `f32` slice to append. Reproduced verbatim from the
+/// minibatch loop in `57dd565`'s parent `dqn_agent.rs::learn_step`
+/// (`obs_tensor.into_data().convert::<f32>()` +
+/// `extend_from_slice(..as_slice::<f32>()..)`), which no agent runs any more.
 fn stage_roundtrip<const R: usize, const BR: usize, T, B>(
     items: &[T],
     device: &DeviceOf<B>,
@@ -137,11 +137,10 @@ where
     Tensor::from_data(TensorData::new(flat, shape), device)
 }
 
-/// The candidate replacement: write straight into the host buffer, one
+/// The strategy in production: write straight into the host buffer, one
 /// batched upload, zero per-row device round trips. Uses the
-/// `TensorConvertible::write_host_row` primitive that already exists in
-/// `rlevo-core` but is not yet wired into any agent's minibatch loop in this
-/// checkout (see the module-level note on `797d18c`).
+/// `HostRow::write_host_row` primitive from `rlevo-core`, which every agent's
+/// minibatch loop calls since `57dd565` (see the module-level note).
 fn stage_host_row<const R: usize, const BR: usize, T, B>(
     items: &[T],
     device: &DeviceOf<B>,


### PR DESCRIPTION
## Summary

Corrects documentation that asserts things about the tree which are no longer true, in two places left behind by the #362 staging fix. `staging_bench.rs`'s module doc still tells readers that `dqn_agent.rs` "still round-trips" and that "the fix has not been wired into any agent here" — that was true when the bench was authored on a sibling branch, but the stack landed the benches (#369, #370) *before* the fix (#371), so the note has been false on `main` ever since. A reader trusting it would conclude #362 was unfixed and could redo the work. Separately, `stack_to_tensor`'s zero in-tree call sites have now twice been re-derived as neglect — once as #362 itself, once as a correction to ADR 0052's Context — with nothing at the definition site recording that this is deliberate. Both are prose-only corrections; no logic, timing, or measured code path changes.

## Change Type

- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Context: #362 (closed). **This PR closes no issue** — it corrects documentation that #362's own resolution left stale, and records a rationale that #362's mistaken premise revealed was missing. Filing a fresh issue to close would be ceremony over a two-commit doc correction, so I've linked the originating context instead.

## What Was Changed

- `crates/rlevo-reinforcement-learning/benches/staging_bench.rs` — replaced the false "A note on this checkout's actual state" section: the fix *is* applied, `57dd565` is an ancestor of HEAD, and all nine staging sites are listed. Reframed the bench's stated purpose from "is the not-yet-applied fix worth applying" to "did the applied fix help", with `stage_roundtrip` described as a retired baseline kept for regression visibility. Also corrected the `stage_roundtrip` / `stage_host_row` item docs and the Design bullets.
- `crates/rlevo-reinforcement-learning/benches/learn_step_bench.rs` — commit-hash and trait-path corrections only; this file's "actual state" section was already correct in substance.
- Both bench files — re-pointed `797d18c` → `57dd565`. `797d18c` is an orphaned pre-merge commit from a sibling stacked branch and is **not** an ancestor of HEAD (`git merge-base --is-ancestor 797d18c HEAD` → false); the doc's claim about its parent was also wrong (parent is `07d6fca`). Verified that `57dd565`'s parent `01204c8` does contain the pre-fix round-trip at `dqn_agent.rs:417-422`, so "reproduced verbatim from `57dd565`'s parent" is a checked assertion rather than an assumed one.
- Both bench files — `TensorConvertible::write_host_row` → `HostRow::write_host_row`, following the ADR 0052 supertrait split.
- `crates/rlevo-core/src/base.rs` — added a 12-line `# Note` to `stack_to_tensor` recording why it has no in-tree callers: the six off-policy agents fill five buffers in a single pass over the sampled ids, so routing observations through it would force an intermediate `Vec` and split that pass in two. They call `write_host_row` directly and keep the one batched upload. Reaffirms `stack_to_tensor` as the primitive for the homogeneous-slice case the user book teaches.

## How It Was Tested

```
cargo build --workspace                      # Finished, no errors
cargo test --workspace                       # 2616 passed; 0 failed
cargo clippy --all-targets --all-features    # clean, zero warnings
cargo fmt --all --check                      # no drift
cargo doc -p rlevo-core --no-deps            # no rustdoc warnings; intra-doc links resolve
```

Both diffs were checked to be comment-only by filtering the diff for non-comment changed lines — the result was empty for all three files. The `base::stack_to_tensor` doctest still passes (its line number shifted by the 12 inserted lines; the example itself is unchanged).

Benchmarks were **not** run — they are slow and hit wgpu, and nothing in this PR alters a measured path.

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`; `rustc 1.94.1 (e408947bf 2026-03-25)`)
- Burn backend tested: CPU only (`Flex` / `Autodiff<Flex>`) — the workspace test suite's backend. No GPU coverage exists in the suite (see #365).
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 4.8)**. Scope: **the whole of both commits** — investigation, verification, and the prose. Every factual claim in the new text was checked against the code, the vendored dependency source, or `git` before being written, and the diffs were independently confirmed comment-only.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. — **N/A**: doc-only, no behavior change to regress. There is no mechanism to test prose against the tree, which is precisely why this drift survived the merge.
- [x] This PR addresses a single concern. Both commits fix documentation whose premise `stack/1`–`stack/4` invalidated.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Root cause worth noting for future stacks:** the merge order inverted a doc's premise. Any comment phrased as "in this checkout X still does Y" becomes false when the stack lands out of authoring order, and nothing in CI catches prose disagreeing with the tree — not clippy, not tests, not rustdoc. Prefer writing such notes against a named commit rather than "this checkout".

**Deliberately not included:**

- #362's title still reads "Six agents bypass `stack_to_tensor`". Left alone — the issue is closed and its closing comment corrects the framing; retitling would break inbound references.
- ADR 0052's Context (line 18) carries the same framing. Left alone per `CLAUDE.md`: accepted ADRs are immutable and are superseded, never edited. A one-line imprecision in a Context section does not warrant a superseding ADR, and the new `stack_to_tensor` note now stops the re-derivation at the definition site, which is where it kept starting.

**Follow-ups, all filed:** #374 (no CI test protects the nine staging sites against a reorder/interleave regression), #364 (`shape()` vs `row_shape()`, still open by ADR 0052's explicit deferral), #365 item 1 — converting the 14 existing benches to wgpu variants remains the only thing that would actually confirm #362's fix helped on a GPU backend.
