### PR TITLE
test(rl): Close the QA gaps in the BoundedAction series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   under the old signature. `CarRacingAction` is the workspace's only action whose
   components disagree — steering ∈ [-1, 1] but gas and brake ∈ [0, 1].
 
+**Fixed**
+
+- **`ContinuousAction::from_slice` now accepts exactly `COMPONENTS` values on all
+  five multi-component continuous actions**, matching what the trait and
+  `docs/rules.md` §3 have always documented. `ReacherAction` and `SwimmerAction`
+  had **no** length check at all — a short slice panicked with a bare
+  index-out-of-bounds and a long one was silently truncated — while
+  `CarRacingAction`, `BipedalWalkerAction` and `LunarLanderContinuousAction`
+  asserted only `len() >= COMPONENTS` and so accepted (and truncated) a long
+  slice. All five now `assert_eq!` and carry a matching `# Panics` line. No
+  in-workspace caller passed a non-exact slice, so nothing else changes.
+
 ### `rlevo-reinforcement-learning`
 
 **Breaking changes**
@@ -455,6 +467,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **The `BoundedAction` construction-time check now enforces the ordering half of
+  the contract too**, not just the length half. `low()[i] < high()[i]` is stated
+  in the trait docs and in `docs/rules.md` §3, but only the lengths were verified
+  at agent construction; an inverted pair surfaced mid-episode as an empty-range
+  panic inside `Rng::random_range` or a `min > max` panic inside `f32::clamp`,
+  naming the agent rather than the offending impl, and an *equal* pair produced a
+  degenerate action space that reported nothing at all.
 - **DDPG, TD3 and SAC truncated every action to its tensor rank** (ADR 0053,
   resolves #253). The `act`/`act_with` paths looped `0..A::RANK` and
   `.take(A::RANK)` over the actor's output — the rank is the number of *axes*,

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/action.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/action.rs
@@ -55,15 +55,21 @@ impl ContinuousAction<1> for BipedalWalkerAction {
         Self(self.0.map(|v| v.clamp(min, max)))
     }
 
-    /// Constructs an action from the first four elements of `values`.
+    /// Constructs an action from exactly `COMPONENTS` motor targets.
     ///
     /// # Panics
     ///
-    /// Panics if `values.len() < 4`.
+    /// Panics if `values.len() != Self::COMPONENTS`.
     fn from_slice(values: &[f32]) -> Self {
-        assert!(values.len() >= 4, "BipedalWalkerAction needs 4 values");
+        assert_eq!(
+            values.len(),
+            Self::COMPONENTS,
+            "BipedalWalkerAction needs exactly {} components, got {}",
+            Self::COMPONENTS,
+            values.len(),
+        );
         let mut arr = [0.0f32; 4];
-        arr.copy_from_slice(&values[..4]);
+        arr.copy_from_slice(values);
         Self(arr)
     }
 }
@@ -149,6 +155,20 @@ mod tests {
     fn test_from_slice() {
         let a = BipedalWalkerAction::from_slice(&[0.1, 0.2, 0.3, 0.4]);
         assert_eq!(a.0, [0.1, 0.2, 0.3, 0.4]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 4 components, got 5")]
+    fn test_from_slice_rejects_an_over_long_slice() {
+        // `ContinuousAction::from_slice` accepts *exactly* `COMPONENTS` values
+        // (docs/rules.md §3); the previous `>= 4` check silently truncated.
+        let _ = BipedalWalkerAction::from_slice(&[0.1, 0.2, 0.3, 0.4, 0.5]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 4 components, got 3")]
+    fn test_from_slice_rejects_a_short_slice() {
+        let _ = BipedalWalkerAction::from_slice(&[0.1, 0.2, 0.3]);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/car_racing/action.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/action.rs
@@ -113,13 +113,20 @@ impl ContinuousAction<1> for CarRacingAction {
         }
     }
 
-    /// Construct from a slice of at least 3 values `[steer, gas, brake]`.
+    /// Construct from a slice of exactly `COMPONENTS` values
+    /// `[steer, gas, brake]`.
     ///
     /// # Panics
     ///
-    /// Panics if `values.len() < 3`.
+    /// Panics if `values.len() != Self::COMPONENTS`.
     fn from_slice(values: &[f32]) -> Self {
-        assert!(values.len() >= 3, "CarRacingAction needs 3 values");
+        assert_eq!(
+            values.len(),
+            Self::COMPONENTS,
+            "CarRacingAction needs exactly {} components, got {}",
+            Self::COMPONENTS,
+            values.len(),
+        );
         Self::new(values[0], values[1], values[2])
     }
 
@@ -232,6 +239,21 @@ mod tests {
         assert!((a.steer() - 0.1).abs() < 1e-6);
         assert!((a.gas() - 0.5).abs() < 1e-6);
         assert!((a.brake() - 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 3 components, got 4")]
+    fn test_from_slice_rejects_an_over_long_slice() {
+        // `ContinuousAction::from_slice` accepts *exactly* `COMPONENTS` values
+        // (docs/rules.md §3). A `>=` check would silently truncate the extra
+        // value, hiding a caller that disagreed with this action's width.
+        let _ = CarRacingAction::from_slice(&[0.1, 0.5, 0.2, 0.9]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 3 components, got 2")]
+    fn test_from_slice_rejects_a_short_slice() {
+        let _ = CarRacingAction::from_slice(&[0.1, 0.5]);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/lunar_lander/action_continuous.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/action_continuous.rs
@@ -43,15 +43,18 @@ impl ContinuousAction<1> for LunarLanderContinuousAction {
         Self(self.0.map(|v| v.clamp(min, max)))
     }
 
-    /// Construct from a slice, taking the first two elements.
+    /// Construct from a slice of exactly `COMPONENTS` values.
     ///
     /// # Panics
     ///
-    /// Panics if `values.len() < 2`.
+    /// Panics if `values.len() != Self::COMPONENTS`.
     fn from_slice(values: &[f32]) -> Self {
-        assert!(
-            values.len() >= 2,
-            "LunarLanderContinuousAction needs 2 values"
+        assert_eq!(
+            values.len(),
+            Self::COMPONENTS,
+            "LunarLanderContinuousAction needs exactly {} components, got {}",
+            Self::COMPONENTS,
+            values.len(),
         );
         Self([values[0], values[1]])
     }
@@ -121,6 +124,20 @@ mod tests {
         let a = LunarLanderContinuousAction([2.0, -2.0]);
         let c = a.clip(-1.0, 1.0);
         assert_eq!(c.0, [1.0, -1.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 2 components, got 3")]
+    fn test_from_slice_rejects_an_over_long_slice() {
+        // `ContinuousAction::from_slice` accepts *exactly* `COMPONENTS` values
+        // (docs/rules.md §3); the previous `>= 2` check silently truncated.
+        let _ = LunarLanderContinuousAction::from_slice(&[0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 2 components, got 1")]
+    fn test_from_slice_rejects_a_short_slice() {
+        let _ = LunarLanderContinuousAction::from_slice(&[0.1]);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/locomotion/reacher/action.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/action.rs
@@ -50,9 +50,20 @@ impl ContinuousAction<1> for ReacherAction {
         Self([self.0[0].clamp(min, max), self.0[1].clamp(min, max)])
     }
 
-    /// Construct from a slice. The slice must contain at least two elements;
-    /// only `values[0]` (shoulder) and `values[1]` (elbow) are read.
+    /// Construct from a slice of exactly `COMPONENTS` values
+    /// `[shoulder, elbow]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `values.len() != Self::COMPONENTS`.
     fn from_slice(values: &[f32]) -> Self {
+        assert_eq!(
+            values.len(),
+            Self::COMPONENTS,
+            "ReacherAction needs exactly {} components, got {}",
+            Self::COMPONENTS,
+            values.len(),
+        );
         Self([values[0], values[1]])
     }
 
@@ -136,6 +147,22 @@ mod tests {
         assert!(ReacherAction::from_slice(high).is_valid());
         assert!(!ReacherAction::new(1.1, 0.0).is_valid());
         assert!(!ReacherAction::new(0.0, -1.1).is_valid());
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 2 components, got 3")]
+    fn from_slice_rejects_an_over_long_slice() {
+        // `ContinuousAction::from_slice` accepts *exactly* `COMPONENTS` values
+        // (docs/rules.md §3). Before ADR 0053's follow-up there was no length
+        // check at all here: a long slice was silently truncated and a short
+        // one panicked with a bare index-out-of-bounds.
+        let _ = ReacherAction::from_slice(&[0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 2 components, got 1")]
+    fn from_slice_rejects_a_short_slice() {
+        let _ = ReacherAction::from_slice(&[0.1]);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/locomotion/reacher/env.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/env.rs
@@ -436,6 +436,70 @@ mod tests {
         assert_eq!(ReacherObservation::shape(), [10]);
     }
 
+    /// A **narrowed** `action_clip` must still accept a boundary action of the
+    /// static [`BoundedAction`] space, and must saturate it at the narrower
+    /// limit.
+    ///
+    /// This is the direction that matters for ADR 0053 §3's argument that
+    /// `low()`/`high()` may be `&'static` even though `action_clip` is a
+    /// runtime field. `step` gates only on finiteness — it never consults
+    /// `is_valid()` or `action_clip` for admission — and `ReacherConfig::validate`
+    /// does not bound `action_clip` at all, so a narrowed clip can never turn
+    /// an in-space action into an error. It only saturates earlier, which is
+    /// what the three assertions below pin: accepted, equal to the
+    /// hand-saturated command, and genuinely different from the default clip.
+    ///
+    /// The pre-existing `bounds_agree_with_the_default_action_clip` test pins
+    /// only the *default* config, where the two intervals coincide and nothing
+    /// can be distinguished.
+    #[test]
+    fn narrowed_action_clip_accepts_a_boundary_action_and_saturates_early() {
+        fn cfg_with(action_clip: rlevo_core::bounds::Bounds) -> ReacherConfig {
+            ReacherConfig {
+                seed: 11,
+                reset_noise_scale: 0.0,
+                action_clip,
+                ..Default::default()
+            }
+        }
+        let narrow = rlevo_core::bounds::Bounds::new(-0.5, 0.5);
+
+        fn rollout(config: ReacherConfig, action: ReacherAction) -> [f32; 10] {
+            let mut env = ReacherRapier::with_config(config).expect("valid config");
+            env.reset().expect("reset");
+            env.step(action)
+                .expect("a boundary action of the static space must be accepted")
+                .observation()
+                .0
+        }
+
+        // The static space's corner, under the narrowed clip.
+        let at_boundary = rollout(cfg_with(narrow), ReacherAction::new(-1.0, 1.0));
+        // The same command already saturated by hand.
+        let hand_saturated = rollout(cfg_with(narrow), ReacherAction::new(-0.5, 0.5));
+        // The same corner under the default (wider) clip.
+        let unclipped = rollout(
+            cfg_with(ReacherConfig::default().action_clip),
+            ReacherAction::new(-1.0, 1.0),
+        );
+
+        for (i, (a, b)) in at_boundary.iter().zip(&hand_saturated).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-6,
+                "a narrowed action_clip must saturate the boundary action: \
+                 observation[{i}] was {a} but hand-saturating gave {b}"
+            );
+        }
+        assert!(
+            at_boundary
+                .iter()
+                .zip(&unclipped)
+                .any(|(a, b)| (a - b).abs() > 1e-4),
+            "the narrowed clip must actually bind: it produced the same physics \
+             as the default clip ({at_boundary:?} vs {unclipped:?})"
+        );
+    }
+
     #[test]
     fn reset_returns_running() {
         let mut env = ReacherRapier::with_config(cfg(7)).expect("valid config");

--- a/crates/rlevo-environments/src/locomotion/swimmer/action.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/action.rs
@@ -49,8 +49,20 @@ impl ContinuousAction<1> for SwimmerAction {
         Self([self.0[0].clamp(min, max), self.0[1].clamp(min, max)])
     }
 
-    /// Construct from a slice. Panics if `values.len() < 2`.
+    /// Construct from a slice of exactly `COMPONENTS` values
+    /// `[joint1, joint2]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `values.len() != Self::COMPONENTS`.
     fn from_slice(values: &[f32]) -> Self {
+        assert_eq!(
+            values.len(),
+            Self::COMPONENTS,
+            "SwimmerAction needs exactly {} components, got {}",
+            Self::COMPONENTS,
+            values.len(),
+        );
         Self([values[0], values[1]])
     }
 
@@ -133,6 +145,22 @@ mod tests {
         assert!(SwimmerAction::from_slice(high).is_valid());
         assert!(!SwimmerAction::new(1.1, 0.0).is_valid());
         assert!(!SwimmerAction::new(0.0, -1.1).is_valid());
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 2 components, got 3")]
+    fn from_slice_rejects_an_over_long_slice() {
+        // `ContinuousAction::from_slice` accepts *exactly* `COMPONENTS` values
+        // (docs/rules.md §3). Before ADR 0053's follow-up there was no length
+        // check at all here: a long slice was silently truncated and a short
+        // one panicked with a bare index-out-of-bounds.
+        let _ = SwimmerAction::from_slice(&[0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "needs exactly 2 components, got 1")]
+    fn from_slice_rejects_a_short_slice() {
+        let _ = SwimmerAction::from_slice(&[0.1]);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/locomotion/swimmer/env.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/env.rs
@@ -518,6 +518,70 @@ mod tests {
         assert_eq!(a.0, [1.0, -1.0]);
     }
 
+    /// A **narrowed** `action_clip` must still accept a boundary action of the
+    /// static [`BoundedAction`] space, and must saturate it at the narrower
+    /// limit.
+    ///
+    /// This is the direction that matters for ADR 0053 §3's argument that
+    /// `low()`/`high()` may be `&'static` even though `action_clip` is a
+    /// runtime field. `step` gates only on finiteness — it never consults
+    /// `is_valid()` or `action_clip` for admission — and `SwimmerConfig::validate`
+    /// does not bound `action_clip` at all, so a narrowed clip can never turn
+    /// an in-space action into an error. It only saturates earlier, which is
+    /// what the three assertions below pin: accepted, equal to the
+    /// hand-saturated command, and genuinely different from the default clip.
+    ///
+    /// The pre-existing `bounds_agree_with_the_default_action_clip` test pins
+    /// only the *default* config, where the two intervals coincide and nothing
+    /// can be distinguished.
+    #[test]
+    fn narrowed_action_clip_accepts_a_boundary_action_and_saturates_early() {
+        fn cfg_with(action_clip: rlevo_core::bounds::Bounds) -> SwimmerConfig {
+            SwimmerConfig {
+                seed: 11,
+                reset_noise_scale: 0.0,
+                action_clip,
+                ..Default::default()
+            }
+        }
+        let narrow = rlevo_core::bounds::Bounds::new(-0.5, 0.5);
+
+        fn rollout(config: SwimmerConfig, action: SwimmerAction) -> [f32; 8] {
+            let mut env = SwimmerRapier::with_config(config).expect("valid config");
+            env.reset().expect("reset");
+            env.step(action)
+                .expect("a boundary action of the static space must be accepted")
+                .observation()
+                .0
+        }
+
+        // The static space's corner, under the narrowed clip.
+        let at_boundary = rollout(cfg_with(narrow), SwimmerAction::new(-1.0, 1.0));
+        // The same command already saturated by hand.
+        let hand_saturated = rollout(cfg_with(narrow), SwimmerAction::new(-0.5, 0.5));
+        // The same corner under the default (wider) clip.
+        let unclipped = rollout(
+            cfg_with(SwimmerConfig::default().action_clip),
+            SwimmerAction::new(-1.0, 1.0),
+        );
+
+        for (i, (a, b)) in at_boundary.iter().zip(&hand_saturated).enumerate() {
+            assert!(
+                (a - b).abs() < 1e-6,
+                "a narrowed action_clip must saturate the boundary action: \
+                 observation[{i}] was {a} but hand-saturating gave {b}"
+            );
+        }
+        assert!(
+            at_boundary
+                .iter()
+                .zip(&unclipped)
+                .any(|(a, b)| (a - b).abs() > 1e-4),
+            "the narrowed clip must actually bind: it produced the same physics \
+             as the default clip ({at_boundary:?} vs {unclipped:?})"
+        );
+    }
+
     #[test]
     fn reset_returns_running() {
         let mut env = SwimmerRapier::with_config(cfg(7)).expect("valid config");

--- a/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/shared.rs
@@ -146,24 +146,32 @@ pub(crate) struct Slot<M>(Option<M>);
 /// [`ImportanceExponent::ONE`]: crate::replay::ImportanceExponent::ONE
 pub(crate) const UNIFORM_REPLAY_BETA: ImportanceExponent = ImportanceExponent::ONE;
 
-/// Asserts that `A`'s action bounds are keyed on `COMPONENTS`, as
-/// [`BoundedAction`] requires.
+/// Asserts that `A`'s action bounds satisfy the whole [`BoundedAction`]
+/// contract: `low().len() == high().len() == COMPONENTS`, and
+/// `low()[i] < high()[i]` for every component.
 ///
 /// [`BoundedAction::low`] and [`BoundedAction::high`] return `&'static [f32]`,
-/// which cannot encode its own length, so the contract
-/// `low().len() == high().len() == COMPONENTS` is an obligation on the
-/// implementor rather than a compile-time guarantee (ADR 0053 §4). The three
-/// continuous-control agents index those slices per component on every `act`,
-/// so a short slice would surface as an out-of-bounds panic mid-episode,
-/// pointing at the agent rather than at the offending impl.
+/// which cannot encode its own length, so neither half of that contract is a
+/// compile-time guarantee — both are obligations on the implementor
+/// (ADR 0053 §4). The three continuous-control agents index those slices per
+/// component on every `act`, so a short slice would surface as an
+/// out-of-bounds panic mid-episode, pointing at the agent rather than at the
+/// offending impl.
 ///
-/// Calling this once in each agent constructor converts that into a loud,
-/// early failure that names the real culprit.
+/// The **ordering** half fails more quietly still. Both DDPG's and SAC's
+/// warm-up samplers build `self.low[i]..=self.high[i]` and hand it to
+/// [`Rng::random_range`](rand::Rng::random_range), which panics on an empty
+/// range — but only for `low > high`; an *equal* pair yields a degenerate
+/// action space that samples one value forever and never reports anything.
+/// The per-component `clamp` on the policy path is worse: `f32::clamp` panics
+/// on `min > max`, again mid-episode and again naming the agent. Checking here
+/// means a nonconforming impl is rejected at agent-build time, by a message
+/// that names the component.
 ///
 /// # Panics
 ///
 /// Panics if `A::low().len()` or `A::high().len()` differs from
-/// `A::COMPONENTS`.
+/// `A::COMPONENTS`, or if `A::low()[i] >= A::high()[i]` for any component `i`.
 pub(crate) fn assert_bounds_match_components<const DA: usize, A: BoundedAction<DA>>() {
     assert_eq!(
         A::low().len(),
@@ -179,6 +187,13 @@ pub(crate) fn assert_bounds_match_components<const DA: usize, A: BoundedAction<D
         A::high().len(),
         A::COMPONENTS,
     );
+    for (i, (low, high)) in A::low().iter().zip(A::high()).enumerate() {
+        assert!(
+            low < high,
+            "BoundedAction contract violated: component {i} has low() = {low} but \
+             high() = {high}; every component needs low < high",
+        );
+    }
 }
 
 /// Builds the `[1, ..action_shape]` per-component lower/upper bound tensors used
@@ -766,6 +781,91 @@ mod tests {
             rendered.contains("TestNet"),
             "Debug must name the module type, got: {rendered}"
         );
+    }
+
+    // -------- assert_bounds_match_components --------
+
+    use rlevo_core::action::ContinuousAction;
+    use rlevo_core::base::Action;
+
+    /// Declares a two-component [`BoundedAction`] fixture with the given
+    /// bounds, so each way the contract can break has a witness.
+    ///
+    /// Hand-written types rather than one const-generic fixture: `low`/`high`
+    /// return `&'static [f32]`, so every variant needs its own literal anyway.
+    macro_rules! bounds_fixture {
+        ($name:ident, $low:expr, $high:expr) => {
+            #[derive(Debug, Clone, Copy)]
+            struct $name([f32; 2]);
+
+            impl Action<1> for $name {
+                fn shape() -> [usize; 1] {
+                    [2]
+                }
+                fn is_valid(&self) -> bool {
+                    self.0.iter().all(|v| v.is_finite())
+                }
+            }
+
+            impl ContinuousAction<1> for $name {
+                const COMPONENTS: usize = 2;
+
+                fn as_slice(&self) -> &[f32] {
+                    &self.0
+                }
+                fn clip(&self, min: f32, max: f32) -> Self {
+                    Self([self.0[0].clamp(min, max), self.0[1].clamp(min, max)])
+                }
+                fn from_slice(values: &[f32]) -> Self {
+                    assert_eq!(values.len(), Self::COMPONENTS);
+                    Self([values[0], values[1]])
+                }
+            }
+
+            impl BoundedAction<1> for $name {
+                fn low() -> &'static [f32] {
+                    $low
+                }
+                fn high() -> &'static [f32] {
+                    $high
+                }
+            }
+        };
+    }
+
+    bounds_fixture!(ConformingBounds, &[-1.0, 0.0], &[1.0, 1.0]);
+    bounds_fixture!(OverLongLowBounds, &[-1.0, 0.0, 0.0], &[1.0, 1.0]);
+    bounds_fixture!(InvertedBounds, &[1.0, 0.0], &[-1.0, 1.0]);
+    bounds_fixture!(DegenerateBounds, &[1.0, 0.0], &[1.0, 1.0]);
+
+    #[test]
+    fn test_assert_bounds_match_components_accepts_a_conforming_impl() {
+        assert_bounds_match_components::<1, ConformingBounds>();
+    }
+
+    #[test]
+    #[should_panic(expected = "low() has 3 elements but COMPONENTS is 2")]
+    fn test_assert_bounds_match_components_rejects_a_wrong_length() {
+        assert_bounds_match_components::<1, OverLongLowBounds>();
+    }
+
+    #[test]
+    #[should_panic(expected = "component 0 has low() = 1 but high() = -1")]
+    fn test_assert_bounds_match_components_rejects_inverted_bounds() {
+        // ADR 0053's trait docs and docs/rules.md §3 both state
+        // `low()[i] < high()[i]`. Left unchecked, an inverted pair reaches
+        // `rng.random_range(low..=high)` (empty-range panic) and `f32::clamp`
+        // (`min > max` panic) mid-episode, naming the agent instead of the impl.
+        assert_bounds_match_components::<1, InvertedBounds>();
+    }
+
+    #[test]
+    #[should_panic(expected = "component 0 has low() = 1 but high() = 1")]
+    fn test_assert_bounds_match_components_rejects_a_degenerate_component() {
+        // `low == high` is the quieter half: `random_range` is happy with a
+        // one-point inclusive range, so a degenerate action space would train
+        // silently forever rather than reporting anything.
+        assert_bounds_match_components::<1, DegenerateBounds>();
     }
 
     // -------- reduce_weighted_loss --------

--- a/crates/rlevo/tests/bounded_action_multi_component.rs
+++ b/crates/rlevo/tests/bounded_action_multi_component.rs
@@ -22,11 +22,13 @@
 //! one of the three bounds — so the trait half of the fix is a compile-time
 //! prerequisite for the fixture existing at all.)
 
-use burn::module::{AutodiffModule, Module};
+use std::sync::{Arc, Mutex};
+
+use burn::module::{AutodiffModule, Module, Param};
 use burn::nn::{Linear, LinearConfig};
-use burn::tensor::Tensor;
 use burn::tensor::activation::{relu, tanh};
 use burn::tensor::backend::{AutodiffBackend, Backend};
+use burn::tensor::{Tensor, TensorData};
 
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -37,6 +39,11 @@ use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_agent::DdpgAgent;
 use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_config::DdpgTrainingConfigBuilder;
 use rlevo_reinforcement_learning::algorithms::ddpg::ddpg_model::{
     ContinuousQ, DeterministicPolicy,
+};
+use rlevo_reinforcement_learning::algorithms::sac::sac_agent::SacAgent;
+use rlevo_reinforcement_learning::algorithms::sac::sac_config::SacTrainingConfigBuilder;
+use rlevo_reinforcement_learning::algorithms::sac::sac_model::{
+    SampleOutput, SquashedGaussianPolicy,
 };
 use rlevo_reinforcement_learning::utils::polyak_update;
 
@@ -331,4 +338,403 @@ fn noisy_action_stays_within_per_component_bounds() {
         let action = agent.act(&LinearObservation { x: 1.0 }, true, &mut rng);
         assert_within_per_component_bounds(&action);
     }
+}
+
+// ===========================================================================
+// SAC — the same fixture through the squashed-Gaussian agent.
+//
+// `sac_agent.rs` has two `COMPONENTS`-keyed action sites: the warm-up uniform
+// sampler and the per-component clamp on the policy path. Both were `A::RANK`
+// before ADR 0053 §5. Every `BoundedAction` impl reachable from
+// `sac_integration.rs` is 1/1, so nothing there can tell the two apart; this
+// fixture (rank 1, 3 components, asymmetric bounds) can.
+// ===========================================================================
+
+/// Test-local SAC actor with a **controllable saturation direction**.
+///
+/// `mean = obs · gain` with a large `gain`, so a negative observation drives
+/// every pre-squash logit far negative and `tanh` pins the whole row at `≈ -1`
+/// — outside the `gas`/`brake` lower bound of `0`, which is what makes the
+/// per-component clamp observable rather than incidental.
+///
+/// The returned `log_prob` is a differentiable placeholder, **not** the true
+/// squashed-Gaussian density. That is sound here because these tests exercise
+/// only [`SacAgent::act`], which never reads it; `sac_integration.rs` owns the
+/// correctness of the real density.
+#[derive(Module, Debug)]
+struct SquashedActor<B: Backend> {
+    gain: Param<Tensor<B, 2>>,
+    action_dim: usize,
+}
+
+impl<B: Backend> SquashedActor<B> {
+    /// σ on the reparameterized sample. Small enough that a `gain`-saturated
+    /// mean stays saturated for any plausible ε.
+    const SIGMA: f32 = 0.1;
+
+    fn new(
+        action_dim: usize,
+        gain: f32,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        let data = TensorData::new(vec![gain; action_dim], vec![1, action_dim]);
+        Self {
+            gain: Param::from_tensor(Tensor::from_data(data, device)),
+            action_dim,
+        }
+    }
+
+    /// `[batch, 1] × [1, action_dim]` broadcasts to `[batch, action_dim]`.
+    fn sample_impl(&self, obs: Tensor<B, 2>, eps: Tensor<B, 2>) -> (Tensor<B, 2>, Tensor<B, 1>) {
+        let z = obs * self.gain.val() + eps.mul_scalar(Self::SIGMA);
+        let log_prob = z
+            .clone()
+            .powi_scalar(2)
+            .sum_dim(1)
+            .squeeze_dim::<1>(1)
+            .neg();
+        (tanh(z), log_prob)
+    }
+}
+
+impl<B: AutodiffBackend> SquashedGaussianPolicy<B, 2, 2> for SquashedActor<B> {
+    fn action_dim(&self) -> usize {
+        self.action_dim
+    }
+
+    fn forward_sample(&self, obs: Tensor<B, 2>, eps: Tensor<B, 2>) -> SampleOutput<B, 2> {
+        let (action, log_prob) = self.sample_impl(obs, eps);
+        SampleOutput { action, log_prob }
+    }
+
+    fn forward_sample_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 2>,
+        eps: Tensor<B::InnerBackend, 2>,
+    ) -> SampleOutput<B::InnerBackend, 2> {
+        let (action, log_prob) = inner.sample_impl(obs, eps);
+        SampleOutput { action, log_prob }
+    }
+
+    fn deterministic_action(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        tanh(obs * self.gain.val())
+    }
+}
+
+type CarSacAgent =
+    SacAgent<Be, SquashedActor<Be>, Critic<Be>, LinearObservation, CarLikeAction, 1, 2, 1, 2>;
+
+/// Builds a SAC agent over the 3-component fixture. `gain` sets how hard the
+/// policy saturates; the sign of the observation then picks the direction.
+fn build_sac_agent(learning_starts: usize, gain: f32) -> CarSacAgent {
+    let device = seeded_device::<Be>(0x5AC);
+    let actor = SquashedActor::<Be>::new(CarLikeAction::COMPONENTS, gain, &device);
+    let critic_1 = Critic::<Be>::new(1, CarLikeAction::COMPONENTS, &device);
+    let critic_2 = Critic::<Be>::new(1, CarLikeAction::COMPONENTS, &device);
+    let config = SacTrainingConfigBuilder::default()
+        .learning_starts(learning_starts)
+        .batch_size(4)
+        .replay_buffer_capacity(64)
+        .build()
+        .expect("valid SAC config");
+    CarSacAgent::new(actor, critic_1, critic_2, config, device).expect("agent construction")
+}
+
+/// SAC warm-up path: `act(.., training = true)` below `learning_starts` draws
+/// a uniform sample per component (`sac_agent.rs:378`).
+///
+/// Reverting that loop to `0..A::RANK` yields a 1-element `Vec` where
+/// `CarLikeAction::from_slice` demands 3, so the fix is load-bearing for this
+/// test to run at all — and the per-component bound assertion below then pins
+/// that each sampled component used *its own* range rather than component 0's.
+#[test]
+fn sac_warmup_sample_produces_all_components_within_bounds() {
+    let _guard = flex_guard();
+    let agent = build_sac_agent(1_000, 10.0);
+    let mut rng = StdRng::seed_from_u64(0x5AC0_0001);
+
+    for _ in 0..32 {
+        let action = agent.act(&LinearObservation { x: 0.25 }, true, &mut rng);
+        assert_within_per_component_bounds(&action);
+    }
+}
+
+/// SAC policy path: `act` clamps the squashed actor output against
+/// `low[i]`/`high[i]` (`sac_agent.rs:410`).
+///
+/// The actor is driven to saturate at `≈ -1` on **every** component, so `gas`
+/// and `brake` arrive genuinely below their own lower bound of `0`. The
+/// expected row is therefore `[-1, 0, 0]`, which no `low[0]`-keyed clamp can
+/// produce, and which the pre-fix `0..A::RANK` loop cannot even reach — it
+/// hands 1 value to a `from_slice` that requires 3.
+#[test]
+fn sac_policy_action_clamps_each_component_against_its_own_bound() {
+    let _guard = flex_guard();
+    let agent = build_sac_agent(0, 10.0);
+    let mut rng = StdRng::seed_from_u64(0x5AC0_0002);
+
+    // `training = false` ⇒ ε = 0 ⇒ the deterministic squashed mean.
+    let action = agent.act(&LinearObservation { x: -1.0 }, false, &mut rng);
+    assert_within_per_component_bounds(&action);
+    let values = action.as_slice();
+    for (i, want) in [-1.0_f32, 0.0, 0.0].iter().enumerate() {
+        assert!(
+            (values[i] - want).abs() < 1e-5,
+            "a fully-negative squashed action must clamp to each component's own \
+             lower bound: wanted {want} at component {i}, got {} (full row: {values:?})",
+            values[i]
+        );
+    }
+
+    // The noisy branch takes the same clamp.
+    for _ in 0..16 {
+        let noisy = agent.act(&LinearObservation { x: -1.0 }, true, &mut rng);
+        assert_within_per_component_bounds(&noisy);
+    }
+}
+
+// ===========================================================================
+// DDPG `learn_step` — the target-action clip, end to end.
+//
+// `clip_to_action_bounds` is unit-tested in `shared.rs`, but in isolation:
+// nothing there exercises DDPG's *wiring* of `low_t`/`high_t` through
+// `action_bound_tensors::<B::InnerBackend, A, DA, DAB>` at construction. A
+// swapped pair, or a wrong generic at that call site, would pass every
+// existing test. These two tests observe the tensor the target critic is
+// actually handed.
+// ===========================================================================
+
+/// Actions the **target** critic was evaluated on, one flat `[batch × C]` row
+/// per `forward_inner` call.
+type RecordedActions = Arc<Mutex<Vec<Vec<f32>>>>;
+
+/// Critic that records every action batch reaching its no-autodiff path.
+///
+/// In DDPG's `learn_step`, `forward_inner` is called exactly once — on the
+/// target critic, with the clipped target action (`ddpg_agent.rs:499-505`).
+/// The live critic's `forward` is a different method and is not recorded, so
+/// the capture is unambiguous.
+///
+/// `recorded` is `#[module(skip)]`, so the derive treats it as a plain cloned
+/// field rather than a submodule; `AutodiffModule::valid()` clones the `Arc`,
+/// which is what lets the target twin write into the same buffer the test
+/// reads.
+#[derive(Module, Debug)]
+struct RecordingCritic<B: Backend> {
+    head: Linear<B>,
+    #[module(skip)]
+    recorded: RecordedActions,
+}
+
+impl<B: Backend> RecordingCritic<B> {
+    fn new(
+        obs_dim: usize,
+        action_dim: usize,
+        recorded: RecordedActions,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        Self {
+            head: LinearConfig::new(obs_dim + action_dim, 1).init(device),
+            recorded,
+        }
+    }
+
+    fn forward_impl(&self, obs: Tensor<B, 2>, act: Tensor<B, 2>) -> Tensor<B, 1> {
+        let x = Tensor::cat(vec![obs, act], 1);
+        relu(self.head.forward(x)).squeeze_dim::<1>(1)
+    }
+}
+
+impl<B: AutodiffBackend> ContinuousQ<B, 2, 2> for RecordingCritic<B> {
+    fn forward(&self, obs: Tensor<B, 2>, act: Tensor<B, 2>) -> Tensor<B, 1> {
+        self.forward_impl(obs, act)
+    }
+    fn forward_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 2>,
+        act: Tensor<B::InnerBackend, 2>,
+    ) -> Tensor<B::InnerBackend, 1> {
+        let row = act
+            .clone()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .expect("target action host read");
+        inner.recorded.lock().expect("recorder mutex").push(row);
+        inner.forward_impl(obs, act)
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+        polyak_update::<B::InnerBackend, RecordingCritic<B::InnerBackend>>(
+            &active.valid(),
+            target,
+            tau as f32,
+        )
+    }
+}
+
+/// Actor whose output saturates at `±1` on **every** component, with the sign
+/// chosen by the sign of the observation.
+///
+/// The target actor is a `valid()` snapshot taken at construction and is only
+/// Polyak-nudged *after* the target computation, so the single `learn_step`
+/// below sees exactly this mapping.
+#[derive(Module, Debug)]
+struct SaturatingActor<B: Backend> {
+    gain: Param<Tensor<B, 2>>,
+}
+
+impl<B: Backend> SaturatingActor<B> {
+    fn new(
+        action_dim: usize,
+        gain: f32,
+        device: &<B as burn::tensor::backend::BackendTypes>::Device,
+    ) -> Self {
+        let data = TensorData::new(vec![gain; action_dim], vec![1, action_dim]);
+        Self {
+            gain: Param::from_tensor(Tensor::from_data(data, device)),
+        }
+    }
+
+    fn forward_impl(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        tanh(obs * self.gain.val())
+    }
+}
+
+impl<B: AutodiffBackend> DeterministicPolicy<B, 2, 2> for SaturatingActor<B> {
+    fn forward(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        self.forward_impl(obs)
+    }
+    fn forward_inner(
+        inner: &Self::InnerModule,
+        obs: Tensor<B::InnerBackend, 2>,
+    ) -> Tensor<B::InnerBackend, 2> {
+        inner.forward_impl(obs)
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    fn soft_update(active: &Self, target: Self::InnerModule, tau: f64) -> Self::InnerModule {
+        polyak_update::<B::InnerBackend, SaturatingActor<B::InnerBackend>>(
+            &active.valid(),
+            target,
+            tau as f32,
+        )
+    }
+}
+
+type SaturatingAgent = DdpgAgent<
+    Be,
+    SaturatingActor<Be>,
+    RecordingCritic<Be>,
+    LinearObservation,
+    CarLikeAction,
+    1,
+    2,
+    1,
+    2,
+>;
+
+const LEARN_BATCH: usize = 4;
+
+/// Runs one DDPG `learn_step` whose every `next_obs` is `next_obs_x`, and
+/// returns the target-action rows the target critic was handed, one `Vec` of
+/// `COMPONENTS` values per batch element.
+fn target_actions_after_one_learn_step(next_obs_x: f32) -> Vec<Vec<f32>> {
+    let device = seeded_device::<Be>(0xD06);
+    let recorded: RecordedActions = Arc::new(Mutex::new(Vec::new()));
+    let actor = SaturatingActor::<Be>::new(CarLikeAction::COMPONENTS, 10.0, &device);
+    let critic =
+        RecordingCritic::<Be>::new(1, CarLikeAction::COMPONENTS, Arc::clone(&recorded), &device);
+    let config = DdpgTrainingConfigBuilder::default()
+        .learning_starts(0)
+        .batch_size(LEARN_BATCH)
+        .replay_buffer_capacity(64)
+        .build()
+        .expect("valid DDPG config");
+    let mut agent =
+        SaturatingAgent::new(actor, critic, config, device).expect("agent construction");
+
+    let mut rng = StdRng::seed_from_u64(0xD06_0001);
+    for _ in 0..(LEARN_BATCH * 2) {
+        agent.remember(
+            LinearObservation { x: 0.1 },
+            &CarLikeAction([0.0, 0.5, 0.5]),
+            1.0,
+            LinearObservation { x: next_obs_x },
+            false,
+        );
+    }
+    agent
+        .learn_step(&mut rng)
+        .expect("learn_step must run: learning_starts is 0 and the buffer is full");
+
+    let calls = recorded.lock().expect("recorder mutex").clone();
+    assert_eq!(
+        calls.len(),
+        1,
+        "DDPG's learn_step evaluates the target critic exactly once"
+    );
+    calls[0]
+        .chunks(CarLikeAction::COMPONENTS)
+        .map(<[f32]>::to_vec)
+        .collect()
+}
+
+/// Asserts every recorded target-action row equals `expected`.
+fn assert_every_target_row(rows: &[Vec<f32>], expected: [f32; 3], why: &str) {
+    assert_eq!(
+        rows.len(),
+        LEARN_BATCH,
+        "one target action per batch element"
+    );
+    for (r, row) in rows.iter().enumerate() {
+        for (i, want) in expected.iter().enumerate() {
+            assert!(
+                (row[i] - want).abs() < 1e-5,
+                "{why}: row {r} component {i} should be {want}, got {} (full row: {row:?})",
+                row[i]
+            );
+        }
+    }
+}
+
+/// Guards `d1bdbb5`'s replacement of DDPG's scalar
+/// `.clamp(self.low[0], self.high[0])` with the per-component
+/// `clip_to_action_bounds(.., self.low_t, self.high_t)`.
+///
+/// The target actor saturates at `≈ [-1, -1, -1]`. Per component that clips to
+/// `[-1, 0, 0]`; the scalar collapse uses `low[0]/high[0]` = `-1`/`1` for all
+/// three and yields `[-1, -1, -1]` — negative gas and negative brake, the
+/// "values of impossible actions" TD3 Eq. 14's clip exists to suppress.
+///
+/// Unlike the `shared.rs` unit tests, this observes the tensor DDPG actually
+/// builds, so it also covers `action_bound_tensors::<B::InnerBackend, A, DA,
+/// DAB>` being called with the right generics at the right place.
+#[test]
+fn ddpg_learn_step_clips_the_target_action_per_component() {
+    let _guard = flex_guard();
+    let rows = target_actions_after_one_learn_step(-1.0);
+    assert_every_target_row(
+        &rows,
+        [-1.0, 0.0, 0.0],
+        "a saturated-low target action must be floored at each component's own low()",
+    );
+}
+
+/// The companion direction, which is what makes a swapped `low_t`/`high_t`
+/// detectable.
+///
+/// Swapping the pair computes `max_pair(high).min_pair(low)`. On a
+/// saturated-**low** action that happens to reproduce the correct
+/// `[-1, 0, 0]`, so the test above cannot see it. On a saturated-**high**
+/// action the two disagree maximally: correct gives `[1, 1, 1]`, swapped gives
+/// `[-1, 0, 0]`.
+#[test]
+fn ddpg_learn_step_target_clip_does_not_swap_low_and_high() {
+    let _guard = flex_guard();
+    let rows = target_actions_after_one_learn_step(1.0);
+    assert_every_target_row(
+        &rows,
+        [1.0, 1.0, 1.0],
+        "a saturated-high target action must be capped at high(), not floored at low()",
+    );
 }

--- a/crates/rlevo/tests/car_racing_continuous_control.rs
+++ b/crates/rlevo/tests/car_racing_continuous_control.rs
@@ -34,7 +34,7 @@ use rand::rngs::StdRng;
 
 use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
-use rlevo_core::environment::{ConstructableEnv, Environment, Snapshot};
+use rlevo_core::environment::{Environment, Snapshot};
 use rlevo_environments::box2d::car_racing::{
     CarRacing, CarRacingAction, CarRacingConfig, CarRacingObservation,
 };
@@ -179,7 +179,11 @@ fn build_env() -> CarRacing {
         max_steps: 64,
         ..CarRacingConfig::default()
     };
-    CarRacing::with_config(config).unwrap_or_else(|_| CarRacing::new(false))
+    // Not `unwrap_or_else(|_| CarRacing::new(false))`: that fallback silently
+    // substitutes a *differently* configured env (the default `max_steps`, not
+    // 64), so a config regression would turn into a slower test rather than a
+    // failing one.
+    CarRacing::with_config(config).expect("valid CarRacing config")
 }
 
 /// Asserts an action sits inside its own per-component bound.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -202,7 +202,7 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
 | Site | Condition |
 |------|-----------|
 | `DiscreteAction::from_index(i)` | `i >= ACTION_COUNT` |
-| `ContinuousAction::from_slice(v)` | `v.len() != D` |
+| `ContinuousAction::from_slice(v)` | `v.len() != COMPONENTS` (**not** `D`, the tensor rank — ADR 0038/0053) |
 | `MultiDiscreteAction::from_indices(arr)` | any `arr[i] >= space[i]` |
 | Builder `with_capacity(n)` | `n == 0` |
 | Builder `with_alpha(x)` | `x ∉ [0.0, 1.0]` |


### PR DESCRIPTION
**Stack 5 of 5** — base `253-stack/4-docs` (#382). Completes #253.

A QA pass over stacks 1–4 proved two fixes were **untested** by reverting each in an isolated worktree and re-running the suite: it stayed green. This PR makes those reverts fail.

### Blocking gaps closed

**SAC's whole `RANK`→`COMPONENTS` fix had no test.** No test constructed a `SacAgent` with `COMPONENTS != RANK`; the "regression witness" file drove only `DdpgAgent`. Reverting both call sites now fails with `expected 3 components, got 1`.

**DDPG's per-component target clip had no end-to-end test.** The unit tests covered the shared helper in isolation, not DDPG's wiring of `low_t`/`high_t` at construction. Reverting the scalar collapse now fails with `row 0 component 1 should be 0, got -1`.

Worth recording: **a swapped `low_t`/`high_t` is invisible on a saturated-low action** — `max_pair(high).min_pair(low)` reproduces the correct row. Only the saturated-high companion test catches it, so a single-direction test would have been worthless for that failure mode. Both directions are covered.

### Also fixed

- **The series had broken its own doc claim.** Stack 1 rewrote `docs/rules.md` to say `from_slice` accepts *exactly* `COMPONENTS` values; stack 3 then shipped five impls that didn't enforce it (two with no length check at all, three accepting over-long slices silently). All five are now strict `assert_eq!` with `# Panics` docs. No in-workspace caller passes a non-exact slice.
- `docs/rules.md:205` was stale the same way, still saying `from_slice` panics on `v.len() != D` — contradicting line 115 after stack 1 corrected it.
- The documented `low()[i] < high()[i]` ordering invariant was enforced nowhere at runtime. It now sits alongside the length check that already runs at every agent construction, including the **degenerate `low == high`** case — the quiet one, since `random_range` accepts a one-point inclusive range and would train silently forever.
- The `action_clip` seam is now tested in the direction that matters: a narrowed `[-0.5, 0.5]` clip driven with a boundary `[-1, 1]` action, asserting acceptance, correct saturation, **and** a result different from the default clip. Without that third assertion a clip that stopped binding would pass vacuously.
- A silent `unwrap_or_else` env-construction fallback in the CarRacing test replaced with `expect`.

### Deferred

QA's third finding — four of the five new environments are never driven by an agent — is filed as #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HXyaXsUCPT9qQtEvG39uQ