### PR TITLE
fix(ppo): Remove dead action config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,6 +384,42 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `Clone, Debug` and has no serde impl, so nothing on disk encodes these
   fields.
 
+- **`PpoTrainingConfig::action_log_std_init` / `action_scale` removed — the same
+  write-only defect, one algorithm over** (resolves #385). Both fields were
+  public, defaulted (`0.0` / `1.0`), had public builder setters, and
+  `action_scale` was even positivity-validated — but **no runtime path ever read
+  them**. `PpoAgent`, `PpgAgent`, `ppo/train.rs`, and every policy head left
+  them untouched; the only reads were `validate()` and the config's own
+  round-trip test. Calling `.action_scale(2.0)` returned a config that accepted
+  and reported the value while the actions reaching the env were scaled by
+  whatever the *head* said. `PpgConfig` embeds `PpoTrainingConfig` verbatim, so
+  it inherited both dead fields and is fixed by the same removal.
+
+  The values that actually run have always come from
+  `TanhGaussianPolicyHeadConfig` (`ppo/policies/gaussian.rs`), which carries its
+  own `log_std_init` and `action_scale` — and that copy is untouched here. The
+  duplication was the defect; the head is the surviving owner, which is what ADR
+  0049 already established for PPO's `log σ` bounds. As with SAC, removal rather
+  than delegation is the only viable fix: `PpoAgent::new` and `PpgAgent::new`
+  both take an already-built `policy`, so the head's scale is fixed before the
+  training config is ever consulted — there is no seam to wire through.
+
+  *Migration.* Set `log_std_init` and `action_scale` on the
+  `TanhGaussianPolicyHeadConfig` you use to build the policy passed to
+  `PpoAgent::new` / `PpgAgent::new`, and drop any `.action_log_std_init(..)` /
+  `.action_scale(..)` calls on `PpoTrainingConfigBuilder`. Because the removed
+  setters never had an effect, this changes no training behaviour — code that
+  compiled and trained before trains identically after.
+  `PpoTrainingConfig::validate()` no longer emits an `action_scale` error; the
+  head config carries the equivalent check. **The trap this closes is worth
+  naming**: both in-repo call sites (`crates/rlevo/tests/ppo_integration.rs`,
+  `crates/rlevo/benches/pendulum_rl.rs`) set the identical value on *both* the
+  dead builder and the live head literal, so they were correct by accident. A
+  maintainer retuning the Pendulum torque limit through the prominent, fluently
+  named builder alone would have silently no-op'd while the head kept the old
+  scale. **Persisted configs are unaffected**: `PpoTrainingConfig` derives only
+  `Clone, Debug` and has no serde impl, so nothing on disk encodes these fields.
+
 - **The `memory` module — `PrioritizedExperienceReplay`, its builder, and
   `TrainingBatch` — is removed outright, with no deprecation shim** (ADR 0050,
   resolves #188). The docs advertised the module as the sanctioned

--- a/crates/rlevo-reinforcement-learning/README.md
+++ b/crates/rlevo-reinforcement-learning/README.md
@@ -154,6 +154,12 @@ Default hyperparameters follow CleanRL's `ppo.py`:
 
 `num_envs` is currently fixed at `1`; vectorised rollout is deferred.
 
+The continuous head's `log_std` initialisation and action scale (`log_std_init`,
+`action_scale`, plus the `log_std_min` / `log_std_max` bounds) are **not**
+training-config fields — they live on `TanhGaussianPolicyHeadConfig`, the config
+consumed to build the head and where the `scale · tanh(z)` squash is applied
+(ADR 0049).
+
 `clip_grad` is the only gradient-clipping knob and is **off by default**. Burn's
 `GradientClippingConfig::Norm` clips per tensor, not across the global flattened
 parameter vector, so setting it does not reproduce Huang et al. #10

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
@@ -5,6 +5,12 @@
 //! [Huang et al. 2022, *The 37 Implementation Details of PPO*](https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/)
 //! for the rationale behind each value.
 //!
+//! The continuous policy head's `log_std` initialisation and action scale are
+//! **not** here: they live on
+//! [`TanhGaussianPolicyHeadConfig`](crate::algorithms::ppo::policies::gaussian::TanhGaussianPolicyHeadConfig),
+//! the config that is actually consumed to build the head and where the squash
+//! is applied (ADR 0049).
+//!
 //! [`ppo_continuous_action.py`]: https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_continuous_actionpy
 
 use burn::grad_clipping::GradientClippingConfig;
@@ -13,11 +19,10 @@ use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
 /// Configuration for training a PPO agent.
 ///
-/// Covers rollout sizing, optimization, objective weights, and (for continuous
-/// action spaces) the policy-head scale. One `PpoAgent` instance is
-/// parameterised by the same config regardless of whether the env is discrete
-/// or continuous; the continuous-specific fields are simply ignored when the
-/// plugged-in policy head is categorical.
+/// Covers rollout sizing, optimization, and objective weights. One `PpoAgent`
+/// instance is parameterised by the same config regardless of whether the env
+/// is discrete or continuous; head-specific knobs (`log_std` init, action
+/// scale) belong to the policy head's own config, not to this one.
 #[derive(Clone, Debug)]
 pub struct PpoTrainingConfig {
     // ----- rollout sizing -----
@@ -92,16 +97,6 @@ pub struct PpoTrainingConfig {
     /// `Some(k)`, the update epoch loop aborts as soon as the running
     /// mean-approx-KL exceeds `1.5 · k`.
     pub target_kl: Option<f32>,
-
-    // ----- continuous-only (ignored for categorical policies) -----
-    /// Initial value of the state-independent `log_std` parameter used by the
-    /// tanh-squashed Gaussian policy head.
-    pub action_log_std_init: f32,
-
-    /// Scale applied to the tanh-squashed action before it reaches the
-    /// environment. Set to match the env's action-bound magnitude (for
-    /// Pendulum-v1 with `max_torque = 2.0`, use `2.0`).
-    pub action_scale: f32,
 }
 
 impl PpoTrainingConfig {
@@ -141,8 +136,6 @@ impl Default for PpoTrainingConfig {
             value_coef: 0.5,
             normalize_advantages: true,
             target_kl: None,
-            action_log_std_init: 0.0,
-            action_scale: 1.0,
         }
     }
 }
@@ -181,7 +174,6 @@ impl Validate for PpoTrainingConfig {
         if let Some(kl) = self.target_kl {
             config::positive(C, "target_kl", f64::from(kl))?;
         }
-        config::positive(C, "action_scale", f64::from(self.action_scale))?;
         Ok(())
     }
 }
@@ -305,21 +297,6 @@ impl PpoTrainingConfigBuilder {
         self
     }
 
-    /// Sets the initial value for the state-independent `log_std` parameter
-    /// used by the tanh-Gaussian policy head. Ignored for categorical policies.
-    pub fn action_log_std_init(mut self, v: f32) -> Self {
-        self.config.action_log_std_init = v;
-        self
-    }
-
-    /// Sets the tanh-squash scale applied before the env sees a continuous
-    /// action. Match this to the env's action-bound magnitude. Ignored for
-    /// categorical policies.
-    pub fn action_scale(mut self, v: f32) -> Self {
-        self.config.action_scale = v;
-        self
-    }
-
     /// Consumes the builder and returns the assembled [`PpoTrainingConfig`].
     ///
     /// # Errors
@@ -400,14 +377,12 @@ mod tests {
             .num_steps(256)
             .clip_coef(0.1)
             .entropy_coef(0.0)
-            .action_scale(2.0)
             .clip_grad(Some(GradientClippingConfig::Norm(0.5)))
             .build()
             .expect("valid config");
         assert_eq!(cfg.num_steps, 256);
         assert_eq!(cfg.clip_coef, 0.1);
         assert_eq!(cfg.entropy_coef, 0.0);
-        assert_eq!(cfg.action_scale, 2.0);
         // `GradientClippingConfig` is not `PartialEq`, so match on the variant.
         match cfg.clip_grad {
             Some(GradientClippingConfig::Norm(n)) => assert!((n - 0.5).abs() < 1e-6),

--- a/crates/rlevo/benches/pendulum_rl.rs
+++ b/crates/rlevo/benches/pendulum_rl.rs
@@ -186,6 +186,8 @@ fn train_ppo_agent() -> PpoAgent_ {
         log_std_init: 0.0,
         log_std_min: -20.0,
         log_std_max: 2.0,
+        // Sole owner of the action scale (and of `log_std_init`) — the
+        // training config has no such knobs. Change them here, nowhere else.
         action_scale: 2.0,
     }
     .init::<Backend_>(&device);
@@ -201,8 +203,6 @@ fn train_ppo_agent() -> PpoAgent_ {
         .value_coef(0.5)
         .gamma(0.9)
         .gae_lambda(0.95)
-        .action_log_std_init(0.0)
-        .action_scale(2.0)
         .build()
         .expect("valid config");
     let total_iterations = TRAIN_TIMESTEPS / config.batch_size().max(1);

--- a/crates/rlevo/tests/ppo_integration.rs
+++ b/crates/rlevo/tests/ppo_integration.rs
@@ -228,10 +228,11 @@ fn ppo_cartpole_produces_finite_rewards() {
 /// produce identical initial weights. Callers must hold the [`flex_guard`] lock
 /// for the duration of the test.
 ///
-/// The hyperparameters (higher `update_epochs`, zero entropy coefficient,
-/// `action_scale` matching the ±2 N·m torque limit, GAE λ, γ=0.9) are tuned
-/// for the 3-observation / 1-action continuous Pendulum task with a 2 048-step
-/// rollout buffer.
+/// The hyperparameters (higher `update_epochs`, zero entropy coefficient, GAE
+/// λ, γ=0.9) are tuned for the 3-observation / 1-action continuous Pendulum
+/// task with a 2 048-step rollout buffer. The head's `action_scale` matches
+/// the ±2 N·m torque limit and is set on `TanhGaussianPolicyHeadConfig`, the
+/// only place it exists.
 fn make_pendulum_agent(
     seed: u64,
     num_steps: usize,
@@ -246,6 +247,8 @@ fn make_pendulum_agent(
         log_std_init: 0.0,
         log_std_min: -20.0,
         log_std_max: 2.0,
+        // Sole owner of the action scale — the training config has no such
+        // knob. Change the torque limit here, nowhere else.
         action_scale: 2.0,
     }
     .init::<Be>(&device);
@@ -262,7 +265,6 @@ fn make_pendulum_agent(
         .value_coef(0.5)
         .gamma(0.9)
         .gae_lambda(0.95)
-        .action_scale(2.0)
         .build()
         .expect("valid config");
     let total_iterations = total_timesteps / config.batch_size().max(1);


### PR DESCRIPTION
Resolves #385. **Stack 2 of 3** — base is #388, not `main`. Merge after #388.

Same defect class as #185, found while triaging its ripple. `PpoTrainingConfig::action_log_std_init` and `action_scale` are write-only: public, defaulted, with builder setters, and `action_scale` was even self-validated — but no runtime path read either. `PpgConfig` embeds `PpoTrainingConfig` verbatim, so it inherited both.

The live values have always come from `TanhGaussianPolicyHeadConfig`: `log_std_init` (`gaussian.rs:136`, consumed `:194-195`) and `action_scale` (`gaussian.rs:150`, applied `:560,582`). As in #185, `PpoAgent::new` and `PpgAgent::new` take an already-built `policy: P`, so removal is the only viable fix.

### Why this one is worse than #185's

Both in-repo call sites set the value on the dead builder *and* separately hardcoded it on the live head literal — so the two agreed by duplication rather than by wiring:

```rust
// crates/rlevo/tests/ppo_integration.rs
let policy = TanhGaussianPolicyHeadConfig { action_scale: 2.0, .. }  // live
    .init::<Be>(&device);
let config = PpoTrainingConfigBuilder::new()
    .action_scale(2.0)   // silently discarded
```

A maintainer retuning the Pendulum torque limit through the fluent builder alone would have silently no-opped. The builder calls are removed; the head literals now carry a comment naming them the sole owner.

### Scope

TD3 and DDPG were checked and have no such fields — this is **not** a workspace-wide pattern. It is confined to the algorithms whose constructor takes a pre-built policy head and whose training config redundantly re-declares the head's knobs.

Also corrected the `PpoTrainingConfig` struct doc, which claimed these fields were "simply ignored when the plugged-in policy head is categorical" — they were ignored for every head, so the doc actively misdirected readers toward the dead API.

### Risk

Breaking (two public fields, two builder methods), but unreachable from every execution path, so training results cannot change. Full workspace suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xny4QPej4LZAeTYNt49Xun