### PR TITLE
chore(github): Add CODEOWNERS for owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Code owners for rlevo.
+#
+# Paired with the `primary-ruleset` repository ruleset, which sets
+# `require_code_owner_review: true` and requires 1 approving review. Together
+# these mean any pull request authored by someone other than the owner needs
+# an explicit approval from @anthonytorlucci before it can merge.
+#
+# Note: GitHub does not allow approving your own pull request, so this rule is
+# satisfiable only for contributor PRs. The owner's own PRs merge via the
+# admin bypass configured on the ruleset.
+#
+# Last matching pattern wins.
+
+# Everything.
+* @anthonytorlucci


### PR DESCRIPTION
## Context

While auditing an unrecognized contributor, we traced PR #339 — a fork PR from a
non-collaborator that merged into `main` 12 minutes after opening with zero
reviews and no confirmation that CI had finished. The change itself was benign
(dropping the mirrored `value_loss` field from `DqnMetrics`), but the path it
took in was unguarded.

Root cause is a configuration gap, not access control. `Devil1716` has no write
access; the merge was performed by the repo owner. `main` has no classic branch
protection, and the `primary-ruleset` ruleset is `disabled`.

## Change

Adds `.github/CODEOWNERS` assigning `* @anthonytorlucci`.

The `primary-ruleset` ruleset already sets `require_code_owner_review: true`, but
that rule is inert without a CODEOWNERS file — it resolves to an empty owner set,
so no review is actually demanded. This file makes the existing rule enforceable.

## This is half a gate

Landing this alone changes review *routing*, not merge *requirements*. CODEOWNERS
takes effect on merge and will begin auto-requesting review on open PRs
immediately, but nothing is blocked until the ruleset is updated separately to:

- `enforcement: active`
- `required_approving_review_count: 1` (currently `0`)
- add the 11 CI contexts as required status checks

That ruleset update is drafted but deliberately not part of this PR — it has to
be applied *after* this merges, or the review requirement goes live with no owner
resolved to satisfy it.

## Known limitation

GitHub does not permit approving your own pull request. Once the ruleset is
active, this gate is satisfiable for contributor PRs but not for the owner's own,
which will need the admin bypass. That tradeoff is accepted: contributor PRs are
the case that actually failed here.