### PR TITLE
docs(changelog): Record DqnMetrics::value_loss removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Breaking changes**
 
+- **`DqnMetrics::value_loss` removed — it was an exact mirror of `policy_loss`**
+  (resolves #415). DQN optimizes a single TD loss; unlike the actor-critic
+  algorithms there is no separate policy/value pair to report. The field was
+  populated with `last_loss`, the same value already assigned to `policy_loss`
+  on the line above it, and its own doc-comment described it as a "mirror ...
+  kept for parity with actor-critic algorithms". Dashboards consuming
+  `DqnMetrics` therefore plotted one curve twice under two names.
+
+  `QrDqnMetrics` never carried the field, so this removal brings the two
+  Q-learning metric structs into agreement rather than splitting them.
+
+  *Migration.* Read `policy_loss` instead — it holds the TD loss and always did.
+  Delete any `value_loss:` initializer from struct literals; those call sites
+  fail to compile. No persisted data or on-disk format is affected.
+
 - **`PpoTrainingConfig::max_grad_norm` removed — it was dead state advertising a
   feature the crate does not have** (resolves #183). The field defaulted to
   `0.5`, was validated as positive, and had a public builder setter, but nothing


### PR DESCRIPTION
Closes #415.

Adds the missing `[Unreleased]` → `rlevo-reinforcement-learning` → **Breaking changes** entry for the `DqnMetrics::value_loss` removal in #339 (`c63586a`), which landed without a changelog note or a `!` subject marker.

Documentation only — no compiled code touched. The DQN change itself is correct and stands.

Also records that `QrDqnMetrics` never carried the field, so the removal aligns the two Q-learning metric structs rather than splitting them. Noted in the entry so the question isn't re-opened.

---

Secondary purpose: this is the first PR opened since `primary-ruleset` was activated, and serves as the live test that the merge gate actually engages (review required + 11 status checks) rather than merely reading correct via the API.