### PR TITLE
build(rlevo-core): Enforce the workspace lint table

### DIFF
--- a/crates/rlevo-core/Cargo.toml
+++ b/crates/rlevo-core/Cargo.toml
@@ -27,3 +27,6 @@ approx = { workspace = true }
 # root, so a `../../` path here silently works locally but 404s on docs.rs.
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "katex-header.html"]
+
+[lints]
+workspace = true

--- a/crates/rlevo-core/src/action.rs
+++ b/crates/rlevo-core/src/action.rs
@@ -138,6 +138,7 @@ pub trait DiscreteAction<const R: usize>: Action<R> {
     ///
     /// If you already have an index from another source (e.g., a neural network
     /// output), use `from_index()` directly instead of this method.
+    #[must_use]
     fn random() -> Self
     where
         Self: Sized,
@@ -217,6 +218,7 @@ pub trait MultiDiscreteAction<const R: usize>: Action<R> {
     /// let random_action = StrategyAction::random();
     /// assert!(random_action.is_valid());
     /// ```
+    #[must_use]
     fn random() -> Self
     where
         Self: Sized,
@@ -245,14 +247,11 @@ pub trait MultiDiscreteAction<const R: usize>: Action<R> {
     /// # Panics
     ///
     /// May panic or run out of memory if the action space is too large.
+    #[must_use]
     fn enumerate() -> Vec<Self>
     where
         Self: Sized,
     {
-        let space = Self::shape();
-        let total: usize = space.iter().product();
-        let mut actions = Vec::with_capacity(total);
-
         fn generate<const R: usize, T: MultiDiscreteAction<R>>(
             space: &[usize; R],
             current: &mut [usize; R],
@@ -268,6 +267,10 @@ pub trait MultiDiscreteAction<const R: usize>: Action<R> {
                 generate(space, current, axis + 1, actions);
             }
         }
+
+        let space = Self::shape();
+        let total: usize = space.iter().product();
+        let mut actions = Vec::with_capacity(total);
 
         let mut current = [0; R];
         generate(&space, &mut current, 0, &mut actions);
@@ -324,6 +327,7 @@ pub trait ContinuousAction<const R: usize>: Action<R> {
     /// - Enforcing action space bounds after neural network output
     /// - Adding exploration noise while maintaining validity
     /// - Recovering from numerical instability
+    #[must_use]
     fn clip(&self, min: f32, max: f32) -> Self;
 
     /// Samples a random action with components uniformly distributed in `[-1.0, 1.0)`.
@@ -341,6 +345,7 @@ pub trait ContinuousAction<const R: usize>: Action<R> {
     /// [`is_valid`](Action::is_valid). Override it also for Gaussian noise,
     /// domain-specific distributions, or bounds derived from [`BoundedAction`].
     /// See ADR 0038.
+    #[must_use]
     fn random() -> Self
     where
         Self: Sized,
@@ -494,6 +499,12 @@ pub struct InvalidActionError {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    // The `as u8` casts below are in fixtures that assert their index is in
+    // range first, so the truncation the lint warns about cannot occur.
+    #![allow(clippy::float_cmp, clippy::cast_possible_truncation)]
     use super::*;
     use std::error::Error;
 
@@ -529,7 +540,7 @@ mod tests {
                 1 => SimpleDiscreteAction::Right,
                 2 => SimpleDiscreteAction::Up,
                 3 => SimpleDiscreteAction::Down,
-                _ => panic!("Index out of bounds: {}", index),
+                _ => panic!("Index out of bounds: {index}"),
             }
         }
 
@@ -562,12 +573,16 @@ mod tests {
 
     impl MultiDiscreteAction<2> for MultiActionTest {
         fn from_indices(indices: [usize; 2]) -> Self {
-            if indices[0] >= 4 {
-                panic!("Direction index out of bounds: {}", indices[0]);
-            }
-            if indices[1] >= 3 {
-                panic!("Intensity index out of bounds: {}", indices[1]);
-            }
+            assert!(
+                indices[0] < 4,
+                "Direction index out of bounds: {}",
+                indices[0]
+            );
+            assert!(
+                indices[1] < 3,
+                "Intensity index out of bounds: {}",
+                indices[1]
+            );
             MultiActionTest {
                 direction: indices[0],
                 intensity: indices[1],
@@ -811,7 +826,7 @@ mod tests {
         impl MultiDiscreteAction<3> for LargeMultiAction {
             fn from_indices(indices: [usize; 3]) -> Self {
                 for (i, &idx) in indices.iter().enumerate() {
-                    assert!(idx < 5, "Index {} out of bounds", i);
+                    assert!(idx < 5, "Index {i} out of bounds");
                 }
                 LargeMultiAction(indices)
             }
@@ -991,7 +1006,7 @@ mod tests {
         let error = InvalidActionError {
             message: String::from("Invalid value"),
         };
-        let displayed = format!("{}", error);
+        let displayed = format!("{error}");
         assert_eq!(displayed, "Invalid action: Invalid value");
     }
 
@@ -1000,7 +1015,7 @@ mod tests {
         let error = InvalidActionError {
             message: String::from("Test error"),
         };
-        let debug_str = format!("{:?}", error);
+        let debug_str = format!("{error:?}");
         assert!(debug_str.contains("Test error"));
     }
 
@@ -1048,7 +1063,7 @@ mod tests {
         let cloned = action;
         assert_eq!(action, cloned);
 
-        let debug_str = format!("{:?}", action);
+        let debug_str = format!("{action:?}");
         assert!(debug_str.contains("Left"));
     }
 
@@ -1058,7 +1073,7 @@ mod tests {
         let cloned = action;
         assert_eq!(action, cloned);
 
-        let debug_str = format!("{:?}", action);
+        let debug_str = format!("{action:?}");
         assert!(debug_str.contains("direction"));
     }
 
@@ -1070,7 +1085,7 @@ mod tests {
         let cloned = action.clone();
         assert_eq!(action.as_slice(), cloned.as_slice());
 
-        let debug_str = format!("{:?}", action);
+        let debug_str = format!("{action:?}");
         assert!(debug_str.contains("values"));
     }
 

--- a/crates/rlevo-core/src/base.rs
+++ b/crates/rlevo-core/src/base.rs
@@ -34,7 +34,7 @@ pub trait Observation<const R: usize>:
     /// order), *not* the size of any axis.
     ///
     /// "Rank" here means the count of indices needed to address an element
-    /// (NumPy `ndim`, Burn's `Tensor<B, R>`), not matrix rank or CP-decomposition
+    /// (`NumPy` `ndim`, Burn's `Tensor<B, R>`), not matrix rank or CP-decomposition
     /// rank. This is automatically set to match the const generic parameter `R`.
     const RANK: usize = R;
 
@@ -62,7 +62,7 @@ pub trait State<const R: usize>: Debug + Clone + Send + Sync {
     /// *not* the size of any axis.
     ///
     /// "Rank" here means the count of indices needed to address an element
-    /// (NumPy `ndim`, Burn's `Tensor<B, R>`), not matrix rank or CP-decomposition
+    /// (`NumPy` `ndim`, Burn's `Tensor<B, R>`), not matrix rank or CP-decomposition
     /// rank. This is automatically set to match the const generic parameter `R`.
     const RANK: usize = R;
 
@@ -130,7 +130,7 @@ pub trait Action<const R: usize>: Debug + Clone + Sized {
     /// *not* the size of any axis.
     ///
     /// "Rank" here means the count of indices needed to address an element
-    /// (NumPy `ndim`, Burn's `Tensor<B, R>`), not matrix rank or CP-decomposition
+    /// (`NumPy` `ndim`, Burn's `Tensor<B, R>`), not matrix rank or CP-decomposition
     /// rank. This is automatically set to match the const generic parameter `R`.
     const RANK: usize = R;
 
@@ -415,6 +415,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    // The `as f32` casts below are on small grid coordinates, well inside the
+    // range f32 represents exactly.
+    #![allow(clippy::float_cmp, clippy::cast_precision_loss)]
     use super::*;
 
     /// Simple scalar reward implementation for testing
@@ -443,7 +449,7 @@ mod tests {
 
     // ===== Basic Reward Trait Tests =====
 
-    /// Test that zero() creates a neutral element for addition
+    /// Test that `zero()` creates a neutral element for addition
     #[test]
     fn test_reward_zero_is_additive_identity() {
         let zero = TestReward::zero();
@@ -509,7 +515,7 @@ mod tests {
     #[test]
     fn test_reward_debug() {
         let reward = TestReward(42.0);
-        let debug_str = format!("{:?}", reward);
+        let debug_str = format!("{reward:?}");
 
         assert!(!debug_str.is_empty());
         assert!(debug_str.contains("TestReward"));
@@ -611,7 +617,7 @@ mod tests {
     }
 
     /// ========================================================================
-    /// GameState example to test the State trait implementation
+    /// `GameState` example to test the State trait implementation
     /// ========================================================================
     #[derive(Debug, Clone, PartialEq)]
     enum GameState {
@@ -657,8 +663,7 @@ mod tests {
             let playing_state = GameState::Playing { level };
             assert!(
                 playing_state.is_valid(),
-                "Playing state with level {} should be valid",
-                level
+                "Playing state with level {level} should be valid"
             );
         }
 
@@ -668,8 +673,7 @@ mod tests {
             let invalid_state = GameState::Playing { level };
             assert!(
                 !invalid_state.is_valid(),
-                "Playing state with level {} should be invalid",
-                level
+                "Playing state with level {level} should be invalid"
             );
         }
     }
@@ -710,7 +714,7 @@ mod tests {
         }
     }
 
-    /// Test the invariant: numel() should equal product of shape()
+    /// Test the invariant: `numel()` should equal product of `shape()`
     #[test]
     fn test_game_state_consistency() {
         let test_states = [
@@ -724,8 +728,7 @@ mod tests {
             let shape_product: usize = GameState::shape().iter().product();
             assert_eq!(
                 numel, shape_product,
-                "numel({}) should equal shape product({})",
-                numel, shape_product
+                "numel({numel}) should equal shape product({shape_product})"
             );
         }
     }
@@ -740,7 +743,7 @@ mod tests {
             GameState::GameOver { score: 1000 },
         ];
 
-        let valid_states: Vec<_> = states.into_iter().filter(|s| s.is_valid()).collect();
+        let valid_states: Vec<_> = states.into_iter().filter(super::State::is_valid).collect();
 
         assert_eq!(
             valid_states.len(),
@@ -748,7 +751,7 @@ mod tests {
             "Should have 3 valid states out of 4 total"
         );
         assert!(
-            valid_states.iter().all(|s| s.is_valid()),
+            valid_states.iter().all(super::State::is_valid),
             "All filtered states should be valid"
         );
 
@@ -789,7 +792,7 @@ mod tests {
     }
 
     /// ========================================================================
-    /// GridPosition example to test the State trait implementation
+    /// `GridPosition` example to test the State trait implementation
     /// ========================================================================
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct GridPosition {
@@ -825,7 +828,7 @@ mod tests {
         }
     }
 
-    /// Test GridPosition validation
+    /// Test `GridPosition` validation
     #[test]
     fn test_grid_position_validation() {
         let valid = GridPosition {
@@ -848,7 +851,7 @@ mod tests {
         );
     }
 
-    /// Test GridPosition flatten
+    /// Test `GridPosition` flatten
     #[test]
     fn test_grid_position_flattening() {
         let pos1 = GridPosition {
@@ -878,7 +881,7 @@ mod tests {
         assert_eq!(flat3, vec![9.0, 9.0, 10.0, 10.0]);
     }
 
-    /// Test that GridPosition numel matches shape product
+    /// Test that `GridPosition` numel matches shape product
     #[test]
     fn test_grid_position_consistency() {
         let pos = GridPosition {

--- a/crates/rlevo-core/src/bounds.rs
+++ b/crates/rlevo-core/src/bounds.rs
@@ -167,6 +167,10 @@ pub struct BoundsError {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    #![allow(clippy::float_cmp)]
     use super::{Bounds, BoundsError};
 
     #[test]

--- a/crates/rlevo-core/src/environment.rs
+++ b/crates/rlevo-core/src/environment.rs
@@ -30,16 +30,19 @@ pub enum EpisodeStatus {
 
 impl EpisodeStatus {
     /// `true` when the episode loop should stop (`Terminated` or `Truncated`).
+    #[must_use]
     pub const fn is_done(self) -> bool {
         matches!(self, Self::Terminated | Self::Truncated)
     }
 
     /// `true` only for intrinsic MDP termination.
+    #[must_use]
     pub const fn is_terminated(self) -> bool {
         matches!(self, Self::Terminated)
     }
 
     /// `true` only for extrinsic step-limit truncation.
+    #[must_use]
     pub const fn is_truncated(self) -> bool {
         matches!(self, Self::Truncated)
     }
@@ -60,17 +63,20 @@ pub struct SnapshotMetadata {
 
 impl SnapshotMetadata {
     /// Creates an empty `SnapshotMetadata`.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Builder-style insert for a named reward component.
+    #[must_use]
     pub fn with(mut self, key: &'static str, value: f32) -> Self {
         self.components.insert(key, value);
         self
     }
 
     /// Builder-style insert for a named 3D position.
+    #[must_use]
     pub fn with_position(mut self, key: &'static str, xyz: [f32; 3]) -> Self {
         self.positions.insert(key, xyz);
         self
@@ -94,7 +100,7 @@ pub enum EnvironmentError {
     /// Rendering or display failed.
     #[error("Render failed: {0}")]
     RenderFailed(String),
-    /// An I/O operation failed (wraps std::io::Error).
+    /// An I/O operation failed (wraps `std::io::Error`).
     #[error("IO operation failed: {0}")]
     IoError(#[from] std::io::Error),
     /// A configuration-domain invariant failed during a lifecycle operation.
@@ -517,6 +523,10 @@ pub trait ConstructableEnv {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    #![allow(clippy::float_cmp)]
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -590,7 +600,7 @@ mod tests {
             match index {
                 0 => MockAction::MoveLeft,
                 1 => MockAction::MoveRight,
-                _ => panic!("Unknown action index: {}", index),
+                _ => panic!("Unknown action index: {index}"),
             }
         }
 
@@ -674,8 +684,7 @@ mod tests {
         ) -> Result<Self::SnapshotType, EnvironmentError> {
             if !action.is_valid() {
                 return Err(EnvironmentError::InvalidAction(format!(
-                    "Invalid action: {:?}.",
-                    action
+                    "Invalid action: {action:?}."
                 )));
             }
 
@@ -788,7 +797,7 @@ mod tests {
     fn test_snapshot_debug() {
         let obs = MockObservation { position: 5 };
         let snapshot = SnapshotBase::terminated(obs, ScalarReward(2.0));
-        let debug_str = format!("{:?}", snapshot);
+        let debug_str = format!("{snapshot:?}");
 
         assert!(debug_str.contains("SnapshotBase"));
         assert!(debug_str.contains("position: 5"));
@@ -893,7 +902,7 @@ mod tests {
     #[test]
     fn test_environment_error_display() {
         let error = EnvironmentError::InvalidAction("test action".to_string());
-        let display_str = format!("{}", error);
+        let display_str = format!("{error}");
         assert!(display_str.contains("Invalid action"));
         assert!(display_str.contains("test action"));
     }
@@ -949,10 +958,10 @@ mod tests {
 
     #[test]
     fn test_environment_error_source() {
+        use std::error::Error;
+
         let io_error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied");
         let env_error = EnvironmentError::IoError(io_error);
-
-        use std::error::Error;
         assert!(env_error.source().is_some());
     }
 

--- a/crates/rlevo-core/src/lib.rs
+++ b/crates/rlevo-core/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! Several traits — [`Observation`], [`State`], [`Action`] — are parameterized
 //! by a const generic `R` (rank) that denotes the *number of tensor axes*
-//! (equivalent to NumPy's `ndim` or Burn's `Tensor<B, R>`). This encodes
+//! (equivalent to `NumPy`'s `ndim` or Burn's `Tensor<B, R>`). This encodes
 //! shape compatibility at compile time: a rank-1 observation and a rank-2
 //! observation cannot be mixed up without a compile error.
 //!

--- a/crates/rlevo-core/src/objective.rs
+++ b/crates/rlevo-core/src/objective.rs
@@ -92,6 +92,10 @@ impl ObjectiveSense {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    #![allow(clippy::float_cmp)]
     use super::ObjectiveSense;
 
     #[test]

--- a/crates/rlevo-core/src/probability.rs
+++ b/crates/rlevo-core/src/probability.rs
@@ -139,6 +139,10 @@ pub struct ProbabilityError {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    #![allow(clippy::float_cmp)]
     use super::{Probability, ProbabilityError};
 
     #[test]

--- a/crates/rlevo-core/src/rate.rs
+++ b/crates/rlevo-core/src/rate.rs
@@ -137,6 +137,10 @@ pub struct NonNegativeRateError {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    #![allow(clippy::float_cmp)]
     use super::{NonNegativeRate, NonNegativeRateError};
 
     #[test]

--- a/crates/rlevo-core/src/render/payload.rs
+++ b/crates/rlevo-core/src/render/payload.rs
@@ -281,13 +281,13 @@ pub trait GridPayloadSource {
 // ---------------------------------------------------------------------------
 
 /// Background class of a [`TabularGrid`] cell — the union of cell semantics
-/// across the grid-shaped toy-text envs (FrozenLake / CliffWalking / Taxi).
+/// across the grid-shaped toy-text envs (`FrozenLake` / `CliffWalking` / Taxi).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum TabularCell {
     /// Plain walkable cell.
     Empty,
-    /// Frozen safe surface (FrozenLake).
+    /// Frozen safe surface (`FrozenLake`).
     Frozen,
     /// Episode start cell.
     Start,
@@ -387,13 +387,13 @@ pub trait TabularPayloadSource {
 pub enum Classic2DRole {
     /// The ground line / track / terrain profile.
     Track,
-    /// The cart (CartPole).
+    /// The cart (`CartPole`).
     Cart,
-    /// A balancing pole (CartPole / Pendulum).
+    /// A balancing pole (`CartPole` / Pendulum).
     Pole,
     /// A rigid link of a multi-link arm (Acrobot).
     Link,
-    /// The car (MountainCar).
+    /// The car (`MountainCar`).
     Car,
     /// A pivot / hinge point (drawn as a small marker).
     Hinge,
@@ -412,7 +412,7 @@ pub struct Classic2DBody {
     pub closed: bool,
 }
 
-/// A snapshot of a classic-control env (CartPole / Pendulum / MountainCar /
+/// A snapshot of a classic-control env (`CartPole` / Pendulum / `MountainCar` /
 /// Acrobot) at one frame: a set of world-space bodies plus the viewport the
 /// renderer fits to.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/rlevo-core/src/render/styled.rs
+++ b/crates/rlevo-core/src/render/styled.rs
@@ -42,6 +42,9 @@ impl StyledFrame {
     /// assert_eq!(frame.plain_text(), "line one\nline two");
     /// ```
     #[must_use]
+    // Callers already own the string they are wrapping (`format!`, `render_ascii`),
+    // so taking `&str` here would only add a redundant copy at every call site.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn unstyled(s: String) -> Self {
         if s.is_empty() {
             return Self { lines: Vec::new() };

--- a/crates/rlevo-core/src/reward.rs
+++ b/crates/rlevo-core/src/reward.rs
@@ -89,6 +89,10 @@ impl From<f32> for ScalarReward {
 
 #[cfg(test)]
 mod tests {
+    // These tests assert exact round-trip of values that are stored and read
+    // back without arithmetic, so bit-exact equality is the property under
+    // test; an approximate comparison would weaken them.
+    #![allow(clippy::float_cmp)]
     use super::*;
 
     #[test]

--- a/crates/rlevo-core/src/state.rs
+++ b/crates/rlevo-core/src/state.rs
@@ -62,6 +62,7 @@ pub trait MarkovState {
     /// The default implementation returns `true`, which is correct for most
     /// fully-observable environments. Override to return `false` for raw pixel
     /// or partially-observable representations that require history stacking.
+    #[must_use]
     fn is_markov() -> bool {
         true
     }
@@ -103,6 +104,7 @@ pub trait BeliefState<
 
     /// Updates the belief distribution given the last action taken and the
     /// newly received observation.
+    #[must_use]
     fn update(&self, action: &A, observation: &Self::Observation) -> Self;
 
     /// Draws a state sample from the current belief distribution.
@@ -135,7 +137,7 @@ pub trait HiddenState<const R: usize>: Clone {
 
 /// Learned compact representation with encode, predict, and decode steps.
 ///
-/// Used by world-model agents (e.g., DreamerV3) that operate in a learned
+/// Used by world-model agents (e.g., `DreamerV3`) that operate in a learned
 /// latent space rather than the raw observation space.
 ///
 /// # Type Parameters
@@ -150,6 +152,7 @@ pub trait LatentState<const R: usize, const AR: usize>: Clone {
     fn encode(observation: &Self::Observation) -> Self;
 
     /// Rolls the latent state forward by one step given `action`.
+    #[must_use]
     fn predict_next<A: Action<AR>>(&self, action: &A) -> Self;
 
     /// Reconstructs an observation from the latent representation.

--- a/crates/rlevo-core/src/util/mod.rs
+++ b/crates/rlevo-core/src/util/mod.rs
@@ -23,6 +23,7 @@ pub mod seed;
 /// assert_eq!(combinations(5, 0), 1);
 /// assert_eq!(combinations(3, 5), 0);
 /// ```
+#[must_use]
 pub fn combinations(n: u64, k: u64) -> u64 {
     if k > n {
         return 0;


### PR DESCRIPTION
First step of #391. `rlevo-core` only, burned down completely.

## Why

`[workspace.lints]` does not apply to a member crate unless that member opts in with `[lints] workspace = true`. `rlevo-core` never did, so neither `missing_debug_implementations` nor any clippy category was active on it. `cargo clippy -p rlevo-core` returning clean was measuring nothing.

## What

Adds the opt-in and clears the 107 warnings it surfaces across `--all-targets`, rather than parking them behind a crate-level `allow`. The first crate to opt in therefore does so unqualified, with no TODO to track.

Most of the diff is mechanical — `cargo clippy --fix` handled format-string inlining, `panic!`-in-`if` → `assert!`, and missing `#[must_use]`. Three groups were decided rather than auto-fixed:

| group | resolution |
|---|---|
| 41 × `float_cmp` | Scoped `#![allow]` per test module. Every site is a construct-then-read-back assertion (`Bounds::new(-5.12, 5.12).lo()`), where bit-exact equality *is* the property under test — `assert_relative_eq!` would strictly weaken them. |
| `cast_precision_loss`, `cast_possible_truncation` | Same treatment. Test fixtures that bounds-check before casting, and grid coordinates well inside f32's exact range. |
| `needless_pass_by_value` on `StyledFrame::unstyled` | Kept the owned `String`. All callers already own their string (`format!`, `render_ascii`), so `&str` would add a redundant copy at each site rather than remove one. |

Each allow carries a comment stating why.

## Reviewer note

`#[must_use]` was added to trait methods on published traits — `ContinuousAction::clip`, `BeliefState::update`, `LatentState::predict_next`, and the `random` family. Additive and non-breaking, but it will warn in downstream code that discards a returned action or belief. That is the one API-visible part of this diff.

## Verification

```
cargo clippy -p rlevo-core --all-targets --all-features   # 0 warnings
cargo test -p rlevo-core --all-features                   # 167 + 30 passed
cargo build --workspace --all-features                    # clean
cargo test --workspace --all-features                     # clean
cargo fmt --all --check                                   # clean
```

## Follow-ups

`rlevo-hybrid` (23 warnings across all targets), `rlevo-reinforcement-learning` (422 pedantic), and `rlevo-environments` remain unenforced — one PR each on this pattern, tracked in #391. See the [correction comment](https://github.com/anthonytorlucci/rlevo/issues/391#issuecomment-5019894699) there for why the staged-override approach in the original issue text does not build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RuzBWYW7uUmEzVULco6zk