### PR TITLE
docs: Record the BoundedAction component fix in the changelog and user book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,29 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   type implements `HostRow` at exactly **one** rank (two ranks makes unqualified
   calls ambiguous again, E0283). **No persisted data format changes** — nothing in
   this path derives serde, and no record schema is affected.
+- **`BoundedAction::low()`/`high()` return `&'static [f32]` instead of
+  `[f32; R]`** (ADR 0053, resolves #253). The bounds were keyed on the tensor
+  **rank** `R`, not on `ContinuousAction::COMPONENTS` — the same rank-vs-component
+  conflation as #100, one layer up. A rank-1 action with `C > 1` components could
+  therefore express only a *single* bound for all `C` of them, which is not
+  representable for an asymmetric space such as CarRacing's
+  `Box([-1,0,0], [1,1,1])`. Keying on `COMPONENTS` needs `[f32; Self::COMPONENTS]`,
+  which requires unstable `generic_const_exprs`, so the length moves to the slice
+  instead; the trait keeps its single const generic parameter.
+
+  *Migration.* Change each impl's return type and wrap the array literal in a
+  borrow — `fn low() -> [f32; 1] { [-2.0] }` becomes
+  `fn low() -> &'static [f32] { &[-2.0] }`. Impls that must compute bounds can
+  use a `OnceLock` or `Box::leak`. Generic code bounded as `A: BoundedAction<AR>`
+  is **unaffected** — the trait arity is unchanged, so no downstream signature
+  moves. New documented invariants: `low().len() == high().len() ==
+  Self::COMPONENTS`, and `low()[i] < high()[i]` for every `i`. **No persisted data
+  format changes.**
+- The trait's doc claim that bounds may be derived from "a runtime env config
+  (e.g. a `max_torque` field)" is **removed as false** — `low()`/`high()` are
+  static methods with no `self` and cannot reach instance state. `from_slice`'s
+  docs (and the matching row in `docs/rules.md`) said the slice must have exactly
+  `RANK` elements; the contract has been `COMPONENTS` since ADR 0038.
 
 **Added**
 
@@ -149,6 +172,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `GoToDoorEnv` implements `Sensor` for its goal-conditioned observation.
   `pixel_grid` keeps `Observable<3>` and delegates its `Sensor` to `project()`.
   Behaviour (observations, rewards, termination) is unchanged.
+
+**Added**
+
+- **`BoundedAction<1>` for the five multi-component continuous actions**
+  (`BipedalWalkerAction`, `CarRacingAction`, `LunarLanderContinuousAction`,
+  `ReacherAction`, `SwimmerAction`; ADR 0053, #253). These were the environments
+  the rank-keyed bounds representation had kept out of DDPG/TD3/SAC: each is
+  rank-1 with more than one component, so it could not state its bounds at all
+  under the old signature. `CarRacingAction` is the workspace's only action whose
+  components disagree — steering ∈ [-1, 1] but gas and brake ∈ [0, 1].
 
 ### `rlevo-reinforcement-learning`
 
@@ -422,6 +455,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **DDPG, TD3 and SAC truncated every action to its tensor rank** (ADR 0053,
+  resolves #253). The `act`/`act_with` paths looped `0..A::RANK` and
+  `.take(A::RANK)` over the actor's output — the rank is the number of *axes*,
+  not the number of scalar components — so for any rank-1 action with `C > 1`
+  components the warm-up sample, the policy mean, and the greedy action were each
+  cut to a single value before `from_slice` asserted the true length and panicked.
+  This is #100's panic resurfacing inside three algorithms. All eight sites now
+  key on `A::COMPONENTS`, and the three constructors assert
+  `A::low().len() == A::COMPONENTS` so a mis-declared impl fails at construction
+  rather than mid-episode.
+
+  No shipped configuration could reach it: every `BoundedAction` impl that existed
+  had `RANK == COMPONENTS`, which is also why the tests missed it — the fixtures
+  were rank-1/1-component and rank-3/3-component, so rank and component count were
+  numerically equal in every case exercised. The regression test is now a
+  deliberately rank-1, 3-component fixture, the one shape that distinguishes them.
+- **DDPG and TD3 clipped target actions against a single scalar bound** (ADR
+  0053, #253). Both collapsed the bound vector to `low[0]`/`high[0]`, citing
+  CleanRL convention. That is correct only while every component shares a bound;
+  for an asymmetric space such as CarRacing's `Box([-1,0,0], [1,1,1])` it admits
+  negative gas and brake into the target action — precisely the "values of
+  impossible actions" that TD3's clip exists to exclude (Fujimoto et al. 2018,
+  arXiv:1802.09477, Eq. 14). Clipping is now per-component via `max_pair`/
+  `min_pair` against `[1, C]` bound tensors cached at construction. TD3's
+  `noise_clip` stays scalar by design: it bounds noise *magnitude*, which is a
+  property of the smoothing rather than of the action space.
 - **`AgentStats::new(0)` silently degenerated into a one-record window instead
   of rejecting the argument** (resolves #191). `record` pops the front whenever
   `recent_history.len() >= window_size`, so with `window_size == 0` the pop

--- a/docs/user-book/src/part-1-foundations/reinforcement-learning/32-action.md
+++ b/docs/user-book/src/part-1-foundations/reinforcement-learning/32-action.md
@@ -182,18 +182,34 @@ When the bounds are known, layer on `BoundedAction`:
 
 ```rust
 pub trait BoundedAction<const R: usize>: ContinuousAction<R> {
-    fn low()  -> [f32; R];
-    fn high() -> [f32; R];
+    fn low()  -> &'static [f32];
+    fn high() -> &'static [f32];
 }
 ```
 
 This exists because continuous-control algorithms (DDPG, TD3, SAC) genuinely
 need the per-component bounds: to rescale a `[-1, 1]` network output into the
-environment's real range, and to sample uniform warm-up actions before the
-policy has learned anything. The invariant is `low()[i] < high()[i]`, and `clip`
-must be a no-op on an action already inside `[low, high]`.
+environment's real range, to clip a target action, and to sample uniform
+warm-up actions before the policy has learned anything. The invariant is
+`low().len() == high().len() == COMPONENTS` and `low()[i] < high()[i]` for
+every component `i`, and `clip` must be a no-op on an action already inside
+`[low, high]`.
 
-Pendulum is a clean single-axis example — one torque value bounded to
+Notice the return type is a slice, not `[f32; R]`. That is deliberate, and it
+is the same rank-vs-component distinction `COMPONENTS` drew above, one level
+up: `R` names the `ContinuousAction<R>` supertrait but never appears in either
+signature, because keying the bounds on rank instead of `COMPONENTS` was
+exactly the bug ([issue #253](https://github.com/anthonytorlucci/rlevo/issues/253),
+the same conflation as [issue #100](https://github.com/anthonytorlucci/rlevo/issues/100))
+— a rank-1 walker action with four components would only ever get one bound
+pair back. `&'static [f32]` sidesteps `[f32; Self::COMPONENTS]`, which needs
+the unstable `generic_const_exprs` feature and isn't available on the stable
+toolchain this workspace pins; see
+[ADR 0053](https://github.com/anthonytorlucci/rlevo/blob/main/docs/adr/0053-bounded-action-per-component-bounds.md)
+for the full design rationale, including why the length agreement is a
+contract test rather than something the compiler checks for you.
+
+Pendulum is a clean single-component example — one torque value bounded to
 \\([-2, 2]\\):
 
 ```rust
@@ -210,8 +226,27 @@ impl ContinuousAction<1> for PendulumAction {
 }
 
 impl BoundedAction<1> for PendulumAction {
-    fn low()  -> [f32; 1] { [-2.0] }
-    fn high() -> [f32; 1] { [ 2.0] }
+    fn low()  -> &'static [f32] { &[-2.0] }
+    fn high() -> &'static [f32] { &[2.0] }
+}
+```
+
+CarRacing is the case that motivates the whole design: three components —
+`[steer, gas, brake]` — sharing one rank-1 `Action<1>`, with bounds that are
+*not* symmetric across components. Steering ranges over \\([-1, 1]\\), but gas
+and brake only make sense as \\([0, 1]\\); a scalar `low()`/`high()` pair could
+never express that gas has a different floor than steering.
+
+```rust
+impl ContinuousAction<1> for CarRacingAction {
+    const COMPONENTS: usize = 3;
+    fn as_slice(&self) -> &[f32] { &self.components }
+    // ...
+}
+
+impl BoundedAction<1> for CarRacingAction {
+    fn low()  -> &'static [f32] { &[-1.0, 0.0, 0.0] }
+    fn high() -> &'static [f32] { &[1.0, 1.0, 1.0] }
 }
 ```
 


### PR DESCRIPTION
**Stack 4 of 5** — base `253-stack/3-env-impls` (#381). Part of #253.

Documentation for stacks 1–3. No code changes.

### `CHANGELOG.md`

Breaking-change entry for the `rlevo-core` signature change with its migration, the DDPG/TD3/SAC rank-to-component correction and the per-component target clip under `**Fixed**`, and the five newly-unblocked environments under `**Added**`. Each entry states the defect and why the existing tests missed it, rather than narrating the diff.

### User book — `part-1-foundations/reinforcement-learning/32-action.md`

The chapter had the old `[f32; R]` signature and a stale `PendulumAction` example. It also already promised "known `[low, high]` **per component**" in its trait table while the signature could not deliver that — so this adds a short rank-vs-component explainer closing a gap the prose had been papering over, and a `CarRacingAction` worked example as the asymmetric multi-component case.

Verified against current source rather than paraphrased; mdBook builds clean.

### Review note

Stack 5 appends a second changelog entry for the post-review hardening. Both entries sit under `## [Unreleased]` and do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HXyaXsUCPT9qQtEvG39uQ