### PR TITLE
feat(environments): Add BoundedAction to five continuous action types

### DIFF
--- a/crates/rlevo-environments/src/box2d/bipedal_walker/action.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/action.rs
@@ -5,7 +5,7 @@
 //! constants (`speed_hip`, `speed_knee`) inside `apply_motors` before being
 //! passed to the Rapier2D impulse-joint motor.
 
-use rlevo_core::action::ContinuousAction;
+use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
 use serde::{Deserialize, Serialize};
 
@@ -68,6 +68,26 @@ impl ContinuousAction<1> for BipedalWalkerAction {
     }
 }
 
+/// Per-component bounds `[-1; 4] .. [1; 4]`.
+///
+/// Source: Gymnasium `BipedalWalker-v3` declares
+/// `Box(-1.0, 1.0, (4,), float32)`, and this crate's
+/// [`all_valid`](BipedalWalkerAction::all_valid) rejects any component with
+/// `abs() > BOUND` where `BOUND == 1.0`. Spec and in-repo dynamics agree.
+///
+/// The bound is on the **pre-gear** motor target: `apply_motors` scales each
+/// component by `speed_hip` / `speed_knee` afterwards, so the torque limits
+/// live in the environment config, not here.
+impl BoundedAction<1> for BipedalWalkerAction {
+    fn low() -> &'static [f32] {
+        &[-1.0, -1.0, -1.0, -1.0]
+    }
+
+    fn high() -> &'static [f32] {
+        &[1.0, 1.0, 1.0, 1.0]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,6 +95,29 @@ mod tests {
     #[test]
     fn test_shape() {
         assert_eq!(BipedalWalkerAction::shape(), [4]);
+    }
+
+    #[test]
+    fn test_bounds_match_components_and_is_valid() {
+        assert_eq!(
+            BipedalWalkerAction::low().len(),
+            BipedalWalkerAction::COMPONENTS
+        );
+        assert_eq!(
+            BipedalWalkerAction::high().len(),
+            BipedalWalkerAction::COMPONENTS
+        );
+        for i in 0..BipedalWalkerAction::COMPONENTS {
+            assert!(BipedalWalkerAction::low()[i] < BipedalWalkerAction::high()[i]);
+            assert!(
+                (BipedalWalkerAction::low()[i] + BipedalWalkerAction::BOUND).abs() < f32::EPSILON
+            );
+            assert!(
+                (BipedalWalkerAction::high()[i] - BipedalWalkerAction::BOUND).abs() < f32::EPSILON
+            );
+        }
+        assert!(BipedalWalkerAction::from_slice(BipedalWalkerAction::low()).is_valid());
+        assert!(BipedalWalkerAction::from_slice(BipedalWalkerAction::high()).is_valid());
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/car_racing/action.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/action.rs
@@ -1,6 +1,6 @@
 //! Action type for CarRacing.
 
-use rlevo_core::action::ContinuousAction;
+use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
 use serde::{Deserialize, Serialize};
 
@@ -131,6 +131,30 @@ impl ContinuousAction<1> for CarRacingAction {
     }
 }
 
+/// Per-component bounds `[-1, 0, 0] .. [1, 1, 1]`.
+///
+/// Source: Gymnasium `CarRacing-v3` declares
+/// `Box([-1, 0, 0], [1, 1, 1], (3,), float32)`, and this crate's own
+/// [`components_valid`](CarRacingAction::components_valid) enforces exactly the
+/// same ranges (`steer.abs() <= 1`, `(0.0..=1.0).contains(gas)`,
+/// `(0.0..=1.0).contains(brake)`), as does
+/// [`random_valid`](CarRacingAction::random_valid). Spec and in-repo dynamics
+/// agree; nothing here is inferred.
+///
+/// This is the **only** action in the workspace whose components disagree on
+/// their bounds, which makes it the regression witness for the per-component
+/// target clip in DDPG/TD3 (ADR 0053 §6/§7): under a scalar `low[0]`/`high[0]`
+/// collapse, gas and brake would inherit steering's `-1` floor.
+impl BoundedAction<1> for CarRacingAction {
+    fn low() -> &'static [f32] {
+        &[-1.0, 0.0, 0.0]
+    }
+
+    fn high() -> &'static [f32] {
+        &[1.0, 1.0, 1.0]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,6 +162,48 @@ mod tests {
     #[test]
     fn test_shape() {
         assert_eq!(CarRacingAction::shape(), [3]);
+    }
+
+    #[test]
+    fn test_bounds_are_per_component_and_asymmetric() {
+        assert_eq!(CarRacingAction::low(), &[-1.0, 0.0, 0.0]);
+        assert_eq!(CarRacingAction::high(), &[1.0, 1.0, 1.0]);
+        assert_eq!(CarRacingAction::low().len(), CarRacingAction::COMPONENTS);
+        assert_eq!(CarRacingAction::high().len(), CarRacingAction::COMPONENTS);
+        for i in 0..CarRacingAction::COMPONENTS {
+            assert!(CarRacingAction::low()[i] < CarRacingAction::high()[i]);
+        }
+        // The asymmetry is load-bearing, not incidental: it is what lets this
+        // type witness a scalar `low[0]` collapse.
+        assert!(
+            CarRacingAction::low()[1] > CarRacingAction::low()[0],
+            "gas must not inherit steering's lower bound"
+        );
+    }
+
+    #[test]
+    fn test_bounds_agree_with_is_valid() {
+        // The bounds and the validity predicate are two statements of the same
+        // contract; a corner action must be valid, and one step outside any
+        // bound must not be.
+        let low = CarRacingAction::low();
+        let high = CarRacingAction::high();
+        assert!(CarRacingAction::from_slice(low).is_valid());
+        assert!(CarRacingAction::from_slice(high).is_valid());
+        for i in 0..CarRacingAction::COMPONENTS {
+            let mut below = low.to_vec();
+            below[i] -= 0.1;
+            assert!(
+                !CarRacingAction::from_slice(&below).is_valid(),
+                "component {i} below its lower bound must be invalid"
+            );
+            let mut above = high.to_vec();
+            above[i] += 0.1;
+            assert!(
+                !CarRacingAction::from_slice(&above).is_valid(),
+                "component {i} above its upper bound must be invalid"
+            );
+        }
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/lunar_lander/action_continuous.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/action_continuous.rs
@@ -1,6 +1,6 @@
 //! Continuous action type for LunarLander (design decision D1).
 
-use rlevo_core::action::ContinuousAction;
+use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
 use serde::{Deserialize, Serialize};
 
@@ -57,6 +57,28 @@ impl ContinuousAction<1> for LunarLanderContinuousAction {
     }
 }
 
+/// Per-component bounds `[-1, -1] .. [1, 1]`.
+///
+/// Source: Gymnasium `LunarLander-v3` with `continuous=True` declares
+/// `Box(-1, +1, (2,), float32)`, and this crate's
+/// [`is_valid`](Action::is_valid) rejects any component with
+/// `abs() > BOUND` where `BOUND == 1.0`. Spec and in-repo dynamics agree.
+///
+/// The main engine's `−1..0` dead band is a property of how the environment
+/// *interprets* component 0, not of the action space: `-1` is a legal
+/// (engine-off) command, so the lower bound is `-1`, not `0`. This is why the
+/// space is symmetric despite one component behaving one-sidedly — unlike
+/// CarRacing, whose gas and brake are genuinely floored at `0`.
+impl BoundedAction<1> for LunarLanderContinuousAction {
+    fn low() -> &'static [f32] {
+        &[-1.0, -1.0]
+    }
+
+    fn high() -> &'static [f32] {
+        &[1.0, 1.0]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,6 +86,22 @@ mod tests {
     #[test]
     fn test_shape() {
         assert_eq!(LunarLanderContinuousAction::shape(), [2]);
+    }
+
+    #[test]
+    fn test_bounds_match_components_and_is_valid() {
+        let low = LunarLanderContinuousAction::low();
+        let high = LunarLanderContinuousAction::high();
+        assert_eq!(low.len(), LunarLanderContinuousAction::COMPONENTS);
+        assert_eq!(high.len(), LunarLanderContinuousAction::COMPONENTS);
+        for i in 0..LunarLanderContinuousAction::COMPONENTS {
+            assert!(low[i] < high[i]);
+        }
+        // `-1` on the main engine is "off", a legal command — the lower bound
+        // is not 0.
+        assert!(LunarLanderContinuousAction::from_slice(low).is_valid());
+        assert!(LunarLanderContinuousAction::from_slice(high).is_valid());
+        assert!(!LunarLanderContinuousAction([-1.1, 0.0]).is_valid());
     }
 
     #[test]

--- a/crates/rlevo-environments/src/locomotion/reacher/action.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/action.rs
@@ -6,7 +6,7 @@
 //! resulting torques to the Rapier rigid bodies.
 
 use burn::prelude::{Backend, Tensor};
-use rlevo_core::action::ContinuousAction;
+use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::{Action, HostRow, TensorConversionError, TensorConvertible};
 use serde::{Deserialize, Serialize};
 
@@ -66,6 +66,34 @@ impl ContinuousAction<1> for ReacherAction {
     }
 }
 
+/// Per-component bounds `[-1, -1] .. [1, 1]`, in pre-gear units.
+///
+/// Source: Gymnasium `Reacher-v5` declares `Box(-1, 1, (2,), float32)`, and
+/// this type's own [`is_valid`](Action::is_valid) rejects any element with
+/// `abs() > 1.0`. Spec and in-repo action contract agree.
+///
+/// # These are the *type's* bounds, not the environment instance's
+///
+/// [`ReacherConfig::action_clip`] is a runtime field that defaults to
+/// `[-1.0, 1.0]` — matching these bounds — but a caller may narrow it. A
+/// narrowed `action_clip` does not change what this type accepts (`is_valid`
+/// is unconditionally `abs() <= 1.0`); it only means the environment squeezes
+/// the command further before applying the gear ratio, so an agent driven by
+/// these bounds stays within the declared space and merely saturates earlier.
+/// `low()`/`high()` take no `self` and cannot observe a config (ADR 0053 §3);
+/// per-instance bounds are a separate seam that would need its own ADR.
+///
+/// [`ReacherConfig::action_clip`]: super::config::ReacherConfig::action_clip
+impl BoundedAction<1> for ReacherAction {
+    fn low() -> &'static [f32] {
+        &[-1.0, -1.0]
+    }
+
+    fn high() -> &'static [f32] {
+        &[1.0, 1.0]
+    }
+}
+
 impl HostRow<1> for ReacherAction {
     fn row_shape() -> [usize; 1] {
         [2]
@@ -88,5 +116,37 @@ impl<B: Backend> TensorConvertible<1, B> for ReacherAction {
             });
         }
         Ok(Self([slice[0], slice[1]]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_match_components_and_is_valid() {
+        let low = ReacherAction::low();
+        let high = ReacherAction::high();
+        assert_eq!(low.len(), ReacherAction::COMPONENTS);
+        assert_eq!(high.len(), ReacherAction::COMPONENTS);
+        for i in 0..ReacherAction::COMPONENTS {
+            assert!(low[i] < high[i], "component {i} must have low < high");
+        }
+        assert!(ReacherAction::from_slice(low).is_valid());
+        assert!(ReacherAction::from_slice(high).is_valid());
+        assert!(!ReacherAction::new(1.1, 0.0).is_valid());
+        assert!(!ReacherAction::new(0.0, -1.1).is_valid());
+    }
+
+    #[test]
+    fn bounds_agree_with_the_default_action_clip() {
+        // The static bounds are the *type's* declared space; the environment's
+        // default `action_clip` is the same interval, so the default
+        // configuration cannot narrow an agent's reachable actions.
+        let (lo, hi): (f32, f32) = super::super::config::ReacherConfig::default()
+            .action_clip
+            .into();
+        assert!((lo - ReacherAction::low()[0]).abs() < f32::EPSILON);
+        assert!((hi - ReacherAction::high()[0]).abs() < f32::EPSILON);
     }
 }

--- a/crates/rlevo-environments/src/locomotion/swimmer/action.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/action.rs
@@ -5,7 +5,7 @@
 //! configured `gear` scalar before applying the torque to the physics body.
 
 use burn::prelude::{Backend, Tensor};
-use rlevo_core::action::ContinuousAction;
+use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::{Action, HostRow, TensorConversionError, TensorConvertible};
 use serde::{Deserialize, Serialize};
 
@@ -64,6 +64,33 @@ impl ContinuousAction<1> for SwimmerAction {
     }
 }
 
+/// Per-component bounds `[-1, -1] .. [1, 1]`, in pre-gear units.
+///
+/// Source: Gymnasium `Swimmer-v5` declares `Box(-1, 1, (2,), float32)`, and
+/// this type's own [`is_valid`](Action::is_valid) rejects any element with
+/// `abs() > 1.0`. Spec and in-repo action contract agree. (The `gear` scalar
+/// this crate applies after clipping is known to differ from Swimmer-v5's
+/// `[150, 150]` — see [`Swimmer::joint_torques`] — but that is a torque-scale
+/// question downstream of the action space, and does not move these bounds.)
+///
+/// As with [`ReacherAction`](super::super::reacher::action::ReacherAction),
+/// [`SwimmerConfig::action_clip`] is a runtime field defaulting to
+/// `[-1.0, 1.0]`. A narrowed value squeezes the command inside the
+/// environment; it does not change the space this *type* declares, which
+/// `low()`/`high()` cannot observe anyway (ADR 0053 §3).
+///
+/// [`Swimmer::joint_torques`]: super::env::Swimmer
+/// [`SwimmerConfig::action_clip`]: super::config::SwimmerConfig::action_clip
+impl BoundedAction<1> for SwimmerAction {
+    fn low() -> &'static [f32] {
+        &[-1.0, -1.0]
+    }
+
+    fn high() -> &'static [f32] {
+        &[1.0, 1.0]
+    }
+}
+
 impl HostRow<1> for SwimmerAction {
     fn row_shape() -> [usize; 1] {
         [2]
@@ -86,5 +113,34 @@ impl<B: Backend> TensorConvertible<1, B> for SwimmerAction {
             });
         }
         Ok(Self([slice[0], slice[1]]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_match_components_and_is_valid() {
+        let low = SwimmerAction::low();
+        let high = SwimmerAction::high();
+        assert_eq!(low.len(), SwimmerAction::COMPONENTS);
+        assert_eq!(high.len(), SwimmerAction::COMPONENTS);
+        for i in 0..SwimmerAction::COMPONENTS {
+            assert!(low[i] < high[i], "component {i} must have low < high");
+        }
+        assert!(SwimmerAction::from_slice(low).is_valid());
+        assert!(SwimmerAction::from_slice(high).is_valid());
+        assert!(!SwimmerAction::new(1.1, 0.0).is_valid());
+        assert!(!SwimmerAction::new(0.0, -1.1).is_valid());
+    }
+
+    #[test]
+    fn bounds_agree_with_the_default_action_clip() {
+        let (lo, hi): (f32, f32) = super::super::config::SwimmerConfig::default()
+            .action_clip
+            .into();
+        assert!((lo - SwimmerAction::low()[0]).abs() < f32::EPSILON);
+        assert!((hi - SwimmerAction::high()[0]).abs() < f32::EPSILON);
     }
 }

--- a/crates/rlevo/tests/car_racing_continuous_control.rs
+++ b/crates/rlevo/tests/car_racing_continuous_control.rs
@@ -1,0 +1,324 @@
+//! Acceptance check for ADR 0053: a continuous-control agent driving the real
+//! [`CarRacing`] environment.
+//!
+//! `CarRacingAction` is the **only** action in the workspace whose components
+//! disagree on their bounds — Gymnasium's `Box([-1,0,0], [1,1,1])`, where
+//! steering is signed but gas and brake are floored at zero. That makes it the
+//! sole in-workspace witness for the two halves of the ADR at once:
+//!
+//! - the trait half (§1): `low()`/`high()` must carry **three** bounds for a
+//!   rank-**1** action, which `[f32; R]` could not express;
+//! - the agent half (§6): the DDPG/TD3 target-action clip must be applied per
+//!   component, not collapsed to `low[0]`/`high[0]`.
+//!
+//! Unlike `bounded_action_multi_component.rs`, which uses a hand-rolled fixture
+//! and a synthetic observation, this drives the shipped environment end to end:
+//! the real 96x96x3 pixel observation, the real physics step, and — critically
+//! — the real [`CarRacing::step`] validity gate, which returns
+//! `Err(InvalidAction)` on a negative gas or brake. An agent whose action path
+//! were not per-component correct could not complete a single episode here.
+//!
+//! The budgets are deliberately tiny (a handful of steps, one learn step, a
+//! 4-sample batch). This is a wiring and correctness check, not a learning
+//! test — `CarRacing` rasterizes a frame per step, so a learning budget would not
+//! fit the default `cargo test` run.
+
+use burn::module::{AutodiffModule, Module};
+use burn::nn::{Linear, LinearConfig};
+use burn::tensor::Tensor;
+use burn::tensor::activation::{relu, tanh};
+use burn::tensor::backend::{AutodiffBackend, Backend};
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use rlevo_core::action::{BoundedAction, ContinuousAction};
+use rlevo_core::base::Action;
+use rlevo_core::environment::{ConstructableEnv, Environment, Snapshot};
+use rlevo_environments::box2d::car_racing::{
+    CarRacing, CarRacingAction, CarRacingConfig, CarRacingObservation,
+};
+use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_model::{
+    ContinuousQ, DeterministicPolicy,
+};
+use rlevo_reinforcement_learning::algorithms::td3::td3_agent::Td3Agent;
+use rlevo_reinforcement_learning::algorithms::td3::td3_config::Td3TrainingConfigBuilder;
+use rlevo_reinforcement_learning::utils::polyak_update;
+
+use rlevo_test_support::flex::{FlexAutodiff as Be, flex_guard, seeded_device};
+
+/// Flattened pixel-observation width: 96 x 96 x 3.
+const OBS_NUMEL: usize = 96 * 96 * 3;
+
+// ---------------------------------------------------------------------------
+// Actor / critic over a rank-3 pixel observation and a 3-component action.
+// ---------------------------------------------------------------------------
+
+/// Single-layer actor: flatten the frame, project to `COMPONENTS`, squash.
+///
+/// `tanh` deliberately emits `[-1, 1]` on **all three** outputs, including gas
+/// and brake, whose true lower bound is `0`. So the raw policy output is out of
+/// bounds on two of three components by construction, and every emitted action
+/// depends on the per-component clip to become legal. A scalar clip against
+/// `low[0] = -1` would leave the negative values in place and `CarRacing::step`
+/// would reject them.
+#[derive(Module, Debug)]
+struct Actor<B: Backend> {
+    head: Linear<B>,
+}
+
+impl<B: Backend> Actor<B> {
+    fn new(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
+        Self {
+            head: LinearConfig::new(OBS_NUMEL, CarRacingAction::COMPONENTS).init(device),
+        }
+    }
+
+    fn forward_impl(&self, obs: Tensor<B, 4>) -> Tensor<B, 2> {
+        let batch = obs.dims()[0];
+        tanh(self.head.forward(obs.reshape([batch, OBS_NUMEL])))
+    }
+}
+
+impl<B: AutodiffBackend> DeterministicPolicy<B, 4, 2> for Actor<B> {
+    fn forward(&self, obs: Tensor<B, 4>) -> Tensor<B, 2> {
+        self.forward_impl(obs)
+    }
+
+    fn forward_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 4>,
+    ) -> Tensor<B::InnerBackend, 2> {
+        inner.forward_impl(obs)
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+        polyak_update::<B::InnerBackend, Actor<B::InnerBackend>>(
+            &active.valid(),
+            target,
+            tau as f32,
+        )
+    }
+}
+
+#[derive(Module, Debug)]
+struct Critic<B: Backend> {
+    head: Linear<B>,
+}
+
+impl<B: Backend> Critic<B> {
+    fn new(device: &<B as burn::tensor::backend::BackendTypes>::Device) -> Self {
+        Self {
+            head: LinearConfig::new(OBS_NUMEL + CarRacingAction::COMPONENTS, 1).init(device),
+        }
+    }
+
+    fn forward_impl(&self, obs: Tensor<B, 4>, act: Tensor<B, 2>) -> Tensor<B, 1> {
+        let batch = obs.dims()[0];
+        let flat = obs.reshape([batch, OBS_NUMEL]);
+        let x = Tensor::cat(vec![flat, act], 1);
+        relu(self.head.forward(x)).squeeze_dim::<1>(1)
+    }
+}
+
+impl<B: AutodiffBackend> ContinuousQ<B, 4, 2> for Critic<B> {
+    fn forward(&self, obs: Tensor<B, 4>, act: Tensor<B, 2>) -> Tensor<B, 1> {
+        self.forward_impl(obs, act)
+    }
+
+    fn forward_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 4>,
+        act: Tensor<B::InnerBackend, 2>,
+    ) -> Tensor<B::InnerBackend, 1> {
+        inner.forward_impl(obs, act)
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+        polyak_update::<B::InnerBackend, Critic<B::InnerBackend>>(
+            &active.valid(),
+            target,
+            tau as f32,
+        )
+    }
+}
+
+type CarAgent =
+    Td3Agent<Be, Actor<Be>, Critic<Be>, CarRacingObservation, CarRacingAction, 3, 4, 1, 2>;
+
+/// Builds a TD3 agent over `CarRacing` with `learning_starts` warm-up steps.
+///
+/// Construction alone exercises ADR 0053 §4's contract assert and §6's
+/// `[1, 3]` bound-tensor build: a `CarRacingAction::low()` of the wrong length,
+/// or a `shape()` disagreeing with `COMPONENTS`, panics here.
+fn build_agent(learning_starts: usize) -> CarAgent {
+    let device = seeded_device::<Be>(0xCA5);
+    let config = Td3TrainingConfigBuilder::default()
+        .learning_starts(learning_starts)
+        .batch_size(4)
+        .replay_buffer_capacity(32)
+        .policy_frequency(1)
+        .build()
+        .expect("valid TD3 config");
+    CarAgent::new(
+        Actor::<Be>::new(&device),
+        Critic::<Be>::new(&device),
+        Critic::<Be>::new(&device),
+        config,
+        device,
+    )
+    .expect("agent construction")
+}
+
+/// A small `CarRacing` instance: a short episode cap keeps the rasterizer cost
+/// bounded without changing the action space under test.
+fn build_env() -> CarRacing {
+    let config = CarRacingConfig {
+        max_steps: 64,
+        ..CarRacingConfig::default()
+    };
+    CarRacing::with_config(config).unwrap_or_else(|_| CarRacing::new(false))
+}
+
+/// Asserts an action sits inside its own per-component bound.
+fn assert_per_component_valid(action: &CarRacingAction) {
+    let (low, high) = (CarRacingAction::low(), CarRacingAction::high());
+    let values = action.as_slice();
+    assert_eq!(
+        values.len(),
+        CarRacingAction::COMPONENTS,
+        "action must carry COMPONENTS values"
+    );
+    for (i, v) in values.iter().enumerate() {
+        assert!(
+            *v >= low[i] && *v <= high[i],
+            "component {i} = {v} outside its own bound [{}, {}]",
+            low[i],
+            high[i]
+        );
+    }
+    assert!(
+        action.is_valid(),
+        "the environment's own validity gate must accept the agent's action: {action:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The shipped impl matches Gymnasium's `Box([-1,0,0], [1,1,1])` and satisfies
+/// the ADR 0053 §4 contract.
+#[test]
+fn car_racing_bounds_match_the_gymnasium_box() {
+    assert_eq!(CarRacingAction::low(), &[-1.0, 0.0, 0.0]);
+    assert_eq!(CarRacingAction::high(), &[1.0, 1.0, 1.0]);
+    assert_eq!(CarRacingAction::low().len(), CarRacingAction::COMPONENTS);
+    assert_eq!(CarRacingAction::high().len(), CarRacingAction::COMPONENTS);
+    assert_eq!(CarRacingAction::RANK, 1);
+    assert_ne!(
+        CarRacingAction::RANK,
+        CarRacingAction::COMPONENTS,
+        "the witness is only a witness while rank and component count disagree"
+    );
+    assert!(
+        CarRacingAction::low()[1] > CarRacingAction::low()[0],
+        "gas must not share steering's lower bound, or this env witnesses nothing"
+    );
+}
+
+/// TD3 drives real `CarRacing` through both the warm-up and the policy branch,
+/// and the environment accepts every action it is handed.
+///
+/// `CarRacing::step` returns `Err(InvalidAction)` for a negative gas or brake,
+/// so this is not a self-referential check against the agent's own bounds: the
+/// environment independently rejects an impossible action, and a run that
+/// completes is evidence that none was produced.
+#[test]
+fn td3_steps_car_racing_without_producing_an_impossible_action() {
+    let _guard = flex_guard();
+    let mut agent = build_agent(4);
+    let mut env = build_env();
+    let mut rng = StdRng::seed_from_u64(0x0D15_EA5E);
+
+    let mut obs = env.reset().expect("reset").observation().clone();
+
+    // 4 warm-up steps (uniform sample per component) then 4 policy steps
+    // (tanh output clipped per component) — both action paths, one run.
+    for step in 0..8 {
+        let action = agent.act(&obs, true, &mut rng);
+        assert_per_component_valid(&action);
+
+        let snapshot = env.step(action.clone()).unwrap_or_else(|e| {
+            panic!("CarRacing rejected the agent's action at step {step}: {e}")
+        });
+        let next_obs = snapshot.observation().clone();
+
+        agent.remember(
+            obs,
+            &action,
+            snapshot.reward().0,
+            next_obs.clone(),
+            snapshot.is_terminated(),
+        );
+        agent.on_env_step();
+
+        if snapshot.is_done() {
+            obs = env.reset().expect("reset").observation().clone();
+        } else {
+            obs = next_obs;
+        }
+    }
+
+    assert_eq!(agent.buffer_len(), 8, "every transition must be stored");
+}
+
+/// A TD3 learn step runs against the asymmetric space.
+///
+/// This is the path ADR 0053 §6 fixes: the target actor's `tanh` output spans
+/// `[-1, 1]` on all three components, so the Eq. 14 clip has real work to do on
+/// gas and brake. The pre-fix scalar collapse did not panic here — it silently
+/// fed the twin critics a target computed at negative gas and negative brake —
+/// which is why the value-level assertion lives in the unit tests on
+/// `clip_to_action_bounds` and `smoothed_target_action`, and this test's job is
+/// to prove the fixed path is actually reachable from the shipped environment.
+#[test]
+fn td3_learn_step_runs_against_the_asymmetric_action_space() {
+    let _guard = flex_guard();
+    let mut agent = build_agent(0);
+    let mut env = build_env();
+    let mut rng = StdRng::seed_from_u64(0xBEEF);
+
+    let mut obs = env.reset().expect("reset").observation().clone();
+    for _ in 0..8 {
+        let action = agent.act(&obs, true, &mut rng);
+        assert_per_component_valid(&action);
+        let snapshot = env.step(action.clone()).expect("valid action accepted");
+        let next_obs = snapshot.observation().clone();
+        agent.remember(
+            obs,
+            &action,
+            snapshot.reward().0,
+            next_obs.clone(),
+            snapshot.is_terminated(),
+        );
+        agent.on_env_step();
+        obs = next_obs;
+    }
+
+    let outcome = agent
+        .learn_step(&mut rng)
+        .expect("buffer holds >= batch_size transitions, so a learn step must run");
+    assert!(
+        outcome.critic_loss.is_finite(),
+        "critic loss must be finite, got {}",
+        outcome.critic_loss
+    );
+    assert!(
+        outcome.q_mean.is_finite(),
+        "mean Q must be finite, got {}",
+        outcome.q_mean
+    );
+}


### PR DESCRIPTION
**Stack 3 of 5** — base `253-stack/2-rl-action-paths` (#380). Part of #253.

Adds `BoundedAction<1>` to the five multi-component rank-1 actions that the old rank-keyed representation had kept out of DDPG/TD3/SAC. Each is rank-1 with more than one component, so under `[f32; R]` it could not state its bounds at all.

| Type | `COMPONENTS` | bounds |
|---|---|---|
| `BipedalWalkerAction` | 4 | `[-1;4] .. [1;4]` |
| `CarRacingAction` | 3 | `[-1,0,0] .. [1,1,1]` — **asymmetric** |
| `LunarLanderContinuousAction` | 2 | `[-1,-1] .. [1,1]` |
| `ReacherAction` | 2 | symmetric |
| `SwimmerAction` | 2 | symmetric |

Bound values are sourced from each environment's own `is_valid` predicate and the canonical Gymnasium space, and each impl documents its provenance. No spec-vs-repo discrepancy was found.

### Why CarRacing carries the weight

It is the workspace's only action whose components disagree — steering ∈ [-1, 1] but gas and brake ∈ [0, 1]. That makes it the sole regression witness for stack 2's per-component target clip, so this PR adds a cross-crate integration test driving TD3 against the real `CarRacing` environment, gated on the environment's own `step` validity check — an oracle independent of the agent.

### Known gap, tracked

Only `CarRacingAction` is driven by an agent in tests. The other four have per-type unit tests but are never constructed into an agent, so this series' two runtime guards have not executed for them. Filed as #378 rather than left implicit.

### Note on the runtime-config seam

`ReacherAction`/`SwimmerAction` have a runtime `config.action_clip` that the static `low()`/`high()` cannot observe. These bounds describe the action *type's* space, which `is_valid` enforces unconditionally before `action_clip` is consulted; a narrowed clip only makes the environment saturate earlier and cannot let an agent leave the declared space. Stack 5 adds a test pinning that. If you would rather bounds be a per-instance seam, it needs its own ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HXyaXsUCPT9qQtEvG39uQ