### PR TITLE
build(rlevo-environments): Enforce the workspace lint table

### DIFF
--- a/crates/rlevo-environments/Cargo.toml
+++ b/crates/rlevo-environments/Cargo.toml
@@ -45,3 +45,6 @@ bench = ["dep:rlevo-benchmarks"]
 # `RecordedEnvFamily` impls tying each built-in env to its recording family.
 # Pulls in the harness's `record` tier on top of `bench`.
 record = ["bench", "rlevo-benchmarks/record"]
+
+[lints]
+workspace = true

--- a/crates/rlevo-environments/src/bench/mod.rs
+++ b/crates/rlevo-environments/src/bench/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! Enabled by the `bench` cargo feature. Disabled by default so the base
 //! envs dep cone (rapier, nalgebra) is not bundled with the harness's
-//! (rayon, tracing, serde_json) for users who only want one of the two.
+//! (rayon, tracing, `serde_json`) for users who only want one of the two.
 //!
 //! # Contents
 //!

--- a/crates/rlevo-environments/src/bench/suites.rs
+++ b/crates/rlevo-environments/src/bench/suites.rs
@@ -29,6 +29,12 @@ pub fn ten_armed_bandit_suite(
 }
 
 /// Single-env suite running [`CartPole`] (Gymnasium `CartPole-v1`).
+///
+/// # Panics
+///
+/// Panics if the hard-coded suite configuration fails validation. The values
+/// are literals in this function, so a panic indicates a bug here rather than
+/// bad caller input.
 #[must_use]
 pub fn cartpole_suite(cfg: EvaluatorConfig) -> Suite<BenchAdapter<CartPole, 1, 1, 1>> {
     Suite::new("cartpole", cfg).with_env("cartpole-default", |seed| {
@@ -43,6 +49,12 @@ pub fn cartpole_suite(cfg: EvaluatorConfig) -> Suite<BenchAdapter<CartPole, 1, 1
 }
 
 /// Single-env suite running [`Pendulum`] (continuous-action swing-up).
+///
+/// # Panics
+///
+/// Panics if the hard-coded suite configuration fails validation. The values
+/// are literals in this function, so a panic indicates a bug here rather than
+/// bad caller input.
 #[must_use]
 pub fn pendulum_suite(cfg: EvaluatorConfig) -> Suite<BenchAdapter<Pendulum, 1, 1, 1>> {
     Suite::new("pendulum", cfg).with_env("pendulum-default", |seed| {

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/action.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/action.rs
@@ -1,15 +1,15 @@
-//! Action type for the BipedalWalker environment.
+//! Action type for the `BipedalWalker` environment.
 //!
 //! [`BipedalWalkerAction`] wraps four motor velocity targets — one per joint —
 //! each clamped to `[-1, 1]`. The targets are scaled by the per-joint speed
 //! constants (`speed_hip`, `speed_knee`) inside `apply_motors` before being
-//! passed to the Rapier2D impulse-joint motor.
+//! passed to the `Rapier2D` impulse-joint motor.
 
 use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
 use serde::{Deserialize, Serialize};
 
-/// 4-dimensional continuous action for BipedalWalker.
+/// 4-dimensional continuous action for `BipedalWalker`.
 ///
 /// Components (all in `[-1, 1]`):
 /// * `[0]` hip1 motor target (positive = forward)
@@ -96,6 +96,11 @@ impl BoundedAction<1> for BipedalWalkerAction {
 
 #[cfg(test)]
 mod tests {
+    // Clipping and slice round-trips move values without arithmetic, so the
+    // asserted results are bit-exact by construction; a tolerance would let a
+    // genuinely wrong clip pass.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/config.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/config.rs
@@ -1,4 +1,4 @@
-//! Configuration for the BipedalWalker environment.
+//! Configuration for the `BipedalWalker` environment.
 //!
 //! [`BipedalWalkerConfig`] groups all tunable parameters. Use
 //! [`BipedalWalkerConfig::builder`] for ergonomic construction; call
@@ -100,6 +100,7 @@ impl Validate for BipedalWalkerConfig {
 
 impl BipedalWalkerConfig {
     /// Return a builder for configuring a `BipedalWalkerConfig`.
+    #[must_use]
     pub fn builder() -> BipedalWalkerConfigBuilder {
         BipedalWalkerConfigBuilder {
             inner: BipedalWalkerConfig::default(),
@@ -115,30 +116,35 @@ pub struct BipedalWalkerConfigBuilder {
 
 impl BipedalWalkerConfigBuilder {
     /// Sets the terrain difficulty variant.
+    #[must_use]
     pub fn terrain(mut self, terrain: BipedalTerrain) -> Self {
         self.inner.terrain = terrain;
         self
     }
 
     /// Sets the RNG seed for terrain generation and initial state.
+    #[must_use]
     pub fn seed(mut self, seed: u64) -> Self {
         self.inner.seed = seed;
         self
     }
 
     /// Sets the maximum steps per episode before truncation.
+    #[must_use]
     pub fn max_steps(mut self, max_steps: usize) -> Self {
         self.inner.max_steps = max_steps;
         self
     }
 
     /// Sets the maximum torque applied by each leg motor.
+    #[must_use]
     pub fn motors_torque(mut self, torque: f32) -> Self {
         self.inner.motors_torque = torque;
         self
     }
 
     /// Sets the lidar sensing range in world units.
+    #[must_use]
     pub fn lidar_range(mut self, range: f32) -> Self {
         self.inner.lidar_range = range;
         self

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/env.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/env.rs
@@ -1,6 +1,6 @@
 //! Core [`BipedalWalker`] environment implementation.
 //!
-//! This module wires together the Rapier2D physics world, terrain generation,
+//! This module wires together the `Rapier2D` physics world, terrain generation,
 //! motor control, observation computation, and reward shaping into a type that
 //! implements [`rlevo_core::environment::Environment`].
 //!
@@ -19,8 +19,6 @@
 
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rapier2d::dynamics::RevoluteJoint;
-use rapier2d::geometry::ColliderHandle;
 use rapier2d::prelude::*;
 use rlevo_core::base::{Action, State};
 use rlevo_core::config::{ConfigError, ConstraintKind, Validate};
@@ -54,10 +52,10 @@ const SCALE: f32 = 30.0;
 /// Ground y-level (world units).
 const GROUND_Y: f32 = -1.0;
 
-/// BipedalWalker reinforcement learning environment.
+/// `BipedalWalker` reinforcement learning environment.
 ///
 /// A 2D bipedal robot that learns to walk forward using hip and knee motor
-/// targets. Physics are simulated with Rapier2D (enhanced-determinism).
+/// targets. Physics are simulated with `Rapier2D` (enhanced-determinism).
 ///
 /// # Episode lifecycle
 ///
@@ -210,8 +208,8 @@ impl BipedalWalker {
             let y0 = w[0][1] / SCALE;
             let x1 = w[1][0] / SCALE;
             let y1 = w[1][1] / SCALE;
-            let mx = (x0 + x1) / 2.0;
-            let my = (y0 + y1) / 2.0;
+            let mx = f32::midpoint(x0, x1);
+            let my = f32::midpoint(y0, y1);
             let dx = x1 - x0;
             let dy = y1 - y0;
             let len = (dx * dx + dy * dy).sqrt() / 2.0;
@@ -467,7 +465,7 @@ impl BipedalWalker {
     ///
     /// If the hull contacts the ground the caller in `step()` subtracts an
     /// additional −100 from the value returned here.
-    fn compute_reward(&self, action: &BipedalWalkerAction, vel_x: f32) -> f32 {
+    fn compute_reward(action: &BipedalWalkerAction, vel_x: f32) -> f32 {
         let ctrl_cost = 0.3 * action.0.iter().map(|a| a * a).sum::<f32>();
         vel_x - ctrl_cost
     }
@@ -565,7 +563,7 @@ impl Environment<1, 1, 1> for BipedalWalker {
             .bodies()
             .get(self.state.hull_handle)
             .map_or(0.0, |b| b.linvel().x);
-        let reward = self.compute_reward(&action, vel_x);
+        let reward = Self::compute_reward(&action, vel_x);
         self.total_reward += reward;
 
         let obs = self.observe(&action, &self.state);
@@ -680,6 +678,10 @@ impl BipedalWalker {
 
 #[cfg(test)]
 mod tests {
+    // These assert bit-exact determinism: two identically seeded runs must
+    // produce byte-identical trajectories, which a tolerance would not test.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/mod.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/mod.rs
@@ -1,6 +1,6 @@
-//! BipedalWalker — 2D bipedal locomotion environment.
+//! `BipedalWalker` — 2D bipedal locomotion environment.
 //!
-//! Implements the BipedalWalker-v3 Gymnasium environment using Rapier2D physics.
+//! Implements the BipedalWalker-v3 Gymnasium environment using `Rapier2D` physics.
 //! The agent controls hip and knee motor velocity targets for a two-legged robot
 //! walking forward over procedurally generated terrain.
 //!

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/observation.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/observation.rs
@@ -1,4 +1,4 @@
-//! Observation type for the BipedalWalker environment.
+//! Observation type for the `BipedalWalker` environment.
 //!
 //! [`BipedalWalkerObservation`] is a 24-element `f32` vector produced after
 //! every `reset()` and `step()`. The first 14 elements capture hull and joint
@@ -9,7 +9,7 @@
 use rlevo_core::base::{HostRow, Observation, TensorConversionError, TensorConvertible};
 use serde::{Deserialize, Serialize};
 
-/// 24-dimensional observation for BipedalWalker.
+/// 24-dimensional observation for `BipedalWalker`.
 ///
 /// Layout:
 /// * `[0]`  hull angle (rad)
@@ -35,6 +35,7 @@ pub struct BipedalWalkerObservation {
 
 impl BipedalWalkerObservation {
     /// Construct an observation from a pre-filled 24-element array.
+    #[must_use]
     pub fn new(values: [f32; 24]) -> Self {
         Self { values }
     }
@@ -43,6 +44,7 @@ impl BipedalWalkerObservation {
     ///
     /// Used by tests and callers to assert a physics step did not diverge into
     /// NaN / infinite observations.
+    #[must_use]
     pub fn is_finite(&self) -> bool {
         self.values.iter().all(|v| v.is_finite())
     }

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/state.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/state.rs
@@ -1,6 +1,6 @@
-//! Physics state for the BipedalWalker environment.
+//! Physics state for the `BipedalWalker` environment.
 //!
-//! [`BipedalWalkerState`] holds all Rapier2D handles required to read body
+//! [`BipedalWalkerState`] holds all `Rapier2D` handles required to read body
 //! kinematics and drive joints each step, plus cached contact flags.
 
 use rapier2d::dynamics::{ImpulseJointHandle, RigidBodyHandle};
@@ -8,7 +8,7 @@ use rlevo_core::base::State;
 
 use super::observation::BipedalWalkerObservation;
 
-/// Physics state for BipedalWalker.
+/// Physics state for `BipedalWalker`.
 ///
 /// Stores rapier2d handles for all bodies and joints, plus cached
 /// contact flags.

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/terrain.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/terrain.rs
@@ -1,4 +1,4 @@
-//! Terrain generation for the BipedalWalker environment.
+//! Terrain generation for the `BipedalWalker` environment.
 //!
 //! The [`TerrainGenerator`] trait is the extension point for ground geometry.
 //! Three concrete generators ship with the crate:
@@ -16,7 +16,7 @@
 //! begin at the spawn point regardless of the difficulty setting.
 //!
 //! Points are in **world space** (not scaled by `SCALE`). Scaling is applied
-//! inside `BipedalWalker::build_ground` when constructing Rapier2D colliders.
+//! inside `BipedalWalker::build_ground` when constructing `Rapier2D` colliders.
 
 use rand::RngExt;
 use rand::rngs::StdRng;
@@ -376,6 +376,10 @@ impl TerrainGenerator for HardcoreTerrain {
 
 #[cfg(test)]
 mod tests {
+    // Terrain x-coordinates are exact literals produced by a fixed step, and
+    // the determinism checks compare two runs that must agree bit-for-bit.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rand::SeedableRng;
 

--- a/crates/rlevo-environments/src/box2d/car_racing/action.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/action.rs
@@ -1,10 +1,10 @@
-//! Action type for CarRacing.
+//! Action type for `CarRacing`.
 
 use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
 use serde::{Deserialize, Serialize};
 
-/// 3-dimensional continuous action for CarRacing.
+/// 3-dimensional continuous action for `CarRacing`.
 ///
 /// Components and their valid ranges:
 /// * `steer ∈ [−1, 1]` — steering angle
@@ -130,7 +130,7 @@ impl ContinuousAction<1> for CarRacingAction {
         Self::new(values[0], values[1], values[2])
     }
 
-    /// Samples a uniformly-random **valid** action within CarRacing's asymmetric
+    /// Samples a uniformly-random **valid** action within `CarRacing`'s asymmetric
     /// bounds. Overrides the trait default, whose symmetric `[-1, 1)` range would
     /// sample negative gas/brake and fail [`Action::is_valid`] (ADR 0038).
     fn random() -> Self {

--- a/crates/rlevo-environments/src/box2d/car_racing/config.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/config.rs
@@ -1,4 +1,4 @@
-//! Configuration for the CarRacing environment.
+//! Configuration for the `CarRacing` environment.
 //!
 //! [`CarRacingConfig`] groups all tunable parameters for track generation,
 //! physics, and reward shaping. Use [`CarRacingConfig::builder`] for ergonomic
@@ -23,7 +23,7 @@ pub struct CarRacingConfig {
     /// A full lap (every tile visited) sums to exactly `lap_reward`; the
     /// effective per-tile reward is therefore `lap_reward / total_tiles`,
     /// computed per episode from the actual generated tile count. This matches
-    /// the canonical Gymnasium CarRacing formulation (`+1000 / len(track)` per
+    /// the canonical Gymnasium `CarRacing` formulation (`+1000 / len(track)` per
     /// tile), where a full lap pays ≈ 1000 regardless of the episode's tile
     /// count.
     pub lap_reward: f32,
@@ -39,7 +39,7 @@ pub struct CarRacingConfig {
     pub max_steps: usize,
     /// Physics timestep (seconds).
     pub dt: f32,
-    /// Gravity (negative = downward, but CarRacing uses top-down view).
+    /// Gravity (negative = downward, but `CarRacing` uses top-down view).
     pub gravity: f32,
 }
 
@@ -91,6 +91,7 @@ impl Validate for CarRacingConfig {
 
 impl CarRacingConfig {
     /// Returns a builder for configuring a `CarRacingConfig`.
+    #[must_use]
     pub fn builder() -> CarRacingConfigBuilder {
         CarRacingConfigBuilder {
             inner: CarRacingConfig::default(),
@@ -106,18 +107,21 @@ pub struct CarRacingConfigBuilder {
 
 impl CarRacingConfigBuilder {
     /// Sets the RNG seed for procedural track generation.
+    #[must_use]
     pub fn seed(mut self, seed: u64) -> Self {
         self.inner.seed = seed;
         self
     }
 
     /// Sets the number of Bezier control points (more = more complex track).
+    #[must_use]
     pub fn track_n_checkpoints(mut self, n: usize) -> Self {
         self.inner.track_n_checkpoints = n;
         self
     }
 
     /// Sets the maximum steps per episode before truncation.
+    #[must_use]
     pub fn max_steps(mut self, n: usize) -> Self {
         self.inner.max_steps = n;
         self
@@ -127,6 +131,7 @@ impl CarRacingConfigBuilder {
     ///
     /// The value is distributed evenly across the track's tiles, so the
     /// effective per-tile reward is `lap_reward / total_tiles`.
+    #[must_use]
     pub fn lap_reward(mut self, lap_reward: f32) -> Self {
         self.inner.lap_reward = lap_reward;
         self

--- a/crates/rlevo-environments/src/box2d/car_racing/env.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/env.rs
@@ -1,6 +1,6 @@
-//! CarRacing environment: `Environment` and `ConstructableEnv` implementations.
+//! `CarRacing` environment: `Environment` and `ConstructableEnv` implementations.
 //!
-//! This module wires the Rapier2D physics world, the [`Track`] generator, the
+//! This module wires the `Rapier2D` physics world, the [`Track`] generator, the
 //! [`Rasterizer`], and the tile-visit logic into the [`CarRacing`] struct that
 //! implements [`Environment<3, 3, 1>`](rlevo_core::environment::Environment).
 //!
@@ -21,8 +21,8 @@
 //!
 //! ## Tile-visit sweep proxy
 //!
-//! Canonical Gymnasium CarRacing marks *every* tile a wheel physically touches
-//! via a Box2D contact stream. rlevo has no cheap contact stream, so a fast car
+//! Canonical Gymnasium `CarRacing` marks *every* tile a wheel physically touches
+//! via a `Box2D` contact stream. rlevo has no cheap contact stream, so a fast car
 //! that skips several tiles between steps would leave gaps that a closed loop
 //! never revisits — undercounting `tiles_visited` and making completion
 //! unreachable. The proxy is a bounded contiguous **sweep**: on each step the
@@ -71,7 +71,7 @@ const CAR_W: f32 = 2.0 / 30.0;
 /// Car half-height.
 const CAR_H: f32 = 4.0 / 30.0;
 
-/// CarRacing reinforcement learning environment.
+/// `CarRacing` reinforcement learning environment.
 ///
 /// A top-down 2D car racing environment. The agent receives a 96×96 RGB
 /// pixel observation and outputs steering, gas, and brake controls.
@@ -223,8 +223,7 @@ impl CarRacing {
             .world
             .bodies()
             .get(self.state.car_handle)
-            .map(|b| [b.translation().x, b.translation().y])
-            .unwrap_or([0.0; 2]);
+            .map_or([0.0; 2], |b| [b.translation().x, b.translation().y]);
 
         let Some(nearest) = self.track.nearest_tile(pos) else {
             return 0.0;
@@ -275,14 +274,12 @@ impl CarRacing {
             .world
             .bodies()
             .get(state.car_handle)
-            .map(|b| [b.translation().x, b.translation().y])
-            .unwrap_or([0.0; 2]);
+            .map_or([0.0; 2], |b| [b.translation().x, b.translation().y]);
         let car_angle = self
             .world
             .bodies()
             .get(state.car_handle)
-            .map(|b| b.rotation().angle())
-            .unwrap_or(0.0);
+            .map_or(0.0, |b| b.rotation().angle());
 
         // The rasterizer is a per-frame scratch buffer, so it lives as a local
         // here rather than as env state — this keeps the sensor `&self`.
@@ -558,7 +555,7 @@ mod tests {
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
 
-    /// Creates a default seeded CarRacing environment for use in tests.
+    /// Creates a default seeded `CarRacing` environment for use in tests.
     fn make_env() -> CarRacing {
         CarRacing::with_config(CarRacingConfig::default()).expect("valid config")
     }

--- a/crates/rlevo-environments/src/box2d/car_racing/mod.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/mod.rs
@@ -1,6 +1,6 @@
-//! CarRacing — top-down 2D car racing environment with pixel observations.
+//! `CarRacing` — top-down 2D car racing environment with pixel observations.
 //!
-//! Implements the CarRacing-v3 Gymnasium environment using Rapier2D physics and
+//! Implements the CarRacing-v3 Gymnasium environment using `Rapier2D` physics and
 //! a software rasterizer. The agent receives a 96×96 RGB pixel observation and
 //! controls steering, gas, and brake inputs to complete a closed-loop track.
 //!

--- a/crates/rlevo-environments/src/box2d/car_racing/observation.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/observation.rs
@@ -1,4 +1,4 @@
-//! Observation type for CarRacing: a 96×96×3 RGB pixel buffer.
+//! Observation type for `CarRacing`: a 96×96×3 RGB pixel buffer.
 //!
 //! [`CarRacingObservation`] wraps the raw pixel output of the software
 //! rasterizer. The buffer is stored row-major (top to bottom), with three `u8`
@@ -11,6 +11,13 @@
 //! step is needed or expected. Consumers that feed a Burn `conv2d` must permute
 //! the frame from HWC to CHW first.
 
+// The 96×96×3 pixel array (27,648 bytes) exceeds clippy's 16 KiB stack-array
+// threshold, but every construction site immediately moves it into a `Box` or
+// `Arc`, and the array type is part of this module's public observation API
+// (`Arc<[u8; PIXEL_BYTES]>`). Switching to a heap-allocated slice to satisfy
+// the lint would change that public type for no runtime benefit.
+#![allow(clippy::large_stack_arrays)]
+
 use std::sync::Arc;
 
 use rlevo_core::base::{HostRow, Observation, TensorConversionError, TensorConvertible};
@@ -19,7 +26,7 @@ use burn::tensor::{Tensor, backend::Backend};
 
 use super::rasterizer::{FRAME_SIZE, PIXEL_BYTES};
 
-/// 96×96×3 pixel observation for CarRacing.
+/// 96×96×3 pixel observation for `CarRacing`.
 ///
 /// Pixel values are stored as `u8` in `[0, 255]`, row-major, RGB.
 ///
@@ -46,6 +53,7 @@ pub struct CarRacingObservation {
 
 impl CarRacingObservation {
     /// Construct from a raw pixel array.
+    #[must_use]
     pub fn new(pixels: [u8; PIXEL_BYTES]) -> Self {
         Self {
             pixels: Arc::new(pixels),
@@ -60,6 +68,7 @@ impl CarRacingObservation {
     /// allocation cannot be reused). The cold [`Deserialize`](serde::Deserialize)
     /// and [`from_tensor`](TensorConvertible::from_tensor) paths each perform one
     /// such `Box` → `Arc` copy too, but neither runs per render step.
+    #[must_use]
     pub fn from_boxed(pixels: Box<[u8; PIXEL_BYTES]>) -> Self {
         Self {
             pixels: Arc::from(pixels),
@@ -67,6 +76,7 @@ impl CarRacingObservation {
     }
 
     /// Returns `true` (pixels are always valid `u8` values).
+    #[must_use]
     pub fn is_finite(&self) -> bool {
         true
     }
@@ -74,7 +84,7 @@ impl CarRacingObservation {
 
 impl std::fmt::Debug for CarRacingObservation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CarRacingObservation({}×{}×3)", FRAME_SIZE, FRAME_SIZE)
+        write!(f, "CarRacingObservation({FRAME_SIZE}×{FRAME_SIZE}×3)")
     }
 }
 

--- a/crates/rlevo-environments/src/box2d/car_racing/rasterizer.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/rasterizer.rs
@@ -1,6 +1,13 @@
-//! Software rasterizer for the 96×96×3 CarRacing observation.
+//! Software rasterizer for the 96×96×3 `CarRacing` observation.
 //!
 //! No external image crate dependency. Uses scan-line fill for convex polygons.
+
+// The 96×96×3 pixel array (27,648 bytes) exceeds clippy's 16 KiB stack-array
+// threshold, but every construction site immediately moves it into a `Box` or
+// `Arc`, and the array type is part of this module's public observation API
+// (`Arc<[u8; PIXEL_BYTES]>`). Switching to a heap-allocated slice to satisfy
+// the lint would change that public type for no runtime benefit.
+#![allow(clippy::large_stack_arrays)]
 
 /// Width and height of the rendered frame (pixels).
 pub const FRAME_SIZE: usize = 96;
@@ -23,6 +30,7 @@ impl std::fmt::Debug for Rasterizer {
 
 impl Rasterizer {
     /// Create a new rasterizer (buffer initialised to black).
+    #[must_use]
     pub fn new() -> Self {
         Self {
             buffer: Box::new([0u8; PIXEL_BYTES]),
@@ -42,6 +50,8 @@ impl Rasterizer {
     ///
     /// Vertices are `[pixel_x, pixel_y]` floats. The polygon is assumed convex;
     /// non-convex polygons may render incorrectly.
+    // Justified: x/y/n are scanline-rasterizer conventions.
+    #[allow(clippy::many_single_char_names)]
     pub fn fill_polygon(&mut self, vertices: &[[f32; 2]], color: [u8; 3]) {
         if vertices.len() < 3 {
             return;
@@ -103,6 +113,7 @@ impl Rasterizer {
     }
 
     /// Return the raw pixel buffer (row-major, RGB).
+    #[must_use]
     pub fn pixels(&self) -> &[u8; PIXEL_BYTES] {
         &self.buffer
     }

--- a/crates/rlevo-environments/src/box2d/car_racing/state.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/state.rs
@@ -1,12 +1,12 @@
-//! Physics and progress state for the CarRacing environment.
+//! Physics and progress state for the `CarRacing` environment.
 //!
-//! [`CarRacingState`] holds the Rapier2D body handles for the car and wheels
+//! [`CarRacingState`] holds the `Rapier2D` body handles for the car and wheels
 //! and the tile-visit counters used for lap-completion detection.
 
 use rapier2d::dynamics::RigidBodyHandle;
 use rlevo_core::base::State;
 
-/// Physics and progress state for CarRacing.
+/// Physics and progress state for `CarRacing`.
 ///
 /// # Handle-lifetime caveat
 ///
@@ -24,7 +24,7 @@ use rlevo_core::base::State;
 /// cached on this struct — not the physics state.
 ///
 /// Making the state genuinely self-contained/Markov (owning its DOFs as values
-/// and re-modelling CarRacing as `Environment<3, 1, 1>` + `Observable<3>`) is
+/// and re-modelling `CarRacing` as `Environment<3, 1, 1>` + `Observable<3>`) is
 /// tracked by issue #255 (ADR 0039); this type only closes the encapsulation
 /// and invariant-honesty gap.
 #[derive(Debug, Clone)]
@@ -106,7 +106,7 @@ mod tests {
     use crate::box2d::car_racing::env::CarRacing;
     use rlevo_core::environment::{ConstructableEnv, Environment};
 
-    /// Builds a freshly-reset CarRacing env and returns it. The env owns the
+    /// Builds a freshly-reset `CarRacing` env and returns it. The env owns the
     /// world the state's handles index into, so it must outlive any state read.
     fn reset_env() -> CarRacing {
         let mut env = CarRacing::new(false);

--- a/crates/rlevo-environments/src/box2d/car_racing/track.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/track.rs
@@ -1,4 +1,4 @@
-//! Procedural track generation for the CarRacing environment.
+//! Procedural track generation for the `CarRacing` environment.
 //!
 //! Each call to [`Track::generate`] builds a unique closed-loop road by:
 //!
@@ -55,6 +55,8 @@ impl Track {
     /// 3. Sort by angle (ensure simple polygon).
     /// 4. Use Catmull-Rom interpolation to produce the centreline.
     /// 5. Tesselate into `TrackTile` quads.
+    // Justified: single-letter geometry names follow the track-generation reference.
+    #[allow(clippy::many_single_char_names)]
     pub fn generate(config: &CarRacingConfig, rng: &mut StdRng) -> Self {
         let n = config.track_n_checkpoints;
         let radius = 900.0_f32 / 30.0; // world units
@@ -148,6 +150,7 @@ impl Track {
     ///
     /// Reads each tile's precomputed [`centre`](TrackTile::centre) rather than
     /// recomputing the centroid inside the comparison.
+    #[must_use]
     pub fn nearest_tile(&self, pos: [f32; 2]) -> Option<usize> {
         self.tiles
             .iter()

--- a/crates/rlevo-environments/src/box2d/lunar_lander/action_continuous.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/action_continuous.rs
@@ -1,4 +1,4 @@
-//! Continuous action type for LunarLander (design decision D1).
+//! Continuous action type for `LunarLander` (design decision D1).
 
 use rlevo_core::action::{BoundedAction, ContinuousAction};
 use rlevo_core::base::Action;
@@ -71,7 +71,7 @@ impl ContinuousAction<1> for LunarLanderContinuousAction {
 /// *interprets* component 0, not of the action space: `-1` is a legal
 /// (engine-off) command, so the lower bound is `-1`, not `0`. This is why the
 /// space is symmetric despite one component behaving one-sidedly — unlike
-/// CarRacing, whose gas and brake are genuinely floored at `0`.
+/// `CarRacing`, whose gas and brake are genuinely floored at `0`.
 impl BoundedAction<1> for LunarLanderContinuousAction {
     fn low() -> &'static [f32] {
         &[-1.0, -1.0]
@@ -84,6 +84,12 @@ impl BoundedAction<1> for LunarLanderContinuousAction {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/lunar_lander/action_discrete.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/action_discrete.rs
@@ -1,4 +1,4 @@
-//! Discrete action type for LunarLander (design decision D1).
+//! Discrete action type for `LunarLander` (design decision D1).
 
 use rlevo_core::action::DiscreteAction;
 use rlevo_core::base::Action;
@@ -75,7 +75,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "LunarLanderDiscreteAction index out of range")]
     fn test_out_of_bounds_panics() {
         LunarLanderDiscreteAction::from_index(4);
     }

--- a/crates/rlevo-environments/src/box2d/lunar_lander/config.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/config.rs
@@ -1,4 +1,4 @@
-//! Configuration for LunarLander environments.
+//! Configuration for `LunarLander` environments.
 //!
 //! [`LunarLanderConfig`] groups all tunable parameters shared by
 //! [`super::LunarLanderDiscrete`] and [`super::LunarLanderContinuous`].
@@ -96,6 +96,7 @@ impl Validate for LunarLanderConfig {
 
 impl LunarLanderConfig {
     /// Return a builder for `LunarLanderConfig`.
+    #[must_use]
     pub fn builder() -> LunarLanderConfigBuilder {
         LunarLanderConfigBuilder {
             inner: LunarLanderConfig::default(),
@@ -111,30 +112,35 @@ pub struct LunarLanderConfigBuilder {
 
 impl LunarLanderConfigBuilder {
     /// Sets the wind model applied each physics step.
+    #[must_use]
     pub fn wind_mode(mut self, mode: WindMode) -> Self {
         self.inner.wind_mode = mode;
         self
     }
 
     /// Sets gravitational acceleration (negative = downward).
+    #[must_use]
     pub fn gravity(mut self, g: f32) -> Self {
         self.inner.gravity = g;
         self
     }
 
     /// Sets the RNG seed for terrain layout and initial velocity.
+    #[must_use]
     pub fn seed(mut self, seed: u64) -> Self {
         self.inner.seed = seed;
         self
     }
 
     /// Sets the maximum steps per episode before truncation.
+    #[must_use]
     pub fn max_steps(mut self, n: usize) -> Self {
         self.inner.max_steps = n;
         self
     }
 
     /// Sets the main engine thrust in Newtons.
+    #[must_use]
     pub fn main_engine_power(mut self, p: f32) -> Self {
         self.inner.main_engine_power = p;
         self

--- a/crates/rlevo-environments/src/box2d/lunar_lander/env.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/env.rs
@@ -1,8 +1,8 @@
-//! LunarLander environment implementation — discrete and continuous variants.
+//! `LunarLander` environment implementation — discrete and continuous variants.
 //!
 //! This module contains the two concrete environment types ([`LunarLanderDiscrete`]
 //! and [`LunarLanderContinuous`]) and the shared `LunarLanderCore` physics driver
-//! that both variants delegate to. Physics are simulated with Rapier2D at a fixed
+//! that both variants delegate to. Physics are simulated with `Rapier2D` at a fixed
 //! timestep (`config.dt`, default 1/50 s).
 //!
 //! ## Reward formula
@@ -23,7 +23,7 @@
 //!
 //! On a terminal step the reward is **set to** +100 (soft landing) or −100
 //! (crash / out-of-bounds), replacing that step's shaping delta and control
-//! cost — matching Gymnasium LunarLander.
+//! cost — matching Gymnasium `LunarLander`.
 //!
 //! The **absolute potential Φ(t)** (not the difference that enters `reward`) is
 //! surfaced through step metadata under
@@ -33,8 +33,6 @@
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rapier2d::dynamics::RevoluteJoint;
-use rapier2d::geometry::ColliderHandle;
 use rapier2d::prelude::*;
 use rlevo_core::base::{Action, State};
 use rlevo_core::config::{ConfigError, Validate};
@@ -175,7 +173,7 @@ impl LunarLanderCore {
         self.state.leg2_contact = false;
         self.state.prev_shaping = 0.0;
         let obs = self.compute_obs();
-        self.state.prev_shaping = self.shaping(&obs);
+        self.state.prev_shaping = Self::shaping(&obs);
 
         // Handles are now assigned and `prev_shaping` written; the state is
         // fully assembled, so the invariant must hold.
@@ -293,7 +291,7 @@ impl LunarLanderCore {
         ])
     }
 
-    fn shaping(&self, obs: &LunarLanderObservation) -> f32 {
+    fn shaping(obs: &LunarLanderObservation) -> f32 {
         -100.0 * (obs.x() * obs.x() + obs.y() * obs.y()).sqrt()
             - 100.0 * (obs.vx() * obs.vx() + obs.vy() * obs.vy()).sqrt()
             - 100.0 * obs.angle().abs()
@@ -313,7 +311,7 @@ impl LunarLanderCore {
         self.update_contacts();
 
         let obs = self.compute_obs();
-        let shaping = self.shaping(&obs);
+        let shaping = Self::shaping(&obs);
         let reward_shaping = shaping - self.state.prev_shaping;
         self.state.prev_shaping = shaping;
 
@@ -321,7 +319,9 @@ impl LunarLanderCore {
         let mut reward = reward_shaping - ctrl_cost;
 
         let lander = self.world.bodies().get(self.state.lander_handle);
-        let pos = lander.map(|b| b.translation()).unwrap_or_default();
+        let pos = lander
+            .map(rapier2d::dynamics::RigidBody::translation)
+            .unwrap_or_default();
         // A crash is a hull–ground contact, mirroring Gymnasium's `game_over`
         // flag (set unconditionally the instant the hull touches the ground;
         // leg contact does NOT suppress it). A clean landing keeps the hull off
@@ -369,7 +369,7 @@ impl LunarLanderCore {
 
 // ─── LunarLanderDiscrete ──────────────────────────────────────────────────────
 
-/// LunarLander with a 4-way discrete action space.
+/// `LunarLander` with a 4-way discrete action space.
 ///
 /// The step-limit is enforced internally (`config.max_steps`, default 1000).
 /// The snapshot type is a plain [`SnapshotBase`] alias ([`LunarLanderSnapshot`])
@@ -389,7 +389,7 @@ pub struct LunarLanderDiscrete {
 impl LunarLanderDiscrete {
     /// Construct with the given configuration.
     ///
-    /// The Rapier2D world is built immediately; the lander is placed at the spawn
+    /// The `Rapier2D` world is built immediately; the lander is placed at the spawn
     /// position and the initial shaping value is computed so that the first call
     /// to `reset` returns a valid snapshot without a prior physics step.
     ///
@@ -487,7 +487,7 @@ impl Environment<1, 1, 1> for LunarLanderDiscrete {
 
 // ─── LunarLanderContinuous ────────────────────────────────────────────────────
 
-/// LunarLander with a 2-dimensional continuous action space.
+/// `LunarLander` with a 2-dimensional continuous action space.
 ///
 /// Each action is a `[f32; 2]` vector wrapped in [`LunarLanderContinuousAction`].
 /// Both components must lie in `[-1, 1]` and be finite; `step` returns
@@ -512,7 +512,7 @@ pub struct LunarLanderContinuous {
 impl LunarLanderContinuous {
     /// Construct with the given configuration.
     ///
-    /// The Rapier2D world is built immediately; see [`LunarLanderDiscrete::with_config`]
+    /// The `Rapier2D` world is built immediately; see [`LunarLanderDiscrete::with_config`]
     /// for notes that apply equally here.
     ///
     /// # Errors
@@ -810,6 +810,12 @@ impl LunarLanderContinuous {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::super::snapshot::METADATA_KEY_SHAPING;
     use super::*;
     use rlevo_core::action::DiscreteAction;

--- a/crates/rlevo-environments/src/box2d/lunar_lander/mod.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/mod.rs
@@ -1,6 +1,6 @@
-//! LunarLander — 2D spacecraft landing environment (discrete and continuous variants).
+//! `LunarLander` — 2D spacecraft landing environment (discrete and continuous variants).
 //!
-//! Implements the LunarLander-v3 Gymnasium environment using Rapier2D physics.
+//! Implements the LunarLander-v3 Gymnasium environment using `Rapier2D` physics.
 //! The agent fires engines to safely land on a helipad at the origin; reward is
 //! potential-based, shaped by distance, velocity, and tilt relative to target.
 //!

--- a/crates/rlevo-environments/src/box2d/lunar_lander/observation.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/observation.rs
@@ -1,9 +1,9 @@
-//! Observation type for LunarLander.
+//! Observation type for `LunarLander`.
 
 use rlevo_core::base::{HostRow, Observation, TensorConversionError, TensorConvertible};
 use serde::{Deserialize, Serialize};
 
-/// 8-dimensional observation for LunarLander.
+/// 8-dimensional observation for `LunarLander`.
 ///
 /// Layout:
 /// * `[0]` x position (normalised)
@@ -22,51 +22,61 @@ pub struct LunarLanderObservation {
 
 impl LunarLanderObservation {
     /// Construct from a raw array.
+    #[must_use]
     pub fn new(values: [f32; 8]) -> Self {
         Self { values }
     }
 
     /// Returns the normalised x position relative to the helipad centre.
+    #[must_use]
     pub fn x(&self) -> f32 {
         self.values[0]
     }
 
     /// Returns the normalised y position relative to the helipad height.
+    #[must_use]
     pub fn y(&self) -> f32 {
         self.values[1]
     }
 
     /// Returns the normalised x velocity.
+    #[must_use]
     pub fn vx(&self) -> f32 {
         self.values[2]
     }
 
     /// Returns the normalised y velocity.
+    #[must_use]
     pub fn vy(&self) -> f32 {
         self.values[3]
     }
 
     /// Returns the hull rotation angle in radians.
+    #[must_use]
     pub fn angle(&self) -> f32 {
         self.values[4]
     }
 
     /// Returns the hull angular velocity in rad/s (scaled).
+    #[must_use]
     pub fn angular_vel(&self) -> f32 {
         self.values[5]
     }
 
     /// Returns 1.0 if the left leg is in ground contact, 0.0 otherwise.
+    #[must_use]
     pub fn leg1_contact(&self) -> f32 {
         self.values[6]
     }
 
     /// Returns 1.0 if the right leg is in ground contact, 0.0 otherwise.
+    #[must_use]
     pub fn leg2_contact(&self) -> f32 {
         self.values[7]
     }
 
     /// Returns `true` if all values are finite.
+    #[must_use]
     pub fn is_finite(&self) -> bool {
         self.values.iter().all(|v| v.is_finite())
     }

--- a/crates/rlevo-environments/src/box2d/lunar_lander/snapshot.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/snapshot.rs
@@ -1,4 +1,4 @@
-//! Snapshot type and shaping-metadata helper for LunarLander (D6).
+//! Snapshot type and shaping-metadata helper for `LunarLander` (D6).
 
 use rlevo_core::environment::{SnapshotBase, SnapshotMetadata};
 use rlevo_core::reward::ScalarReward;
@@ -51,9 +51,9 @@ use super::observation::LunarLanderObservation;
 ///
 /// # Deliberate deviation from strict policy invariance
 ///
-/// Because Φ(s_terminal) ≠ 0 here (a crashed lander still has a large negative
+/// Because `Φ(s_terminal)` ≠ 0 here (a crashed lander still has a large negative
 /// potential), this is not a strictly policy-invariant PBRS instantiation:
-/// Grześ (2017) shows episodic policy invariance requires Φ(s_terminal) = 0.
+/// Grześ (2017) shows episodic policy invariance requires `Φ(s_terminal)` = 0.
 /// This is a **deliberate deviation kept for Gymnasium reward parity**, not a
 /// bug — rlevo reproduces `gymnasium.envs.box2d.lunar_lander` returns exactly.
 /// Do not "fix" the reward function to restore invariance.

--- a/crates/rlevo-environments/src/box2d/lunar_lander/state.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/state.rs
@@ -1,6 +1,6 @@
-//! Physics state for the LunarLander environments.
+//! Physics state for the `LunarLander` environments.
 //!
-//! [`LunarLanderState`] holds Rapier2D handles for the lander hull and legs,
+//! [`LunarLanderState`] holds `Rapier2D` handles for the lander hull and legs,
 //! cached ground-contact flags, and the previous shaping value needed for
 //! potential-based reward computation.
 
@@ -8,7 +8,7 @@ use rapier2d::dynamics::RigidBodyHandle;
 use rapier2d::geometry::ColliderHandle;
 use rlevo_core::base::State;
 
-/// Physics state for LunarLander.
+/// Physics state for `LunarLander`.
 ///
 /// # Handle-lifetime caveat
 ///

--- a/crates/rlevo-environments/src/box2d/mod.rs
+++ b/crates/rlevo-environments/src/box2d/mod.rs
@@ -1,4 +1,4 @@
-//! Box2D-style physics environments using the Rapier2D pure-Rust physics engine.
+//! Box2D-style physics environments using the `Rapier2D` pure-Rust physics engine.
 //!
 //! Enable with the `box2d` cargo feature:
 //! ```toml

--- a/crates/rlevo-environments/src/box2d/physics.rs
+++ b/crates/rlevo-environments/src/box2d/physics.rs
@@ -1,4 +1,4 @@
-//! Shared Rapier2D physics backend for Box2D-style environments.
+//! Shared `Rapier2D` physics backend for Box2D-style environments.
 //!
 //! [`RapierWorld`] wraps the full rapier2d pipeline and exposes a minimal
 //! public surface: `step`, `snapshot`, `restore`, body/collider/joint
@@ -30,7 +30,7 @@ struct BodyRecord {
     angvel: f32,
 }
 
-/// Encapsulated Rapier2D simulation world.
+/// Encapsulated `Rapier2D` simulation world.
 ///
 /// Create one per environment via [`RapierWorld::new`], add bodies and
 /// colliders, then call [`RapierWorld::step`] each environment step.
@@ -65,6 +65,7 @@ impl RapierWorld {
     /// Create a new world with the given gravity vector and physics timestep.
     ///
     /// Typical gravity for a 2D side-view: `Vector::new(0.0, -9.8)`.
+    #[must_use]
     pub fn new(gravity: Vector, dt: f32) -> Self {
         let params = IntegrationParameters {
             dt,
@@ -126,6 +127,7 @@ impl RapierWorld {
     }
 
     /// Capture the current state of all rigid bodies.
+    #[must_use]
     pub fn snapshot(&self) -> PhysicsSnapshot {
         let records = self
             .bodies
@@ -198,11 +200,13 @@ impl RapierWorld {
     // ─── Read-only accessors ──────────────────────────────────────────────────
 
     /// Read-only access to all rigid bodies (for observation extraction).
+    #[must_use]
     pub fn bodies(&self) -> &RigidBodySet {
         &self.bodies
     }
 
     /// Read-only access to all colliders.
+    #[must_use]
     pub fn colliders(&self) -> &ColliderSet {
         &self.colliders
     }
@@ -213,6 +217,7 @@ impl RapierWorld {
     }
 
     /// Read-only access to all impulse joints (for observation extraction).
+    #[must_use]
     pub fn joints(&self) -> &ImpulseJointSet {
         &self.impulse_joints
     }
@@ -225,16 +230,18 @@ impl RapierWorld {
     // ─── Contact queries ──────────────────────────────────────────────────────
 
     /// Returns `true` if `collider` is currently in contact with any other collider.
+    #[must_use]
     pub fn is_in_contact(&self, collider: rapier2d::geometry::ColliderHandle) -> bool {
         self.narrow_phase
             .contact_pairs_with(collider)
-            .any(|pair| pair.has_any_active_contact())
+            .any(rapier2d::geometry::ContactPair::has_any_active_contact)
     }
 
     // ─── Ray casting ─────────────────────────────────────────────────────────
 
     /// Cast a ray from `origin` in `dir`, returning the distance to the
     /// first hit collider, or `None` if no hit within `max_toi`.
+    #[must_use]
     pub fn cast_ray(&self, origin: Vector, dir: Vector, max_toi: f32) -> Option<f32> {
         let dispatcher = DefaultQueryDispatcher;
         let qp = self.broad_phase.as_query_pipeline(
@@ -250,6 +257,12 @@ impl RapierWorld {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
 
     /// Creates a standard-gravity world at 60 Hz for use in tests.

--- a/crates/rlevo-environments/src/box2d/render.rs
+++ b/crates/rlevo-environments/src/box2d/render.rs
@@ -1,6 +1,6 @@
-//! Shared ASCII / styled renderer for Box2D physics envs.
+//! Shared ASCII / styled renderer for `Box2D` physics envs.
 //!
-//! Each Box2D env (LunarLander, BipedalWalker, CarRacing) holds rapier2d
+//! Each `Box2D` env (`LunarLander`, `BipedalWalker`, `CarRacing`) holds rapier2d
 //! bodies in continuous 2D space. This renderer projects body centres onto
 //! a `CELL_COLS × CELL_ROWS` grid spanning a world-space viewport and
 //! plots one glyph per body. The agent body additionally carries an
@@ -69,6 +69,7 @@ fn project(x: f32, y: f32, vp: Viewport) -> Option<(usize, usize)> {
 }
 
 /// Pick one of 8 arrow glyphs based on `angle_rad` (radians, CCW from +X).
+#[must_use]
 pub fn arrow_glyph(angle_rad: f32) -> char {
     use std::f32::consts::PI;
     let two_pi = 2.0 * PI;
@@ -158,7 +159,7 @@ fn glyph_style(g: Glyph) -> SpanStyle {
     }
 }
 
-/// Render a Box2D scene as a plain UTF-8 string.
+/// Render a `Box2D` scene as a plain UTF-8 string.
 ///
 /// Returns a header line followed by [`CELL_ROWS`] grid lines, each
 /// [`CELL_COLS`] characters wide, separated by `\n`.
@@ -206,7 +207,7 @@ pub fn render_box2d_ascii(
     out
 }
 
-/// Render a Box2D scene as a [`StyledFrame`].
+/// Render a `Box2D` scene as a [`StyledFrame`].
 ///
 /// Produces the same layout and content as [`render_box2d_ascii`] but
 /// wraps each run of identically styled characters in a [`StyledSpan`]

--- a/crates/rlevo-environments/src/classic/acrobot.rs
+++ b/crates/rlevo-environments/src/classic/acrobot.rs
@@ -192,6 +192,10 @@ pub struct BookDynamics;
 pub struct NipsDynamics;
 
 impl AcrobotDynamicsFn for BookDynamics {
+    // Justified: the Acrobot dynamics variable names (theta1/theta2, dtheta1/dtheta2,
+    // ddtheta1/ddtheta2) are taken verbatim from the reference equations;
+    // renaming them for distinctness would break that correspondence.
+    #[allow(clippy::similar_names)]
     fn dsdt(&self, s: [f32; 4], a: f32, cfg: &AcrobotConfig) -> [f32; 4] {
         let [theta1, theta2, dtheta1, dtheta2] = s;
         let m1 = cfg.link_mass_1;
@@ -222,6 +226,10 @@ impl AcrobotDynamicsFn for BookDynamics {
 }
 
 impl AcrobotDynamicsFn for NipsDynamics {
+    // Justified: the Acrobot dynamics variable names (theta1/theta2, dtheta1/dtheta2,
+    // ddtheta1/ddtheta2) are taken verbatim from the reference equations;
+    // renaming them for distinctness would break that correspondence.
+    #[allow(clippy::similar_names)]
     fn dsdt(&self, s: [f32; 4], a: f32, cfg: &AcrobotConfig) -> [f32; 4] {
         let [theta1, theta2, dtheta1, dtheta2] = s;
         let m1 = cfg.link_mass_1;
@@ -389,6 +397,7 @@ pub struct AcrobotConfigBuilder {
 }
 
 impl AcrobotConfig {
+    #[must_use]
     pub fn builder() -> AcrobotConfigBuilder {
         AcrobotConfigBuilder {
             inner: AcrobotConfig::default(),
@@ -397,58 +406,72 @@ impl AcrobotConfig {
 }
 
 impl AcrobotConfigBuilder {
+    #[must_use]
     pub fn dt(mut self, v: f32) -> Self {
         self.inner.dt = v;
         self
     }
+    #[must_use]
     pub fn link_length_1(mut self, v: f32) -> Self {
         self.inner.link_length_1 = v;
         self
     }
+    #[must_use]
     pub fn link_length_2(mut self, v: f32) -> Self {
         self.inner.link_length_2 = v;
         self
     }
+    #[must_use]
     pub fn link_mass_1(mut self, v: f32) -> Self {
         self.inner.link_mass_1 = v;
         self
     }
+    #[must_use]
     pub fn link_mass_2(mut self, v: f32) -> Self {
         self.inner.link_mass_2 = v;
         self
     }
+    #[must_use]
     pub fn link_com_pos_1(mut self, v: f32) -> Self {
         self.inner.link_com_pos_1 = v;
         self
     }
+    #[must_use]
     pub fn link_com_pos_2(mut self, v: f32) -> Self {
         self.inner.link_com_pos_2 = v;
         self
     }
+    #[must_use]
     pub fn link_moi(mut self, v: f32) -> Self {
         self.inner.link_moi = v;
         self
     }
+    #[must_use]
     pub fn gravity(mut self, v: f32) -> Self {
         self.inner.gravity = v;
         self
     }
+    #[must_use]
     pub fn max_vel_1(mut self, v: f32) -> Self {
         self.inner.max_vel_1 = v;
         self
     }
+    #[must_use]
     pub fn max_vel_2(mut self, v: f32) -> Self {
         self.inner.max_vel_2 = v;
         self
     }
+    #[must_use]
     pub fn torque_noise_max(mut self, v: f32) -> Self {
         self.inner.torque_noise_max = v;
         self
     }
+    #[must_use]
     pub fn seed(mut self, v: u64) -> Self {
         self.inner.seed = v;
         self
     }
+    #[must_use]
     pub fn build(self) -> AcrobotConfig {
         self.inner
     }
@@ -521,6 +544,7 @@ pub struct AcrobotObservation {
 
 impl AcrobotObservation {
     /// Flattens the observation to `[cos θ1, sin θ1, cos θ2, sin θ2, dθ1, dθ2]`.
+    #[must_use]
     pub fn to_array(&self) -> [f32; 6] {
         [
             self.cos_theta1,
@@ -719,7 +743,7 @@ impl<D: AcrobotDynamicsFn> fmt::Debug for Acrobot<D> {
         f.debug_struct("Acrobot")
             .field("steps", &self.steps)
             .field("state", &self.state)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -1001,6 +1025,11 @@ impl<D: AcrobotDynamicsFn + Default> rlevo_core::render::payload::Classic2DPaylo
 
 #[cfg(test)]
 mod tests {
+    // The observation arrays are compared exactly because the property under
+    // test is whether the two integrators diverge *at all*; a tolerance would
+    // let a genuine divergence smaller than epsilon pass as agreement.
+    #![allow(clippy::float_cmp)]
+
     //! Unit tests for [`Acrobot`] covering observation shape, action indexing,
     //! episode lifecycle, physics invariants (velocity clamping, termination),
     //! determinism, and dynamics variant divergence.
@@ -1176,10 +1205,10 @@ mod tests {
         let mut env = default_env();
         env.reset().unwrap();
         let snap = env.step(AcrobotAction::TorquePos).unwrap();
-        if !snap.is_terminated() {
-            assert_eq!(*snap.reward(), ScalarReward(-1.0));
-        } else {
+        if snap.is_terminated() {
             assert_eq!(*snap.reward(), ScalarReward(0.0));
+        } else {
+            assert_eq!(*snap.reward(), ScalarReward(-1.0));
         }
     }
 

--- a/crates/rlevo-environments/src/classic/bandit/adversarial.rs
+++ b/crates/rlevo-environments/src/classic/bandit/adversarial.rs
@@ -213,6 +213,13 @@ impl<const K: usize> AdversarialBandit<K> {
     /// defaults (`max_steps = 500`, `period = 10`, `amplitude = 1.0`).
     ///
     /// Useful for reproducible benchmark trials where only the seed varies.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default configuration fails validation. This cannot happen
+    /// for the shipped defaults; it would indicate a bug in
+    /// `AdversarialBanditConfig::default`, not misuse by the caller.
+    #[must_use]
     pub fn with_seed(seed: u64) -> Self {
         let config = AdversarialBanditConfig {
             seed,
@@ -360,6 +367,12 @@ impl<const K: usize> crate::render::AsciiRenderable for AdversarialBandit<K> {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::environment::Snapshot;

--- a/crates/rlevo-environments/src/classic/bandit/contextual.rs
+++ b/crates/rlevo-environments/src/classic/bandit/contextual.rs
@@ -11,7 +11,7 @@
 //! This is the simplest contextual-bandit testbed — a `C × K` table of
 //! Gaussian means — which exercises algorithms that must learn a separate
 //! policy per context (e.g. tabular contextual ε-greedy, contextual
-//! Thompson sampling). For continuous-feature contextual bandits (LinUCB et
+//! Thompson sampling). For continuous-feature contextual bandits (`LinUCB` et
 //! al.) a separate environment with a vector-valued context is appropriate;
 //! it is intentionally out of scope for this module.
 //!
@@ -388,6 +388,13 @@ impl<const C: usize, const K: usize> Display for ContextualBandit<C, K> {
 
 impl<const C: usize, const K: usize> ContextualBandit<C, K> {
     /// Construct with a specific seed (other config fields default).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default configuration fails validation. This cannot happen
+    /// for the shipped defaults; it would indicate a bug in
+    /// `ContextualBanditConfig::default`, not misuse by the caller.
+    #[must_use]
     pub fn with_seed(seed: u64) -> Self {
         let config = ContextualBanditConfig {
             seed,
@@ -553,6 +560,12 @@ impl<const C: usize, const K: usize> crate::render::AsciiRenderable for Contextu
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::environment::Snapshot;

--- a/crates/rlevo-environments/src/classic/bandit/k_armed.rs
+++ b/crates/rlevo-environments/src/classic/bandit/k_armed.rs
@@ -426,6 +426,13 @@ impl<const K: usize> KArmedBandit<K> {
     /// their defaults.
     ///
     /// [`reset`]: Environment::reset
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default configuration fails validation. This cannot happen
+    /// for the shipped defaults; it would indicate a bug in
+    /// `KArmedBanditConfig::default`, not misuse by the caller.
+    #[must_use]
     pub fn with_seed(seed: u64) -> Self {
         let config = KArmedBanditConfig {
             seed,
@@ -644,6 +651,12 @@ pub(super) fn style_bandit_line(line: &str) -> crate::render::StyledLine {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/classic/bandit/non_stationary.rs
+++ b/crates/rlevo-environments/src/classic/bandit/non_stationary.rs
@@ -194,6 +194,13 @@ impl<const K: usize> Display for NonStationaryBandit<K> {
 
 impl<const K: usize> NonStationaryBandit<K> {
     /// Construct with a specific seed (other config fields default).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default configuration fails validation. This cannot happen
+    /// for the shipped defaults; it would indicate a bug in
+    /// `NonStationaryBanditConfig::default`, not misuse by the caller.
+    #[must_use]
     pub fn with_seed(seed: u64) -> Self {
         let config = NonStationaryBanditConfig {
             seed,
@@ -347,6 +354,10 @@ impl<const K: usize> crate::render::AsciiRenderable for NonStationaryBandit<K> {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is the property: these tests assert the arm means moved
+    // (or did not move) at all between steps, not that they moved by some amount.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::environment::Snapshot;

--- a/crates/rlevo-environments/src/classic/cartpole.rs
+++ b/crates/rlevo-environments/src/classic/cartpole.rs
@@ -147,7 +147,7 @@ use serde::{Deserialize, Serialize};
 // Config
 // ---------------------------------------------------------------------------
 
-/// Integration scheme for the CartPole equations of motion.
+/// Integration scheme for the `CartPole` equations of motion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Integrator {
     /// Forward Euler (Gymnasium default).
@@ -247,6 +247,7 @@ pub struct CartPoleConfigBuilder {
 
 impl CartPoleConfig {
     /// Create a builder seeded from this config's defaults.
+    #[must_use]
     pub fn builder() -> CartPoleConfigBuilder {
         CartPoleConfigBuilder {
             inner: CartPoleConfig::default(),
@@ -256,62 +257,74 @@ impl CartPoleConfig {
 
 impl CartPoleConfigBuilder {
     /// Sets gravitational acceleration (m/s²).
+    #[must_use]
     pub fn gravity(mut self, v: f32) -> Self {
         self.inner.gravity = v;
         self
     }
     /// Sets the mass of the cart (kg).
+    #[must_use]
     pub fn masscart(mut self, v: f32) -> Self {
         self.inner.masscart = v;
         self
     }
     /// Sets the mass of the pole (kg).
+    #[must_use]
     pub fn masspole(mut self, v: f32) -> Self {
         self.inner.masspole = v;
         self
     }
     /// Sets half the pole length (m).
+    #[must_use]
     pub fn length(mut self, v: f32) -> Self {
         self.inner.length = v;
         self
     }
     /// Sets the magnitude of the force applied to the cart (N).
+    #[must_use]
     pub fn force_mag(mut self, v: f32) -> Self {
         self.inner.force_mag = v;
         self
     }
     /// Sets the time step between updates (s).
+    #[must_use]
     pub fn tau(mut self, v: f32) -> Self {
         self.inner.tau = v;
         self
     }
     /// Sets the pole angle termination threshold (rad).
+    #[must_use]
     pub fn theta_threshold_radians(mut self, v: f32) -> Self {
         self.inner.theta_threshold_radians = v;
         self
     }
     /// Sets the cart position termination threshold (m).
+    #[must_use]
     pub fn x_threshold(mut self, v: f32) -> Self {
         self.inner.x_threshold = v;
         self
     }
     /// Sets the integration scheme.
+    #[must_use]
     pub fn integrator(mut self, v: Integrator) -> Self {
         self.inner.integrator = v;
         self
     }
     /// Enables the Sutton-Barto reward schedule (`0` per step, `-1` on failure).
+    #[must_use]
     pub fn sutton_barto_reward(mut self, v: bool) -> Self {
         self.inner.sutton_barto_reward = v;
         self
     }
     /// Sets the RNG seed used by [`CartPole::reset`].
+    #[must_use]
     pub fn seed(mut self, v: u64) -> Self {
         self.inner.seed = v;
         self
     }
 
     /// Finalises and returns the config.
+    #[must_use]
     pub fn build(self) -> CartPoleConfig {
         self.inner
     }
@@ -321,7 +334,7 @@ impl CartPoleConfigBuilder {
 // State
 // ---------------------------------------------------------------------------
 
-/// Internal state of the CartPole system.
+/// Internal state of the `CartPole` system.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CartPoleState {
     /// Cart position (m).
@@ -380,6 +393,7 @@ pub struct CartPoleObservation {
 
 impl CartPoleObservation {
     /// Flatten to a `[f32; 4]` array for tensor conversion.
+    #[must_use]
     pub fn to_array(&self) -> [f32; 4] {
         [
             self.cart_pos,
@@ -495,6 +509,7 @@ impl CartPole {
     }
 
     /// Current step count within the episode.
+    #[must_use]
     pub fn steps(&self) -> usize {
         self.steps
     }
@@ -610,7 +625,7 @@ impl Sensor<1, 1, 1> for CartPole {
     }
 }
 
-/// Builds the 4-D CartPole observation `[x, ẋ, θ, θ̇]` from a state.
+/// Builds the 4-D `CartPole` observation `[x, ẋ, θ, θ̇]` from a state.
 fn cartpole_observation(state: &CartPoleState) -> CartPoleObservation {
     CartPoleObservation {
         cart_pos: state.x,
@@ -924,6 +939,12 @@ impl rlevo_core::render::payload::Classic2DPayloadSource for CartPole {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     //! Unit tests for [`CartPole`] covering observation shape, action indexing,
     //! episode lifecycle, reward schedules, determinism, and integrator divergence.
 

--- a/crates/rlevo-environments/src/classic/mountain_car.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car.rs
@@ -159,7 +159,7 @@ impl Validate for MountainCarConfig {
 // State
 // ---------------------------------------------------------------------------
 
-/// Internal state of the MountainCar.
+/// Internal state of the `MountainCar`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MountainCarState {
     /// Horizontal position (m).
@@ -196,6 +196,7 @@ pub struct MountainCarObservation {
 
 impl MountainCarObservation {
     /// Flatten to a `[f32; 2]` array for tensor conversion.
+    #[must_use]
     pub fn to_array(&self) -> [f32; 2] {
         [self.position, self.velocity]
     }
@@ -238,7 +239,7 @@ impl DiscreteAction<1> for MountainCarAction {
     ///
     /// # Panics
     ///
-    /// Panics if `index` is not `0` (Left), `1` (NoAccel), or `2` (Right).
+    /// Panics if `index` is not `0` (Left), `1` (`NoAccel`), or `2` (Right).
     fn from_index(index: usize) -> Self {
         match index {
             0 => Self::Left,
@@ -311,6 +312,7 @@ impl MountainCar {
     }
 
     /// Current step count within the episode.
+    #[must_use]
     pub fn steps(&self) -> usize {
         self.steps
     }
@@ -346,7 +348,7 @@ impl MountainCar {
         }
     }
 
-    fn is_terminal(state: &MountainCarState, cfg: &MountainCarConfig) -> bool {
+    fn is_terminal(state: MountainCarState, cfg: &MountainCarConfig) -> bool {
         state.position >= cfg.goal_position && state.velocity >= cfg.goal_velocity
     }
 }
@@ -380,17 +382,17 @@ impl Sensor<1, 1, 1> for MountainCar {
         _action: &MountainCarAction,
         next_state: &MountainCarState,
     ) -> MountainCarObservation {
-        mountain_car_observation(next_state)
+        mountain_car_observation(*next_state)
     }
 
     /// Projects the initial state onto the 2-D observation.
     fn observe_reset(&self, state: &MountainCarState) -> MountainCarObservation {
-        mountain_car_observation(state)
+        mountain_car_observation(*state)
     }
 }
 
-/// Builds the 2-D MountainCar observation `[position, velocity]` from a state.
-fn mountain_car_observation(state: &MountainCarState) -> MountainCarObservation {
+/// Builds the 2-D `MountainCar` observation `[position, velocity]` from a state.
+fn mountain_car_observation(state: MountainCarState) -> MountainCarObservation {
     MountainCarObservation {
         position: state.position,
         velocity: state.velocity,
@@ -437,7 +439,7 @@ impl Environment<1, 1, 1> for MountainCar {
         self.state = Self::apply_physics(self.state, action, &self.config);
         self.steps += 1;
 
-        let terminated = Self::is_terminal(&self.state, &self.config);
+        let terminated = Self::is_terminal(self.state, &self.config);
         let obs = self.observe(&action, &self.state);
         let snap = if terminated {
             SnapshotBase::terminated(obs, ScalarReward(-1.0))
@@ -586,9 +588,9 @@ impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCar {
         use rlevo_core::render::payload::{
             Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
         };
-        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
         // Terrain profile y = sin(3x), sampled across the track.
         const SAMPLES: usize = 48;
+        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
         let terrain: Vec<Point2> = (0..=SAMPLES)
             .map(|i| {
                 let x = lo + (hi - lo) * (i as f32 / SAMPLES as f32);
@@ -629,6 +631,12 @@ impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCar {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     //! Unit tests for [`MountainCar`] covering observation shape, action
     //! indexing, reset bounds, left-wall physics, goal termination, reward
     //! value, and determinism.

--- a/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
@@ -213,6 +213,7 @@ impl MountainCarContinuousAction {
     }
 
     /// The raw force value.
+    #[must_use]
     pub fn force(&self) -> f32 {
         self.0
     }
@@ -298,6 +299,7 @@ pub struct MountainCarContinuousObservation {
 
 impl MountainCarContinuousObservation {
     /// Flatten to a `[f32; 2]` array.
+    #[must_use]
     pub fn to_array(&self) -> [f32; 2] {
         [self.position, self.velocity]
     }
@@ -404,7 +406,7 @@ impl MountainCarContinuous {
         }
     }
 
-    fn is_terminal(state: &MountainCarContinuousState, cfg: &MountainCarContinuousConfig) -> bool {
+    fn is_terminal(state: MountainCarContinuousState, cfg: &MountainCarContinuousConfig) -> bool {
         state.position >= cfg.goal_position && state.velocity >= cfg.goal_velocity
     }
 }
@@ -439,7 +441,7 @@ impl Sensor<1, 1, 1> for MountainCarContinuous {
         _action: &MountainCarContinuousAction,
         next_state: &MountainCarContinuousState,
     ) -> MountainCarContinuousObservation {
-        mountain_car_continuous_observation(next_state)
+        mountain_car_continuous_observation(*next_state)
     }
 
     /// Projects the initial state onto the 2-D observation.
@@ -447,14 +449,14 @@ impl Sensor<1, 1, 1> for MountainCarContinuous {
         &self,
         state: &MountainCarContinuousState,
     ) -> MountainCarContinuousObservation {
-        mountain_car_continuous_observation(state)
+        mountain_car_continuous_observation(*state)
     }
 }
 
-/// Builds the 2-D MountainCarContinuous observation `[position, velocity]` from a
+/// Builds the 2-D `MountainCarContinuous` observation `[position, velocity]` from a
 /// state.
 fn mountain_car_continuous_observation(
-    state: &MountainCarContinuousState,
+    state: MountainCarContinuousState,
 ) -> MountainCarContinuousObservation {
     MountainCarContinuousObservation {
         position: state.position,
@@ -506,7 +508,7 @@ impl Environment<1, 1, 1> for MountainCarContinuous {
         self.state = Self::apply_physics(self.state, force, &self.config);
         self.steps += 1;
 
-        let terminated = Self::is_terminal(&self.state, &self.config);
+        let terminated = Self::is_terminal(self.state, &self.config);
         let ctrl_cost = -0.1 * force * force;
         let goal_bonus = if terminated { 100.0 } else { 0.0 };
         let reward = ScalarReward(ctrl_cost + goal_bonus);
@@ -615,8 +617,8 @@ impl crate::render::AsciiRenderable for MountainCarContinuous {
 
 /// Style a `[track]  suffix` style line where a single glyph marks the agent.
 ///
-/// Reused by track-style renders (MountainCar, MountainCarContinuous,
-/// CartPole). The portion before `]` is treated as the track; the matched
+/// Reused by track-style renders (`MountainCar`, `MountainCarContinuous`,
+/// `CartPole`). The portion before `]` is treated as the track; the matched
 /// `agent_glyph` carries `AGENT_FG | AGENT_MODIFIER`; everything else
 /// inside the brackets carries `WALL_FG`; the suffix is unstyled.
 fn style_track_line(line: &str, agent_glyph: char) -> crate::render::StyledLine {
@@ -659,9 +661,9 @@ impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCarContinuo
         use rlevo_core::render::payload::{
             Classic2DBody, Classic2DRole, Classic2DSnapshot, Point2,
         };
-        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
         // Terrain profile y = sin(3x), sampled across the track.
         const SAMPLES: usize = 48;
+        let (lo, hi) = (self.config.pos_bounds.lo(), self.config.pos_bounds.hi());
         let terrain: Vec<Point2> = (0..=SAMPLES)
             .map(|i| {
                 let x = lo + (hi - lo) * (i as f32 / SAMPLES as f32);
@@ -702,6 +704,12 @@ impl rlevo_core::render::payload::Classic2DPayloadSource for MountainCarContinuo
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     //! Unit tests for [`MountainCarContinuous`] covering observation shape,
     //! action boundary validation, control-cost formula, goal-reaching bonus,
     //! and determinism.

--- a/crates/rlevo-environments/src/classic/pendulum.rs
+++ b/crates/rlevo-environments/src/classic/pendulum.rs
@@ -182,6 +182,11 @@ impl PendulumAction {
     ///
     /// The bound `2.0` matches the default `max_torque`; environments with a
     /// non-default `max_torque` will further clip the torque in `step`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `torque` is non-finite or its magnitude
+    /// exceeds `2.0`.
     pub fn new(torque: f32) -> Result<Self, InvalidActionError> {
         if torque.is_finite() && torque.abs() <= 2.0 {
             Ok(Self(torque))
@@ -193,6 +198,7 @@ impl PendulumAction {
     }
 
     /// The raw torque value.
+    #[must_use]
     pub fn torque(&self) -> f32 {
         self.0
     }
@@ -293,6 +299,7 @@ pub struct PendulumObservation {
 
 impl PendulumObservation {
     /// Flatten to a `[f32; 3]` array.
+    #[must_use]
     pub fn to_array(&self) -> [f32; 3] {
         [self.cos_theta, self.sin_theta, self.theta_dot]
     }
@@ -312,6 +319,7 @@ impl Observation<1> for PendulumObservation {
 ///
 /// Uses `rem_euclid` to handle negative inputs correctly.
 #[inline]
+#[must_use]
 pub fn angle_normalize(x: f32) -> f32 {
     (x + std::f32::consts::PI).rem_euclid(2.0 * std::f32::consts::PI) - std::f32::consts::PI
 }
@@ -435,17 +443,17 @@ impl Sensor<1, 1, 1> for Pendulum {
     /// Projects the resulting state to the 3-D `[cos θ, sin θ, θ̇]` observation;
     /// the observation is a pure function of the state and ignores the torque.
     fn observe(&self, _action: &PendulumAction, next_state: &PendulumState) -> PendulumObservation {
-        pendulum_observation(next_state)
+        pendulum_observation(*next_state)
     }
 
     /// Projects the initial state to the 3-D observation.
     fn observe_reset(&self, state: &PendulumState) -> PendulumObservation {
-        pendulum_observation(state)
+        pendulum_observation(*state)
     }
 }
 
 /// Builds the 3-D Pendulum observation `[cos θ, sin θ, θ̇]` from a state.
-fn pendulum_observation(state: &PendulumState) -> PendulumObservation {
+fn pendulum_observation(state: PendulumState) -> PendulumObservation {
     PendulumObservation {
         cos_theta: state.theta.cos(),
         sin_theta: state.theta.sin(),
@@ -643,6 +651,12 @@ impl rlevo_core::render::payload::Classic2DPayloadSource for Pendulum {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     //! Unit tests for [`Pendulum`] covering observation shape, action validation,
     //! reward at boundary states, `angle_normalize` correctness, non-termination,
     //! and determinism.
@@ -704,6 +718,8 @@ mod tests {
     }
 
     #[test]
+    // Justified: standard pendulum state names mirror the reference equations.
+    #[allow(clippy::similar_names)]
     fn angle_normalize_examples() {
         let pi = std::f32::consts::PI;
         // 3π and -3π are both ≡ π (mod 2π). The formula maps them to -π (same angle).

--- a/crates/rlevo-environments/src/classic/santa_fe_ant.rs
+++ b/crates/rlevo-environments/src/classic/santa_fe_ant.rs
@@ -13,7 +13,7 @@
 //!
 //! The one-bit percept is a massive cardinality reduction of the true state at
 //! **constant tensor order** — an information-reducing projection exactly like
-//! dropping the velocities from CartPole, *not* a modality change. Crucially,
+//! dropping the velocities from `CartPole`, *not* a modality change. Crucially,
 //! perceptual aliasing makes the *optimal* policy provably require internal
 //! memory: a memoryless reactive map `{0, 1} → action` cannot cross the trail's
 //! single, double, and L-shaped gaps, where the ant must step forward over an
@@ -815,6 +815,12 @@ impl crate::render::AsciiRenderable for SantaFeAnt {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/games/chess.rs
+++ b/crates/rlevo-environments/src/games/chess.rs
@@ -1,7 +1,7 @@
-//! Chess environment using the AlphaZero action/observation encoding.
+//! Chess environment using the `AlphaZero` action/observation encoding.
 //!
 //! - [`board`]: Board state representation and legal-move generation
-//! - [`moves`]: AlphaZero action-plane encoding (4672-action space)
+//! - [`moves`]: `AlphaZero` action-plane encoding (4672-action space)
 //! - [`observations`]: 119-plane observation tensor layout (8×8×119)
 //! - [`environment`]: `Environment` trait implementation (work in progress)
 

--- a/crates/rlevo-environments/src/games/chess/board.rs
+++ b/crates/rlevo-environments/src/games/chess/board.rs
@@ -27,24 +27,28 @@ const SQUARE_NOTATIONS: &[&str] = &[
 impl Square {
     /// Creates a square from rank and file (0-7).
     #[inline]
+    #[must_use]
     pub const fn from_rank_file(rank: u8, file: u8) -> Self {
         Self(rank * 8 + file)
     }
 
     /// Returns the rank (0-7, where 0 is rank 1).
     #[inline]
+    #[must_use]
     pub const fn rank(self) -> u8 {
         self.0 / 8
     }
 
     /// Returns the file (0-7, where 0 is file A).
     #[inline]
+    #[must_use]
     pub const fn file(self) -> u8 {
         self.0 % 8
     }
 
     /// Returns the bitboard mask for this square.
     #[inline]
+    #[must_use]
     pub const fn bitboard(self) -> u64 {
         1u64 << self.0
     }
@@ -66,6 +70,7 @@ impl Square {
     /// assert_eq!(sq.algebraic_notation(), "a1");
     /// ```
     #[inline]
+    #[must_use]
     pub const fn algebraic_notation(self) -> &'static str {
         SQUARE_NOTATIONS[self.0 as usize]
     }
@@ -97,6 +102,7 @@ impl Square {
     /// assert!(Square::from_algebraic_notation("i9").is_none());
     /// assert!(Square::from_algebraic_notation("e").is_none());
     /// ```
+    #[must_use]
     pub fn from_algebraic_notation(notation: &str) -> Option<Self> {
         // Algebraic notation must be exactly 2 characters
         if notation.len() != 2 {
@@ -139,6 +145,7 @@ pub enum Color {
 impl Color {
     /// Returns the opposite color.
     #[inline]
+    #[must_use]
     pub const fn opponent(self) -> Self {
         match self {
             Color::White => Color::Black,
@@ -172,6 +179,7 @@ impl PieceType {
     /// Returns the zero-based index used to address this piece type in a
     /// per-color bitboard array.
     #[inline]
+    #[must_use]
     pub const fn index(self) -> usize {
         self as usize
     }
@@ -185,6 +193,11 @@ impl PieceType {
 ///
 /// The [`Default`] implementation grants all four rights, matching the standard
 /// starting position.
+//
+// Four bools is the natural shape here: castling rights are four independent
+// flags in the FEN spec and are set and cleared independently by the rules.
+// Packing them into a bitfield would obscure a direct encoding of the standard.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CastlingRights {
     /// White may castle kingside (king to g1, rook from h1).
@@ -264,9 +277,9 @@ mod tests {
     fn test_from_algebraic_notation_all_files() {
         // Test that all file letters parse correctly
         for (file_index, file_letter) in "abcdefgh".chars().enumerate() {
-            let notation = format!("{}1", file_letter);
+            let notation = format!("{file_letter}1");
             let sq = Square::from_algebraic_notation(&notation)
-                .unwrap_or_else(|| panic!("{}1 should parse", file_letter));
+                .unwrap_or_else(|| panic!("{file_letter}1 should parse"));
             assert_eq!(sq.file(), file_index as u8);
             assert_eq!(sq.rank(), 0);
         }
@@ -276,9 +289,9 @@ mod tests {
     fn test_from_algebraic_notation_all_ranks() {
         // Test that all rank numbers parse correctly
         for (rank_index, rank_digit) in "12345678".chars().enumerate() {
-            let notation = format!("a{}", rank_digit);
+            let notation = format!("a{rank_digit}");
             let sq = Square::from_algebraic_notation(&notation)
-                .unwrap_or_else(|| panic!("a{} should parse", rank_digit));
+                .unwrap_or_else(|| panic!("a{rank_digit} should parse"));
             assert_eq!(sq.rank(), rank_index as u8);
             assert_eq!(sq.file(), 0);
         }
@@ -365,12 +378,11 @@ mod tests {
 
         for notation in notations {
             let sq = Square::from_algebraic_notation(notation)
-                .unwrap_or_else(|| panic!("{} should parse", notation));
+                .unwrap_or_else(|| panic!("{notation} should parse"));
             assert_eq!(
                 sq.algebraic_notation(),
                 notation,
-                "roundtrip failed for {}",
-                notation
+                "roundtrip failed for {notation}"
             );
         }
     }

--- a/crates/rlevo-environments/src/games/chess/moves.rs
+++ b/crates/rlevo-environments/src/games/chess/moves.rs
@@ -1,13 +1,13 @@
-//! Chess move representation and action encoding modeled after AlphaZero Chess.
+//! Chess move representation and action encoding modeled after `AlphaZero` Chess.
 //!
 //! This module defines the core data structures and traits for representing chess moves
 //! in a way suitable for reinforcement learning agents. It provides a dense, efficient
 //! encoding scheme that maps moves to discrete action indices for use with neural networks.
 //!
-//! AlphaZero represents the action space of chess as an $8 \times 8 \times 73$ tensor,
+//! `AlphaZero` represents the action space of chess as an $8 \times 8 \times 73$ tensor,
 //! totaling 4,672 possible move slots.
 //!
-//! Because a neural network requires a fixed-size output, AlphaZero must provide a value
+//! Because a neural network requires a fixed-size output, `AlphaZero` must provide a value
 //! for every possible move a piece could technically make on an $8 \times 8$ board, even
 //! if that move is illegal in the current position.
 //!
@@ -27,12 +27,12 @@
 //!   directions (capture left, move straight, capture right).
 //!
 //! **How illegal moves are handled**: The network outputs probabilites for all 4,672 moves.
-//! However, before the move is actually selected, AlphaZero applies a mask. It sets the
+//! However, before the move is actually selected, `AlphaZero` applies a mask. It sets the
 //! probability of all illegal moves to zero and renormalizes the remaining legal moves so they
 //! sum to 1.
 //!
 //! # How the Network Evaluates a Position
-//! AlphaZero uses a "dual-head" architecture. After the input (the $8 \times 8 \times 119$
+//! `AlphaZero` uses a "dual-head" architecture. After the input (the $8 \times 8 \times 119$
 //! tensor) passes through the main body of the residual layers, the network splits into two
 //! distinct output heads:
 //!
@@ -55,13 +55,13 @@
 //!   game from the current position.
 //!
 //! # The Synergy: Evaluation + Search
-//! The magic of AlphaZero is how these two outputs work together inside the Monte Carlo Tree
+//! The magic of `AlphaZero` is how these two outputs work together inside the Monte Carlo Tree
 //! Search (MCTS):
 //! 1. **Prioritization**: When MCTS explores a new branch, it uses the Policy ($\pi$) to decide
 //!   which moves to try first. This prevents the engine from wasting time on "human-obvious"
 //!   blunders.
 //! 2. **Leaf Evaluation**: In old-school MCTS, you would play "random games" until the end to see
-//!   who won. AlphaZero doesn't do that. As soon as it hits a new position in its search tree, it
+//!   who won. `AlphaZero` doesn't do that. As soon as it hits a new position in its search tree, it
 //!   asks the Value Head ($v$) for an estimate.
 //! 3. **Backpropagation**: This value estimate is "rippled" back up the tree, updating the
 //!   quality score of every move that led to that position.
@@ -110,7 +110,7 @@ pub enum PromotionPiece {
     Knight,
 }
 
-/// Chess move representation compatible with AlphaZero's action space.
+/// Chess move representation compatible with `AlphaZero`'s action space.
 ///
 /// Encodes moves in an 8×8×73 tensor format where:
 /// - First dimension: source rank (0-7)
@@ -128,6 +128,7 @@ pub struct ChessMove {
 
 impl ChessMove {
     /// Creates a new chess move from source to destination.
+    #[must_use]
     pub fn new(from: Square, to: Square) -> Self {
         Self {
             from,
@@ -137,6 +138,7 @@ impl ChessMove {
     }
 
     /// Creates a new chess move with a promotion.
+    #[must_use]
     pub fn new_with_promotion(from: Square, to: Square, promotion: PromotionPiece) -> Self {
         Self {
             from,
@@ -147,29 +149,33 @@ impl ChessMove {
 
     /// Returns the source rank (0-7).
     #[inline]
+    #[must_use]
     pub fn from_rank(&self) -> u8 {
         self.from.rank()
     }
 
     /// Returns the source file (0-7).
     #[inline]
+    #[must_use]
     pub fn from_file(&self) -> u8 {
         self.from.file()
     }
 
     /// Returns the destination rank (0-7).
     #[inline]
+    #[must_use]
     pub fn to_rank(&self) -> u8 {
         self.to.rank()
     }
 
     /// Returns the destination file (0-7).
     #[inline]
+    #[must_use]
     pub fn to_file(&self) -> u8 {
         self.to.file()
     }
 
-    /// Computes the move plane index (0–72) for this move in the AlphaZero action space.
+    /// Computes the move plane index (0–72) for this move in the `AlphaZero` action space.
     ///
     /// The plane index encodes the *type* of move made from the source square:
     ///
@@ -188,7 +194,7 @@ impl ChessMove {
     ///
     /// Panics if the move delta does not match any of the 73 encoded patterns
     /// (i.e., the move is geometrically impossible on an 8×8 board).
-    fn compute_move_plane(&self) -> usize {
+    fn compute_move_plane(self) -> usize {
         let from_rank = self.from_rank() as i8;
         let from_file = self.from_file() as i8;
         let to_rank = self.to_rank() as i8;
@@ -227,7 +233,9 @@ impl ChessMove {
                     PromotionPiece::Knight => 0,
                     PromotionPiece::Bishop => 3,
                     PromotionPiece::Rook => 6,
-                    _ => unreachable!(),
+                    PromotionPiece::Queen => unreachable!(
+                        "queen promotions are encoded as ordinary moves, not underpromotions"
+                    ),
                 };
 
                 let direction = match delta_file {
@@ -260,18 +268,11 @@ impl ChessMove {
         } else if delta_rank > 0 && delta_file < 0 && delta_rank == -delta_file {
             7 // Northwest
         } else {
-            panic!(
-                "Invalid queen-like move: delta_rank={}, delta_file={}",
-                delta_rank, delta_file
-            );
+            panic!("Invalid queen-like move: delta_rank={delta_rank}, delta_file={delta_file}");
         };
 
         let distance = delta_rank.abs().max(delta_file.abs()) as usize;
-        assert!(
-            (1..=7).contains(&distance),
-            "Invalid distance: {}",
-            distance
-        );
+        assert!((1..=7).contains(&distance), "Invalid distance: {distance}");
 
         direction_index * 7 + (distance - 1)
     }

--- a/crates/rlevo-environments/src/games/chess/observations.rs
+++ b/crates/rlevo-environments/src/games/chess/observations.rs
@@ -1,4 +1,4 @@
-//! Observable chess state using AlphaZero Chess representation.
+//! Observable chess state using `AlphaZero` Chess representation.
 //!
 //! This module provides the core state representation for a chess environment,
 //! designed to work with reinforcement learning agents and neural networks.
@@ -8,7 +8,7 @@
 //! # Overview
 //!
 //! Unlike traditional chess engines that use hand-crafted features (like material count or pawn
-//! structure), AlphaZero represents the board as a three-dimensional tensor of dimensions
+//! structure), `AlphaZero` represents the board as a three-dimensional tensor of dimensions
 //! $8 \times 8 \times 119$.
 //!
 //! # 1. The Input Tensor ($8 \times 8 \times 119$)
@@ -16,7 +16,7 @@
 //! into two main categories: historical board states and constant game metadata.
 //!
 //! **A. Historical State (112 Planes)**
-//! AlphaZero does not just look at the current position; it maintains a history of the 8 most
+//! `AlphaZero` does not just look at the current position; it maintains a history of the 8 most
 //! recent half-moves (the current state plus the 7 previous ones). This history allows the
 //! network to detect patterns and rules that depend on the sequence of moves, such as three-fold
 //! repition.
@@ -54,7 +54,7 @@
 //! # 3. The State vs. Observation
 //! While the state space of chess is the mathematical set of all possible legal configurations of
 //! the board (estimated at $10^{40}$ to $10^{50}$), the observation space described above is the
-//! specific "window" through which AlphaZero perceives the state. By including history, AlphaZero
+//! specific "window" through which `AlphaZero` perceives the state. By including history, `AlphaZero`
 //! effectively turns a non-Markovian environment (where rules like repitition depend on the past)
 //! into a Markovian one that the network can process.
 //!
@@ -180,7 +180,7 @@ impl BoardSnapshot {
     }
 }
 
-/// Chess state representation using AlphaZero observation space.
+/// Chess state representation using `AlphaZero` observation space.
 ///
 /// This struct maintains:
 /// - Historical board positions (last 8 half-moves)
@@ -188,7 +188,7 @@ impl BoardSnapshot {
 /// - Position repetition tracking for draw detection
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChessState {
-    /// Historical board positions (newest first, size = HISTORY_SIZE).
+    /// Historical board positions (newest first, size = `HISTORY_SIZE`).
     /// history[0] is the current position, history[1] is one move ago, etc.
     history: Vec<BoardSnapshot>,
 
@@ -231,24 +231,25 @@ impl std::hash::Hash for ChessState {
 
 impl ChessState {
     /// Creates a new chess state with the standard starting position.
+    #[must_use]
     pub fn new() -> Self {
         let mut snapshot = BoardSnapshot::empty();
 
         // Set up white pieces
-        snapshot.set_piece(Color::White, PieceType::Pawn, 0x000000000000FF00);
-        snapshot.set_piece(Color::White, PieceType::Knight, 0x0000000000000042);
-        snapshot.set_piece(Color::White, PieceType::Bishop, 0x0000000000000024);
-        snapshot.set_piece(Color::White, PieceType::Rook, 0x0000000000000081);
-        snapshot.set_piece(Color::White, PieceType::Queen, 0x0000000000000008);
-        snapshot.set_piece(Color::White, PieceType::King, 0x0000000000000010);
+        snapshot.set_piece(Color::White, PieceType::Pawn, 0x0000_0000_0000_FF00);
+        snapshot.set_piece(Color::White, PieceType::Knight, 0x0000_0000_0000_0042);
+        snapshot.set_piece(Color::White, PieceType::Bishop, 0x0000_0000_0000_0024);
+        snapshot.set_piece(Color::White, PieceType::Rook, 0x0000_0000_0000_0081);
+        snapshot.set_piece(Color::White, PieceType::Queen, 0x0000_0000_0000_0008);
+        snapshot.set_piece(Color::White, PieceType::King, 0x0000_0000_0000_0010);
 
         // Set up black pieces
-        snapshot.set_piece(Color::Black, PieceType::Pawn, 0x00FF000000000000);
-        snapshot.set_piece(Color::Black, PieceType::Knight, 0x4200000000000000);
-        snapshot.set_piece(Color::Black, PieceType::Bishop, 0x2400000000000000);
-        snapshot.set_piece(Color::Black, PieceType::Rook, 0x8100000000000000);
-        snapshot.set_piece(Color::Black, PieceType::Queen, 0x0800000000000000);
-        snapshot.set_piece(Color::Black, PieceType::King, 0x1000000000000000);
+        snapshot.set_piece(Color::Black, PieceType::Pawn, 0x00FF_0000_0000_0000);
+        snapshot.set_piece(Color::Black, PieceType::Knight, 0x4200_0000_0000_0000);
+        snapshot.set_piece(Color::Black, PieceType::Bishop, 0x2400_0000_0000_0000);
+        snapshot.set_piece(Color::Black, PieceType::Rook, 0x8100_0000_0000_0000);
+        snapshot.set_piece(Color::Black, PieceType::Queen, 0x0800_0000_0000_0000);
+        snapshot.set_piece(Color::Black, PieceType::King, 0x1000_0000_0000_0000);
 
         let mut history = Vec::with_capacity(HISTORY_SIZE);
         history.push(snapshot);
@@ -278,30 +279,35 @@ impl ChessState {
 
     /// Returns the side to move.
     #[inline]
+    #[must_use]
     pub fn to_move(&self) -> Color {
         self.to_move
     }
 
     /// Returns the castling rights.
     #[inline]
+    #[must_use]
     pub fn castling_rights(&self) -> CastlingRights {
         self.castling_rights
     }
 
     /// Returns the en passant target square, if any.
     #[inline]
+    #[must_use]
     pub fn en_passant(&self) -> Option<Square> {
         self.en_passant
     }
 
     /// Returns the half-move clock (for 50-move rule).
     #[inline]
+    #[must_use]
     pub fn halfmove_clock(&self) -> u8 {
         self.halfmove_clock
     }
 
     /// Returns the full move number.
     #[inline]
+    #[must_use]
     pub fn fullmove_number(&self) -> u16 {
         self.fullmove_number
     }
@@ -309,6 +315,7 @@ impl ChessState {
     /// Checks how many times the current position has occurred (for repetition draws).
     /// Returns the number of times the current position has appeared in the game.
     /// Used for detecting threefold repetition draws.
+    #[must_use]
     pub fn repetition_count(&self) -> u8 {
         let hash = self.position_hash();
         *self.repetition_history.get(&hash).unwrap_or(&0)
@@ -323,7 +330,6 @@ impl ChessState {
     /// `DefaultHasher` as a placeholder.
     fn position_hash(&self) -> u64 {
         use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
 
         let mut hasher = DefaultHasher::new();
         self.history[0].hash(&mut hasher);
@@ -351,7 +357,7 @@ impl ChessState {
 
     /// Flips a binary plane vertically so that rank 1 becomes rank 8 and vice versa.
     ///
-    /// AlphaZero always presents the board from the perspective of the side to move.
+    /// `AlphaZero` always presents the board from the perspective of the side to move.
     /// When it is Black's turn, the board is flipped so that Black's pieces appear at
     /// the "bottom" (rank 1 in the output plane), matching the orientation used when
     /// it is White's turn. This allows the network to learn a single set of positional
@@ -437,6 +443,12 @@ impl Default for ChessState {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use burn::backend::Flex;
 
@@ -483,7 +495,7 @@ mod tests {
     fn test_validation_no_pawns_on_first_rank() {
         let mut state = ChessState::new();
         // Manually set invalid pawn position (pawn on rank 1)
-        state.history[0].set_piece(Color::White, PieceType::Pawn, 0x0000000000000001);
+        state.history[0].set_piece(Color::White, PieceType::Pawn, 0x0000_0000_0000_0001);
         // assert!(!state.is_valid());
     }
 
@@ -491,7 +503,7 @@ mod tests {
     fn test_validation_no_pawns_on_last_rank() {
         let mut state = ChessState::new();
         // Manually set invalid pawn position (pawn on rank 8)
-        state.history[0].set_piece(Color::Black, PieceType::Pawn, 0x8000000000000000);
+        state.history[0].set_piece(Color::Black, PieceType::Pawn, 0x8000_0000_0000_0000);
         // assert!(!state.is_valid());
     }
 
@@ -519,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_bitboard_to_plane() {
-        let bitboard = 0x0000000000000001; // A1 square
+        let bitboard = 0x0000_0000_0000_0001; // A1 square
         let plane = ChessState::bitboard_to_plane(bitboard);
         assert_eq!(plane[0], 1.0);
         for i in 1..64 {

--- a/crates/rlevo-environments/src/grids/core/reward.rs
+++ b/crates/rlevo-environments/src/grids/core/reward.rs
@@ -17,6 +17,12 @@ pub fn success_reward(step: usize, max_steps: usize) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
 
     #[test]

--- a/crates/rlevo-environments/src/grids/crossing.rs
+++ b/crates/rlevo-environments/src/grids/crossing.rs
@@ -254,6 +254,11 @@ pub struct CrossingEnv {
     config: CrossingConfig,
     steps: usize,
     render: bool,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -435,6 +440,12 @@ impl rlevo_core::render::payload::GridPayloadSource for CrossingEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/dist_shift.rs
+++ b/crates/rlevo-environments/src/grids/dist_shift.rs
@@ -1,4 +1,4 @@
-//! Fixed 9×7 gridworld from DeepMind's AI-safety distribution-shift suite.
+//! Fixed 9×7 gridworld from `DeepMind`'s AI-safety distribution-shift suite.
 //!
 //! Ports Farama Minigrid's [`DistShiftEnv`]. The agent starts at `(1, 1)`
 //! facing East and must reach the goal at `(7, 1)` along the safe top
@@ -244,6 +244,11 @@ pub struct DistShiftEnv {
     config: DistShiftConfig,
     steps: usize,
     render: bool,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -393,6 +398,12 @@ impl rlevo_core::render::payload::GridPayloadSource for DistShiftEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/door_key.rs
+++ b/crates/rlevo-environments/src/grids/door_key.rs
@@ -214,6 +214,11 @@ pub struct DoorKeyEnv {
     config: DoorKeyConfig,
     steps: usize,
     render: bool,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -392,6 +397,12 @@ impl rlevo_core::render::payload::GridPayloadSource for DoorKeyEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
+++ b/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
@@ -194,7 +194,7 @@ impl FromStr for DynamicObstaclesConfig {
                     0 => cfg.size = raw.parse().map_err(|e| format!("size: {e}"))?,
                     1 => {
                         cfg.num_obstacles =
-                            raw.parse().map_err(|e| format!("num_obstacles: {e}"))?
+                            raw.parse().map_err(|e| format!("num_obstacles: {e}"))?;
                     }
                     2 => cfg.max_steps = raw.parse().map_err(|e| format!("max_steps: {e}"))?,
                     3 => cfg.seed = raw.parse().map_err(|e| format!("seed: {e}"))?,
@@ -560,6 +560,12 @@ impl rlevo_core::render::payload::GridPayloadSource for DynamicObstaclesEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/empty.rs
+++ b/crates/rlevo-environments/src/grids/empty.rs
@@ -208,6 +208,11 @@ pub struct EmptyEnv {
     steps: usize,
     render: bool,
     /// RNG slot held for parity with random-spawn variants.
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -355,6 +360,12 @@ impl rlevo_core::render::payload::GridPayloadSource for EmptyEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::base::Observation;

--- a/crates/rlevo-environments/src/grids/four_rooms.rs
+++ b/crates/rlevo-environments/src/grids/four_rooms.rs
@@ -216,6 +216,11 @@ pub struct FourRoomsEnv {
     config: FourRoomsConfig,
     steps: usize,
     render: bool,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -382,6 +387,12 @@ impl rlevo_core::render::payload::GridPayloadSource for FourRoomsEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/go_to_door.rs
+++ b/crates/rlevo-environments/src/grids/go_to_door.rs
@@ -767,18 +767,15 @@ impl Environment<3, 3, 1> for GoToDoorEnv {
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
-        let (reward, done) = match outcome {
-            StepOutcome::DoneAction => {
-                if self.door_in_front_color() == Some(self.mission.target_color) {
-                    (success_reward(self.steps, self.config.max_steps), true)
-                } else {
-                    (0.0, true)
-                }
+        let (reward, done) = if outcome == StepOutcome::DoneAction {
+            if self.door_in_front_color() == Some(self.mission.target_color) {
+                (success_reward(self.steps, self.config.max_steps), true)
+            } else {
+                (0.0, true)
             }
-            _ => {
-                let done = self.steps >= self.config.max_steps;
-                (0.0, done)
-            }
+        } else {
+            let done = self.steps >= self.config.max_steps;
+            (0.0, done)
         };
         let observation = self.observe(&action, &self.state);
         Ok(self.emit(observation, reward, done))
@@ -793,6 +790,12 @@ impl rlevo_core::render::payload::GridPayloadSource for GoToDoorEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
     use std::collections::HashSet;

--- a/crates/rlevo-environments/src/grids/lava_gap.rs
+++ b/crates/rlevo-environments/src/grids/lava_gap.rs
@@ -189,6 +189,11 @@ pub struct LavaGapEnv {
     config: LavaGapConfig,
     steps: usize,
     render: bool,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -365,6 +370,12 @@ impl rlevo_core::render::payload::GridPayloadSource for LavaGapEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/memory.rs
+++ b/crates/rlevo-environments/src/grids/memory.rs
@@ -764,18 +764,15 @@ impl Environment<3, 3, 1> for MemoryEnv {
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
-        let (reward, done) = match outcome {
-            StepOutcome::DoneAction => {
-                if self.facing_match() {
-                    (success_reward(self.steps, self.config.max_steps), true)
-                } else {
-                    (0.0, true)
-                }
+        let (reward, done) = if outcome == StepOutcome::DoneAction {
+            if self.facing_match() {
+                (success_reward(self.steps, self.config.max_steps), true)
+            } else {
+                (0.0, true)
             }
-            _ => {
-                let done = self.steps >= self.config.max_steps;
-                (0.0, done)
-            }
+        } else {
+            let done = self.steps >= self.config.max_steps;
+            (0.0, done)
         };
         Ok(self.emit(reward, done))
     }
@@ -789,6 +786,12 @@ impl rlevo_core::render::payload::GridPayloadSource for MemoryEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
     use std::collections::HashSet;

--- a/crates/rlevo-environments/src/grids/multi_room.rs
+++ b/crates/rlevo-environments/src/grids/multi_room.rs
@@ -10,7 +10,7 @@
 //! a configurable structural knob (`num_rooms`), giving it a long-horizon
 //! planning flavor without depending on randomization.
 //!
-//! ## Layout (3 rooms, room_width = 5, height = 5 — default)
+//! ## Layout (3 rooms, `room_width` = 5, height = 5 — default)
 //!
 //! ```text
 //! # # # # # # # # # # # # # # # #
@@ -247,6 +247,11 @@ pub struct MultiRoomEnv {
     config: MultiRoomConfig,
     steps: usize,
     render: bool,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -432,6 +437,12 @@ impl rlevo_core::render::payload::GridPayloadSource for MultiRoomEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/grids/unlock.rs
+++ b/crates/rlevo-environments/src/grids/unlock.rs
@@ -192,6 +192,11 @@ pub struct UnlockEnv {
     steps: usize,
     render: bool,
     door_pos: (i32, i32),
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 

--- a/crates/rlevo-environments/src/grids/unlock_pickup.rs
+++ b/crates/rlevo-environments/src/grids/unlock_pickup.rs
@@ -196,6 +196,11 @@ pub struct UnlockPickupEnv {
     steps: usize,
     render: bool,
     target: Entity,
+    // Never sampled: this env's layout builder is fully deterministic and
+    // ignores `config.seed`, so the field is written but never read. Kept
+    // as-is rather than renamed — see #397, which decides whether these
+    // envs become genuinely stochastic or drop the seed entirely.
+    #[allow(clippy::used_underscore_binding)]
     _rng: StdRng,
 }
 
@@ -368,6 +373,12 @@ impl rlevo_core::render::payload::GridPayloadSource for UnlockPickupEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::environment::Snapshot;
 

--- a/crates/rlevo-environments/src/landscapes/alpine1.rs
+++ b/crates/rlevo-environments/src/landscapes/alpine1.rs
@@ -9,7 +9,7 @@
 //! Evaluated over `[-10, 10]^n`. Requires `n ≥ 1`.
 //!
 //! Note: the canonical formula is `|x_i·sin(x_i) + 0.1·x_i|`; some libraries
-//! (e.g. NiaPy) drop the leading `x_i` factor — that is a different function.
+//! (e.g. `NiaPy`) drop the leading `x_i` factor — that is a different function.
 
 use rlevo_core::config::{self, ConfigError};
 
@@ -62,7 +62,7 @@ impl Alpine1 {
     ///
     /// Coordinates beyond the first two are held at `0.0` so the rendered slice
     /// passes through the global optimum at the origin.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/branin.rs
+++ b/crates/rlevo-environments/src/landscapes/branin.rs
@@ -84,7 +84,7 @@ impl Branin {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }

--- a/crates/rlevo-environments/src/landscapes/bukin6.rs
+++ b/crates/rlevo-environments/src/landscapes/bukin6.rs
@@ -66,7 +66,7 @@ impl Bukin6 {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }
@@ -163,9 +163,9 @@ mod tests {
         // rectangle x₁ ∈ [-15, -5], x₂ ∈ [-3, 3] (e.g. x₁ = +2, which the sweep below
         // visits) — this test is precisely the check that those extra points are
         // harmless: none of them can beat f*.
+        const STEPS: i32 = 300;
         let b = Bukin6::new();
         let (lo, hi) = b.bounds();
-        const STEPS: i32 = 300;
         let step = (hi - lo) / f64::from(STEPS);
 
         for i in 0..=STEPS {

--- a/crates/rlevo-environments/src/landscapes/cross_in_tray.rs
+++ b/crates/rlevo-environments/src/landscapes/cross_in_tray.rs
@@ -50,7 +50,7 @@ impl CrossInTray {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }

--- a/crates/rlevo-environments/src/landscapes/deb1.rs
+++ b/crates/rlevo-environments/src/landscapes/deb1.rs
@@ -63,7 +63,7 @@ impl Deb1 {
     ///
     /// Coordinates beyond the first two are fixed at `0.1`, one of the
     /// per-dimension optima, so the rendered slice passes through a global minimum.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.1_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/easom.rs
+++ b/crates/rlevo-environments/src/landscapes/easom.rs
@@ -49,7 +49,7 @@ impl Easom {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }

--- a/crates/rlevo-environments/src/landscapes/eggholder.rs
+++ b/crates/rlevo-environments/src/landscapes/eggholder.rs
@@ -89,7 +89,7 @@ impl Eggholder {
     /// The first two coordinates vary across the render window — and the `n = 2`
     /// optimum `(512, 404.2318)` lies in that plane — so coordinates beyond the
     /// first two are held at `0.0`.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/goldstein_price.rs
+++ b/crates/rlevo-environments/src/landscapes/goldstein_price.rs
@@ -48,7 +48,7 @@ impl GoldsteinPrice {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }

--- a/crates/rlevo-environments/src/landscapes/griewank.rs
+++ b/crates/rlevo-environments/src/landscapes/griewank.rs
@@ -70,7 +70,7 @@ impl Griewank {
     ///
     /// Coordinates beyond the first two are held at `0.0` so the rendered slice
     /// passes through the global optimum at the origin.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/himmelblau.rs
+++ b/crates/rlevo-environments/src/landscapes/himmelblau.rs
@@ -41,7 +41,7 @@ impl Himmelblau {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }

--- a/crates/rlevo-environments/src/landscapes/lunacek_bi_rastrigin.rs
+++ b/crates/rlevo-environments/src/landscapes/lunacek_bi_rastrigin.rs
@@ -120,7 +120,7 @@ impl LunacekBiRastrigin {
     ///
     /// Coordinates beyond the first two are fixed at `μ₁ = 2.5` (the optimum) so
     /// the rendered slice passes through the global funnel.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![MU1; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/michalewicz.rs
+++ b/crates/rlevo-environments/src/landscapes/michalewicz.rs
@@ -112,6 +112,12 @@ impl crate::render::AsciiRenderable for Michalewicz {
 
 #[cfg(test)]
 mod tests {
+    // The optimum coordinate 2.20290552 is quoted digit-for-digit from the
+    // certified Michalewicz n=2 result; digit-group separators would make it
+    // harder to check against the published table, which is the only reason
+    // the literal is written out in full.
+    #![allow(clippy::unreadable_literal)]
+
     use super::*;
     use approx::assert_relative_eq;
 

--- a/crates/rlevo-environments/src/landscapes/needle_eye.rs
+++ b/crates/rlevo-environments/src/landscapes/needle_eye.rs
@@ -78,7 +78,7 @@ impl Needle {
     /// Coordinates beyond the first two are held at `0.0` (inside the needle).
     /// The rendered surface is uniformly dense — the optimal patch is invisible
     /// at any reasonable grid resolution, which documents the function's difficulty.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/penalized1.rs
+++ b/crates/rlevo-environments/src/landscapes/penalized1.rs
@@ -100,7 +100,7 @@ impl Penalized1 {
     ///
     /// Coordinates beyond the first two are fixed at `−1.0` (the per-dimension
     /// optimum) so the rendered slice passes through the global minimum.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         // `new` guarantees `dim >= 1`, so index 0 always exists.
         let mut p = vec![-1.0_f64; self.dim];
         p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/rosenbrock.rs
+++ b/crates/rlevo-environments/src/landscapes/rosenbrock.rs
@@ -73,7 +73,7 @@ impl Rosenbrock {
     /// Coordinates beyond the first two are fixed at `1.0` (the per-dimension
     /// optimum) so the rendered slice passes through the valley floor rather
     /// than a flat cross-section.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![1.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/rosenbrock_flat.rs
+++ b/crates/rlevo-environments/src/landscapes/rosenbrock_flat.rs
@@ -44,7 +44,7 @@
 //!
 //! # References
 //!
-//! Monismith, D.R. (2010), PhD dissertation, Oklahoma State University — source
+//! Monismith, D.R. (2010), `PhD` dissertation, Oklahoma State University — source
 //! of the canonical `[-2000, 2000]^n` domain, catalogued as function #170 in
 //! Al-Roomi's benchmark repository.
 //!
@@ -124,7 +124,7 @@ impl RosenbrockFlat {
     ///
     /// Coordinates beyond the first two are fixed at `1.0` (the optimum) so the
     /// rendered slice passes through the valley.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![1.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;
@@ -237,9 +237,9 @@ mod tests {
         // [-2000, 2000]^n or the cited reduced [-30, 30] — can therefore contain
         // a point better than f*. Pinned by a dense deterministic sweep of the
         // 2-D slice over bounds()².
+        const STEPS: i32 = 300;
         let r = RosenbrockFlat::new(2).expect("dim >= 2");
         let (lo, hi) = r.bounds();
-        const STEPS: i32 = 300;
         let step = (hi - lo) / f64::from(STEPS);
 
         for i in 0..=STEPS {

--- a/crates/rlevo-environments/src/landscapes/schwefel.rs
+++ b/crates/rlevo-environments/src/landscapes/schwefel.rs
@@ -79,7 +79,7 @@ impl Schwefel {
     /// Coordinates beyond the first two are fixed at the per-dimension optimum
     /// `x_i* = 420.9687…`, not `0.0`, so the rendered slice shows the global
     /// basin rather than a cross-section through the deceptive near-zero region.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![X_OPT; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/six_hump_camel.rs
+++ b/crates/rlevo-environments/src/landscapes/six_hump_camel.rs
@@ -50,7 +50,7 @@ impl SixHumpCamel {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }

--- a/crates/rlevo-environments/src/landscapes/sphere.rs
+++ b/crates/rlevo-environments/src/landscapes/sphere.rs
@@ -80,7 +80,7 @@ impl Sphere {
     /// For 2-D landscapes this is the exact surface; for higher dimensions
     /// the remaining coordinates are held at zero so the rendered slice
     /// passes through the global optimum at the origin.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         let mut p = vec![0.0_f64; self.dim];
         if !p.is_empty() {
             p[0] = x;

--- a/crates/rlevo-environments/src/landscapes/trefethen.rs
+++ b/crates/rlevo-environments/src/landscapes/trefethen.rs
@@ -90,7 +90,7 @@ impl Trefethen {
     }
 
     /// 2D projection used by the renderer — the exact surface for a 2-D function.
-    fn evaluate_2d(&self, x: f64, y: f64) -> f64 {
+    fn evaluate_2d(self, x: f64, y: f64) -> f64 {
         self.evaluate(x, y)
     }
 }
@@ -174,9 +174,9 @@ mod tests {
         // any point with f < f*. Trefethen oscillates at frequencies 50–80, so a
         // 400×400 grid will NOT land near the true optimum — that is expected.
         // This test asserts only that the lower bound f* is never breached.
+        const STEPS: usize = 400;
         let t = Trefethen::new();
         let (lo, hi) = t.bounds();
-        const STEPS: usize = 400;
         #[expect(
             clippy::cast_precision_loss,
             reason = "STEPS is 400; grid indices are exactly representable in f64"

--- a/crates/rlevo-environments/src/lib.rs
+++ b/crates/rlevo-environments/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Module Organization
 //!
-//! - [`classic`]: Classic control problems (CartPole, MountainCar, Pendulum, Acrobot, TenArmedBandit)
+//! - [`classic`]: Classic control problems (`CartPole`, `MountainCar`, Pendulum, Acrobot, `TenArmedBandit`)
 //! - [`episode`]: [`EpisodeGuard`](episode::EpisodeGuard) — the shared post-terminal
 //!   `step()` guard consumed by `toy_text` and [`wrappers::time_limit`]
 //! - [`landscapes`]: Optimization fitness landscapes (Sphere, Ackley, Rastrigin,
@@ -15,11 +15,11 @@
 //! - [`grids`]: Gridworld environments inspired by Farama Minigrid
 //! - [`pixel_grid`]: Synthetic pixel-over-grid env — a rank-1 latent observed as
 //!   a rank-3 RGB image (first real [`rlevo_core::state::Observable`] consumer)
-//! - [`toy_text`]: Tabular RL environments (Blackjack, Taxi, CliffWalking, FrozenLake)
-//! - [`wrappers`]: Environment wrappers (TimeLimit)
+//! - [`toy_text`]: Tabular RL environments (Blackjack, Taxi, `CliffWalking`, `FrozenLake`)
+//! - [`wrappers`]: Environment wrappers (`TimeLimit`)
 //! - [`render`]: Re-exports of the render surface defined in `rlevo-core`
-//! - [`box2d`]: Box2D-style physics environments (BipedalWalker, LunarLander, CarRacing)
-//! - [`locomotion`]: MuJoCo-inspired locomotion environments via Rapier3D
+//! - [`box2d`]: Box2D-style physics environments (`BipedalWalker`, `LunarLander`, `CarRacing`)
+//! - [`locomotion`]: MuJoCo-inspired locomotion environments via `Rapier3D`
 //!
 //! # Design Principles
 //!
@@ -34,6 +34,21 @@
 //!   when the episode ends.
 //!
 //! Environments may be deterministic or stochastic depending on their configuration.
+
+// The numeric-cast family is suppressed crate-wide pending the per-site audit
+// tracked in #396. Enabling `[workspace.lints]` here surfaced 194 cast warnings
+// in production physics, rasterizer, and grid-indexing paths. Each needs a real
+// range argument at the site (is this `f32` provably non-negative before `as
+// usize`?) rather than a mechanical rewrite, so they are burned down module by
+// module — narrow this allow as modules are cleared, do not widen it.
+//
+// Every *other* lint in the workspace table is enforced on this crate today.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
 
 pub mod landscapes {
     pub mod ackley;

--- a/crates/rlevo-environments/src/locomotion/backend/mod.rs
+++ b/crates/rlevo-environments/src/locomotion/backend/mod.rs
@@ -99,9 +99,9 @@ pub trait LocomotionBackend: 'static {
     /// Apply a scalar actuator torque to a revolute joint's single free axis.
     ///
     /// `torque` is the **generalized force** on the joint's one free angular
-    /// degree of freedom — the direct analogue of a MuJoCo `motor` actuator on a
+    /// degree of freedom — the direct analogue of a `MuJoCo` `motor` actuator on a
     /// hinge joint, where the generalized force is `gear × ctrl`. Torque is in
-    /// world-scale units (newton-metres for Rapier3D); **gear scaling stays the
+    /// world-scale units (newton-metres for `Rapier3D`); **gear scaling stays the
     /// caller's responsibility** — see [`crate::locomotion::common::Gear`].
     ///
     /// # Semantics
@@ -150,12 +150,12 @@ pub trait LocomotionBackend: 'static {
     ///   (`impulse / substep_dt`) from the **last** solved substep — an
     ///   instantaneous per-timestep quantity, **not** a step-integrated or
     ///   frame-skip-averaged one. It mirrors Gymnasium's read-after-last-substep
-    ///   semantics: MuJoCo recomputes `cfrc_ext` via `mj_rnePostConstraint`
+    ///   semantics: `MuJoCo` recomputes `cfrc_ext` via `mj_rnePostConstraint`
     ///   *once*, after `mj_step(nstep = frame_skip)`, so it too reflects only the
     ///   final substep's state. The value is therefore independent of
     ///   `frame_skip`.
     /// - **Sign — force ON the queried body.** The wrench is the external
-    ///   contact force-torque acting *on* `body` (the analogue of MuJoCo
+    ///   contact force-torque acting *on* `body` (the analogue of `MuJoCo`
     ///   `cfrc_ext` = "external force acting on the body"): a body resting on the
     ///   ground reports a positive upward vertical force. By Newton's third law
     ///   the force part of `contact_force(A)` is the negation of that of
@@ -163,19 +163,19 @@ pub trait LocomotionBackend: 'static {
     ///   taken about its own body's centre of mass). The sign is independent of
     ///   collider insertion order.
     /// - **Layout `[force(3), torque(3)]`** — an intentional deviation from
-    ///   MuJoCo's `cfrc_ext`, which is `[torque(3), force(3)]` ("rotation(3),
+    ///   `MuJoCo`'s `cfrc_ext`, which is `[torque(3), force(3)]` ("rotation(3),
     ///   translation(3)" per `mj_rnePostConstraint`). Consumers packing an
     ///   observation must map fields accordingly; this layout is **not**
     ///   `cfrc_ext`-compatible.
     /// - **Torque reference point: the body's own centre of mass**, whereas
-    ///   MuJoCo references its `cfrc_ext` torque to the *kinematic-subtree* CoM.
+    ///   `MuJoCo` references its `cfrc_ext` torque to the *kinematic-subtree* `CoM`.
     ///   These coincide for a leaf body but differ materially for an internal
     ///   body — a calibration caveat for Ant/Humanoid `contact_cost`.
-    /// - **Content: contact-manifold forces only.** MuJoCo's `cfrc_ext` is the
+    /// - **Content: contact-manifold forces only.** `MuJoCo`'s `cfrc_ext` is the
     ///   full Recursive-Newton-Euler post-constraint external wrench (all
     ///   external interactions), a strict superset of contact forces.
     /// - **Self-contacts never contribute.** Two colliders sharing one rigid body
-    ///   cannot produce a contact pair in rapier 0.32, matching MuJoCo's
+    ///   cannot produce a contact pair in rapier 0.32, matching `MuJoCo`'s
     ///   undisableable same-body geom filter.
     fn contact_force(world: &Self::World, body: Self::BodyHandle) -> [f32; 6];
 }

--- a/crates/rlevo-environments/src/locomotion/backend/rapier3d.rs
+++ b/crates/rlevo-environments/src/locomotion/backend/rapier3d.rs
@@ -1,10 +1,10 @@
-//! Rapier3D implementation of [`LocomotionBackend`].
+//! `Rapier3D` implementation of [`LocomotionBackend`].
 //!
 //! Wraps the rapier3d simulation pipeline in [`Rapier3DWorld`] and provides a
 //! [`Rapier3DJointHandle`] union covering both impulse and multibody joints.
 //! Bodies are kept in maximal coordinates; articulated chains (Ant legs,
-//! Humanoid torso/arms/legs, Walker2D) are driven via `MultibodyJointSet` so
-//! they behave closer to MuJoCo's generalised coordinates than plain impulse
+//! Humanoid torso/arms/legs, `Walker2D`) are driven via `MultibodyJointSet` so
+//! they behave closer to `MuJoCo`'s generalised coordinates than plain impulse
 //! joints would.
 //!
 //! Note on math types: rapier3d 0.32's `Vector`, `Rotation`, and `Isometry`
@@ -14,12 +14,11 @@
 //! ([`Pose`], [`Twist`], and the `[f32; 6]` contact wrench), so no glam (or
 //! nalgebra) type ever crosses into observation/state code.
 
-use rapier3d::math::{Real, Vector};
 use rapier3d::prelude::*;
 
 use super::{BackendError, LocomotionBackend, Pose, Twist};
 
-/// Rapier3D scene for one locomotion environment.
+/// `Rapier3D` scene for one locomotion environment.
 ///
 /// Holds every set the rapier3d pipeline needs, plus env-level bookkeeping
 /// (`gravity`, `frame_skip`). Fields are `pub(crate)` so env modules can
@@ -56,6 +55,7 @@ impl std::fmt::Debug for Rapier3DWorld {
 impl Rapier3DWorld {
     /// Create a world with the given gravity vector, physics substep `dt`, and
     /// `frame_skip` substeps per environment step.
+    #[must_use]
     pub fn new(gravity: Vector, dt: Real, frame_skip: u32) -> Self {
         let integration_parameters = IntegrationParameters {
             dt,
@@ -83,7 +83,7 @@ impl Rapier3DWorld {
     /// live **exactly one** substep — each [`step_once`](Self::step_once)
     /// integrates the current accumulator and then clears it. A control input
     /// applied once before this call therefore affects only the *first*
-    /// substep. To hold an actuator constant across the frame skip (MuJoCo
+    /// substep. To hold an actuator constant across the frame skip (`MuJoCo`
     /// `ctrl`-held-across-substeps semantics), apply control every substep via
     /// [`step_actuated`](Self::step_actuated) instead. See ADR 0037.
     pub fn step_with_frame_skip(&mut self) {
@@ -128,7 +128,7 @@ impl Rapier3DWorld {
     ///
     /// rapier 0.32 `add_force`/`add_torque` are additive and consumed+cleared by
     /// [`step_once`](Self::step_once); to hold an actuator constant across the
-    /// frame skip (MuJoCo `ctrl`-held-across-substeps semantics) the caller MUST
+    /// frame skip (`MuJoCo` `ctrl`-held-across-substeps semantics) the caller MUST
     /// re-apply control every substep. `apply` is invoked with `&mut self`
     /// immediately before each `step_once`. See ADR 0037.
     pub fn step_actuated(&mut self, mut apply: impl FnMut(&mut Self)) {
@@ -191,7 +191,7 @@ impl Rapier3DWorld {
 
     /// Link two bodies with a multibody (generalised-coordinate) joint.
     ///
-    /// Multibody joints behave closer to MuJoCo's generalised coordinates than
+    /// Multibody joints behave closer to `MuJoCo`'s generalised coordinates than
     /// impulse joints and are preferred for articulated limb chains.  Returns
     /// `None` if rapier3d rejects the insertion (e.g. cyclic topology).
     pub(crate) fn add_multibody_joint(
@@ -218,9 +218,9 @@ impl Rapier3DWorld {
 
 /// Tagged handle covering both rapier joint kinds.
 ///
-/// Rapier3D has two disjoint joint stores: [`ImpulseJointSet`] (good for
+/// `Rapier3D` has two disjoint joint stores: [`ImpulseJointSet`] (good for
 /// high-frequency / contact-rich joints like wheels and feet) and
-/// [`MultibodyJointSet`] (analogous to MuJoCo's generalised coordinates for
+/// [`MultibodyJointSet`] (analogous to `MuJoCo`'s generalised coordinates for
 /// serial chains). Envs tag each actuated joint so torque application
 /// dispatches to the right store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -241,7 +241,7 @@ impl From<MultibodyJointHandle> for Rapier3DJointHandle {
     }
 }
 
-/// Backend marker type; implements [`LocomotionBackend`] with Rapier3D semantics.
+/// Backend marker type; implements [`LocomotionBackend`] with `Rapier3D` semantics.
 #[derive(Debug, Clone, Copy)]
 pub struct Rapier3DBackend;
 
@@ -258,7 +258,7 @@ fn is_revolute_axes(locked: JointAxesMask) -> bool {
     let all_lin_locked = locked.contains(JointAxesMask::LIN_AXES);
     // … and exactly one free angular axis.
     let free_ang = JointAxesMask::ANG_AXES.difference(locked);
-    all_lin_locked && free_ang.bits().count_ones() == 1
+    all_lin_locked && free_ang.bits().is_power_of_two()
 }
 
 impl LocomotionBackend for Rapier3DBackend {
@@ -305,7 +305,7 @@ impl LocomotionBackend for Rapier3DBackend {
         )
     }
 
-    /// Drive a revolute joint's free axis by a scalar torque (MuJoCo `motor`
+    /// Drive a revolute joint's free axis by a scalar torque (`MuJoCo` `motor`
     /// analogue). Dispatches on the [`Rapier3DJointHandle`] kind — the maximal-
     /// vs reduced-coordinate mechanics differ and this split is load-bearing.
     ///
@@ -528,6 +528,12 @@ impl LocomotionBackend for Rapier3DBackend {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
 
     fn make_world() -> Rapier3DWorld {
@@ -908,7 +914,7 @@ mod tests {
     ///
     /// SIGN: the wrench is the external contact force acting ON the ball, so the
     /// ground below pushes UP and `wrench[2]` is **positive** (≈ +m·g). This is
-    /// the physically correct convention (MuJoCo `cfrc_ext` = "external force
+    /// the physically correct convention (`MuJoCo` `cfrc_ext` = "external force
     /// acting on the body"); it is verified insertion-order invariant and
     /// Newton's-third-law antisymmetric by the companion tests below. A slight
     /// `> m·g` magnitude is rapier's steady-state penetration bias.
@@ -965,7 +971,7 @@ mod tests {
 
     /// Same-body invariant: two overlapping colliders on ONE body, zero gravity,
     /// no other body — rapier clears same-parent contact pairs, so the wrench is
-    /// exactly zero (pins rapier 0.32 narrow_phase.rs:841).
+    /// exactly zero (pins rapier 0.32 `narrow_phase.rs:841`).
     #[test]
     fn contact_force_same_body_colliders_zero_wrench() {
         let mut world = Rapier3DWorld::new(Vector::ZERO, 1.0 / 60.0, 1);
@@ -994,7 +1000,7 @@ mod tests {
     /// per-contact impulse that acts oppositely on the two bodies
     /// (`-force_mag·normal` on collider1, `+force_mag·normal` on collider2), so
     /// the aggregated force vectors are exactly antisymmetric. (Torque parts are
-    /// taken about each body's own CoM and need not cancel.)
+    /// taken about each body's own `CoM` and need not cancel.)
     #[test]
     fn contact_force_newton_third_law_antisymmetric() {
         let radius = 0.25f32;
@@ -1095,6 +1101,8 @@ mod tests {
     /// collider was inserted first — the branch that flips `normal` and the
     /// `flipped` flag together must leave the sign (and magnitude) invariant.
     #[test]
+    // Justified: paired linear/angular quantities differ by one character by convention.
+    #[allow(clippy::similar_names)]
     fn contact_force_insertion_order_robust() {
         let (w_gf, ball_gf) = resting_ball_insertion_order(true);
         let (w_bf, ball_bf) = resting_ball_insertion_order(false);

--- a/crates/rlevo-environments/src/locomotion/common.rs
+++ b/crates/rlevo-environments/src/locomotion/common.rs
@@ -32,6 +32,11 @@ use rlevo_core::reward::ScalarReward;
 ///
 /// Envs whose Gymnasium counterpart doesn't expose a given toggle simply
 /// ignore the corresponding field.
+//
+// One independent toggle per optional observation block, mirroring the MuJoCo
+// observation spec these environments reproduce. A bitfield or enum set would
+// break the one-field-per-spec-entry correspondence that makes this readable.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ObservationComponents {
     /// Include the torso's world-frame `(x, y)` in the observation.
@@ -59,7 +64,7 @@ impl ObservationComponents {
         }
     }
 
-    /// Ant-v5 defaults: exclude xy, include cfrc_ext (no cinert / cvel / qfrc).
+    /// Ant-v5 defaults: exclude xy, include `cfrc_ext` (no cinert / cvel / qfrc).
     #[must_use]
     pub const fn ant_default() -> Self {
         Self {
@@ -94,7 +99,7 @@ impl Default for ObservationComponents {
 ///
 /// Each range is an `Option`; when `None`, that dimension is not checked.
 /// Hopper sets all three (z + angle + state); Ant only sets `z_range`;
-/// HalfCheetah / Swimmer / Reacher / Pusher / HumanoidStandup set none
+/// `HalfCheetah` / Swimmer / Reacher / Pusher / `HumanoidStandup` set none
 /// (they never terminate on unhealthy).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct HealthyCheck {
@@ -158,14 +163,14 @@ pub enum TerminationMode {
     /// Terminate the episode when [`HealthyCheck::is_healthy`] returns false.
     #[default]
     OnUnhealthy,
-    /// Never terminate for health reasons (HalfCheetah, Swimmer, Reacher, ...).
+    /// Never terminate for health reasons (`HalfCheetah`, Swimmer, Reacher, ...).
     Never,
 }
 
 /// Gear ratios for an N-actuator env: `torque_i = action_i * gear_i`.
 ///
 /// The const generic `N` pins the actuator count at the type level, so
-/// swapping a 6-gear HalfCheetah vector for an 8-gear Ant vector is a compile
+/// swapping a 6-gear `HalfCheetah` vector for an 8-gear Ant vector is a compile
 /// error rather than a runtime mismatch.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Gear<const N: usize>([f32; N]);
@@ -258,6 +263,12 @@ pub type LocomotionSnapshot<O> = SnapshotBase<1, O, ScalarReward>;
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
 
     #[test]

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/config.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/config.rs
@@ -7,7 +7,7 @@ use crate::locomotion::common::{Gear, HealthyCheck, TerminationMode};
 
 /// Environment configuration for [`super::InvertedDoublePendulum`].
 ///
-/// Defaults match the Gymnasium v5 XML: gear 100, dt 0.01, frame_skip 1,
+/// Defaults match the Gymnasium v5 XML: gear 100, dt 0.01, `frame_skip` 1,
 /// reset noise 0.1, truncation at 1000, termination on `y_tip ≤ 1.0`.
 #[derive(Debug, Clone)]
 pub struct InvertedDoublePendulumConfig {

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/env.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/env.rs
@@ -1,11 +1,10 @@
-//! InvertedDoublePendulum environment implementation.
+//! `InvertedDoublePendulum` environment implementation.
 
 use std::marker::PhantomData;
 
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rand_distr::{Distribution, Normal};
-use rapier3d::math::Vector;
 use rapier3d::prelude::*;
 use rlevo_core::config::{ConfigError, Validate};
 use rlevo_core::environment::{
@@ -98,6 +97,8 @@ impl InvertedDoublePendulum<Rapier3DBackend> {
         self.reset()
     }
 
+    // Justified: paired per-joint initial values differ only by joint index.
+    #[allow(clippy::similar_names)]
     fn build_world(
         config: &InvertedDoublePendulumConfig,
         rng: &mut StdRng,
@@ -222,7 +223,7 @@ impl InvertedDoublePendulum<Rapier3DBackend> {
     /// minus pole1 world angle), wrapped to `(-π, π]`.
     ///
     /// `obs[8]` is the aggregated contact wrench on pole2 (`cfrc_ext[0]`). With
-    /// jointed-neighbour contacts disabled for MuJoCo parent–child filter parity
+    /// jointed-neighbour contacts disabled for `MuJoCo` parent–child filter parity
     /// (ADR 0041), pole2 touches nothing in normal operation, so this slot is
     /// `≈ 0`; it is retained as a placeholder for the `qfrc_constraint`-based
     /// re-model tracked in issue #271.
@@ -257,7 +258,7 @@ impl InvertedDoublePendulum<Rapier3DBackend> {
     /// Compute the world-x cart force for `action` (clip → gear). Pure: the
     /// force is *applied* inside the `step_actuated` closure so it is re-applied
     /// fresh each substep (ADR 0037 force-lifetime contract).
-    fn control_force(&self, action: &InvertedDoublePendulumAction) -> f32 {
+    fn control_force(&self, action: InvertedDoublePendulumAction) -> f32 {
         let (lo, hi): (f32, f32) = self.config.action_clip.into();
         let clipped = [action.0[0].clamp(lo, hi)];
         let torques = self.config.gear.apply(&clipped);
@@ -387,7 +388,7 @@ impl Environment<1, 1, 1> for InvertedDoublePendulum<Rapier3DBackend> {
         // across the frame skip and cannot accumulate (ADR 0037). The handle is
         // `Copy` and `force` is precomputed, so the closure borrows only the
         // world — not `self`.
-        let force = self.control_force(&action);
+        let force = self.control_force(action);
         let cart_handle = self.state.cart;
         self.world.step_actuated(|w| {
             if let Some(cart) = w.bodies_mut().get_mut(cart_handle) {
@@ -457,6 +458,8 @@ fn pole_y_angle(pose: &Pose) -> f32 {
 ///
 /// Uses the standard `v' = v + 2·u × (u × v + w·v)` identity where
 /// `u = (x, y, z)`. Avoids pulling glam / nalgebra into the env layer.
+// Justified: single-letter names mirror the reference dynamics equations.
+#[allow(clippy::many_single_char_names)]
 fn rotate_by_quat(q: [f32; 4], v: [f32; 3]) -> [f32; 3] {
     let [w, x, y, z] = q;
     let [vx, vy, vz] = v;
@@ -474,6 +477,12 @@ fn rotate_by_quat(q: [f32; 4], v: [f32; 3]) -> [f32; 3] {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::ContinuousAction;
     use rlevo_core::base::Action;

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/mod.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Physics note
 //!
-//! This env simulates dynamics via Rapier3D, not MuJoCo. Observation shape,
+//! This env simulates dynamics via `Rapier3D`, not `MuJoCo`. Observation shape,
 //! action dimensionality, reward structure, and termination conditions match
 //! Gymnasium v5 exactly. **Absolute reward values, learned policies, and
 //! trained scores will NOT transfer to real Gymnasium/MuJoCo benchmarks
@@ -33,18 +33,18 @@
 //!
 //! * `constraint_force_x` (`obs[8]`) is approximated by reading Rapier's
 //!   aggregated contact force on pole2 (`Rapier3DBackend::contact_force`).
-//!   MuJoCo's equivalent `cfrc_inv[0]` is a joint reaction force computed in
+//!   `MuJoCo`'s equivalent `cfrc_inv[0]` is a joint reaction force computed in
 //!   generalised coordinates. Signs and rough magnitudes follow the same
 //!   dynamics; absolute values will differ.
 //!
 //!   Note: jointed-neighbour contacts are disabled on both revolute joints for
-//!   MuJoCo parent–child contact-filter parity (ADR 0041), so pole2 touches
+//!   `MuJoCo` parent–child contact-filter parity (ADR 0041), so pole2 touches
 //!   nothing in normal operation and `obs[8]` is `≈ 0`. The slot is retained as
 //!   a placeholder for a future re-model against Gymnasium's `qfrc_constraint`
 //!   (the generalised constraint force on the cart slider DOF), tracked in
 //!   issue #271.
 //! * `ω₂` is reported as world-frame angular velocity (not relative to pole1),
-//!   matching MuJoCo's `qvel` for the second hinge — i.e. it is the body's
+//!   matching `MuJoCo`'s `qvel` for the second hinge — i.e. it is the body's
 //!   absolute rate, not the rate of the relative joint angle.
 
 pub mod action;

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/observation.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/observation.rs
@@ -54,7 +54,7 @@ impl InvertedDoublePendulumObservation {
     }
     /// `obs[8]` — approximated constraint force along world-x at the tip of
     /// pole2, sampled from Rapier's contact-force accumulator. See the
-    /// [module documentation](super) for the divergence from MuJoCo's
+    /// [module documentation](super) for the divergence from `MuJoCo`'s
     /// `cfrc_inv`.
     #[must_use]
     pub const fn constraint_force_x(&self) -> f32 {

--- a/crates/rlevo-environments/src/locomotion/inverted_pendulum/config.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_pendulum/config.rs
@@ -7,7 +7,7 @@ use crate::locomotion::common::{Gear, HealthyCheck, TerminationMode};
 
 /// Environment configuration for [`super::InvertedPendulum`].
 ///
-/// Defaults match the Gymnasium v5 XML (gear 100, dt 0.01, frame_skip 1,
+/// Defaults match the Gymnasium v5 XML (gear 100, dt 0.01, `frame_skip` 1,
 /// healthy-angle band `(-0.2, 0.2)`, reset noise 0.01, truncation at 1000).
 #[derive(Debug, Clone)]
 pub struct InvertedPendulumConfig {

--- a/crates/rlevo-environments/src/locomotion/inverted_pendulum/env.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_pendulum/env.rs
@@ -1,4 +1,4 @@
-//! InvertedPendulum environment implementation.
+//! `InvertedPendulum` environment implementation.
 
 use std::marker::PhantomData;
 
@@ -22,7 +22,7 @@ use super::state::InvertedPendulumState;
 /// Reward-component metadata key: `+1` if alive at this step, `0` otherwise.
 pub const METADATA_KEY_ALIVE: &str = "alive";
 
-/// InvertedPendulum — cart-pole balance in 3D, with the cart restricted to
+/// `InvertedPendulum` — cart-pole balance in 3D, with the cart restricted to
 /// the world-x axis and the pole free to rotate about the world-y axis.
 ///
 /// Generic in the physics backend; v1 only implements `B = Rapier3DBackend`
@@ -80,6 +80,8 @@ impl InvertedPendulum<Rapier3DBackend> {
         self.reset()
     }
 
+    // Justified: paired per-joint initial values differ only by joint index.
+    #[allow(clippy::similar_names)]
     fn build_world(
         config: &InvertedPendulumConfig,
         rng: &mut StdRng,
@@ -192,7 +194,7 @@ impl InvertedPendulum<Rapier3DBackend> {
     /// Compute the world-x cart force for `action` (clip → gear). Pure: the
     /// force is *applied* inside the `step_actuated` closure so it is re-applied
     /// fresh each substep (ADR 0037 force-lifetime contract).
-    fn control_force(&self, action: &InvertedPendulumAction) -> f32 {
+    fn control_force(&self, action: InvertedPendulumAction) -> f32 {
         let (lo, hi): (f32, f32) = self.config.action_clip.into();
         let clipped = [action.0[0].clamp(lo, hi)];
         let torques = self.config.gear.apply(&clipped);
@@ -307,7 +309,7 @@ impl Environment<1, 1, 1> for InvertedPendulum<Rapier3DBackend> {
         // across the frame skip and cannot accumulate (ADR 0037). The handle is
         // `Copy` and `force` is precomputed, so the closure borrows only the
         // world — not `self`.
-        let force = self.control_force(&action);
+        let force = self.control_force(action);
         let cart_handle = self.state.cart;
         self.world.step_actuated(|w| {
             if let Some(cart) = w.bodies_mut().get_mut(cart_handle) {
@@ -402,6 +404,12 @@ impl rlevo_core::render::Locomotion2DPayloadSource for InvertedPendulum<Rapier3D
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::ContinuousAction;
     use rlevo_core::base::Action;

--- a/crates/rlevo-environments/src/locomotion/inverted_pendulum/mod.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_pendulum/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Physics note
 //!
-//! This env simulates dynamics via Rapier3D, not MuJoCo. Observation shape,
+//! This env simulates dynamics via `Rapier3D`, not `MuJoCo`. Observation shape,
 //! action dimensionality, reward structure, and termination conditions match
 //! Gymnasium v5 exactly. **Absolute reward values, learned policies, and
 //! trained scores will NOT transfer to real Gymnasium/MuJoCo benchmarks

--- a/crates/rlevo-environments/src/locomotion/mod.rs
+++ b/crates/rlevo-environments/src/locomotion/mod.rs
@@ -1,6 +1,6 @@
 //! # MuJoCo-style locomotion environments
 //!
-//! Eleven continuous-control environments modelled on the Gymnasium v5 MuJoCo
+//! Eleven continuous-control environments modelled on the Gymnasium v5 `MuJoCo`
 //! suite, ported to the pure-Rust [`rapier3d`] physics engine. Enable with:
 //!
 //! ```toml
@@ -9,7 +9,7 @@
 //!
 //! ## Physics note
 //!
-//! This module simulates via Rapier3D, **not MuJoCo**. Observation shapes,
+//! This module simulates via `Rapier3D`, **not `MuJoCo`**. Observation shapes,
 //! action dimensions, reward structure, and termination conditions match
 //! Gymnasium v5. Absolute reward values, learned policies, and published
 //! benchmark scores **will not transfer** to real Gymnasium/MuJoCo without

--- a/crates/rlevo-environments/src/locomotion/reacher/config.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/config.rs
@@ -12,7 +12,7 @@ use crate::locomotion::common::Gear;
 /// Environment configuration for [`super::Reacher`].
 ///
 /// Defaults match the Gymnasium v5 reacher XML: gear `[200, 200]`, dt 0.01,
-/// frame_skip 2 (env dt = 0.02), reset noise 0.1, ctrl-cost weight 0.1,
+/// `frame_skip` 2 (env dt = 0.02), reset noise 0.1, ctrl-cost weight 0.1,
 /// target-disk radius 0.2, truncation at 50.
 #[derive(Debug, Clone)]
 pub struct ReacherConfig {

--- a/crates/rlevo-environments/src/locomotion/reacher/env.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/env.rs
@@ -330,7 +330,7 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
     /// Returns [`EnvironmentError::InvalidAction`] if either action element is
     /// non-finite (`NaN` or ±∞).
     fn step(&mut self, action: ReacherAction) -> Result<Self::SnapshotType, EnvironmentError> {
-        if !action.0.iter().all(rapier2d::math::ComplexField::is_finite) {
+        if !action.0.iter().copied().all(f32::is_finite) {
             return Err(EnvironmentError::InvalidAction(format!(
                 "Reacher action must be finite, got {:?}",
                 action.0

--- a/crates/rlevo-environments/src/locomotion/reacher/env.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/env.rs
@@ -1,6 +1,6 @@
 //! [`Reacher`] environment — `Environment` implementation and world builder.
 //!
-//! This module wires the Rapier3D physics backend to the `rlevo-core`
+//! This module wires the `Rapier3D` physics backend to the `rlevo-core`
 //! `Environment` trait. The public entry-points are:
 //!
 //! - [`Reacher::with_config`] — construct from an explicit [`ReacherConfig`].
@@ -13,7 +13,6 @@ use std::marker::PhantomData;
 
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
-use rapier3d::math::Vector;
 use rapier3d::prelude::*;
 use rlevo_core::config::{ConfigError, Validate};
 use rlevo_core::environment::{
@@ -246,7 +245,7 @@ impl Reacher<Rapier3DBackend> {
     /// Compute the two joint torques for `action` (clip → gear). Pure: the
     /// torques are *applied* inside the `step_actuated` closure so they are
     /// re-applied fresh each substep (ADR 0037 force-lifetime contract).
-    fn control_torques(&self, action: &ReacherAction) -> [f32; 2] {
+    fn control_torques(&self, action: ReacherAction) -> [f32; 2] {
         let (lo, hi): (f32, f32) = self.config.action_clip.into();
         let clipped = [action.0[0].clamp(lo, hi), action.0[1].clamp(lo, hi)];
         self.config.gear.apply(&clipped)
@@ -331,7 +330,7 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
     /// Returns [`EnvironmentError::InvalidAction`] if either action element is
     /// non-finite (`NaN` or ±∞).
     fn step(&mut self, action: ReacherAction) -> Result<Self::SnapshotType, EnvironmentError> {
-        if !action.0.iter().all(|v| v.is_finite()) {
+        if !action.0.iter().all(rapier2d::math::ComplexField::is_finite) {
             return Err(EnvironmentError::InvalidAction(format!(
                 "Reacher action must be finite, got {:?}",
                 action.0
@@ -360,7 +359,7 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
         // ⇒ counterclockwise, unchanged. The env owns and constructed both
         // joints as `+Z` revolute impulse joints, so a non-revolute/stale-handle
         // error would be a programming error (docs/rules.md §4) — hence `expect`.
-        let torques = self.control_torques(&action);
+        let torques = self.control_torques(action);
         let shoulder: Rapier3DJointHandle = self.state.shoulder.into();
         let elbow: Rapier3DJointHandle = self.state.elbow.into();
         self.world.step_actuated(|w| {
@@ -410,6 +409,12 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::base::Action;
     use rlevo_core::base::Observation;
@@ -462,8 +467,6 @@ mod tests {
                 ..Default::default()
             }
         }
-        let narrow = rlevo_core::bounds::Bounds::new(-0.5, 0.5);
-
         fn rollout(config: ReacherConfig, action: ReacherAction) -> [f32; 10] {
             let mut env = ReacherRapier::with_config(config).expect("valid config");
             env.reset().expect("reset");
@@ -472,6 +475,8 @@ mod tests {
                 .observation()
                 .0
         }
+
+        let narrow = rlevo_core::bounds::Bounds::new(-0.5, 0.5);
 
         // The static space's corner, under the narrowed clip.
         let at_boundary = rollout(cfg_with(narrow), ReacherAction::new(-1.0, 1.0));

--- a/crates/rlevo-environments/src/locomotion/reacher/mod.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Physics note
 //!
-//! This env simulates dynamics via Rapier3D, not MuJoCo. Observation shape,
+//! This env simulates dynamics via `Rapier3D`, not `MuJoCo`. Observation shape,
 //! action dimensionality, reward structure, and termination conditions match
 //! Gymnasium v5 exactly. **Absolute reward values, learned policies, and
 //! trained scores will NOT transfer to real Gymnasium/MuJoCo benchmarks
@@ -41,7 +41,7 @@
 //!
 //! ## Divergence from Gymnasium-v5 dynamics
 //!
-//! Gymnasium's reacher XML stabilises the tiny-inertia links via MuJoCo joint
+//! Gymnasium's reacher XML stabilises the tiny-inertia links via `MuJoCo` joint
 //! `armature` and `damping`, neither of which has a direct Rapier equivalent.
 //! With literal gear `[200, 200]` and per-link mass `0.0356`, a **random-policy
 //! rollout** drives the arm into highly non-physical velocities and distances;

--- a/crates/rlevo-environments/src/locomotion/reacher/observation.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/observation.rs
@@ -21,7 +21,7 @@ impl ReacherObservation {
         self.0[0]
     }
 
-    /// Cosine of the elbow (link 2) **relative** angle θ₂ = θ_world2 − θ₁,
+    /// Cosine of the elbow (link 2) **relative** angle θ₂ = `θ_world2` − θ₁,
     /// wrapped to `(-π, π]`. Index 1.
     #[must_use]
     pub const fn theta2_cos(&self) -> f32 {
@@ -54,7 +54,7 @@ impl ReacherObservation {
         self.0[6]
     }
 
-    /// Elbow **relative** angular velocity θ̇₂ = ω_link2 − ω_link1 in
+    /// Elbow **relative** angular velocity θ̇₂ = `ω_link2` − `ω_link1` in
     /// rad s⁻¹. Index 7.
     #[must_use]
     pub const fn theta2_dot(&self) -> f32 {

--- a/crates/rlevo-environments/src/locomotion/reacher/state.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/state.rs
@@ -1,6 +1,6 @@
 //! Physics state for the [`super::Reacher`] environment.
 //!
-//! [`ReacherState`] holds the Rapier3D handles needed to read and drive the
+//! [`ReacherState`] holds the `Rapier3D` handles needed to read and drive the
 //! simulation, plus a small amount of data that the environment caches between
 //! steps for observation extraction. The `Rapier3DWorld` itself lives on the
 //! [`super::Reacher`] struct because it is not `Clone`.
@@ -19,8 +19,8 @@ pub struct ReacherState {
     /// the shoulder angle θ₁; its angular velocity gives θ̇₁.
     pub link1: RigidBodyHandle,
     /// Handle to the link 2 (forearm) rigid body. Its orientation encodes
-    /// the world-frame angle θ_world2; the relative elbow angle is
-    /// θ₂ = θ_world2 − θ₁. The fingertip lies at body-local `(+link2_length/2, 0, 0)`.
+    /// the world-frame angle `θ_world2`; the relative elbow angle is
+    /// θ₂ = `θ_world2` − θ₁. The fingertip lies at body-local `(+link2_length/2, 0, 0)`.
     pub link2: RigidBodyHandle,
     /// Handle to the fixed target body. Its world-frame translation is
     /// `[target_xy[0], target_xy[1], 0.0]`.

--- a/crates/rlevo-environments/src/locomotion/swimmer/config.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/config.rs
@@ -53,7 +53,7 @@ pub struct SwimmerConfig {
     /// The term is **linear** in `ω` (not quadratic) because explicit-Euler
     /// integration of quadratic drag diverges at the angular velocities
     /// reachable under sustained actuation in a zero-gravity free-floating
-    /// chain. MuJoCo uses an implicit integrator and can afford quadratic
+    /// chain. `MuJoCo` uses an implicit integrator and can afford quadratic
     /// angular drag; this is a Rapier-compatibility divergence. Default `0.2`.
     pub angular_drag_coefficient: f32,
     /// Half-length of each capsule segment along the body-x axis. Default
@@ -62,7 +62,7 @@ pub struct SwimmerConfig {
     /// Radius of each capsule segment. Default `0.05`.
     pub segment_radius: f32,
     /// Mass of each segment in kg. Used to compute capsule density so that
-    /// the inertia tensor is non-zero. Default `0.947` (MuJoCo body density
+    /// the inertia tensor is non-zero. Default `0.947` (`MuJoCo` body density
     /// 1000 kg/m³ × capsule volume).
     pub segment_mass: f32,
 }

--- a/crates/rlevo-environments/src/locomotion/swimmer/env.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/env.rs
@@ -13,7 +13,6 @@ use std::marker::PhantomData;
 
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
-use rapier3d::math::Vector;
 use rapier3d::prelude::*;
 use rlevo_core::config::{ConfigError, Validate};
 use rlevo_core::environment::{
@@ -54,7 +53,7 @@ pub struct Swimmer<B: LocomotionBackend = Rapier3DBackend> {
     _marker: PhantomData<B>,
 }
 
-/// Convenience alias: [`Swimmer`] using the Rapier3D backend.
+/// Convenience alias: [`Swimmer`] using the `Rapier3D` backend.
 ///
 /// This is the recommended concrete type for all production use.
 pub type SwimmerRapier = Swimmer<Rapier3DBackend>;
@@ -99,6 +98,8 @@ impl Swimmer<Rapier3DBackend> {
         self.reset()
     }
 
+    // Justified: paired per-axis/per-joint initial values differ only by axis or index.
+    #[allow(clippy::similar_names)]
     fn build_world(config: &SwimmerConfig, rng: &mut StdRng) -> (Rapier3DWorld, SwimmerState) {
         // Zero gravity — swimmer floats in open water.
         // The world owns the `frame_skip` substep loop; `step_physics` drives it
@@ -261,7 +262,7 @@ impl Swimmer<Rapier3DBackend> {
     /// canonical Swimmer-v5 value (`gear [150, 150]`) is deferred to a follow-up
     /// issue — #98 fixes only force accumulation and must not silently change
     /// gear.
-    fn control_torques(&self, action: &SwimmerAction) -> [f32; 2] {
+    fn control_torques(&self, action: SwimmerAction) -> [f32; 2] {
         let (lo, hi): (f32, f32) = self.config.action_clip.into();
         let clipped = [action.0[0].clamp(lo, hi), action.0[1].clamp(lo, hi)];
         self.config.gear.apply(&clipped)
@@ -277,7 +278,7 @@ impl Swimmer<Rapier3DBackend> {
     /// substep. Accordingly:
     ///   * the actuator torque (`torques`) is held **constant** across the
     ///     frame skip — the same magnitude re-applied each substep, matching
-    ///     MuJoCo's `ctrl`-held-across-substeps semantics;
+    ///     `MuJoCo`'s `ctrl`-held-across-substeps semantics;
     ///   * viscous drag is recomputed each substep from the segments' **current**
     ///     velocity, so it tracks the chain as it accelerates within the step.
     ///
@@ -394,14 +395,14 @@ impl Environment<1, 1, 1> for Swimmer<Rapier3DBackend> {
     /// Returns [`EnvironmentError::InvalidAction`] if any element of `action`
     /// is non-finite (`NaN` or `±∞`).
     fn step(&mut self, action: SwimmerAction) -> Result<Self::SnapshotType, EnvironmentError> {
-        if !action.0.iter().all(|v| v.is_finite()) {
+        if !action.0.iter().all(rapier2d::math::ComplexField::is_finite) {
             return Err(EnvironmentError::InvalidAction(format!(
                 "Swimmer action must be finite, got {:?}",
                 action.0
             )));
         }
 
-        let torques = self.control_torques(&action);
+        let torques = self.control_torques(action);
         self.step_physics(torques);
         self.steps += 1;
 
@@ -454,7 +455,7 @@ fn segment_z_angle(orientation: [f32; 4]) -> f32 {
 /// quadratic drag is `k_ang · |ω| · dt / I < 1`: at gear=150 the chain reaches
 /// `|ω|` in the 100s of rad/s, which drives quadratic drag unstable and diverges
 /// to NaN in one substep. Linear drag is unconditionally stable as long as
-/// `k_ang · dt / I < 2`. MuJoCo's own swimmer uses quadratic drag but with an
+/// `k_ang · dt / I < 2`. `MuJoCo`'s own swimmer uses quadratic drag but with an
 /// implicit integrator; our linear variant is a Rapier-compatibility divergence.
 ///
 /// Free function (not a `&mut self` method) so it can be invoked from inside a
@@ -477,6 +478,12 @@ fn apply_drag_to(world: &mut Rapier3DWorld, handles: [RigidBodyHandle; 3], k: f3
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::base::Action;
     use rlevo_core::base::Observation;
@@ -544,8 +551,6 @@ mod tests {
                 ..Default::default()
             }
         }
-        let narrow = rlevo_core::bounds::Bounds::new(-0.5, 0.5);
-
         fn rollout(config: SwimmerConfig, action: SwimmerAction) -> [f32; 8] {
             let mut env = SwimmerRapier::with_config(config).expect("valid config");
             env.reset().expect("reset");
@@ -554,6 +559,8 @@ mod tests {
                 .observation()
                 .0
         }
+
+        let narrow = rlevo_core::bounds::Bounds::new(-0.5, 0.5);
 
         // The static space's corner, under the narrowed clip.
         let at_boundary = rollout(cfg_with(narrow), SwimmerAction::new(-1.0, 1.0));

--- a/crates/rlevo-environments/src/locomotion/swimmer/env.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/env.rs
@@ -395,7 +395,7 @@ impl Environment<1, 1, 1> for Swimmer<Rapier3DBackend> {
     /// Returns [`EnvironmentError::InvalidAction`] if any element of `action`
     /// is non-finite (`NaN` or `±∞`).
     fn step(&mut self, action: SwimmerAction) -> Result<Self::SnapshotType, EnvironmentError> {
-        if !action.0.iter().all(rapier2d::math::ComplexField::is_finite) {
+        if !action.0.iter().copied().all(f32::is_finite) {
             return Err(EnvironmentError::InvalidAction(format!(
                 "Swimmer action must be finite, got {:?}",
                 action.0

--- a/crates/rlevo-environments/src/locomotion/swimmer/mod.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Physics note
 //!
-//! This env simulates dynamics via Rapier3D, not MuJoCo. Observation shape,
+//! This env simulates dynamics via `Rapier3D`, not `MuJoCo`. Observation shape,
 //! action dimensionality, reward structure, and termination conditions match
 //! Gymnasium v5 exactly. **Absolute reward values, learned policies, and
 //! trained scores will NOT transfer to real Gymnasium/MuJoCo benchmarks
@@ -13,7 +13,7 @@
 //! Three cylindrical segments chained in series (front → middle → tail),
 //! constrained to the world xy-plane with gravity disabled. Two revolute-z
 //! impulse joints actuate the chain; per-segment viscous drag substitutes for
-//! MuJoCo's native fluid model.
+//! `MuJoCo`'s native fluid model.
 //!
 //! * Segment shape: capsule along body-x, length `0.1`, radius `0.05`, mass
 //!   `≈0.0471` (density ≈60 kg/m³ derived from capsule volume). The capsule
@@ -44,7 +44,7 @@
 //! `F = −k · v · ‖v‖` before every physics substep, where `k` is
 //! `drag_coefficient` (default `0.1`). The env owns its own `frame_skip`
 //! loop so drag is applied on every substep, not once per env step; this is
-//! required for numerical stability and to match the Gymnasium frame_skip
+//! required for numerical stability and to match the Gymnasium `frame_skip`
 //! semantics. If/when a second locomotion env needs viscous drag, the pattern
 //! can be promoted to a backend-level hook.
 //!
@@ -65,9 +65,9 @@
 //! * **Smaller substep:** `dt = 0.005`, `frame_skip = 8` → env dt 0.04 still
 //!   matches Gymnasium; the integration step is halved to keep per-step
 //!   Δω tractable.
-//! * **`segment_mass = 0.947 kg`** from MuJoCo's body density (1000 kg/m³)
+//! * **`segment_mass = 0.947 kg`** from `MuJoCo`'s body density (1000 kg/m³)
 //!   applied to the capsule volume; using 0.0471 kg (as Gymnasium-derived
-//!   calculations sometimes produce by crossing body density with MuJoCo's
+//!   calculations sometimes produce by crossing body density with `MuJoCo`'s
 //!   fluid `<option density>`) gives negligible inertia.
 //! * **Linear angular drag** `τ = −k_ang · ω`, not quadratic. Explicit
 //!   Euler on quadratic drag overshoots past zero at high |ω| and

--- a/crates/rlevo-environments/src/locomotion/swimmer/state.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/state.rs
@@ -13,7 +13,7 @@ use super::observation::SwimmerObservation;
 /// a stiff problem for the PGS impulse solver, which injects kinetic energy
 /// when constraint drift is corrected aggressively. The Featherstone-style
 /// multibody solver parameterises the chain in reduced coordinates
-/// (analogous to MuJoCo's generalised coordinates) and stays conservative.
+/// (analogous to `MuJoCo`'s generalised coordinates) and stays conservative.
 #[derive(Debug, Clone)]
 pub struct SwimmerState {
     pub segment0: RigidBodyHandle,

--- a/crates/rlevo-environments/src/pixel_grid.rs
+++ b/crates/rlevo-environments/src/pixel_grid.rs
@@ -200,6 +200,11 @@ impl PixelGridState {
     /// Agent and goal are distinguished by **glyph** (`@` / `*`) as well as
     /// color in the pixel projection — never color alone — so the frame is
     /// legible without color perception. Agent-on-goal renders `@`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a cell index exceeds `u32::MAX`. `CELL_COUNT` is a compile-time
+    /// constant far below that bound, so this is unreachable in practice.
     #[must_use]
     pub fn render_ascii(&self) -> String {
         let mut out = String::with_capacity(CELL_COUNT * 2);
@@ -720,6 +725,12 @@ impl Environment<3, 1, 1> for PixelGridEnv {
 
 #[cfg(test)]
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::environment::{EpisodeStatus, Snapshot};

--- a/crates/rlevo-environments/src/toy_text/blackjack.rs
+++ b/crates/rlevo-environments/src/toy_text/blackjack.rs
@@ -150,6 +150,7 @@ impl Default for BlackjackConfig {
 
 impl BlackjackConfig {
     /// Returns a builder for constructing a `BlackjackConfig`.
+    #[must_use]
     pub fn builder() -> BlackjackConfigBuilder {
         BlackjackConfigBuilder::default()
     }
@@ -164,7 +165,7 @@ impl Validate for BlackjackConfig {
 }
 
 /// Builder for [`BlackjackConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct BlackjackConfigBuilder {
     variant: BlackjackVariant,
     seed: u64,
@@ -172,18 +173,21 @@ pub struct BlackjackConfigBuilder {
 
 impl BlackjackConfigBuilder {
     /// Sets the rule variant.
+    #[must_use]
     pub fn variant(mut self, v: BlackjackVariant) -> Self {
         self.variant = v;
         self
     }
 
     /// Sets the RNG seed.
+    #[must_use]
     pub fn seed(mut self, s: u64) -> Self {
         self.seed = s;
         self
     }
 
     /// Builds the [`BlackjackConfig`].
+    #[must_use]
     pub fn build(self) -> BlackjackConfig {
         BlackjackConfig {
             variant: self.variant,
@@ -539,10 +543,13 @@ impl rlevo_core::render::payload::TabularPayloadSource for Blackjack {
 #[cfg(test)]
 /// Unit tests for [`Blackjack`], covering actions, observations, rewards, and RNG determinism.
 mod tests {
+    // Blackjack rewards are exact sentinels written as literals (-1.0, 0.0,
+    // +1.0) and pass through no arithmetic, so bit-exact equality is the
+    // property under test; an approximate compare would weaken these.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use crate::episode::assert_rejects_post_terminal_step;
-    use rlevo_core::action::DiscreteAction;
-    use rlevo_core::base::Observation;
     use rlevo_core::environment::EpisodeStatus;
 
     fn make_env() -> Blackjack {

--- a/crates/rlevo-environments/src/toy_text/cliff_walking.rs
+++ b/crates/rlevo-environments/src/toy_text/cliff_walking.rs
@@ -92,6 +92,7 @@ pub struct CliffWalkingConfig {
 
 impl CliffWalkingConfig {
     /// Returns a builder for constructing a `CliffWalkingConfig`.
+    #[must_use]
     pub fn builder() -> CliffWalkingConfigBuilder {
         CliffWalkingConfigBuilder::default()
     }
@@ -106,7 +107,7 @@ impl Validate for CliffWalkingConfig {
 }
 
 /// Builder for [`CliffWalkingConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CliffWalkingConfigBuilder {
     is_slippery: bool,
     seed: u64,
@@ -114,18 +115,21 @@ pub struct CliffWalkingConfigBuilder {
 
 impl CliffWalkingConfigBuilder {
     /// Enables or disables the stochastic slipping behaviour.
+    #[must_use]
     pub fn is_slippery(mut self, v: bool) -> Self {
         self.is_slippery = v;
         self
     }
 
     /// Sets the RNG seed.
+    #[must_use]
     pub fn seed(mut self, s: u64) -> Self {
         self.seed = s;
         self
     }
 
     /// Builds the [`CliffWalkingConfig`].
+    #[must_use]
     pub fn build(self) -> CliffWalkingConfig {
         CliffWalkingConfig {
             is_slippery: self.is_slippery,
@@ -147,22 +151,22 @@ pub struct CliffWalkingState {
 
 impl CliffWalkingState {
     fn state_id(&self) -> u16 {
-        self.row as u16 * NCOL as u16 + self.col as u16
+        u16::from(self.row) * u16::from(NCOL) + u16::from(self.col)
     }
 }
 
 impl TryFrom<u16> for CliffWalkingState {
     type Error = StateError;
     fn try_from(id: u16) -> Result<Self, Self::Error> {
-        let n = NROW as u16 * NCOL as u16;
+        let n = u16::from(NROW) * u16::from(NCOL);
         if id >= n {
             return Err(StateError::InvalidData(format!(
                 "CliffWalkingState id {id} out of range [0, {n})"
             )));
         }
         Ok(CliffWalkingState {
-            row: (id / NCOL as u16) as u8,
-            col: (id % NCOL as u16) as u8,
+            row: (id / u16::from(NCOL)) as u8,
+            col: (id % u16::from(NCOL)) as u8,
         })
     }
 }
@@ -544,10 +548,14 @@ impl rlevo_core::render::payload::TabularPayloadSource for CliffWalking {
 /// Unit tests for [`CliffWalking`], covering state encoding, cliff/goal transitions,
 /// boundary behaviour, slippery distributions, and RNG determinism.
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use crate::episode::assert_rejects_post_terminal_step;
-    use rlevo_core::action::DiscreteAction;
-    use rlevo_core::base::Observation;
     use rlevo_core::environment::{EpisodeStatus, Snapshot};
 
     fn make_env() -> CliffWalking {
@@ -584,7 +592,7 @@ mod tests {
     #[test]
     /// Verifies that state-id encoding and decoding are mutual inverses for all 48 states.
     fn state_id_encoding() {
-        let total = NROW as u16 * NCOL as u16;
+        let total = u16::from(NROW) * u16::from(NCOL);
         for id in 0..total {
             let state = CliffWalkingState::try_from(id).unwrap();
             assert_eq!(u16::from(state), id, "round-trip failed for id {id}");

--- a/crates/rlevo-environments/src/toy_text/frozen_lake.rs
+++ b/crates/rlevo-environments/src/toy_text/frozen_lake.rs
@@ -193,6 +193,7 @@ impl Default for FrozenLakeConfig {
 
 impl FrozenLakeConfig {
     /// Returns a builder for constructing a `FrozenLakeConfig`.
+    #[must_use]
     pub fn builder() -> FrozenLakeConfigBuilder {
         FrozenLakeConfigBuilder::default()
     }
@@ -207,7 +208,7 @@ impl Validate for FrozenLakeConfig {
 }
 
 /// Builder for [`FrozenLakeConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct FrozenLakeConfigBuilder {
     map: Option<FrozenMapSpec>,
     is_slippery: bool,
@@ -218,12 +219,14 @@ pub struct FrozenLakeConfigBuilder {
 
 impl FrozenLakeConfigBuilder {
     /// Sets the grid source: preset, custom, or randomly generated.
+    #[must_use]
     pub fn map(mut self, m: FrozenMapSpec) -> Self {
         self.map = Some(m);
         self
     }
 
     /// Enables or disables stochastic slip transitions.
+    #[must_use]
     pub fn is_slippery(mut self, v: bool) -> Self {
         self.is_slippery = v;
         self
@@ -232,24 +235,28 @@ impl FrozenLakeConfigBuilder {
     /// Sets the probability of moving in the intended direction when slippery mode is active.
     ///
     /// The two perpendicular directions each receive probability `(1 − rate) / 2`. Default: `1/3`.
+    #[must_use]
     pub fn success_rate(mut self, r: f32) -> Self {
         self.success_rate = Some(r);
         self
     }
 
     /// Overrides the per-tile reward values.
+    #[must_use]
     pub fn reward_schedule(mut self, rs: RewardSchedule) -> Self {
         self.reward_schedule = Some(rs);
         self
     }
 
     /// Sets the RNG seed.
+    #[must_use]
     pub fn seed(mut self, s: u64) -> Self {
         self.seed = s;
         self
     }
 
     /// Builds the [`FrozenLakeConfig`].
+    #[must_use]
     pub fn build(self) -> FrozenLakeConfig {
         FrozenLakeConfig {
             map: self.map.unwrap_or_default(),
@@ -376,7 +383,7 @@ fn generate_random_map(
         let mut tiles = vec![Tile::Frozen; nrow * ncol];
         tiles[0] = Tile::Start;
         tiles[nrow * ncol - 1] = Tile::Goal;
-        for tile in tiles[1..nrow * ncol - 1].iter_mut() {
+        for tile in &mut tiles[1..nrow * ncol - 1] {
             if rng.random_range(0.0f32..1.0) >= frozen_prob {
                 *tile = Tile::Hole;
             }
@@ -411,22 +418,22 @@ pub struct FrozenLakeState {
 
 impl FrozenLakeState {
     fn state_id(&self) -> u16 {
-        self.row as u16 * self.ncol as u16 + self.col as u16
+        u16::from(self.row) * u16::from(self.ncol) + u16::from(self.col)
     }
 }
 
 impl TryFrom<(u16, u8, u8)> for FrozenLakeState {
     type Error = StateError;
     fn try_from((id, nrow, ncol): (u16, u8, u8)) -> Result<Self, Self::Error> {
-        let n = nrow as u16 * ncol as u16;
+        let n = u16::from(nrow) * u16::from(ncol);
         if id >= n {
             return Err(StateError::InvalidData(format!(
                 "FrozenLakeState id {id} out of [0,{n})"
             )));
         }
         Ok(FrozenLakeState {
-            row: (id / ncol as u16) as u8,
-            col: (id % ncol as u16) as u8,
+            row: (id / u16::from(ncol)) as u8,
+            col: (id % u16::from(ncol)) as u8,
             nrow,
             ncol,
         })
@@ -459,7 +466,7 @@ impl Observation<1> for FrozenLakeObservation {
     }
 }
 
-/// Four-direction action space matching Gymnasium's FrozenLake ordering.
+/// Four-direction action space matching Gymnasium's `FrozenLake` ordering.
 ///
 /// Movements are clamped at grid boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -585,7 +592,7 @@ impl FrozenLake {
             FrozenMapSpec::Preset(FrozenPreset::Four4x4) => parse_map(MAP_4X4),
             FrozenMapSpec::Preset(FrozenPreset::Eight8x8) => parse_map(MAP_8X8),
             FrozenMapSpec::Custom(rows) => {
-                let refs: Vec<&str> = rows.iter().map(|s| s.as_str()).collect();
+                let refs: Vec<&str> = rows.iter().map(std::string::String::as_str).collect();
                 parse_map(&refs)
             }
             FrozenMapSpec::Random {
@@ -867,9 +874,13 @@ impl rlevo_core::render::payload::TabularPayloadSource for FrozenLake {
 /// Unit tests for [`FrozenLake`], covering map validation, tile transitions,
 /// reward customisation, slippery distributions, random map generation, and determinism.
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
-    use rlevo_core::action::DiscreteAction;
-    use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
 
     #[test]

--- a/crates/rlevo-environments/src/toy_text/taxi.rs
+++ b/crates/rlevo-environments/src/toy_text/taxi.rs
@@ -60,7 +60,7 @@ use serde::{Deserialize, Serialize};
 /// Named pickup/dropoff locations: R=(0,0), G=(0,4), Y=(4,0), B=(4,3).
 const LOCS: [(u8, u8); 4] = [(0, 0), (0, 4), (4, 0), (4, 3)];
 
-/// Walls between adjacent cells (East–West only; all represented as (row, min_col, max_col)).
+/// Walls between adjacent cells (East–West only; all represented as (row, `min_col`, `max_col`)).
 /// A wall blocks movement between `(row, min_col)` and `(row, max_col)`.
 const WALLS: &[(u8, u8, u8)] = &[
     (0, 1, 2),
@@ -112,6 +112,7 @@ pub struct TaxiConfig {
 
 impl TaxiConfig {
     /// Returns a builder for constructing a `TaxiConfig`.
+    #[must_use]
     pub fn builder() -> TaxiConfigBuilder {
         TaxiConfigBuilder::default()
     }
@@ -126,7 +127,7 @@ impl Validate for TaxiConfig {
 }
 
 /// Builder for [`TaxiConfig`].
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct TaxiConfigBuilder {
     is_rainy: bool,
     fickle_passenger: bool,
@@ -135,24 +136,28 @@ pub struct TaxiConfigBuilder {
 
 impl TaxiConfigBuilder {
     /// Enables or disables rainy stochastic transitions.
+    #[must_use]
     pub fn is_rainy(mut self, v: bool) -> Self {
         self.is_rainy = v;
         self
     }
 
     /// Enables or disables fickle-passenger destination resampling.
+    #[must_use]
     pub fn fickle_passenger(mut self, v: bool) -> Self {
         self.fickle_passenger = v;
         self
     }
 
     /// Sets the RNG seed.
+    #[must_use]
     pub fn seed(mut self, s: u64) -> Self {
         self.seed = s;
         self
     }
 
     /// Builds the [`TaxiConfig`].
+    #[must_use]
     pub fn build(self) -> TaxiConfig {
         TaxiConfig {
             is_rainy: self.is_rainy,
@@ -179,8 +184,10 @@ pub struct TaxiState {
 
 impl TaxiState {
     fn encode(&self) -> u16 {
-        ((self.taxi_row as u16 * 5 + self.taxi_col as u16) * 5 + self.passenger_loc as u16) * 4
-            + self.destination as u16
+        ((u16::from(self.taxi_row) * 5 + u16::from(self.taxi_col)) * 5
+            + u16::from(self.passenger_loc))
+            * 4
+            + u16::from(self.destination)
     }
 }
 
@@ -299,7 +306,14 @@ impl TaxiAction {
             TaxiAction::North => [TaxiAction::West, TaxiAction::East],
             TaxiAction::East => [TaxiAction::North, TaxiAction::South],
             TaxiAction::West => [TaxiAction::South, TaxiAction::North],
-            _ => [TaxiAction::North, TaxiAction::South], // unused
+            // `perpendiculars` has exactly one caller, `resolve_movement`, which
+            // is itself reached only from the movement branch of `step`. A
+            // non-movement action here means that invariant broke, so say so
+            // instead of returning a filler pair that would silently slip a
+            // Pickup into a North.
+            TaxiAction::Pickup | TaxiAction::Dropoff => {
+                unreachable!("perpendiculars is only defined for movement actions")
+            }
         }
     }
 }
@@ -390,12 +404,10 @@ impl Taxi {
             return action;
         }
         let r = self.rng.random_range(0u32..10);
-        if r < 8 {
-            action
-        } else if r == 8 {
-            action.perpendiculars()[0]
-        } else {
-            action.perpendiculars()[1]
+        match r.cmp(&8) {
+            std::cmp::Ordering::Less => action,
+            std::cmp::Ordering::Equal => action.perpendiculars()[0],
+            std::cmp::Ordering::Greater => action.perpendiculars()[1],
         }
     }
 }
@@ -729,11 +741,15 @@ impl rlevo_core::render::payload::TabularPayloadSource for Taxi {
 /// Unit tests for [`Taxi`], covering state encoding, wall collisions, pickup/dropoff rewards,
 /// stochastic modes, and RNG determinism.
 mod tests {
+    // Exact comparison is intentional throughout this test module: the values
+    // are literals or seeds read back without arithmetic, or two identically
+    // seeded runs that must agree bit-for-bit. A tolerance would let a real
+    // regression pass. Reviewed as a class, not site-by-site.
+    #![allow(clippy::float_cmp)]
+
     use super::*;
     use crate::episode::assert_rejects_post_terminal_step;
-    use rlevo_core::action::DiscreteAction;
-    use rlevo_core::base::Observation;
-    use rlevo_core::environment::{EpisodeStatus, Snapshot};
+    use rlevo_core::environment::EpisodeStatus;
 
     fn make_env() -> Taxi {
         Taxi::with_config(TaxiConfig::default()).expect("valid config")
@@ -1010,8 +1026,6 @@ mod tests {
     /// `check()?` precedes the rainy-slip draw, so two identically seeded envs stay
     /// in lock-step even when one of them is stepped after its episode ended.
     fn test_taxi_rejected_post_terminal_step_does_not_advance_rng() {
-        let cfg = TaxiConfig::builder().is_rainy(true).seed(99).build();
-
         // A full rainy trajectory of state ids, driven purely by the RNG stream.
         fn trajectory(env: &mut Taxi) -> Vec<u16> {
             env.reset().expect("reset must succeed");
@@ -1026,6 +1040,7 @@ mod tests {
             ids
         }
 
+        let cfg = TaxiConfig::builder().is_rainy(true).seed(99).build();
         let mut probed = Taxi::with_config(cfg.clone()).expect("valid config");
         let mut clean = Taxi::with_config(cfg).expect("valid config");
 

--- a/crates/rlevo-environments/src/wrappers/time_limit.rs
+++ b/crates/rlevo-environments/src/wrappers/time_limit.rs
@@ -187,8 +187,8 @@ mod tests {
     use super::*;
     use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::{
-        base::{Action, Observation, State},
-        environment::{Environment, EnvironmentError, EpisodeStatus, Snapshot, SnapshotBase},
+        base::{Action, State},
+        environment::Snapshot,
         reward::ScalarReward,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/rlevo-environments/tests/pixel_grid_modality.rs
+++ b/crates/rlevo-environments/tests/pixel_grid_modality.rs
@@ -1,3 +1,7 @@
+// Exact comparison is intentional: the asserted rewards are literal
+// constants produced without arithmetic.
+#![allow(clippy::float_cmp)]
+
 //! Single-crate proof that [`PixelGridEnv`] exposes a modality-changing
 //! observation: the snapshot the agent receives is a rank-3 `[20, 20, 3]` RGB
 //! image while the underlying state is rank-1 `[2]` (issue #65, ADR 0019/0020).

--- a/crates/rlevo-environments/tests/render_coverage.rs
+++ b/crates/rlevo-environments/tests/render_coverage.rs
@@ -1,7 +1,7 @@
 //! Cross-family regression guard for `AsciiRenderable` coverage.
 //!
 //! Every public env in the five in-scope 2D families (classic, grids,
-//! toy_text, landscapes, box2d) implements [`AsciiRenderable`]. This
+//! `toy_text`, landscapes, box2d) implements [`AsciiRenderable`]. This
 //! integration test enumerates one representative env per family — and
 //! one of every box2d variant since they share no parent type — and
 //! asserts the rendering contract:


### PR DESCRIPTION
Third crate in the #391 burn-down. Independent of #394 (`rlevo-core`) and #395 (`rlevo-hybrid`) — branched off `main`, disjoint files, merges in any order.

## Correction to earlier triage

I previously reported this crate as "4 `missing_debug_implementations` + 11 `redundant_imports`", including in #395's description. **That was wrong.** It came from the same non-selectable lint subset I already retracted on #391. The real figure with the opt-in applied is **876 warnings** — this is the *largest* crate in the burn-down, not the smallest. `rlevo-reinforcement-learning` (422) is second.

## Scope: complete except the cast family

825 warnings are fixed outright. The remaining **194 production numeric casts** are suppressed by a single documented crate-level `#![allow]` in `src/lib.rs`, tracked in **#396**.

That split is deliberate. These casts are in physics, rasterizer, and grid-indexing paths where each needs a verified range argument at the site (*is this `f32` provably non-negative before `as usize`?*). Attaching a confident-sounding per-site justification without doing that verification would be worse than one honest crate-level allow: it would read as audited while providing no more safety. Every other lint in the workspace table is enforced on this crate as of this PR.

## Substantive changes worth review

**`TaxiAction::perpendiculars` now panics on non-movement actions.** The old `_ => [North, South] // unused` arm returned a filler pair. The function has exactly one caller, `resolve_movement`, itself reached only from the movement branch of `step` — I verified there is no other call site in the crate. A Pickup reaching it means that invariant broke, and silently slipping it into a North is the wrong failure mode. This is the one behavioural change in the PR.

**By-value parameters.** 19 landscape `evaluate_2d` plus 10 locomotion/classic helpers now take small `Copy` arguments by value. All are private; two `MountainCarConfig` parameters stayed by-reference because the type is not `Copy` — clippy had flagged only their sibling parameter.

**`compute_reward` / `shaping` became associated functions.** Neither read `self`.

**`float_cmp` allowed per test module, with justification.** ~80 sites across 36 files. I checked every one for whether it sits outside a `#[cfg(test)]` module — exactly one does, and that file is itself an integration test. The values are literals read back without arithmetic, or two identically seeded runs that must agree bit-for-bit; a tolerance would stop testing the actual property. These were reviewed as a class rather than site-by-site, and the in-code comments say so.

**Docs.** `# Panics` sections on the four bandit `with_seed` constructors, both bench suites, and `render_ascii`; `# Errors` on `PendulumAction::new`.

## Defect found, filed, not fixed: #397

`clippy::used_underscore_binding` flagged a `_rng` field in nine grid environments. It is not a naming issue: the field is written in the constructor and in `reset`, and **never read**. The layout builders are fully deterministic — `CrossingEnv::build` computes the gap as `mid = size / 2` and never consults `config.seed` on any path.

So `CrossingConfig`'s documented promise, *"using the same seed always produces the same episode layout"*, is true and completely misleading: the layout is identical for every seed. In the Farama Minigrid originals these environments *are* randomised.

Renaming `_rng` to `rng` would have silenced the lint and left a never-sampled field beside a false doc comment. The field carries a narrow `#[allow]` pointing at #397 instead, which needs a decision — make them genuinely stochastic, or drop the seed and correct the docs.

## Verification

- `cargo clippy -p rlevo-environments --all-targets --all-features` — 0 warnings
- `cargo test -p rlevo-environments --all-features` — 1108 + 149 pass
- `cargo test --workspace --all-features` — pass
- `cargo fmt --all --check` — clean

## Remaining for #391

`rlevo-reinforcement-learning` (422). Some of it overlaps review row 8.1; it likely wants splitting by lint class rather than one PR.