### PR TITLE
fix(sac): Remove dead log_std bound config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,38 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   at the default bounds, which never bind on a healthy run (verified: the
   Pendulum end-to-end run passes unchanged at avg −1167.78).
 
+- **`SacTrainingConfig::log_std_min` / `log_std_max` removed — they were dead
+  state that silently did nothing** (resolves #185). Both fields were public,
+  defaulted to CleanRL's `-5.0` / `2.0`, were ordering-validated against each
+  other, and had public builder setters — but **no runtime path ever read
+  them**. `SacAgent`, `sac/train.rs`, and `SacModel` never touch them; the only
+  reads were `validate()` and the config's own tests. A user who called
+  `.log_std_min(-10.0)` got a config that accepted the value, reported it back
+  on the struct, and trained with the bounds entirely unchanged.
+
+  The clamp that actually runs has always come from
+  `SquashedGaussianPolicyHeadConfig` (`sac_policy.rs`), which carries its own
+  copy of the same two names — and that copy is untouched here. The duplication
+  was the defect; the head is the surviving owner, matching the convention ADR
+  0049 established for PPO's `TanhGaussianPolicyHeadConfig`. There was no seam
+  to wire the training-config fields through in the first place:
+  `SacAgent::new` takes an already-built `actor`, so the head's bounds are
+  fixed before the training config is ever consulted.
+
+  *Migration.* Set the bounds on the `SquashedGaussianPolicyHeadConfig` you use
+  to build the actor passed to `SacAgent::new`, and drop any
+  `.log_std_min(..)` / `.log_std_max(..)` calls on
+  `SacTrainingConfigBuilder`. Because the removed setters never had an effect,
+  this changes no training behaviour — code that compiled and trained before
+  trains identically after. `SacTrainingConfig::validate()` no longer emits a
+  `log_std_max` ordering error. `SquashedGaussianPolicyHeadConfig` carries the
+  equivalent check, but it is only reached if a caller invokes `.validate()` on
+  the head config explicitly — neither `init()` nor `SacAgent::new` does. That
+  was equally true before this change, so nothing that was running
+  automatically has been lost. **Persisted configs are unaffected**: `SacTrainingConfig` derives only
+  `Clone, Debug` and has no serde impl, so nothing on disk encodes these
+  fields.
+
 - **The `memory` module — `PrioritizedExperienceReplay`, its builder, and
   `TrainingBatch` — is removed outright, with no deprecation shim** (ADR 0050,
   resolves #188). The docs advertised the module as the sanctioned

--- a/crates/rlevo-reinforcement-learning/README.md
+++ b/crates/rlevo-reinforcement-learning/README.md
@@ -302,10 +302,13 @@ Default hyperparameters follow CleanRL:
 | `autotune` (\(\alpha\) auto-tune) | true | Haarnoja et al. (2018b) |
 | `initial_alpha` | 1.0 | CleanRL |
 | `target_entropy` | \(-\left | A \right |\) heuristic | Haarnoja et al. (2018b) |
-| `log_std_min` | -5.0 | CleanRL |
-| `log_std_max` | 2.0 | CleanRL |
 | `policy_frequency` | 2 | CleanRL |
 | `target_update_frequency` | 1 | CleanRL |
+
+The squashed-Gaussian head's `log σ` bounds (`log_std_min = -5.0`,
+`log_std_max = 2.0`, both CleanRL) are **not** training-config fields — they
+live on `SquashedGaussianPolicyHeadConfig`, the config consumed to build the
+head and where the clamp is applied.
 
 **References**
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_config.rs
@@ -7,7 +7,12 @@
 //! SAC drops the deterministic-exploration / target-policy-smoothing knobs
 //! (`exploration_noise`, `policy_noise`, `noise_clip`) and adds the
 //! entropy-temperature controls (`alpha_lr`, `autotune`, `initial_alpha`,
-//! `target_entropy`) plus the squashed-Gaussian head's `log σ` bounds.
+//! `target_entropy`).
+//!
+//! The squashed-Gaussian head's `log σ` bounds are **not** here: they live on
+//! [`SquashedGaussianPolicyHeadConfig`](crate::algorithms::sac::sac_policy::SquashedGaussianPolicyHeadConfig),
+//! the config that is actually consumed to build the head and where the clamp
+//! is applied.
 
 use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
@@ -43,10 +48,6 @@ pub struct SacTrainingConfig {
     /// Target entropy H̄. `None` ⇒ `-(A::COMPONENTS as f32)` (the common
     /// heuristic from Haarnoja et al. 2018b, matching CleanRL).
     pub target_entropy: Option<f32>,
-    /// Lower clamp applied to the policy's `log σ` head. CleanRL uses `-5`.
-    pub log_std_min: f32,
-    /// Upper clamp applied to the policy's `log σ` head. CleanRL uses `2`.
-    pub log_std_max: f32,
     /// Critic-update cadence at which the actor and α updates run. `2`
     /// matches CleanRL's `sac_continuous_action.py` default.
     pub policy_frequency: usize,
@@ -76,8 +77,6 @@ impl Default for SacTrainingConfig {
             autotune: true,
             initial_alpha: 1.0,
             target_entropy: None,
-            log_std_min: -5.0,
-            log_std_max: 2.0,
             policy_frequency: 2,
             target_update_frequency: 1,
             clip_grad: None,
@@ -97,12 +96,6 @@ impl Validate for SacTrainingConfig {
         config::in_range(C, "gamma", 0.0, 1.0, f64::from(self.gamma))?;
         config::in_range(C, "tau", 0.0, 1.0, f64::from(self.tau))?;
         config::positive(C, "initial_alpha", f64::from(self.initial_alpha))?;
-        config::ordered(
-            C,
-            "log_std_max",
-            f64::from(self.log_std_min),
-            f64::from(self.log_std_max),
-        )?;
         config::at_least(C, "policy_frequency", self.policy_frequency, 1)?;
         config::at_least(
             C,
@@ -214,18 +207,6 @@ impl SacTrainingConfigBuilder {
         self
     }
 
-    /// Sets the lower clamp applied to the policy's `log σ` head.
-    pub fn log_std_min(mut self, v: f32) -> Self {
-        self.config.log_std_min = v;
-        self
-    }
-
-    /// Sets the upper clamp applied to the policy's `log σ` head.
-    pub fn log_std_max(mut self, v: f32) -> Self {
-        self.config.log_std_max = v;
-        self
-    }
-
     /// Sets the critic-step cadence at which the actor + α updates run.
     pub fn policy_frequency(mut self, frequency: usize) -> Self {
         self.config.policy_frequency = frequency;
@@ -257,8 +238,8 @@ impl SacTrainingConfigBuilder {
     /// # Errors
     ///
     /// Returns a [`ConfigError`] if the assembled config violates any invariant
-    /// checked by [`SacTrainingConfig::validate`] (e.g. `log_std_min >=
-    /// log_std_max` or a non-positive `initial_alpha`).
+    /// checked by [`SacTrainingConfig::validate`] (e.g. a non-positive
+    /// `initial_alpha` or a zero `batch_size`).
     pub fn build(self) -> Result<SacTrainingConfig, ConfigError> {
         self.config.validate()?;
         Ok(self.config)
@@ -283,8 +264,6 @@ mod tests {
         assert!(cfg.autotune);
         assert!((cfg.initial_alpha - 1.0).abs() < 1e-6);
         assert!(cfg.target_entropy.is_none());
-        assert!((cfg.log_std_min - -5.0).abs() < 1e-6);
-        assert!((cfg.log_std_max - 2.0).abs() < 1e-6);
         assert_eq!(cfg.policy_frequency, 2);
         assert_eq!(cfg.target_update_frequency, 1);
     }
@@ -311,15 +290,5 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         assert!(SacTrainingConfig::default().validate().is_ok());
-    }
-
-    #[test]
-    fn rejects_inverted_log_std_bounds() {
-        let err = SacTrainingConfigBuilder::new()
-            .log_std_min(2.0)
-            .log_std_max(-5.0)
-            .build()
-            .unwrap_err();
-        assert_eq!(err.field, "log_std_max");
     }
 }


### PR DESCRIPTION
Resolves #185. **Stack 1 of 3** — base `main`. Merge this one first.

`SacTrainingConfig::log_std_min` / `log_std_max` were public, defaulted to CleanRL's `-5`/`2`, ordering-validated, and had builder setters — but no runtime path read them. Every read was `validate()` or the config's own tests. Calling `.log_std_min(-10.0)` returned a config that accepted and reported the value while training with the bounds unchanged.

The clamp that actually runs has always come from `SquashedGaussianPolicyHeadConfig`. Removal rather than delegation is the only viable fix: `SacAgent::new` takes an already-built `actor`, so the head's bounds are fixed before the training config is consulted — there is no seam to wire through.

### Triage note

The issue as originally filed claimed these values **diverge** and called it a correctness trap. Both were refuted against the tree: the head config has no `Default`, so there is nothing to diverge *from*, and every construction site uses `-5`/`2` on both sides. A user setting the dead fields got the values already in effect, not wrong ones. Rescoped 🔴 High → 🟡 Low. The proposed "or wire them through" fix was also refuted — no seam exists.

### Risk

Breaking API change (two public fields, two public builder methods), but it cannot alter training results: the removed items were unreachable from every execution path. `cargo test --workspace` passes unchanged.

Also corrected the crate README's hyperparameter table and two doc comments that described the dead fields as working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xny4QPej4LZAeTYNt49Xun