### PR TITLE
fix(rl-experience): Reject a zero-capacity History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -686,6 +686,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   upstream NaN origins are already guarded (#184's SAC alpha optimizer, #173's
   Gaussian `log_std` clamp — both closed), which makes the filter a backstop
   against sources that no longer produce, not a deferred repair.
+- **`History::new(0)` silently degenerated into a one-record buffer instead of
+  rejecting the argument** (resolves #190). The same eviction arithmetic as
+  `AgentStats` above: `add` pops the front whenever `trace.len() >= capacity`,
+  so with `capacity == 0` the pop fires on every call and the buffer pins at
+  exactly one transition forever — while `capacity()` keeps reporting `0` and
+  `is_full()` returns `true` from the first insert. That is a standing violation
+  of the `len() <= capacity` invariant `docs/rules.md` §3 states for this crate's
+  buffers, and it discards every experience the caller collects without
+  signalling anything. `new` now asserts `capacity > 0` and documents the panic.
+
+  `History` has no call sites at all today — `memory.rs`, its only former
+  consumer, was deleted by ADR 0050 — which is why no test caught it and why the
+  fix is cheap now. It is reachable from user code the moment the POMDP work
+  adopts `HistoryRepresentation` or `SufficientStatistic`, both of which take
+  `&History` in their signatures; fixing it before a call site exists is the
+  point, not an argument against it.
+
+  The companion claim — that `Send`/`Sync` "isn't guaranteed" for the stored
+  `A`/`R` and needs explicit bounds plus an ADR — was **refuted**. `Send` and
+  `Sync` are auto-traits: `History` and `ExperienceTuple` hold owned fields in a
+  plain `VecDeque` with no interior mutability, so both are already `Send`/`Sync`
+  exactly when `O`, `A`, and `R` are. Declaring the bounds on the struct would
+  have *restricted* the types without adding a guarantee, against Rust API
+  Guidelines C-STRUCT-BOUNDS. What was genuinely missing is that the property was
+  neither documented nor pinned, so a later field addition (an `Rc` for cheap
+  clones, a `Cell` for a cached statistic) could strip it silently; both types now
+  document the propagation and a static assertion in the test module holds it.
 
 - **A non-finite `next_q_max` survived terminal transitions in
   `compute_target_q_values`, defeating the terminal-bootstrap convention**

--- a/crates/rlevo-reinforcement-learning/src/experience.rs
+++ b/crates/rlevo-reinforcement-learning/src/experience.rs
@@ -16,6 +16,16 @@ use std::ops::Index;
 ///
 /// All five fields are required to compute the Bellman target for off-policy
 /// algorithms such as DQN and SAC.
+///
+/// # Thread safety
+///
+/// This type holds its observation, action, and reward by value and contains no
+/// interior mutability, raw pointers, or reference counting, so the [`Send`] and
+/// [`Sync`] auto-traits propagate from its type parameters: an
+/// `ExperienceTuple<D, AD, O, A, R>` is [`Send`] exactly when `O`, `A`, and `R`
+/// are, and [`Sync`] exactly when `O`, `A`, and `R` are. No explicit bounds are
+/// declared on the struct — per the Rust API Guidelines (C-STRUCT-BOUNDS) that
+/// would restrict the type without adding guarantees.
 #[derive(Clone)]
 pub struct ExperienceTuple<
     const D: usize,
@@ -54,6 +64,18 @@ pub struct ExperienceTuple<
 /// When the buffer is full, the oldest entry is evicted before each new push.
 /// This is a thin wrapper around [`VecDeque`] that enforces the capacity
 /// contract at the API level.
+///
+/// # Thread safety
+///
+/// The buffer is a plain [`VecDeque`] of owned [`ExperienceTuple`]s with no
+/// interior mutability, raw pointers, or reference counting, so the [`Send`] and
+/// [`Sync`] auto-traits propagate from its type parameters: a
+/// `History<D, AD, O, A, R>` is [`Send`] exactly when `O`, `A`, and `R` are, and
+/// [`Sync`] exactly when `O`, `A`, and `R` are. This is what lets a history be
+/// moved into a worker thread or shared behind a `Mutex` across parallel
+/// rollouts. No explicit bounds are declared on the struct — per the Rust API
+/// Guidelines (C-STRUCT-BOUNDS) that would restrict the type without adding
+/// guarantees.
 #[derive(Clone)]
 pub struct History<const D: usize, const AD: usize, O: Observation<D>, A: Action<AD>, R: Reward> {
     trace: VecDeque<ExperienceTuple<D, AD, O, A, R>>,
@@ -74,7 +96,25 @@ impl<const D: usize, const AD: usize, O: Observation<D>, A: Action<AD>, R: Rewar
     History<D, AD, O, A, R>
 {
     /// Creates an empty `History` with the given maximum `capacity`.
+    ///
+    /// # Arguments
+    /// * `capacity` - Maximum number of transitions retained before the oldest
+    ///   is evicted. Must be greater than 0.
+    ///
+    /// # Panics
+    /// Panics if `capacity` is 0. A zero-capacity buffer cannot hold any
+    /// transitions: [`Self::add`] would evict before every push, pinning
+    /// `len()` at 1 while [`Self::capacity`] reports 0 and [`Self::is_full`]
+    /// returns `true` from the first insert — a buffer that permanently
+    /// violates its own `len() <= capacity` invariant while silently accepting
+    /// and discarding every experience the agent collects.
     pub fn new(capacity: usize) -> Self {
+        assert!(
+            capacity > 0,
+            "capacity must be greater than 0; a zero-capacity buffer cannot \
+             hold transitions and would pin len() at 1 while reporting a \
+             capacity of 0, breaking the len() <= capacity invariant"
+        );
         Self {
             trace: VecDeque::with_capacity(capacity),
             capacity,
@@ -258,6 +298,32 @@ mod tests {
     }
 
     // ===== History Integration Tests =====
+
+    #[test]
+    #[should_panic(expected = "capacity must be greater than 0")]
+    fn new_rejects_zero_capacity() {
+        let _ = History::<1, 1, TestObs, TestAct, TestReward>::new(0);
+    }
+
+    /// Pins the [`Send`]/[`Sync`] auto-trait propagation documented on
+    /// [`History`] and [`ExperienceTuple`].
+    ///
+    /// This is deliberately *not* tautological, despite compiling to nothing:
+    /// auto-traits are derived structurally, so adding a single non-`Send` or
+    /// non-`Sync` field (an `Rc` for cheap clones, a `Cell` for a lazily
+    /// computed statistic) would silently strip `Send`/`Sync` from both types
+    /// and break every downstream caller that moves a history into a worker
+    /// thread — with nothing else in the suite to catch it. Do not delete.
+    #[test]
+    fn history_and_experience_tuple_are_send_and_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<History<1, 1, TestObs, TestAct, TestReward>>();
+        assert_sync::<History<1, 1, TestObs, TestAct, TestReward>>();
+        assert_send::<ExperienceTuple<1, 1, TestObs, TestAct, TestReward>>();
+        assert_sync::<ExperienceTuple<1, 1, TestObs, TestAct, TestReward>>();
+    }
 
     /// Test that History can store rewards of different values
     #[test]


### PR DESCRIPTION
Resolves #190.

## §1.1 — fixed as filed

`History::new(0)` was silently accepted and degenerated into a one-record buffer. `add` pops the front whenever `len >= capacity`, so a zero capacity evicts on every call and pins at exactly one entry — while `capacity()` keeps reporting `0` and `is_full()` returns `true` from the first insert. That is a standing violation of the `len() <= capacity` invariant `docs/rules.md` §3 states for this crate's buffers, and it discards every experience the caller collects without signalling anything.

`new` now asserts `capacity > 0` and documents the panic, following the `AgentStats` precedent in c945903 (#191).

**Deviation from the issue text: no `try_new`.** The issue originally proposed a fallible constructor, but both sibling fixed-capacity buffers panic on this exact condition — `AgentStats::new` (`metrics.rs:48`) and `UniformReplay::new` (`replay/uniform.rs:87`), the latter with the rationale spelled out: every in-crate call site passes a config field `Validate` has already rejected zero for, making it a programming error rather than user data. A `Result` here would be the odd one out among three sibling buffers. The reopen comment on #190 also asked specifically for "reject zero at construction".

**No call site is affected** — `History` has none at all. `memory.rs`, its only former consumer, was deleted by ADR 0050. It becomes reachable the moment the POMDP work adopts `HistoryRepresentation` or `SufficientStatistic`, both of which take `&History` in their signatures. Guarding it before a call site exists is the point, not an argument against it.

## §6.1 — refuted, not implemented

The issue asked for explicit `Send`/`Sync` bounds plus an ADR, on the grounds that no such bound appears in the file. True observation, but the conclusion doesn't follow: **`Send` and `Sync` are auto-traits.** `History` and `ExperienceTuple` hold owned fields in a plain `VecDeque` with no interior mutability, raw pointers, or refcounting, so both are already `Send`/`Sync` exactly when `O`, `A`, and `R` are. There is nothing to guarantee. Declaring the bounds on the struct definitions would have made the types strictly *less* usable while adding no guarantee, against Rust API Guidelines C-STRUCT-BOUNDS, and the ADR would have recorded a decision Rust already makes.

What was genuinely missing: the property was neither documented nor pinned, so a later field addition could strip it silently. Both types now document the propagation, and a static assertion holds it.

That assertion compiles to nothing and reads as tautological, so it is the change most likely to be deleted by a future cleanup — its doc comment says why it must not be. Verified load-bearing by compiling the exact regression (a structurally identical `History` with an added `Rc<()>` field) against it:

```
error[E0277]: `Rc<()>` cannot be sent between threads safely
error[E0277]: `Rc<()>` cannot be shared between threads safely
```

## Verification

```
cargo fmt --all --check                                                   clean
cargo clippy -p rlevo-reinforcement-learning --all-targets --all-features  0 warnings
cargo test -p rlevo-reinforcement-learning                                 354 passed, 0 failed
```

⚠️ **That clippy result is not worth much, and this PR is how we found out.** See #391: `rlevo-reinforcement-learning` has no `[lints] workspace = true`, so Cargo never applies the workspace lint table to it. Same for `rlevo-core`, `rlevo-environments`, and `rlevo-hybrid`. Forcing the lints on yields 422 pedantic warnings in this crate and 33 in core. That is pre-existing and out of scope here, but it means "clippy is clean" has been giving false confidence on 4 of 7 production crates.

## Also filed while verifying

- **#391** (high) — the unenforced workspace lint table described above. Also explains why review row 8.1 (missing `Debug` derives) never surfaced in CI.
- **#392** (medium) — `experience.rs` follow-ups the original review left unpromoted: no test covers FIFO eviction, `is_full()`, OOB `get()`, or the `Index` panic (`test_history_reward_accumulation` accumulates nothing despite its name); `HistoryRepresentation::update_with` omits `terminated`/`next_obs`, so no episode-aware incremental statistic is possible. Zero impls exist, so it is still free to change.

Review rows 1.1 and 6.1 in `code-review-30-06-2026-rl.md` are updated; rows 2.1/3.1/5.1/7.1/8.1 are re-pointed at #391/#392 rather than left at `n/a`, since this PR does not do that work.

## Scope

This tracks the two filed defects only. Whether `ExperienceTuple`/`History` should exist at all remains a POMDP design decision, which ADR 0050 explicitly declined to make as a side effect of a replay refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYNjPkrTjGTT1yi9PczMqv