### PR TITLE
build(rlevo-hybrid): Enforce the workspace lint table

### DIFF
--- a/crates/rlevo-hybrid/Cargo.toml
+++ b/crates/rlevo-hybrid/Cargo.toml
@@ -24,3 +24,6 @@ approx = { workspace = true }
 # `PolicyNeuroevolution` is generic over `E: Environment`, so the production
 # crate carries no environment dependency.
 rlevo-environments = { path = "../rlevo-environments", version = "0.3.1" }
+
+[lints]
+workspace = true

--- a/crates/rlevo-hybrid/src/policy.rs
+++ b/crates/rlevo-hybrid/src/policy.rs
@@ -8,7 +8,7 @@
 //!
 //! [`ReactivePolicy`] is the `Hidden = ()` convenience for memoryless (Markov)
 //! policies: implement one method and get [`StatefulPolicy`] for free via the
-//! blanket impl below. Classic-control policies (CartPole, MountainCar, …) take
+//! blanket impl below. Classic-control policies (`CartPole`, `MountainCar`, …) take
 //! this path.
 //!
 //! Both traits are env-generic: `act` owns the **full** `&Observation ->
@@ -56,7 +56,7 @@ pub trait StatefulPolicy<B: Backend, E: Environment<1, 1, 1>> {
 /// A reactive (memoryless) policy: `observation -> action`.
 ///
 /// The [`StatefulPolicy::Hidden`] `= ()` restriction, for Markov environments
-/// (CartPole, MountainCar, …). Implement this single method and the blanket
+/// (`CartPole`, `MountainCar`, …). Implement this single method and the blanket
 /// impl below supplies [`StatefulPolicy`] for free.
 ///
 /// A recurrent policy must **never** implement this trait — the blanket impl

--- a/crates/rlevo-hybrid/src/rollout_fitness.rs
+++ b/crates/rlevo-hybrid/src/rollout_fitness.rs
@@ -31,7 +31,7 @@
 //!
 //! `E: Environment<1, 1, 1>` — weight-only policy neuroevolution v1 targets
 //! vector-observation, scalar/discrete-action classic-control environments
-//! (CartPole, MountainCar, Pendulum, Acrobot), all rank-1. Higher-rank
+//! (`CartPole`, `MountainCar`, Pendulum, Acrobot), all rank-1. Higher-rank
 //! observation/action spaces are a future generalization.
 //!
 //! # Gradient isolation
@@ -151,7 +151,7 @@ where
     ///   are the factory's responsibility).
     /// - `episodes_per_eval`: episodes averaged per genome (≥ 1).
     /// - `max_steps_per_episode`: hard per-episode step cap. Required because
-    ///   environments such as CartPole have no intrinsic terminal step limit;
+    ///   environments such as `CartPole` have no intrinsic terminal step limit;
     ///   the cap guarantees evaluation terminates regardless of policy skill.
     /// - `device`: captured into the rollout scorer (the inner [`ModuleEvalFn`]
     ///   scorer takes no device parameter). Must equal the `device` later
@@ -161,6 +161,13 @@ where
     /// The policy is the module itself: `M` implements [`StatefulPolicy`]
     /// (recurrent) or [`ReactivePolicy`](crate::policy::ReactivePolicy)
     /// (memoryless), so there is no policy closure argument.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `episodes_per_eval` or `max_steps_per_episode` is zero. Both
+    /// are rejected at construction rather than yielding a degenerate scorer:
+    /// zero episodes would divide by zero, and a zero step cap would score
+    /// every genome identically at 0.
     pub fn new<FacFn>(
         reshaper: ModuleReshaper<B, M>,
         env_factory: FacFn,

--- a/crates/rlevo-hybrid/tests/cartpole_smoke.rs
+++ b/crates/rlevo-hybrid/tests/cartpole_smoke.rs
@@ -1,6 +1,6 @@
-//! Integration smoke test: `PolicyNeuroevolution` evolves a CartPole policy.
+//! Integration smoke test: `PolicyNeuroevolution` evolves a `CartPole` policy.
 //!
-//! This verifies correctness (compiles, wires CartPole through the full
+//! This verifies correctness (compiles, wires `CartPole` through the full
 //! weight-only stack, runs without panic), **not** convergence — two
 //! generations on a tiny population is far too little to balance the pole.
 
@@ -19,7 +19,7 @@ use rlevo_hybrid::{PolicyNeuroevolution, ReactivePolicy, RolloutFitness};
 type TestBackend = Flex;
 type Dev = <TestBackend as burn::tensor::backend::BackendTypes>::Device;
 
-/// CartPole policy: `obs(4) -> 8 -> logits(2)`.
+/// `CartPole` policy: `obs(4) -> 8 -> logits(2)`.
 ///
 /// Backend generic must be `B` — Burn's `#[derive(Module)]` references
 /// `B::Device` literally.

--- a/crates/rlevo-hybrid/tests/stateful_rollout.rs
+++ b/crates/rlevo-hybrid/tests/stateful_rollout.rs
@@ -117,14 +117,15 @@ impl Environment<1, 1, 1> for AlternatingEnv {
 /// counter threaded as `Hidden`, ignoring the (constant) observation.
 #[derive(Module, Debug)]
 struct AlternatingPolicy<B: Backend> {
-    // Unused weights — present so the module has flattenable parameters.
-    _w: Linear<B>,
+    // Never read by `act`, but read by the `Module` derive — present so the
+    // module has flattenable parameters for the reshaper to round-trip.
+    w: Linear<B>,
 }
 
 impl<B: Backend> AlternatingPolicy<B> {
     fn new(device: &B::Device) -> Self {
         Self {
-            _w: LinearConfig::new(1, 1).init(device),
+            w: LinearConfig::new(1, 1).init(device),
         }
     }
 }
@@ -151,13 +152,13 @@ impl StatefulPolicy<TestBackend, AlternatingEnv> for AlternatingPolicy<TestBacke
 /// Reactive baseline: always `Move` (index 0), regardless of observation.
 #[derive(Module, Debug)]
 struct ConstantPolicy<B: Backend> {
-    _w: Linear<B>,
+    w: Linear<B>,
 }
 
 impl<B: Backend> ConstantPolicy<B> {
     fn new(device: &B::Device) -> Self {
         Self {
-            _w: LinearConfig::new(1, 1).init(device),
+            w: LinearConfig::new(1, 1).init(device),
         }
     }
 }


### PR DESCRIPTION
Second crate in the #391 burn-down. Independent of #394 (`rlevo-core`) — branched off `main`, different crate, no shared files, so the two can review and merge in either order.

## The bug

`rlevo-hybrid` inherited nothing from `[workspace.lints]`. Cargo applies that table only to members that opt in with `[lints] workspace = true`, which this crate lacked. Adding the opt-in exposed 23 warnings; all 23 are fixed here, so the enforcement is unqualified — no blanket allow, no deferred TODO.

## What changed

Most were `doc_markdown` backticks (`CartPole` -> `` `CartPole` ``), applied by `clippy --fix`. Two were substantive:

**`used_underscore_binding` on the test policies' `_w` fields.** These fields are not unused — the `Module` derive reads them to flatten parameters, which is the only reason they exist. The underscore was claiming the opposite. Renamed to `w` and corrected the stale `// Unused weights` comment, rather than silencing a lint that had read the code correctly.

**`missing_panics_doc` on `RolloutFitness::new`.** Two real `assert!` preconditions with no `# Panics` section. Documented, including why zero is rejected at construction rather than producing a degenerate scorer.

## Review note

The `_w` -> `w` rename touches fields consumed by Burn's `#[derive(Module)]`, which reflects over field names. The reshaper round-trip test exercises that flatten/unflatten path and passes, but it is the one part of the diff where the name itself is load-bearing.

## Verification

- `cargo clippy -p rlevo-hybrid --all-targets --all-features` — 0 warnings
- `cargo test -p rlevo-hybrid --all-features` — pass
- `cargo test --workspace --all-features` — pass
- `cargo fmt --all --check` — clean

Verified on this branch with #394 *not* applied, so the result doesn't depend on the core PR landing.

## Remaining for #391

`rlevo-environments` (4 `missing_debug_implementations` + 11 `redundant_imports`) and `rlevo-reinforcement-learning` (422 pedantic — the genuinely large one, likely wants splitting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RuzBWYW7uUmEzVULco6zk