### PR TITLE
fix(ppg): Step aux phase at its policy phase's LR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,6 +690,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **PPG's auxiliary phase no longer anneals one iteration ahead of the policy
+  phase it accompanies** (resolves #324). `maybe_aux_phase` read
+  `current_learning_rate()`, but `policy_phase_update` had already incremented
+  the iteration counter on its way out — so every auxiliary phase stepped at the
+  *next* tick's rate, and whenever `total_iterations % n_iteration == 0` the
+  final one landed on `iteration == total_iterations`, where the linear anneal
+  is exactly `0.0`. That closing phase ran its full complement of forward and
+  backward passes and moved no parameter at all: wasted compute, plus a
+  `last_aux_phase().policy_kl` of bit-exactly `0x00000000` that reads as a
+  broken auxiliary phase to anyone instrumenting it (it is what raised the false
+  alarm in #319). The rate the policy phase applies is now snapshotted before
+  the increment and reused by the auxiliary phase, matching CleanRL's
+  `ppg_procgen.py` — whose `# AUXILIARY PHASE` block is nested inside the phase
+  body, shares the policy optimizer, and never rewrites its `lr` — and Algorithm
+  1 of Cobbe et al. (2021), which places the auxiliary phase inside the phase
+  rather than after a schedule tick. `current_learning_rate()` is unchanged and
+  still reports the rate the *next* policy phase will use; its doc now says so.
+  The existing tests missed this because the PPG suite asserts that the
+  auxiliary phase *fires* and that its metrics are *finite* — and zero is
+  finite — while the annealing tests live in `ppo_config` and only check the
+  arithmetic, never the phase ordering that consumes it. `ppg_aux_phase_actually_runs`
+  demonstrably passed against the bug it was positioned to guard; it and the new
+  regression test now assert `policy_kl > 0.0`, guarded by an explicit
+  `minibatches > 1` precondition (the first minibatch of the first auxiliary
+  epoch forward-passes the same weights `π_old` was snapshotted from, so its KL
+  term is structurally zero and a single-minibatch phase would report `0.0` at a
+  perfectly healthy rate). Training impact is one phase per run and small in
+  absolute terms; the diagnostic trap was the real cost.
 - **`polyak_update` no longer mis-updates target networks with tied or subset
   parameter topologies** (ADR 0057, resolves #341, partially #317). The mapper
   pairs `active` and `target` parameters by [`ParamId`], and its bookkeeping was

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
@@ -168,6 +168,14 @@ where
     device: B::Device,
     iteration: usize,
     total_iterations: usize,
+    /// Learning rate the most recent [`policy_phase_update`](Self::policy_phase_update)
+    /// actually applied, snapshotted *before* that update bumped `iteration`.
+    ///
+    /// The auxiliary phase belongs to the policy phase it follows, so it steps
+    /// at this rate rather than at `current_learning_rate()` — which, read from
+    /// [`maybe_aux_phase`](Self::maybe_aux_phase), has already advanced one
+    /// annealing tick (#324).
+    policy_phase_lr: f64,
     step: usize,
     stats: AgentStats<PpgMetrics>,
     last_aux: Option<AuxPhaseStats>,
@@ -194,6 +202,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PpgAgent")
             .field("iteration", &self.iteration)
+            .field("policy_phase_lr", &self.policy_phase_lr)
             .field("step", &self.step)
             .field("buffer_len", &self.buffer.len())
             .field("aux_slices", &self.aux_buffer.num_slices())
@@ -284,6 +293,12 @@ where
         let buffer = RolloutBuffer::new(capacity, action_dim);
         let aux_buffer = AuxRolloutBuffer::new();
         let stats = AgentStats::<PpgMetrics>::new(100);
+        // What `current_learning_rate()` returns at `iteration == 0`: the
+        // annealed rate at tick zero is the base rate, and with annealing off it
+        // is the base rate throughout. Seeding the field here keeps a
+        // `maybe_aux_phase` that somehow precedes any policy phase on-schedule
+        // instead of stepping at an uninitialised rate.
+        let policy_phase_lr = config.ppo.learning_rate;
 
         Ok(Self {
             policy: Slot::new(policy),
@@ -296,6 +311,7 @@ where
             device,
             iteration: 0,
             total_iterations,
+            policy_phase_lr,
             step: 0,
             stats,
             last_aux: None,
@@ -377,10 +393,20 @@ where
         self.value.get()
     }
 
-    /// Current effective learning rate, accounting for linear annealing.
+    /// Learning rate the **next** policy phase will use, accounting for linear
+    /// annealing.
     ///
     /// Returns `config.ppo.learning_rate` unchanged when `anneal_lr` is
-    /// `false`; otherwise linearly decays toward zero over `total_iterations`.
+    /// `false`; otherwise linearly decays toward zero over `total_iterations`,
+    /// reaching exactly `0.0` at `iteration == total_iterations`.
+    ///
+    /// This is a *forward-looking* read: it is a pure function of `iteration`,
+    /// which [`policy_phase_update`](Self::policy_phase_update) increments on
+    /// its way out. Called after an update, it therefore reports one annealing
+    /// tick *past* the rate that update applied — and at the end of a run it
+    /// reports `0.0`. Anything that must step at the rate of the phase that just
+    /// ran reads `policy_phase_lr` instead; that is exactly what the auxiliary
+    /// phase does (see [`maybe_aux_phase`](Self::maybe_aux_phase), #324).
     pub fn current_learning_rate(&self) -> f64 {
         if self.config.ppo.anneal_lr {
             annealed_learning_rate(
@@ -534,6 +560,10 @@ where
     /// [`crate::algorithms::ppo::ppo_agent::PpoAgent::update`].
     /// Clears the rollout buffer, increments the iteration counter, returns
     /// the same [`PpoUpdateStats`].
+    ///
+    /// The annealed learning rate is snapshotted once, *before* the increment,
+    /// and retained in `policy_phase_lr` so the auxiliary phase that may follow
+    /// this update steps at the same rate (#324).
     // The body is one linear pipeline — sample, forward, loss, backward,
     // optimizer step, priority writeback, metrics — with a borrow structure
     // around the module slot that the inline comments below depend on. Splitting
@@ -548,7 +578,11 @@ where
         let cfg = self.config.ppo.clone();
         let batch_size = self.buffer.len();
         let mb_size = (batch_size / cfg.num_minibatches.max(1)).max(1);
+        // Read before `self.iteration += 1` below, so this is the rate for the
+        // phase about to run. Retained for the auxiliary phase, which belongs to
+        // this policy phase and must not anneal ahead of it (#324).
         let lr = self.current_learning_rate();
+        self.policy_phase_lr = lr;
 
         let mut policy_loss_acc = 0.0_f32;
         let mut value_loss_acc = 0.0_f32;
@@ -725,6 +759,20 @@ where
     ///   policy that has just finished `n_iteration` policy-phase updates).
     ///
     /// Drains the buffer afterwards. Otherwise, no-op.
+    ///
+    /// # Learning rate
+    ///
+    /// Both optimizer steps use `policy_phase_lr` — the rate the policy phase
+    /// this auxiliary phase accompanies actually applied — **not**
+    /// [`current_learning_rate`](Self::current_learning_rate), which has already
+    /// advanced past it. This matches `CleanRL`'s `ppg_procgen.py`, where the
+    /// `# AUXILIARY PHASE` block is nested inside the phase body, shares the
+    /// policy optimizer, and never rewrites its `lr`; and Algorithm 1 of Cobbe
+    /// et al. (2021), where the auxiliary phase sits inside the phase rather
+    /// than after a schedule tick. Reading the annealed rate here instead made
+    /// every auxiliary phase run one tick early and, whenever
+    /// `total_iterations % n_iteration == 0`, made the final one a bit-exact
+    /// no-op at `lr == 0.0` (#324).
     // Divisor/normalizer derived from a count -- batch size, minibatch count,
     // history length, iteration number. All are bounded by configured sizes far
     // below f32's 2^24 (f64's 2^53) exact-integer limit.
@@ -734,7 +782,8 @@ where
             return None;
         }
         let cfg = self.config.clone();
-        let lr = self.current_learning_rate();
+        // The accompanying policy phase's rate, not the next one's (#324).
+        let lr = self.policy_phase_lr;
         let total_steps = self.aux_buffer.len_steps();
         if total_steps == 0 {
             self.aux_buffer.clear();
@@ -1045,12 +1094,28 @@ mod tests {
             .expect("f32 weight host read")
     }
 
-    /// Builds an agent with a single four-step rollout collected and finalized
-    /// (advantages/returns populated) with *healthy* networks. `n_iteration = 1`
-    /// so a single `snapshot_into_aux_buffer` makes the auxiliary phase ready.
+    /// Collects and finalizes one four-step rollout on `agent`, leaving the
+    /// buffer full and its advantages/returns populated — i.e. ready for
+    /// `policy_phase_update`.
     // Test fixture data: the loop counter is bounded by a small constant, far
     // below f32's 2^24 exact-integer limit.
     #[allow(clippy::cast_precision_loss)]
+    fn collect_rollout(agent: &mut TestAgent, rng: &mut StdRng) {
+        let mut last = TestObs([0.4, 0.6]);
+        for i in 0..4usize {
+            let x = i as f32 * 0.1;
+            let obs = TestObs([x, 1.0 - x]);
+            let next = TestObs([x + 0.1, 0.9 - x]);
+            let outcome = agent.act(&obs, rng);
+            agent.record_step(obs, &outcome, 1.0, &next, EpisodeStatus::Running);
+            last = next;
+        }
+        agent.finalize_rollout(&last);
+    }
+
+    /// Builds an agent with a single four-step rollout collected and finalized
+    /// (advantages/returns populated) with *healthy* networks. `n_iteration = 1`
+    /// so a single `snapshot_into_aux_buffer` makes the auxiliary phase ready.
     fn primed_ppg_agent() -> TestAgent {
         let device = Default::default();
         let policy: PpgCategoricalPolicyHead<TestBackend> = PpgCategoricalPolicyHeadConfig {
@@ -1078,16 +1143,7 @@ mod tests {
         let mut agent = TestAgent::new(policy, value, config, device, 1).expect("valid config");
 
         let mut rng = StdRng::seed_from_u64(0);
-        let mut last = TestObs([0.4, 0.6]);
-        for i in 0..4usize {
-            let x = i as f32 * 0.1;
-            let obs = TestObs([x, 1.0 - x]);
-            let next = TestObs([x + 0.1, 0.9 - x]);
-            let outcome = agent.act(&obs, &mut rng);
-            agent.record_step(obs, &outcome, 1.0, &next, EpisodeStatus::Running);
-            last = next;
-        }
-        agent.finalize_rollout(&last);
+        collect_rollout(&mut agent, &mut rng);
         agent
     }
 
@@ -1193,6 +1249,92 @@ mod tests {
         assert!(
             stats.main_value_loss.is_finite(),
             "the reported main-value loss must stay finite"
+        );
+    }
+
+    // -------- auxiliary-phase learning-rate alignment (#324) --------
+
+    /// Builds an empty agent with LR annealing **on** over `total_iterations`
+    /// policy phases. Mirrors [`primed_ppg_agent`]'s shapes; the rollout is left
+    /// to the caller so several phases can be driven in sequence.
+    fn annealing_ppg_agent(total_iterations: usize) -> TestAgent {
+        let device = Default::default();
+        let policy: PpgCategoricalPolicyHead<TestBackend> = PpgCategoricalPolicyHeadConfig {
+            obs_dim: 2,
+            hidden: 4,
+            num_actions: 2,
+        }
+        .try_init::<TestBackend>(&device)
+        .expect("valid head config");
+        let value = TestValue::<TestBackend>::init(&device);
+        let config = PpgConfigBuilder::new()
+            .n_iteration(1)
+            .e_aux(1)
+            .aux_batch_size(4)
+            .with_ppo(|p| PpoTrainingConfig {
+                num_envs: 1,
+                num_steps: 4,
+                num_minibatches: 1,
+                update_epochs: 1,
+                anneal_lr: true,
+                ..p
+            })
+            .build()
+            .expect("valid config");
+        TestAgent::new(policy, value, config, device, total_iterations).expect("valid config")
+    }
+
+    /// Regression (issue #324): the auxiliary phase must step at the learning
+    /// rate of the policy phase it accompanies, so `policy_phase_lr` has to hold
+    /// the rate read *before* `policy_phase_update` bumped `iteration` — one
+    /// tick behind `current_learning_rate()`. On the final iteration that
+    /// distinction is the whole defect: `current_learning_rate()` is exactly
+    /// `0.0` there, which would make the closing auxiliary phase a bit-exact
+    /// no-op.
+    #[test]
+    // Exact comparison is the property: `annealed_learning_rate` lands on
+    // *exactly* 0.0 at the last tick, and `policy_phase_lr` is a copy of a
+    // `current_learning_rate()` return value, not a recomputation. A tolerance
+    // would let the one-tick offset this test exists to catch slip through.
+    #[allow(clippy::float_cmp)]
+    fn ppg_policy_phase_lr_trails_current_learning_rate_by_one_tick() {
+        const TOTAL_ITERATIONS: usize = 4;
+        let mut agent = annealing_ppg_agent(TOTAL_ITERATIONS);
+        let mut rng = StdRng::seed_from_u64(9);
+
+        for completed in 0..TOTAL_ITERATIONS {
+            let lr_of_this_phase = agent.current_learning_rate();
+            collect_rollout(&mut agent, &mut rng);
+            agent.policy_phase_update(&mut rng);
+
+            assert_eq!(
+                agent.iteration(),
+                completed + 1,
+                "each policy phase must advance the iteration counter exactly once"
+            );
+            assert_eq!(
+                agent.policy_phase_lr, lr_of_this_phase,
+                "policy_phase_lr must be the pre-increment rate the phase applied"
+            );
+            assert!(
+                agent.policy_phase_lr > agent.current_learning_rate(),
+                "the annealed rate must have advanced past the phase that just ran: \
+                 policy_phase_lr = {}, current_learning_rate() = {}",
+                agent.policy_phase_lr,
+                agent.current_learning_rate()
+            );
+        }
+
+        assert_eq!(
+            agent.current_learning_rate(),
+            0.0,
+            "the anneal lands on exactly 0.0 at iteration == total_iterations"
+        );
+        assert!(
+            agent.policy_phase_lr > 0.0,
+            "the last policy phase ran at a positive rate, so the auxiliary phase \
+             that accompanies it must too — got {}",
+            agent.policy_phase_lr
         );
     }
 }

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -178,8 +178,29 @@ fn ppg_without_aux_phase_matches_ppo_baseline() {
     );
 }
 
+/// The auxiliary phase must fire *and* move the policy — including on the
+/// terminal iteration (issues #319, #324).
+///
+/// `total / num_steps = 2048 / 128 = 16` policy-phase iterations with
+/// `n_iteration = 4`, so `16 % 4 == 0` and the aux phase this test inspects via
+/// [`PpgAgent::last_aux_phase`] is the **terminal** one, at
+/// `iteration == total_iterations`. That is exactly #324's trigger: the phase
+/// used to read the annealed learning rate one schedule tick ahead of the
+/// policy phase it accompanies, and at the terminal tick the anneal is exactly
+/// `0.0`, so every minibatch stepped by nothing.
+///
+/// This test previously asserted only `aux_value_loss.is_finite()` and
+/// `policy_kl.is_finite()`. `0.0` is finite, so a bit-exactly zero `policy_kl`
+/// — the precise signature of the #324 no-op — satisfied both: the test passed
+/// against the bug it is positioned to guard (recorded in #319's closing
+/// comment). #319 also warned that asserting `policy_kl > 0.0` would fail for a
+/// benign reason; #324's fix is what retired that warning, since the terminal
+/// phase now steps at the rate of the policy phase it accompanies.
+///
+/// The `> 0.0` form is now load-bearing here, and it rests on the
+/// more-than-one-minibatch precondition asserted in the body.
 #[test]
-#[ignore = "2 048-step PPG run (n_iteration=4) verifying the aux phase fires and produces finite KL/value-loss metrics — run with `cargo test -- --ignored`"]
+#[ignore = "2 048-step PPG run (n_iteration=4) verifying the terminal aux phase fires and moves the policy at a nonzero learning rate (#324) — run with `cargo test -- --ignored`"]
 fn ppg_aux_phase_actually_runs() {
     let _guard = flex_guard();
     // Use a small n_iteration so the aux phase fires within a tiny budget.
@@ -202,9 +223,44 @@ fn ppg_aux_phase_actually_runs() {
     let aux = agent
         .last_aux_phase()
         .expect("aux phase should have run at least once");
-    assert!(aux.minibatches > 0);
-    assert!(aux.aux_value_loss.is_finite());
-    assert!(aux.policy_kl.is_finite());
+    // Precondition for the `policy_kl > 0.0` assertion below. `maybe_aux_phase`
+    // snapshots `π_old` once, before the aux epoch loop, so the *first*
+    // minibatch of the *first* epoch compares that snapshot against weights the
+    // phase has not stepped yet: its KL term is structurally `0.0` at any
+    // learning rate. `policy_kl` is the mean over minibatches, so it can only be
+    // strictly positive when the phase runs more than one of them.
+    //
+    // This config does: 4 aux slices × 128 steps = 512 aux steps, chunked at
+    // `aux_batch_size = 128` → 4 chunks, × `e_aux = 6` epochs = 24 minibatches.
+    assert!(
+        aux.minibatches > 1,
+        "`policy_kl > 0.0` is only meaningful when the aux phase runs more than one \
+         minibatch (the first minibatch's KL is structurally zero — π_old is snapshotted \
+         before the epoch loop); got {} minibatches, so shrinking the aux step count or \
+         growing `aux_batch_size` into a single chunk has invalidated this test rather \
+         than regressed #324",
+        aux.minibatches
+    );
+    // Guards the #318 all-minibatches-skipped path, which reports both aux
+    // losses as a literal `0.0` sentinel rather than NaN: an aux-value MSE
+    // against CartPole returns is bounded below by 0 and can only *be* 0 on a
+    // bit-exact perfect regression, which a freshly initialised head does not
+    // achieve.
+    assert!(
+        aux.aux_value_loss > 0.0,
+        "the aux-value MSE must be strictly positive; `0.0` is also the sentinel reported \
+         when every minibatch was skipped as non-finite (#318), got {}",
+        aux.aux_value_loss
+    );
+    // The #324 assertion. `is_finite()` alone passed on the bit-exactly zero
+    // KL that the terminal aux phase produced when it ran at `lr == 0.0`.
+    assert!(
+        aux.policy_kl > 0.0,
+        "the terminal aux phase moved the policy by exactly nothing (policy_kl = {}), \
+         which means it ran at lr = 0.0 — it must step at the rate of the policy phase it \
+         accompanies (#324); `is_finite()` alone does not catch this (#319)",
+        aux.policy_kl
+    );
 }
 
 #[test]
@@ -233,6 +289,89 @@ fn ppg_cartpole_produces_finite_rewards() {
     assert_all_finite(
         "value_loss",
         &history.iter().map(|m| m.value_loss).collect::<Vec<_>>(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Auxiliary-phase learning rate (issue #324)
+// ---------------------------------------------------------------------------
+
+/// Regression (issue #324): the auxiliary phase used to read the *annealed*
+/// learning rate after `policy_phase_update` had already bumped the iteration
+/// counter, so it ran one schedule tick ahead of the policy phase it
+/// accompanies. Whenever `total_iterations % n_iteration == 0` the final
+/// auxiliary phase therefore landed on `iteration == total_iterations`, where
+/// the anneal is exactly `0.0` — its minibatches moved no parameter and its
+/// reported `policy_kl` was bit-exactly zero.
+///
+/// This is that configuration, minimised: `total / num_steps = 4` iterations
+/// with `n_iteration = 2`, so auxiliary phases fire at iterations 2 and 4 and
+/// the second one is the failing terminal case.
+#[test]
+fn ppg_final_aux_phase_steps_at_a_nonzero_learning_rate() {
+    const SEED: u64 = 19;
+    const NUM_STEPS: usize = 128;
+    const TOTAL: usize = 512; // 4 policy-phase iterations.
+    const N_ITERATION: usize = 2; // aux phases at iterations 2 and 4.
+
+    let _guard = flex_guard();
+
+    let mut env = TimeLimit::new(cartpole_seeded(SEED), 500);
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let mut agent = make_cart_pole_agent(SEED, NUM_STEPS, TOTAL, N_ITERATION);
+    train_discrete::<Be, _, _, _, _, CartPoleAction, _, 1, 1, 2>(
+        &mut agent, &mut env, &mut rng, TOTAL, 0,
+    )
+    .expect("training");
+
+    // The run must actually reach the terminal iteration, or the regression
+    // below is checking an interior aux phase that never had the bug.
+    assert_eq!(
+        agent.iteration(),
+        TOTAL / NUM_STEPS,
+        "the run must complete all {} policy phases for the terminal aux phase to fire",
+        TOTAL / NUM_STEPS
+    );
+
+    let aux = agent
+        .last_aux_phase()
+        .expect("the aux phase must have fired at the final iteration");
+    // Soundness precondition for `policy_kl > 0.0` below, not just a
+    // liveness check. `maybe_aux_phase` snapshots `π_old` once, before the aux
+    // epoch loop, so the *first* minibatch of the *first* epoch runs its
+    // "new" forward pass over weights the phase has not stepped yet — that
+    // minibatch's KL is structurally `0.0` at any learning rate, healthy or
+    // annealed to nothing. `policy_kl` is the mean over minibatches, so it is
+    // strictly positive only when more than one minibatch runs. A
+    // single-minibatch aux phase (`e_aux = 1` with `aux_batch_size` ≥ the total
+    // aux step count) reports `policy_kl == 0.0` at a perfectly healthy lr.
+    //
+    // This config does: `n_iteration = 2` slices × `NUM_STEPS = 128` = 256 aux
+    // steps, chunked at `aux_batch_size = 128` → 2 chunks, × `e_aux = 6`
+    // epochs = 12 minibatches.
+    assert!(
+        aux.minibatches > 1,
+        "`policy_kl > 0.0` is only meaningful when the aux phase runs more than one \
+         minibatch (the first minibatch's KL is structurally zero — π_old is snapshotted \
+         before the epoch loop); got {} minibatches, so shrinking `n_iteration × NUM_STEPS` \
+         or growing `aux_batch_size` into a single chunk has invalidated this test rather \
+         than regressed #324",
+        aux.minibatches
+    );
+    assert!(
+        aux.policy_kl.is_finite(),
+        "the final aux phase's distillation KL must be finite, got {}",
+        aux.policy_kl
+    );
+    // The load-bearing assertion. `policy_kl` is `KL(π_old ‖ π_new)` against a
+    // snapshot taken at the start of the phase, so at `lr == 0.0` the policy
+    // cannot move and every minibatch contributes an exact zero.
+    assert!(
+        aux.policy_kl > 0.0,
+        "the final aux phase moved the policy by exactly nothing (policy_kl = {}), which \
+         means it ran at lr = 0.0 — it must step at the rate of the policy phase it \
+         accompanies (#324)",
+        aux.policy_kl
     );
 }
 


### PR DESCRIPTION
Resolves #324.

## The defect

`maybe_aux_phase` read `current_learning_rate()` at `ppg_agent.rs` *after* `policy_phase_update` had already done `self.iteration += 1`, so every auxiliary phase annealed one tick ahead of the policy phase it accompanies.

Measured before the fix (CartPole / `FlexAutodiff`, `num_steps=128, total=2048, n_iteration=4, anneal_lr=true, lr=2.5e-4` → `total_iterations=16`):

```
AUX iter 4   lr_policy=2.03125e-4  lr_aux=1.875e-4  policy_kl=8.004483e-4
AUX iter 8   lr_policy=1.40625e-4  lr_aux=1.25e-4   policy_kl=4.0885843e-5
AUX iter 12  lr_policy=7.8125e-5   lr_aux=6.25e-5   policy_kl=4.1634644e-6
AUX iter 16  lr_policy=1.5625e-5   lr_aux=0e0       policy_kl=0e0  (0x00000000)
```

The terminal phase ran 24 minibatches of forward/backward plus its main-value updates and moved nothing — Adam at `lr = 0` leaves parameters bit-identical. Wasted compute, and a headline `last_aux_phase().policy_kl` of bit-exactly zero that reads as a broken auxiliary phase. That zero is what raised the false alarm in #319.

**One scope correction to the issue as filed:** the one-tick offset is unconditional, but the final auxiliary phase is a *guaranteed* no-op only when `total_iterations % n_iteration == 0`. Otherwise the last phase fires before the terminal tick and merely runs at a slightly-too-cold rate.

## The fix

`PpgAgent` gains a private `policy_phase_lr: f64`, snapshotted in `policy_phase_update` before the increment and consumed by `maybe_aux_phase`. No public API change, no new config knob.

## Why this shape

Validated against the literature before implementing — notes in `docs/.private/research/2026-07-24-ppg-aux-phase-learning-rate.md`:

- **CleanRL `ppg_procgen.py`** (verified byte-exact against raw source, not a summary): `# AUXILIARY PHASE` (L420) is nested inside `for phase` (L285), *after* the `for update` loop (L288) exits. It never writes `optimizer.param_groups[0]["lr"]` and shares the policy optimizer — so it runs at exactly the rate the last policy-phase iteration left behind.
- **Cobbe et al. 2021** (arXiv:2009.04416): does not anneal at all (fixed Adam 5e-4), and Algorithm 1 places the auxiliary phase *inside* the phase body, not after a schedule tick.
- **OpenAI's reference implementation** gives the aux phase its own `aux_lr` and a separate Adam instance. Rejected — a larger public-API change that neither the paper nor the baseline rlevo tracks uses.

Also deliberately **not** ported: CleanRL resets `update` per phase while dividing by a global `num_iterations`, so its schedule barely decays and jumps back near `frac = 1.0` every phase. rlevo's monotone global counter is the better behavior and is left alone.

## Test hardening

`ppg_aux_phase_actually_runs` had been passing against the bug it was positioned to guard. Its config (`total=2048, num_steps=128, n_iteration=4` → `16 % 4 == 0`) is the exact trigger, and its assertions were `minibatches > 0` plus two `is_finite()` calls — and `0.0` is finite. Confirmed by reverting the fix and running it: `test ppg_aux_phase_actually_runs ... ok`.

It and the new regression test now assert `policy_kl > 0.0`, behind an explicit `minibatches > 1` guard. That guard is load-bearing: `maybe_aux_phase` snapshots `old_logits_flat` once before the epoch loop, so the first minibatch of the first epoch forward-passes the same unstepped weights `π_old` came from and contributes a structurally-zero KL term regardless of learning rate. A single-minibatch aux phase reports `policy_kl == 0.0` at a perfectly healthy rate — so a future "let's speed this test up" edit that fits the aux buffer into one chunk would fail for a reason unrelated to #324 and look exactly like a regression of it.

## Verification

```
cargo fmt --all --check                                                   # clean
cargo clippy -p rlevo-reinforcement-learning --all-targets --all-features  # 0 warnings
cargo test -p rlevo-reinforcement-learning --lib      # 376 passed, 0 failed
cargo test -p rlevo --test ppg_integration            # 2 passed, 5 ignored
cargo test -p rlevo --test ppg_integration -- --ignored   # 5 passed, 0 failed
```

The new integration test fails pre-fix for the right reason, confirmed by reverting only the one line:

```
the final aux phase moved the policy by exactly nothing (policy_kl = 0),
which means it ran at lr = 0.0 — it must step at the rate of the policy
phase it accompanies (#324)
```

## Reviewer note

⚠️ **The new tests will not run in CI.** `crate-tests.yml`'s matrix omits the `rlevo` crate and `weekly-tests.yml` runs the agent binaries with `-- --ignored`, which filters non-ignored tests out. Filed as #519 — not a blocker for this PR, but the green checks below do not cover `ppg_integration.rs`. Run it locally to confirm.

## Ripple

- #319 — [corrected](https://github.com/anthonytorlucci/rlevo/issues/319#issuecomment-5066628214). Its closing comment (mine) told future readers that asserting `policy_kl > 0.0` would fail "for the benign reason"; this fix removes that reason, so the advice had become actively harmful.
- #320 — [corrected](https://github.com/anthonytorlucci/rlevo/issues/320#issuecomment-5066831233). Its "wider context" claim was already false, and its `#[ignore]` diagnosis is the wrong mechanism. Core Slot ask untouched.
- #519 — filed, the CI wiring gap above.

## Not addressed

- `anneal_lr` defaults to `true` in rlevo (inherited from `PpoTrainingConfig`), while CleanRL's PPG defaults it **off**. Deliberate or accidental is unknown; out of scope.
- Post-fix terminal `policy_kl` is small (`4.1e-7`–`5.8e-6`), bit-reproducible on `Flex`. A different backend could in principle round it to zero and make the hardened assertions flaky — relevant if #519 ever puts these on other hardware.
- `ppo_agent.rs`'s `ppo_nonfinite_value_loss_skips_and_warns` asserts only `is_finite()` where its sibling pairs that with a weight-delta check. Same defect class, unfiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8My6uLMLbzy8xSfSgUfGS
