### PR TITLE
fix(ppo): Floor minibatch_size() to at least 1 (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1122,6 +1122,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   either way. The defect was pure throughput, invisible to any correctness
   assertion, and the existing tests pass unmodified — which is the acceptance
   criterion here rather than evidence of a gap.
+- **`PpoTrainingConfig::minibatch_size()` could return `0`** (#166). The accessor
+  guarded only the divisor (`num_minibatches.max(1)`) but not the quotient, so a
+  config with `num_minibatches > batch_size` (e.g. `num_steps = 10,
+  num_minibatches = 20`) reported a minibatch size of `0` while `PpoAgent::update`
+  clamped its own `mb_size` to `1` — the public API and the training loop
+  disagreed, and a caller pre-sizing a buffer from the accessor got a zero-length
+  allocation. The quotient is now floored to `1`, matching the loop. The existing
+  config tests only exercised the well-formed case (`batch_size` a multiple of
+  `num_minibatches`), where the two agree, so the divergence never surfaced. PPG
+  inherits the fix through its wrapped `PpoTrainingConfig`.
 
 **Added**
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
@@ -102,10 +102,12 @@ pub struct PpoTrainingConfig {
 impl PpoTrainingConfig {
     /// Size of a single minibatch under the configured rollout.
     ///
-    /// `(num_envs · num_steps) / num_minibatches`.
+    /// `(num_envs · num_steps) / num_minibatches`, floored to `1` so a
+    /// mis-sized `num_minibatches` never yields a zero-length batch. This
+    /// mirrors the `.max(1)` clamp in `PpoAgent::update`'s `mb_size`.
     #[must_use]
     pub fn minibatch_size(&self) -> usize {
-        self.batch_size() / self.num_minibatches.max(1)
+        (self.batch_size() / self.num_minibatches.max(1)).max(1)
     }
 
     /// Total transitions per rollout: `num_envs · num_steps`.
@@ -382,6 +384,19 @@ mod tests {
             .expect("valid config");
         assert_eq!(cfg.batch_size(), 128);
         assert_eq!(cfg.minibatch_size(), 32);
+    }
+
+    #[test]
+    fn minibatch_size_never_zero() {
+        // Regression for #166: num_minibatches > batch_size must floor to 1,
+        // matching PpoAgent::update's mb_size, not integer-divide to 0.
+        let cfg = PpoTrainingConfigBuilder::new()
+            .num_envs(1)
+            .num_steps(10)
+            .num_minibatches(20)
+            .build()
+            .expect("valid config");
+        assert_eq!(cfg.minibatch_size(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves the **last live sub-item of #166**: `PpoTrainingConfig::minibatch_size()` could return `0`.

The accessor guarded only the divisor (`num_minibatches.max(1)`) but not the quotient, so a config with `num_minibatches > batch_size` (e.g. `num_steps=10, num_minibatches=20`) reported a minibatch size of `0`, while `PpoAgent::update` (`ppo_agent.rs:470`) clamped its own `mb_size` to `1`. The public API and the training loop disagreed, and a caller pre-sizing a buffer from the accessor got a zero-length allocation.

```rust
// ppo_config.rs
// before: self.batch_size() / self.num_minibatches.max(1)
(self.batch_size() / self.num_minibatches.max(1)).max(1)
```

PPG inherits the fix through its composed `pub ppo: PpoTrainingConfig` — no separate change needed.

## Scope note

This is API-consistency plumbing, **not an algorithm-behavior change**: `update()` already clamped; only the accessor was out of step. No training semantics change.

The other three #166 sub-items (`validate()`/`build() -> Result`, `num_envs` handling, PPG config validation) were already closed by the ADR 0026 rollout; their two genuine remainders live in #502 (`beta_clone = +inf`) and #484 (dead error variants), both verified independent of this fix.

## Testing

- New regression test `minibatch_size_never_zero` (fails pre-fix `left: 0, right: 1`, passes post-fix).
- `cargo test -p rlevo-reinforcement-learning --lib -- ppo` → 73 passed.
- `cargo clippy -p rlevo-reinforcement-learning --all-targets --all-features` → clean.

## Known pre-existing property (not addressed here)

`minibatch_size()` reports the size for the *configured* rollout (`num_envs * num_steps`); `update()` divides the *actual* `buffer.len()`, which is smaller on the final partial rollout (`train.rs:232` can break early). This matches the accessor's documented "under the configured rollout" contract and is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCuvyLiBNsizrCTXcjSRGi