### PR TITLE
fix(rl): Key DDPG/TD3/SAC action paths on COMPONENTS and clip targets per component

### DIFF
--- a/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
@@ -26,7 +26,7 @@ use rlevo_core::config::Validate;
 use crate::algorithms::ddpg::ddpg_config::DdpgTrainingConfig;
 use crate::algorithms::ddpg::ddpg_model::{ContinuousQ, DeterministicPolicy};
 use crate::algorithms::ddpg::exploration::GaussianNoise;
-use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA};
+use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA, assert_bounds_match_components};
 use crate::utils::compute_target_q_values;
 
 /// Error variants returned by [`DdpgAgent`] operations.
@@ -203,6 +203,14 @@ where
     ///
     /// Returns a [`ConfigError`](rlevo_core::config::ConfigError) if `config`
     /// fails [`DdpgTrainingConfig::validate`](rlevo_core::config::Validate::validate).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `A`'s [`BoundedAction`] impl violates its length contract —
+    /// i.e. if `A::low().len()` or `A::high().len()` differs from
+    /// `A::COMPONENTS`. `&'static [f32]` cannot carry that guarantee in the
+    /// type system (ADR 0053), so it is checked once here rather than being
+    /// discovered as an out-of-bounds index mid-episode.
     pub fn new(
         actor: Actor,
         critic: Critic,
@@ -210,6 +218,7 @@ where
         device: B::Device,
     ) -> Result<Self, rlevo_core::config::ConfigError> {
         config.validate()?;
+        assert_bounds_match_components::<DA, A>();
         let target_actor = actor.valid();
         let target_critic = critic.valid();
         let adam = config.optimizer.clone();
@@ -285,7 +294,7 @@ where
     /// in [`learn_step`](Self::learn_step) leaves this method working.
     pub fn act<R: Rng + ?Sized>(&self, obs: &O, training: bool, rng: &mut R) -> A {
         if training && self.step < self.config.learning_starts {
-            let sample: Vec<f32> = (0..A::RANK)
+            let sample: Vec<f32> = (0..A::COMPONENTS)
                 .map(|i| rng.random_range(self.low[i]..=self.high[i]))
                 .collect();
             return A::from_slice(&sample);
@@ -296,7 +305,7 @@ where
         let raw: Tensor<B, DAB> = self.actor.get().forward(batched);
         let data = raw.into_data().convert::<f32>();
         let slice = data.as_slice::<f32>().expect("actor output is f32");
-        let mean: Vec<f32> = slice.iter().take(A::RANK).copied().collect();
+        let mean: Vec<f32> = slice.iter().take(A::COMPONENTS).copied().collect();
         let out = if training {
             self.exploration.apply(&mean, self.low, self.high, rng)
         } else {
@@ -336,7 +345,7 @@ where
         let raw: Tensor<B::InnerBackend, DAB> = Actor::forward_inner(net, batched);
         let data = raw.into_data().convert::<f32>();
         let slice = data.as_slice::<f32>().expect("actor output is f32");
-        let out: Vec<f32> = (0..A::RANK)
+        let out: Vec<f32> = (0..A::COMPONENTS)
             .map(|i| slice[i].clamp(self.low[i], self.high[i]))
             .collect();
         A::from_slice(&out)

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
@@ -26,7 +26,10 @@ use rlevo_core::config::Validate;
 use crate::algorithms::ddpg::ddpg_config::DdpgTrainingConfig;
 use crate::algorithms::ddpg::ddpg_model::{ContinuousQ, DeterministicPolicy};
 use crate::algorithms::ddpg::exploration::GaussianNoise;
-use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA, assert_bounds_match_components};
+use crate::algorithms::shared::{
+    Slot, UNIFORM_REPLAY_BETA, action_bound_tensors, assert_bounds_match_components,
+    clip_to_action_bounds,
+};
 use crate::utils::compute_target_q_values;
 
 /// Error variants returned by [`DdpgAgent`] operations.
@@ -151,6 +154,10 @@ pub struct DdpgAgent<
     exploration: GaussianNoise,
     low: &'static [f32],
     high: &'static [f32],
+    /// `[1, ..action_shape]` per-component bounds for the target-action clip,
+    /// built once at construction — see [`action_bound_tensors`].
+    low_t: Tensor<B::InnerBackend, DAB>,
+    high_t: Tensor<B::InnerBackend, DAB>,
     config: DdpgTrainingConfig,
     device: B::Device,
     step: usize,
@@ -238,6 +245,7 @@ where
         };
         let exploration = GaussianNoise::new(config.exploration_noise);
         let stats = AgentStats::<DdpgMetrics>::new(100);
+        let (low_t, high_t) = action_bound_tensors::<B::InnerBackend, A, DA, DAB>(&device);
         Ok(Self {
             actor: Slot::new(actor),
             target_actor,
@@ -249,6 +257,8 @@ where
             exploration,
             low: A::low(),
             high: A::high(),
+            low_t,
+            high_t,
             config,
             device,
             step: 0,
@@ -477,13 +487,20 @@ where
             Tensor::from_data(TensorData::new(terminated, vec![batch_size]), &device);
 
         // --- Target computation (no autodiff) ---
-        // CleanRL uses low[0]/high[0] as a scalar clip on the target action;
-        // adopt the same convention (documented in BoundedAction).
-        let low_scalar = self.low[0];
-        let high_scalar = self.high[0];
-        let next_actions: Tensor<B::InnerBackend, DAB> =
-            Actor::forward_inner(&self.target_actor, next_t_inner.clone())
-                .clamp(low_scalar, high_scalar);
+        // Clip the target action per component, against the `Box(low, high)`
+        // vectors — TD3 Eq. 14 (Fujimoto et al. 2018, arXiv:1802.09477), whose
+        // clip DDPG's target path shares. A scalar `low[0]`/`high[0]` collapse
+        // is only equivalent when every component shares a bound; for an
+        // asymmetric space such as CarRacing's `Box([-1,0,0], [1,1,1])` it would
+        // admit negative gas and brake into the target — precisely the "values
+        // of impossible actions" the clip exists to suppress. Burn's `clamp` is
+        // scalar-only, so this goes through `max_pair`/`min_pair` against the
+        // `[1, ..action_shape]` bound tensors, broadcast over the batch.
+        let next_actions: Tensor<B::InnerBackend, DAB> = clip_to_action_bounds(
+            Actor::forward_inner(&self.target_actor, next_t_inner.clone()),
+            self.low_t.clone(),
+            self.high_t.clone(),
+        );
         let next_q: Tensor<B::InnerBackend, 1> =
             Critic::forward_inner(&self.target_critic, next_t_inner, next_actions);
         let target_inner: Tensor<B::InnerBackend, 1> =

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
@@ -32,7 +32,7 @@ use rlevo_core::config::Validate;
 use crate::algorithms::sac::sac_alpha::LogAlpha;
 use crate::algorithms::sac::sac_config::SacTrainingConfig;
 use crate::algorithms::sac::sac_model::{ContinuousQ, SquashedGaussianPolicy};
-use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA};
+use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA, assert_bounds_match_components};
 use crate::utils::compute_target_q_values;
 
 /// Error variants returned by [`SacAgent`] operations.
@@ -242,6 +242,14 @@ where
     ///
     /// Returns a [`ConfigError`](rlevo_core::config::ConfigError) if `config`
     /// fails [`SacTrainingConfig::validate`](rlevo_core::config::Validate::validate).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `A`'s [`BoundedAction`] impl violates its length contract —
+    /// i.e. if `A::low().len()` or `A::high().len()` differs from
+    /// `A::COMPONENTS`. `&'static [f32]` cannot carry that guarantee in the
+    /// type system (ADR 0053), so it is checked once here rather than being
+    /// discovered as an out-of-bounds index mid-episode.
     pub fn new(
         actor: Actor,
         critic_1: Critic,
@@ -250,6 +258,7 @@ where
         device: B::Device,
     ) -> Result<Self, rlevo_core::config::ConfigError> {
         config.validate()?;
+        assert_bounds_match_components::<DA, A>();
         let actor_snapshot = actor.valid();
         let target_critic_1 = critic_1.valid();
         let target_critic_2 = critic_2.valid();
@@ -366,7 +375,7 @@ where
     /// [`Slot`](crate::algorithms::shared::Slot).
     pub fn act<R: Rng + ?Sized>(&self, obs: &O, training: bool, rng: &mut R) -> A {
         if training && self.step < self.config.learning_starts {
-            let sample: Vec<f32> = (0..A::RANK)
+            let sample: Vec<f32> = (0..A::COMPONENTS)
                 .map(|i| rng.random_range(self.low[i]..=self.high[i]))
                 .collect();
             return A::from_slice(&sample);
@@ -398,7 +407,7 @@ where
         // Actions are already squashed into `[bias - scale, bias + scale]`
         // by the policy; still clip against `low/high` to be robust to users
         // whose scale/bias disagree with the action type's bounds.
-        let out: Vec<f32> = (0..A::RANK)
+        let out: Vec<f32> = (0..A::COMPONENTS)
             .map(|i| slice[i].clamp(self.low[i], self.high[i]))
             .collect();
         A::from_slice(&out)

--- a/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
@@ -181,6 +181,76 @@ pub(crate) fn assert_bounds_match_components<const DA: usize, A: BoundedAction<D
     );
 }
 
+/// Builds the `[1, ..action_shape]` per-component lower/upper bound tensors used
+/// by the DDPG and TD3 target-action clip.
+///
+/// TD3 Eq. 14 (Fujimoto et al. 2018) clips the target action against the
+/// `Box(low, high)` **vectors**, one limit per component. Burn 0.21's `clamp`
+/// family takes a scalar and cannot express that, so the clip goes through
+/// `max_pair`/`min_pair`, which need a tensor operand broadcastable to the
+/// `[batch, ..action_shape]` action tensor. Leading dim `1` broadcasts across
+/// the batch.
+///
+/// Built once per agent, at construction: the bounds are `&'static` (ADR 0053
+/// §2) and the device is already in hand, so nothing here belongs on the
+/// per-`learn_step` path.
+///
+/// # Panics
+///
+/// Panics if `A::shape()` does not describe exactly `A::COMPONENTS` scalars.
+/// The learn path already assumes this — it lays out the batched action tensor
+/// as `[batch, ..A::shape()]` and fills it from `A::as_slice()`, which is
+/// `COMPONENTS` long — so an action using ADR 0053 §8's Convention B (rank > 1
+/// with a non-matching `shape()` product) is unusable with these agents, and
+/// says so here rather than as a `TensorData` shape error.
+pub(crate) fn action_bound_tensors<BI, A, const DA: usize, const DAB: usize>(
+    device: &BI::Device,
+) -> (Tensor<BI, DAB>, Tensor<BI, DAB>)
+where
+    BI: Backend,
+    A: BoundedAction<DA>,
+{
+    let action_shape = A::shape();
+    let numel: usize = action_shape.iter().product();
+    assert_eq!(
+        numel,
+        A::COMPONENTS,
+        "action shape {action_shape:?} describes {numel} scalars but COMPONENTS is {}; \
+         the continuous-control agents require shape().product() == COMPONENTS",
+        A::COMPONENTS,
+    );
+
+    let mut shape: Vec<usize> = Vec::with_capacity(DAB);
+    shape.push(1);
+    shape.extend_from_slice(&action_shape);
+
+    let low = Tensor::from_data(TensorData::new(A::low().to_vec(), shape.clone()), device);
+    let high = Tensor::from_data(TensorData::new(A::high().to_vec(), shape), device);
+    (low, high)
+}
+
+/// Clips a batch of actions to `[low, high]` **per component**.
+///
+/// This is TD3 Eq. 14's outer clip, shared by DDPG's target path (which is the
+/// same clip without the smoothing noise). `low` and `high` come from
+/// [`action_bound_tensors`] and are shaped `[1, ..action_shape]`, so they
+/// broadcast across the batch dimension of `actions`.
+///
+/// Burn 0.21's `clamp` / `clamp_min` / `clamp_max` take a scalar
+/// `E: ElementConversion` and cannot express one limit per component, so this
+/// is `max_pair` followed by `min_pair` — two broadcast elementwise ops rather
+/// than one fused scalar clamp, over the same `[batch, ..action_shape]` data.
+pub(crate) fn clip_to_action_bounds<BI, const DAB: usize>(
+    actions: Tensor<BI, DAB>,
+    low: Tensor<BI, DAB>,
+    high: Tensor<BI, DAB>,
+) -> Tensor<BI, DAB>
+where
+    BI: Backend,
+{
+    actions.max_pair(low).min_pair(high)
+}
+
 /// Reduces a per-sample `[batch]` loss to a scalar, first scaling each sample by
 /// its importance-sampling weight when the batch carries any.
 ///
@@ -753,6 +823,77 @@ mod tests {
             (scalar(reduced) - 2.0).abs() < 1e-6,
             "each sample must be scaled by its own weight before the batch mean"
         );
+    }
+
+    // -------- clip_to_action_bounds --------
+
+    fn bound_row(values: &[f32]) -> Tensor<Flex, 2> {
+        let device = <Flex as burn::tensor::backend::BackendTypes>::Device::default();
+        Tensor::from_data(
+            TensorData::new(values.to_vec(), vec![1, values.len()]),
+            &device,
+        )
+    }
+
+    #[test]
+    fn test_clip_to_action_bounds_respects_asymmetric_components() {
+        // ADR 0053 §6's regression witness, at the level DDPG's target path
+        // uses directly. CarRacing is `Box([-1,0,0], [1,1,1])`: steering is
+        // signed, gas and brake are not. The pre-fix scalar clip used
+        // `low[0]`/`high[0]` = `-1`/`1` for all three components, so a target
+        // actor emitting -5 everywhere produced a target action of
+        // `[-1, -1, -1]` — negative gas and negative brake, actions the
+        // environment cannot execute, whose Q-values TD3 Eq. 14 exists to keep
+        // out of the target. Per-component clipping floors both at 0.
+        let device = <Flex as burn::tensor::backend::BackendTypes>::Device::default();
+        let low = bound_row(&[-1.0, 0.0, 0.0]);
+        let high = bound_row(&[1.0, 1.0, 1.0]);
+        // Two rows: the `[1, 3]` bounds must broadcast over the batch dim.
+        let actions: Tensor<Flex, 2> = Tensor::from_data(
+            TensorData::new(vec![-5.0_f32, -5.0, -5.0, 5.0, 5.0, 5.0], vec![2, 3]),
+            &device,
+        );
+
+        let out = clip_to_action_bounds(actions, low, high);
+        let data = out.into_data().convert::<f32>();
+        let got = data.as_slice::<f32>().expect("f32 host read");
+
+        let expected = [-1.0_f32, 0.0, 0.0, 1.0, 1.0, 1.0];
+        for (i, want) in expected.iter().enumerate() {
+            assert!(
+                (got[i] - want).abs() < 1e-6,
+                "component {i} must clip to its own bound {want}, got {} (full row: {got:?})",
+                got[i]
+            );
+        }
+        assert!(
+            got[1] >= -1e-6 && got[2] >= -1e-6,
+            "gas and brake have a lower bound of 0 and must never go negative, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn test_clip_to_action_bounds_is_a_noop_inside_the_box() {
+        let device = <Flex as burn::tensor::backend::BackendTypes>::Device::default();
+        let low = bound_row(&[-1.0, 0.0, 0.0]);
+        let high = bound_row(&[1.0, 1.0, 1.0]);
+        let actions: Tensor<Flex, 2> = Tensor::from_data(
+            TensorData::new(vec![-0.5_f32, 0.25, 0.75], vec![1, 3]),
+            &device,
+        );
+
+        let out = clip_to_action_bounds(actions, low, high);
+        let data = out.into_data().convert::<f32>();
+        let got = data.as_slice::<f32>().expect("f32 host read");
+
+        for (i, want) in [-0.5_f32, 0.25, 0.75].iter().enumerate() {
+            assert!(
+                (got[i] - want).abs() < 1e-6,
+                "an in-bounds action must pass through unchanged at component {i}: \
+                 wanted {want}, got {}",
+                got[i]
+            );
+        }
     }
 
     // -------- LogWatermark --------

--- a/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
@@ -63,6 +63,8 @@ use burn::optim::{GradientsParams, LearningRate, Optimizer};
 use burn::tensor::backend::{AutodiffBackend, Backend};
 use burn::tensor::{Tensor, TensorData};
 
+use rlevo_core::action::BoundedAction;
+
 use crate::replay::{ImportanceExponent, SampledBatch};
 
 /// Panic message for a read against a poisoned slot.
@@ -143,6 +145,41 @@ pub(crate) struct Slot<M>(Option<M>);
 /// [`ImportanceExponent`]: crate::replay::ImportanceExponent
 /// [`ImportanceExponent::ONE`]: crate::replay::ImportanceExponent::ONE
 pub(crate) const UNIFORM_REPLAY_BETA: ImportanceExponent = ImportanceExponent::ONE;
+
+/// Asserts that `A`'s action bounds are keyed on `COMPONENTS`, as
+/// [`BoundedAction`] requires.
+///
+/// [`BoundedAction::low`] and [`BoundedAction::high`] return `&'static [f32]`,
+/// which cannot encode its own length, so the contract
+/// `low().len() == high().len() == COMPONENTS` is an obligation on the
+/// implementor rather than a compile-time guarantee (ADR 0053 §4). The three
+/// continuous-control agents index those slices per component on every `act`,
+/// so a short slice would surface as an out-of-bounds panic mid-episode,
+/// pointing at the agent rather than at the offending impl.
+///
+/// Calling this once in each agent constructor converts that into a loud,
+/// early failure that names the real culprit.
+///
+/// # Panics
+///
+/// Panics if `A::low().len()` or `A::high().len()` differs from
+/// `A::COMPONENTS`.
+pub(crate) fn assert_bounds_match_components<const DA: usize, A: BoundedAction<DA>>() {
+    assert_eq!(
+        A::low().len(),
+        A::COMPONENTS,
+        "BoundedAction contract violated: low() has {} elements but COMPONENTS is {}",
+        A::low().len(),
+        A::COMPONENTS,
+    );
+    assert_eq!(
+        A::high().len(),
+        A::COMPONENTS,
+        "BoundedAction contract violated: high() has {} elements but COMPONENTS is {}",
+        A::high().len(),
+        A::COMPONENTS,
+    );
+}
 
 /// Reduces a per-sample `[batch]` loss to a scalar, first scaling each sample by
 /// its importance-sampling weight when the batch carries any.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/target_smoothing.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/target_smoothing.rs
@@ -14,29 +14,49 @@
 //! a' = clip(target_actor(s') + clip(N(0, σ²), -c, c), low, high)
 //! ```
 //!
-//! where `σ = policy_noise` and `c = noise_clip`.
+//! where `σ = policy_noise` and `c = noise_clip`. `c` is a scalar; `low` and
+//! `high` are the per-component `Box` bound vectors (ADR 0053 §6).
 
 use burn::tensor::backend::Backend;
 use burn::tensor::{Tensor, TensorData};
 use rand::Rng;
 use rand_distr::{Distribution, StandardNormal};
 
+use crate::algorithms::shared::clip_to_action_bounds;
+
 /// Applies target-policy smoothing to a batch of target-actor outputs.
 ///
 /// Adds independent `N(0, policy_noise²)` noise to each element of
-/// `target_action`, clips the noise to `[-noise_clip, +noise_clip]`, and
-/// clips the summed result to `[low, high]`. The operation runs on the
-/// target's (non-autodiff) backend; no gradients are produced.
+/// `target_action`, clips the noise to the **scalar** range
+/// `[-noise_clip, +noise_clip]`, and clips the summed result **per component**
+/// against `low` / `high`. The operation runs on the target's (non-autodiff)
+/// backend; no gradients are produced.
+///
+/// # Arguments
+///
+/// - `noise_clip` — the symmetric magnitude limit `c` on the smoothing noise.
+///   This is a scalar in Eq. 14 and stays one here: it bounds how far the
+///   target may be perturbed, which is a property of the smoothing, not of the
+///   action space.
+/// - `low` / `high` — the `Box(low, high)` bound tensors, shaped
+///   `[1, ..action_shape]` so they broadcast across the batch. Per-component,
+///   because Eq. 14's outer clip is against the bound *vectors*: an asymmetric
+///   space (e.g. CarRacing's `Box([-1,0,0], [1,1,1])`) has no single scalar
+///   that expresses it, and a scalar collapse would pass impossible actions —
+///   negative gas, negative brake — to the critic. Burn's `clamp` is
+///   scalar-only, so the clip goes through `max_pair` / `min_pair`.
 ///
 /// # Panics
 ///
-/// Panics if `policy_noise < 0`, `noise_clip < 0`, or `low > high`.
+/// Panics if `policy_noise < 0` or `noise_clip < 0`. The `low <= high` ordering
+/// is a [`BoundedAction`](rlevo_core::action::BoundedAction) invariant checked
+/// at agent construction, not here.
 pub fn smoothed_target_action<BI, R, const DAB: usize>(
     target_action: Tensor<BI, DAB>,
     policy_noise: f32,
     noise_clip: f32,
-    low: f32,
-    high: f32,
+    low: Tensor<BI, DAB>,
+    high: Tensor<BI, DAB>,
     rng: &mut R,
 ) -> Tensor<BI, DAB>
 where
@@ -50,10 +70,6 @@ where
     assert!(
         noise_clip.is_finite() && noise_clip >= 0.0,
         "noise_clip must be finite and non-negative, got {noise_clip}"
-    );
-    assert!(
-        low <= high,
-        "low must be <= high, got low={low} high={high}"
     );
 
     let device = target_action.device();
@@ -71,7 +87,7 @@ where
     let noise_tensor: Tensor<BI, DAB> =
         Tensor::from_data(TensorData::new(noise_vec, dims.to_vec()), &device);
 
-    (target_action + noise_tensor).clamp(low, high)
+    clip_to_action_bounds(target_action + noise_tensor, low, high)
 }
 
 #[cfg(test)]
@@ -84,13 +100,29 @@ mod tests {
 
     type B = Flex;
 
+    /// Builds a `[1, C]` bound tensor from the per-component limits.
+    fn bounds(values: &[f32]) -> Tensor<B, 2> {
+        let device = Default::default();
+        Tensor::from_data(
+            TensorData::new(values.to_vec(), vec![1, values.len()]),
+            &device,
+        )
+    }
+
+    /// Uniform bounds repeated across `c` components — the symmetric case the
+    /// old scalar signature covered.
+    fn uniform_bounds(low: f32, high: f32, c: usize) -> (Tensor<B, 2>, Tensor<B, 2>) {
+        (bounds(&vec![low; c]), bounds(&vec![high; c]))
+    }
+
     #[test]
     fn zero_policy_noise_reduces_to_action_clip() {
         let device = Default::default();
         let action: Tensor<B, 2> =
             Tensor::from_data(TensorData::new(vec![0.3_f32, -5.0], vec![1, 2]), &device);
         let mut rng = StdRng::seed_from_u64(42);
-        let out = smoothed_target_action::<B, _, 2>(action, 0.0, 0.5, -1.0, 1.0, &mut rng);
+        let (low, high) = uniform_bounds(-1.0, 1.0, 2);
+        let out = smoothed_target_action::<B, _, 2>(action, 0.0, 0.5, low, high, &mut rng);
         let data = out.into_data().convert::<f32>();
         let slice = data.as_slice::<f32>().unwrap();
         // `0.3` passes through; `-5.0` clips to `-1.0`.
@@ -106,11 +138,10 @@ mod tests {
         // inactive and the output is the clipped noise itself.
         let device = Default::default();
         let noise_clip: f32 = 0.5;
-        let low = -100.0_f32;
-        let high = 100.0_f32;
         let mut rng = StdRng::seed_from_u64(7);
         for _ in 0..256 {
             let action: Tensor<B, 2> = Tensor::zeros([4, 2], &device);
+            let (low, high) = uniform_bounds(-100.0, 100.0, 2);
             let out =
                 smoothed_target_action::<B, _, 2>(action, 100.0, noise_clip, low, high, &mut rng);
             let data = out.into_data().convert::<f32>();
@@ -128,15 +159,62 @@ mod tests {
         // Push the mean outside the bounds; the outer clip should force
         // every output into `[low, high]`.
         let device = Default::default();
-        let low = -1.0_f32;
-        let high = 1.0_f32;
+        let high_value = 1.0_f32;
         let mut rng = StdRng::seed_from_u64(0);
         let action: Tensor<B, 2> =
             Tensor::from_data(TensorData::new(vec![10.0_f32; 6], vec![3, 2]), &device);
+        let (low, high) = uniform_bounds(-1.0, high_value, 2);
         let out = smoothed_target_action::<B, _, 2>(action, 0.1, 0.1, low, high, &mut rng);
         let data = out.into_data().convert::<f32>();
         for v in data.as_slice::<f32>().unwrap() {
-            assert!((*v - high).abs() < 1e-6, "expected clip to {high}, got {v}");
+            assert!(
+                (*v - high_value).abs() < 1e-6,
+                "expected clip to {high_value}, got {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn asymmetric_bounds_clip_each_component_independently() {
+        // Regression witness for ADR 0053 §6. CarRacing's action space is
+        // `Box([-1,0,0], [1,1,1])`: steering is signed, gas and brake are not.
+        // A scalar clip on `low[0]`/`high[0]` = `-1`/`1` — the pre-fix
+        // behaviour — leaves the -1 in components 1 and 2 untouched, handing
+        // the critic a negative gas and a negative brake: actions the
+        // environment cannot execute. Only a per-component clip floors them
+        // at 0.
+        let device = Default::default();
+        let low = bounds(&[-1.0, 0.0, 0.0]);
+        let high = bounds(&[1.0, 1.0, 1.0]);
+        let mut rng = StdRng::seed_from_u64(0);
+        // Two rows, so the `[1, 3]` bounds must broadcast over the batch.
+        let action: Tensor<B, 2> = Tensor::from_data(
+            TensorData::new(vec![-5.0_f32, -5.0, -5.0, 5.0, 5.0, 5.0], vec![2, 3]),
+            &device,
+        );
+        // Zero policy noise isolates the outer clip from the smoothing.
+        let out = smoothed_target_action::<B, _, 2>(action, 0.0, 0.5, low, high, &mut rng);
+        let data = out.into_data().convert::<f32>();
+        let slice = data.as_slice::<f32>().unwrap();
+
+        assert!(
+            (slice[0] + 1.0).abs() < 1e-6,
+            "steering must clip to its own low of -1, got {}",
+            slice[0]
+        );
+        for (i, name) in [(1_usize, "gas"), (2, "brake")] {
+            assert!(
+                slice[i] >= -1e-6,
+                "{name} has a lower bound of 0 and must never go negative, got {}",
+                slice[i]
+            );
+        }
+        for (i, expected) in [(3_usize, 1.0_f32), (4, 1.0), (5, 1.0)] {
+            assert!(
+                (slice[i] - expected).abs() < 1e-6,
+                "component {i} must clip to its upper bound {expected}, got {}",
+                slice[i]
+            );
         }
     }
 
@@ -146,7 +224,8 @@ mod tests {
         let device = Default::default();
         let action: Tensor<B, 2> = Tensor::zeros([1, 1], &device);
         let mut rng = StdRng::seed_from_u64(0);
-        let _ = smoothed_target_action::<B, _, 2>(action, -0.1, 0.5, -1.0, 1.0, &mut rng);
+        let (low, high) = uniform_bounds(-1.0, 1.0, 1);
+        let _ = smoothed_target_action::<B, _, 2>(action, -0.1, 0.5, low, high, &mut rng);
     }
 
     #[test]
@@ -155,6 +234,7 @@ mod tests {
         let device = Default::default();
         let action: Tensor<B, 2> = Tensor::zeros([1, 1], &device);
         let mut rng = StdRng::seed_from_u64(0);
-        let _ = smoothed_target_action::<B, _, 2>(action, 0.2, -0.1, -1.0, 1.0, &mut rng);
+        let (low, high) = uniform_bounds(-1.0, 1.0, 1);
+        let _ = smoothed_target_action::<B, _, 2>(action, 0.2, -0.1, low, high, &mut rng);
     }
 }

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
@@ -29,7 +29,9 @@ use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
 
 use crate::algorithms::ddpg::exploration::GaussianNoise;
-use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA, assert_bounds_match_components};
+use crate::algorithms::shared::{
+    Slot, UNIFORM_REPLAY_BETA, action_bound_tensors, assert_bounds_match_components,
+};
 use crate::algorithms::td3::target_smoothing::smoothed_target_action;
 use crate::algorithms::td3::td3_config::Td3TrainingConfig;
 use crate::algorithms::td3::td3_model::{ContinuousQ, DeterministicPolicy};
@@ -179,6 +181,10 @@ pub struct Td3Agent<
     exploration: GaussianNoise,
     low: &'static [f32],
     high: &'static [f32],
+    /// `[1, ..action_shape]` per-component bounds for the Eq. 14 target clip,
+    /// built once at construction — see [`action_bound_tensors`].
+    low_t: Tensor<B::InnerBackend, DAB>,
+    high_t: Tensor<B::InnerBackend, DAB>,
     config: Td3TrainingConfig,
     device: B::Device,
     step: usize,
@@ -271,6 +277,7 @@ where
         };
         let exploration = GaussianNoise::new(config.exploration_noise);
         let stats = AgentStats::<Td3Metrics>::new(100);
+        let (low_t, high_t) = action_bound_tensors::<B::InnerBackend, A, DA, DAB>(&device);
         Ok(Self {
             actor: Slot::new(actor),
             target_actor,
@@ -285,6 +292,8 @@ where
             exploration,
             low: A::low(),
             high: A::high(),
+            low_t,
+            high_t,
             config,
             device,
             step: 0,
@@ -526,18 +535,22 @@ where
             Tensor::from_data(TensorData::new(terminated, vec![batch_size]), &device);
 
         // --- Target computation (no autodiff) ---
-        // Convention matches DDPG and CleanRL: clip to `low[0]`/`high[0]`.
-        let low_scalar = self.low[0];
-        let high_scalar = self.high[0];
-
+        // Eq. 14's outer clip is against the `Box(low, high)` **vectors**, one
+        // limit per component. Collapsing them to `low[0]`/`high[0]` is only
+        // equivalent when every component shares a bound; under an asymmetric
+        // space such as CarRacing's `Box([-1,0,0], [1,1,1])` it would leave
+        // negative gas and brake in the target action — the "values of
+        // impossible actions" the clip exists to suppress. The inner
+        // `noise_clip` stays scalar: it bounds the smoothing noise *magnitude*
+        // symmetrically and is scalar in the paper too.
         let raw_next_action: Tensor<B::InnerBackend, DAB> =
             Actor::forward_inner(&self.target_actor, next_t_inner.clone());
         let next_actions = smoothed_target_action::<B::InnerBackend, R, DAB>(
             raw_next_action,
             self.config.policy_noise,
             self.config.noise_clip,
-            low_scalar,
-            high_scalar,
+            self.low_t.clone(),
+            self.high_t.clone(),
             rng,
         );
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
@@ -29,7 +29,7 @@ use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
 
 use crate::algorithms::ddpg::exploration::GaussianNoise;
-use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA};
+use crate::algorithms::shared::{Slot, UNIFORM_REPLAY_BETA, assert_bounds_match_components};
 use crate::algorithms::td3::target_smoothing::smoothed_target_action;
 use crate::algorithms::td3::td3_config::Td3TrainingConfig;
 use crate::algorithms::td3::td3_model::{ContinuousQ, DeterministicPolicy};
@@ -230,6 +230,14 @@ where
     ///
     /// Returns a [`ConfigError`](rlevo_core::config::ConfigError) if `config`
     /// fails [`Td3TrainingConfig::validate`](rlevo_core::config::Validate::validate).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `A`'s [`BoundedAction`] impl violates its length contract —
+    /// i.e. if `A::low().len()` or `A::high().len()` differs from
+    /// `A::COMPONENTS`. `&'static [f32]` cannot carry that guarantee in the
+    /// type system (ADR 0053), so it is checked once here rather than being
+    /// discovered as an out-of-bounds index mid-episode.
     pub fn new(
         actor: Actor,
         critic_1: Critic,
@@ -238,6 +246,7 @@ where
         device: B::Device,
     ) -> Result<Self, rlevo_core::config::ConfigError> {
         config.validate()?;
+        assert_bounds_match_components::<DA, A>();
         let target_actor = actor.valid();
         let target_critic_1 = critic_1.valid();
         let target_critic_2 = critic_2.valid();
@@ -326,7 +335,7 @@ where
     /// rebuilt.
     pub fn act<R: Rng + ?Sized>(&self, obs: &O, training: bool, rng: &mut R) -> A {
         if training && self.step < self.config.learning_starts {
-            let sample: Vec<f32> = (0..A::RANK)
+            let sample: Vec<f32> = (0..A::COMPONENTS)
                 .map(|i| rng.random_range(self.low[i]..=self.high[i]))
                 .collect();
             return A::from_slice(&sample);
@@ -337,7 +346,7 @@ where
         let raw: Tensor<B, DAB> = self.actor.get().forward(batched);
         let data = raw.into_data().convert::<f32>();
         let slice = data.as_slice::<f32>().expect("actor output is f32");
-        let mean: Vec<f32> = slice.iter().take(A::RANK).copied().collect();
+        let mean: Vec<f32> = slice.iter().take(A::COMPONENTS).copied().collect();
         let out = if training {
             self.exploration.apply(&mean, self.low, self.high, rng)
         } else {
@@ -378,7 +387,7 @@ where
         let raw: Tensor<B::InnerBackend, DAB> = Actor::forward_inner(net, batched);
         let data = raw.into_data().convert::<f32>();
         let slice = data.as_slice::<f32>().expect("actor output is f32");
-        let out: Vec<f32> = (0..A::RANK)
+        let out: Vec<f32> = (0..A::COMPONENTS)
             .map(|i| slice[i].clamp(self.low[i], self.high[i]))
             .collect();
         A::from_slice(&out)

--- a/crates/rlevo/tests/bounded_action_multi_component.rs
+++ b/crates/rlevo/tests/bounded_action_multi_component.rs
@@ -1,0 +1,334 @@
+//! Regression witness for ADR 0053 / issue #253: a **multi-component rank-1**
+//! `BoundedAction` must survive the continuous-control agents' action paths.
+//!
+//! Every `BoundedAction` impl in the workspace happens to satisfy
+//! `RANK == COMPONENTS`, which is exactly what kept the rank-vs-component
+//! conflation latent: `low()`/`high()` returned `[f32; R]` (one bound for all
+//! `C` components) and the agents looped `0..A::RANK` over a `COMPONENTS`-wide
+//! actor output.
+//!
+//! The fixture here is deliberately the shape no existing impl has, and the
+//! shape ADR 0053 §7 names as the regression witness: rank 1, `COMPONENTS = 3`,
+//! and **asymmetric** per-component bounds `[-1, 0, 0] .. [1, 1, 1]` — the real
+//! Gymnasium `CarRacing` action space (steer ∈ [-1,1], gas ∈ [0,1],
+//! brake ∈ [0,1]).
+//!
+//! These tests were verified to **fail** against the pre-fix agent code (the
+//! `A::RANK`-keyed loops temporarily restored): three of the four panicked,
+//! with `from_slice` rejecting a 1-element slice on the warm-up and greedy
+//! paths and `GaussianNoise::apply`'s own length check rejecting a 1-element
+//! mean on the exploration path. Each test's docs record its observed failure.
+//! (Pre-fix the trait could not even *express* this fixture — `[f32; 1]` holds
+//! one of the three bounds — so the trait half of the fix is a compile-time
+//! prerequisite for the fixture existing at all.)
+
+use burn::module::{AutodiffModule, Module};
+use burn::nn::{Linear, LinearConfig};
+use burn::tensor::Tensor;
+use burn::tensor::activation::{relu, tanh};
+use burn::tensor::backend::{AutodiffBackend, Backend};
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_core::action::{BoundedAction, ContinuousAction};
+use rlevo_core::base::Action;
+use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_agent::DdpgAgent;
+use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_config::DdpgTrainingConfigBuilder;
+use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_model::{
+    ContinuousQ, DeterministicPolicy,
+};
+use rlevo_reinforcement_learning::utils::polyak_update;
+
+use rlevo_test_support::env::LinearObservation;
+use rlevo_test_support::flex::{FlexAutodiff as Be, flex_guard, seeded_device};
+
+// ---------------------------------------------------------------------------
+// The fixture: rank 1, three components, asymmetric bounds.
+// ---------------------------------------------------------------------------
+
+/// `CarRacing`-shaped action: `steer ∈ [-1, 1]`, `gas ∈ [0, 1]`,
+/// `brake ∈ [0, 1]`.
+///
+/// Rank **1** with **3** components — the combination that makes the rank/
+/// component distinction observable.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct CarLikeAction([f32; 3]);
+
+impl Action<1> for CarLikeAction {
+    fn shape() -> [usize; 1] {
+        [3]
+    }
+
+    fn is_valid(&self) -> bool {
+        let (low, high) = (Self::low(), Self::high());
+        self.0
+            .iter()
+            .enumerate()
+            .all(|(i, v)| v.is_finite() && *v >= low[i] && *v <= high[i])
+    }
+}
+
+impl ContinuousAction<1> for CarLikeAction {
+    const COMPONENTS: usize = 3;
+
+    fn as_slice(&self) -> &[f32] {
+        &self.0
+    }
+
+    fn clip(&self, min: f32, max: f32) -> Self {
+        Self([
+            self.0[0].clamp(min, max),
+            self.0[1].clamp(min, max),
+            self.0[2].clamp(min, max),
+        ])
+    }
+
+    fn from_slice(values: &[f32]) -> Self {
+        // This is the assertion that fires against the pre-fix agents: they
+        // hand over `RANK == 1` value where `COMPONENTS == 3` are required.
+        assert_eq!(
+            values.len(),
+            Self::COMPONENTS,
+            "expected {} components, got {}",
+            Self::COMPONENTS,
+            values.len()
+        );
+        Self([values[0], values[1], values[2]])
+    }
+}
+
+impl BoundedAction<1> for CarLikeAction {
+    fn low() -> &'static [f32] {
+        &[-1.0, 0.0, 0.0]
+    }
+
+    fn high() -> &'static [f32] {
+        &[1.0, 1.0, 1.0]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal actor / critic over a 1-D observation and a 3-component action.
+// ---------------------------------------------------------------------------
+
+#[derive(Module, Debug)]
+struct Actor<B: Backend> {
+    head: Linear<B>,
+}
+
+impl<B: Backend> Actor<B> {
+    fn new(
+        obs_dim: usize,
+        action_dim: usize,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        Self {
+            head: LinearConfig::new(obs_dim, action_dim).init(device),
+        }
+    }
+
+    fn forward_impl(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        tanh(self.head.forward(obs))
+    }
+}
+
+impl<B: AutodiffBackend> DeterministicPolicy<B, 2, 2> for Actor<B> {
+    fn forward(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        self.forward_impl(obs)
+    }
+    fn forward_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 2>,
+    ) -> Tensor<B::InnerBackend, 2> {
+        inner.forward_impl(obs)
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+        polyak_update::<B::InnerBackend, Actor<B::InnerBackend>>(
+            &active.valid(),
+            target,
+            tau as f32,
+        )
+    }
+}
+
+#[derive(Module, Debug)]
+struct Critic<B: Backend> {
+    head: Linear<B>,
+}
+
+impl<B: Backend> Critic<B> {
+    fn new(
+        obs_dim: usize,
+        action_dim: usize,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        Self {
+            head: LinearConfig::new(obs_dim + action_dim, 1).init(device),
+        }
+    }
+    fn forward_impl(&self, obs: Tensor<B, 2>, act: Tensor<B, 2>) -> Tensor<B, 1> {
+        let x = Tensor::cat(vec![obs, act], 1);
+        relu(self.head.forward(x)).squeeze_dim::<1>(1)
+    }
+}
+
+impl<B: AutodiffBackend> ContinuousQ<B, 2, 2> for Critic<B> {
+    fn forward(&self, obs: Tensor<B, 2>, act: Tensor<B, 2>) -> Tensor<B, 1> {
+        self.forward_impl(obs, act)
+    }
+    fn forward_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 2>,
+        act: Tensor<B::InnerBackend, 2>,
+    ) -> Tensor<B::InnerBackend, 1> {
+        inner.forward_impl(obs, act)
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+        polyak_update::<B::InnerBackend, Critic<B::InnerBackend>>(
+            &active.valid(),
+            target,
+            tau as f32,
+        )
+    }
+}
+
+type CarAgent = DdpgAgent<Be, Actor<Be>, Critic<Be>, LinearObservation, CarLikeAction, 1, 2, 1, 2>;
+
+/// Builds a DDPG agent whose action type has 3 components and a warm-up window
+/// long enough that `act(.., training = true)` takes the uniform-sample branch.
+fn build_agent(learning_starts: usize) -> CarAgent {
+    let device = seeded_device::<Be>(0xA53);
+    let actor = Actor::<Be>::new(1, CarLikeAction::COMPONENTS, &device);
+    let critic = Critic::<Be>::new(1, CarLikeAction::COMPONENTS, &device);
+    let config = DdpgTrainingConfigBuilder::default()
+        .learning_starts(learning_starts)
+        .batch_size(4)
+        .replay_buffer_capacity(64)
+        .build()
+        .expect("valid DDPG config");
+    CarAgent::new(actor, critic, config, device).expect("agent construction")
+}
+
+/// Asserts every component sits inside its **own** bound, not component 0's.
+fn assert_within_per_component_bounds(action: &CarLikeAction) {
+    let (low, high) = (CarLikeAction::low(), CarLikeAction::high());
+    let values = action.as_slice();
+    assert_eq!(
+        values.len(),
+        CarLikeAction::COMPONENTS,
+        "action must carry COMPONENTS values, not RANK"
+    );
+    for (i, v) in values.iter().enumerate() {
+        assert!(
+            *v >= low[i] && *v <= high[i],
+            "component {i} = {v} outside its own bound [{}, {}]",
+            low[i],
+            high[i]
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The trait's own contract, on a fixture where `RANK != COMPONENTS`.
+///
+/// This is the assertion that distinguishes ADR 0053's design from the one it
+/// replaced: `low()` has three entries because the action has three
+/// *components*, not because it has rank 3 (it has rank 1).
+#[test]
+fn bounds_are_keyed_on_components_not_rank() {
+    assert_eq!(CarLikeAction::RANK, 1);
+    assert_eq!(CarLikeAction::COMPONENTS, 3);
+    assert_ne!(
+        CarLikeAction::RANK,
+        CarLikeAction::COMPONENTS,
+        "fixture is pointless unless rank and component count disagree"
+    );
+
+    assert_eq!(CarLikeAction::low().len(), CarLikeAction::COMPONENTS);
+    assert_eq!(CarLikeAction::high().len(), CarLikeAction::COMPONENTS);
+    for i in 0..CarLikeAction::COMPONENTS {
+        assert!(CarLikeAction::low()[i] < CarLikeAction::high()[i]);
+    }
+
+    // The bounds must actually differ per component, or the fixture cannot
+    // distinguish a per-component clip from a `low[0]`/`high[0]` collapse.
+    let low = CarLikeAction::low();
+    assert!(
+        low.iter().any(|v| (v - low[0]).abs() > f32::EPSILON),
+        "asymmetric bounds are the point of this fixture: {low:?}"
+    );
+}
+
+/// Warm-up path: `act(.., training = true)` below `learning_starts` draws a
+/// uniform sample per component.
+///
+/// Pre-fix this looped `0..A::RANK` (= 1), producing a 1-element `Vec` that
+/// `CarLikeAction::from_slice` rejects. Observed pre-fix failure:
+/// `assertion `left == right` failed: expected 3 components, got 1`.
+#[test]
+fn warmup_sample_produces_all_components_within_bounds() {
+    let _guard = flex_guard();
+    let agent = build_agent(1_000);
+    let mut rng = StdRng::seed_from_u64(0x00C0_FFEE);
+
+    for _ in 0..32 {
+        let action = agent.act(&LinearObservation { x: 0.25 }, true, &mut rng);
+        assert_within_per_component_bounds(&action);
+    }
+}
+
+/// Greedy/eval path: `act(.., training = false)` clips the actor output per
+/// component.
+///
+/// The actor emits `tanh(..) ∈ [-1, 1]` on all three outputs, so the `gas` and
+/// `brake` components are genuinely out of *their* bounds before clipping —
+/// which is what makes this a test of per-component clipping rather than of
+/// `low[0]`/`high[0]`.
+///
+/// Pre-fix this looped `0..A::RANK` and failed identically to the warm-up
+/// path (`expected 3 components, got 1`).
+#[test]
+fn greedy_action_clips_each_component_against_its_own_bound() {
+    let _guard = flex_guard();
+    let agent = build_agent(0);
+    let mut rng = StdRng::seed_from_u64(7);
+
+    let action = agent.act(&LinearObservation { x: -0.5 }, false, &mut rng);
+    assert_within_per_component_bounds(&action);
+    assert!(
+        action.is_valid(),
+        "clipped action must satisfy its own validity predicate"
+    );
+
+    // Same path through the pre-snapshotted inner actor.
+    let net = agent.inference_net();
+    let via_snapshot = agent.act_with(&net, &LinearObservation { x: -0.5 });
+    assert_within_per_component_bounds(&via_snapshot);
+}
+
+/// Exploration path: noisy actions are still clipped per component.
+///
+/// Pre-fix this failed *earlier* than the other two and in the more telling
+/// place — `.take(A::RANK)` handed a 1-element mean to a `GaussianNoise` whose
+/// bounds were 3 elements long, so the exploration layer's own length check
+/// fired first:
+/// `exploration.rs:50 — assertion `left == right` failed: mean/low length
+/// mismatch, left: 1, right: 3`. That layer was per-component correct all
+/// along (ADR 0053 §Context (a)); only the trait feeding it was wrong.
+#[test]
+fn noisy_action_stays_within_per_component_bounds() {
+    let _guard = flex_guard();
+    let agent = build_agent(0);
+    let mut rng = StdRng::seed_from_u64(99);
+
+    for _ in 0..32 {
+        let action = agent.act(&LinearObservation { x: 1.0 }, true, &mut rng);
+        assert_within_per_component_bounds(&action);
+    }
+}


### PR DESCRIPTION
**Stack 2 of 5** — base `253-stack/1-core-components` (#379). Part of #253.

Two behavioural defects in DDPG, TD3 and SAC, both correct-by-coincidence until now.

### 1. Every action was truncated to its tensor rank

The `act`/`act_with` paths looped `0..A::RANK` and `.take(A::RANK)` over the actor's output. Rank is the number of *axes*, not the number of scalar components — so for any rank-1 action with `C > 1` components the warm-up sample, the policy mean, and the greedy action were each cut to a single value before `from_slice` asserted the true length and panicked. This is #100's panic resurfacing inside three algorithms.

All eight sites now key on `A::COMPONENTS`, and the three constructors assert `A::low().len() == A::COMPONENTS` so a mis-declared impl fails at construction rather than mid-episode.

### 2. Target actions were clipped against a single scalar bound

DDPG and TD3 both collapsed the bound vector to `low[0]`/`high[0]`, with a comment citing CleanRL convention. That is correct only while every component shares a bound; for an asymmetric space such as CarRacing's `Box([-1,0,0], [1,1,1])` it admits **negative gas and brake** into the target action — precisely the "values of impossible actions" TD3's clip exists to exclude (Fujimoto et al. 2018, [arXiv:1802.09477](https://arxiv.org/abs/1802.09477), Eq. 14).

Clipping is now per-component via `max_pair`/`min_pair` against `[1, C]` bound tensors cached at construction. Burn's `clamp` takes a scalar and cannot do this.

`noise_clip` deliberately stays scalar: it bounds noise *magnitude*, a property of the smoothing rather than of the action space.

### Why the tests missed it

Every `BoundedAction` impl that existed had `RANK == COMPONENTS`, so the two quantities were numerically equal in every case the fixtures exercised (rank-1/1-component and rank-3/3-component). The regression fixture added here is deliberately rank-1 with 3 components — the one shape that distinguishes them.

### Review note

Neither defect is reachable from any shipped configuration at this level, because no multi-component action implements `BoundedAction` until stack 3. SAC's coverage and a swap-detecting test for the DDPG target clip land in stack 5 — see that PR for why they were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HXyaXsUCPT9qQtEvG39uQ