### PR TITLE
ci: Pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/crate-tests.yml
+++ b/.github/workflows/crate-tests.yml
@@ -23,7 +23,7 @@ jobs:
     name: tensor-read hygiene grep
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Forbid unwrap_or_default on tensor host-reads
         run: |
           hits=$(grep -rnE "(into_vec|into_data|to_vec)[^;]*unwrap_or_default" \
@@ -48,7 +48,7 @@ jobs:
     name: workspace lints opt-in
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Every crate must opt into the workspace lint table
         run: |
           missing=""
@@ -91,10 +91,10 @@ jobs:
     name: rlevo-environments feature orthogonality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: feature-orthogonality
 
@@ -121,10 +121,10 @@ jobs:
           - rlevo-evolution
           - rlevo-reinforcement-learning
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: crate-tests-${{ matrix.crate }}
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -18,7 +18,7 @@ jobs:
     name: cargo fmt --check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,13 +18,13 @@ jobs:
     name: integration tests (non-ignored)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@2b818c67b359d9778206f1396bde7f4381ebfeda # just
 
       - name: Cross-crate integration
         run: just test-integration

--- a/.github/workflows/viz-examples.yml
+++ b/.github/workflows/viz-examples.yml
@@ -32,13 +32,13 @@ jobs:
     name: build + clippy (viz examples, all features)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # The toolchain (channel + rustfmt/clippy components) is governed by
       # rust-toolchain.toml at the repo root; rustup auto-installs the pin on
       # the first cargo invocation.
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # The examples pull rapier2d (box2d), rapier3d (locomotion), and
       # burn-wgpu. None need a GPU to *compile*; libudev is the only
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends libudev-dev
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@2b818c67b359d9778206f1396bde7f4381ebfeda # just
 
       - name: Build viz examples (full feature set)
         run: just build-vis-examples

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -56,10 +56,10 @@ jobs:
           - name: "SAC — heavy suite (LinearEnv + Pendulum)"
             bin: sac_integration
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Separate cache key per matrix job so jobs don't thrash each other.
           key: weekly-${{ matrix.bin }}
@@ -88,10 +88,10 @@ jobs:
             bin: qrdqn_integration
             test: qrdqn_cartpole_acceptance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: weekly-${{ matrix.bin }}
 


### PR DESCRIPTION
Pins all 17 `uses:` references across the five workflows to immutable commit SHAs.

| Action | Was | Now | Count |
|---|---|---|---|
| `actions/checkout` | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` | 9 |
| `Swatinem/rust-cache` | `@v2` | `e18b497796c12c097a38f9edb9d0641fb99eee32` | 6 |
| `taiki-e/install-action` | `@just` | `2b818c67b359d9778206f1396bde7f4381ebfeda` | 2 |

## Why

Tags are mutable. Whoever controls an action repo can repoint `@v4` at new code, which then runs in CI on the next push — the `tj-actions/changed-files` compromise pattern. SHAs cannot be repointed.

Exposure here was already low and worth stating precisely: `default_workflow_permissions` is `read`, no workflow references `secrets.*`, and none use `pull_request_target`, so there are no credentials in these runs to exfiltrate. What stayed reachable was cache poisoning and use of CI compute. This removes that.

## No behavior change

Each pin is the **current tip of the tag already in use** — not an upgrade. Same action code as the last run, addressed immutably.

Verified: `rg 'uses:' | rg -v '@[0-9a-f]{40} #'` returns nothing (17/17 pinned), and all five files parse as YAML.

## Follow-ups, not included here

- **`sha_pinning_required` is `false`** on the repo. Flipping it to `true` rejects unpinned actions going forward instead of relying on review. Recommended, but it's a settings change rather than a diff.
- **`actions/checkout` v4 is well behind** (v7.0.1 is current). Deliberately not upgraded — pinning and upgrading in one PR would conflate a security change with a behavioral one. Worth a separate PR.
- **Pinning freezes tool versions.** `taiki-e/install-action@just` no longer tracks new `just` releases. Automated bumps (renovate/dependabot) are the usual companion to SHA pinning; without them these will drift stale.