### PR TITLE
fix(ci): Run every crate's tests in the PR gate (#519)

### DIFF
--- a/.github/workflows/crate-tests.yml
+++ b/.github/workflows/crate-tests.yml
@@ -73,6 +73,43 @@ jobs:
           fi
           echo "all crate manifests opt into [workspace.lints]"
 
+  # Issue #519: the `test` matrix below is hand-maintained, and nothing in cargo
+  # notices when a crate is missing from it — the crate's tests simply never
+  # run, and CI is green because nothing was checked. That is how `rlevo`'s 22
+  # test binaries, plus every test in four other crates, stayed out of the pull
+  # request gate. Same silent-inertness class as the #391 lint-opt-in job above,
+  # and the same remedy: make the omission fail the build.
+  test-matrix-coverage:
+    name: test matrix covers every crate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Every workspace crate must appear in the test matrix
+        run: |
+          # No exclusions: the matrix is total over `crates/*/`. If a crate ever
+          # genuinely cannot be tested in the gate, add it to an `excluded` list
+          # here together with the reason — do not silently drop it from the
+          # matrix, which is the failure mode this job exists to prevent.
+          missing=""
+          for dir in crates/*/; do
+            crate=$(basename "$dir")
+            # Whole-line match against a YAML list item, so `rlevo` is not
+            # considered covered by `rlevo-core`. Bare `- <name>` items appear
+            # only under the matrix's `crate:` key; every other list in this
+            # file is a mapping (`- uses:`, `- name:`, `- crate:`).
+            if ! grep -qE "^ +- ${crate}\$" .github/workflows/crate-tests.yml; then
+              missing="$missing  $crate\n"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::workspace crates absent from the crate-tests matrix (see issue #519):"
+            printf "$missing"
+            echo "A crate outside the matrix has its tests run by no pull-request check."
+            echo "Add it to the matrix, or to this job's 'excluded' list with a reason."
+            exit 1
+          fi
+          echo "every workspace crate is covered by the test matrix"
+
   # ADR 0042 / issue #128: `box2d` and `locomotion` are orthogonal
   # rlevo-environments features (neither implies the other) — a shared type
   # gated behind only one of them silently breaks the other's build. Two
@@ -108,6 +145,13 @@ jobs:
           cargo clippy -p rlevo-environments --all-targets
           --no-default-features --features locomotion -- -D warnings
 
+  # Issue #519: a crate absent from this matrix has its tests compiled and run
+  # by no pull-request check. `rlevo` was the case that surfaced it — all 22 of
+  # its `crates/rlevo/tests/*.rs` binaries were reachable only by
+  # `weekly-tests.yml`, which runs `-- --ignored` and therefore *filters out*
+  # every non-ignored test in them. Four further crates were absent for no
+  # recorded reason at all. Keep this list total over `crates/*/`; the
+  # `test-matrix-coverage` job below fails the build if it drifts.
   test:
     name: ${{ matrix.crate }}
     runs-on: ubuntu-latest
@@ -117,9 +161,24 @@ jobs:
         crate:
           - rlevo-core
           - rlevo-benchmarks
+          - rlevo-benchmarks-report-client
           - rlevo-environments
           - rlevo-evolution
+          - rlevo-examples
+          - rlevo-hybrid
+          - rlevo-metrics-registry
           - rlevo-reinforcement-learning
+          - rlevo-test-support
+          - rlevo
+        include:
+          # `crates/rlevo/tests/recording_episode_count.rs` and
+          # `cartpole_report_smoke.rs` use `rlevo_benchmarks::record` and the
+          # report emitter unconditionally — neither file is `#![cfg]`-gated —
+          # and `viz-report` is not among `rlevo`'s default features. A bare
+          # `cargo test -p rlevo` therefore fails to *compile* those two
+          # binaries rather than skipping them.
+          - crate: rlevo
+            features: --features viz-report
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -128,5 +187,6 @@ jobs:
         with:
           key: crate-tests-${{ matrix.crate }}
 
+      # `matrix.features` is empty for every crate without an `include:` entry.
       - name: Test ${{ matrix.crate }}
-        run: cargo test --package ${{ matrix.crate }}
+        run: cargo test --package ${{ matrix.crate }} ${{ matrix.features }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1257,6 +1257,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Added**
 
+- **`AuxPhaseStats::learning_rate`** — the rate a PPG auxiliary phase's two
+  optimizer steps actually ran at, carried alongside the existing loss fields.
+  Lets a caller distinguish a phase that *ran but moved nothing* (`0.0`, the
+  #324 defect) from one that moved the policy imperceptibly; the loss fields
+  cannot, because at `lr == 0.0` every parameter is bit-exactly unchanged and
+  `policy_kl` collapses to `0.0` — which is also its value on a healthy
+  single-minibatch phase. Additive: `AuxPhaseStats` is constructed only inside
+  `maybe_aux_phase`.
+
+  This replaces the load-bearing assertion in `ppg_integration.rs`'s #324
+  regression test, which previously decided the bug through
+  `policy_kl > 0.0`. That form is correct but is an `f32` mean of
+  log-differences between near-identical logits, measured at ~4.1e-7 — about
+  3.4× `f32::EPSILON` — so a backend with a different reduction order could
+  round a *healthy* phase to zero. Exposure that mattered once #519 put the
+  crate on shared CI hardware. The behavioral half of the check moved to a new
+  in-crate test, `ppg_aux_phase_at_nonzero_lr_moves_policy_parameters`, which
+  measures a host-side weight delta across the terminal auxiliary phase —
+  `lr · step`, linear in the rate and clear of `f32` resolution by orders of
+  magnitude. Both assertions were verified to fail against a deliberately
+  reintroduced #324 (`max |Δw| = 0` exactly).
+
 - **`PpoUpdateStats::min_log_std` and a one-shot warning when the `log_std`
   bound binds** (resolves #173, ADR 0049). Bounding `log_std` trades a *loud*
   failure for a *quiet* one: before, a collapsing policy produced NaN and the run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1377,6 +1377,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `MIN_SIZE = 5`), which is per ADR 0026 the loader's obligation — and no
   config loader exists in the workspace today.
 
+### Infrastructure
+
+**Fixed**
+
+- **Every workspace crate now runs its tests in the pull-request gate, and a
+  meta-check keeps it that way** (resolves #519). `crate-tests.yml`'s matrix was
+  hand-maintained and named five crates; six were missing. The consequence was
+  worst for `rlevo`, whose 22 `crates/rlevo/tests/*.rs` binaries were reachable
+  only through `weekly-tests.yml` — which runs `-- --ignored` and therefore
+  *filters out* every non-ignored test in them. 38 non-ignored tests across 16
+  binaries executed in no workflow at all, including the regression tests
+  written for #321 and #324 specifically so they would gate pull requests.
+  Un-ignoring a test never made it run.
+
+  The gap was not `rlevo`-only: `rlevo-benchmarks-report-client` (80 tests),
+  `rlevo-metrics-registry` (17), `rlevo-test-support` (6),
+  `rlevo-hybrid` (6) and `rlevo-examples` (5) were absent from the matrix for no
+  recorded reason. All six crates are now in it; `rlevo` carries
+  `--features viz-report`, without which `recording_episode_count.rs` and
+  `cartpole_report_smoke.rs` fail to *compile* (neither is `#![cfg]`-gated, and
+  the feature is not in `rlevo`'s defaults). Measured cost of the added
+  coverage: ~55 s of test execution for `rlevo`, under a second each for the
+  other five.
+
+  The new `test-matrix-coverage` job fails the build when a crate under
+  `crates/` is absent from the matrix, on the model of the #391 lint-opt-in
+  job — the omission itself is the bug, and nothing in cargo reports it.
+
 ---
 
 ## [0.3.1] – 2026-07-17

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
@@ -113,6 +113,16 @@ pub struct AuxPhaseStats {
     pub epochs_run: usize,
     /// Minibatches processed.
     pub minibatches: usize,
+    /// Learning rate both optimizer steps ran at — the rate the accompanying
+    /// policy phase applied, not the next tick's (#324).
+    ///
+    /// Reported so callers can tell a phase that *ran but moved nothing*
+    /// (`learning_rate == 0.0`) from one that moved the policy imperceptibly.
+    /// The loss fields cannot make that distinction: at `lr == 0.0` every
+    /// parameter is bit-exactly unchanged and [`policy_kl`](Self::policy_kl)
+    /// collapses to `0.0`, which is also its value on a healthy
+    /// single-minibatch phase.
+    pub learning_rate: f64,
 }
 
 /// Phasic Policy Gradient agent.
@@ -901,6 +911,7 @@ where
             },
             epochs_run,
             minibatches: mb_count,
+            learning_rate: lr,
         };
         self.last_aux = Some(stats);
         Some(stats)
@@ -945,7 +956,7 @@ mod tests {
     use super::*;
     use burn::backend::{Autodiff, Flex};
     use burn::grad_clipping::GradientClippingConfig;
-    use burn::module::{Module, ModuleMapper, Param};
+    use burn::module::{Module, ModuleMapper, ModuleVisitor, Param};
     use burn::nn::{Linear, LinearConfig};
     use burn::tensor::backend::Backend;
     use rand::SeedableRng;
@@ -1080,6 +1091,36 @@ mod tests {
             let (id, tensor, mapper) = param.consume();
             Param::from_mapped_value(id, tensor.mul_scalar(f32::NAN), mapper)
         }
+    }
+
+    /// Flattens every float parameter of a module into one host `Vec<f32>`, in
+    /// visit order, so two snapshots taken around a phase can be diffed
+    /// element-wise.
+    ///
+    /// Visits rather than naming fields: the policy heads keep their `Linear`
+    /// layers private, and a whole-module sweep also cannot miss a parameter a
+    /// future head adds.
+    struct ParamSnapshot {
+        values: Vec<f32>,
+    }
+
+    impl<B: Backend> ModuleVisitor<B> for ParamSnapshot {
+        fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
+            self.values.extend(
+                param
+                    .val()
+                    .into_data()
+                    .convert::<f32>()
+                    .into_vec::<f32>()
+                    .expect("f32 parameter host read"),
+            );
+        }
+    }
+
+    fn param_snapshot<B: Backend, M: Module<B>>(module: &M) -> Vec<f32> {
+        let mut snapshot = ParamSnapshot { values: Vec::new() };
+        module.visit(&mut snapshot);
+        snapshot.values
     }
 
     /// Reads the main value head's weights back to the host, element-wise, so a
@@ -1335,6 +1376,84 @@ mod tests {
             "the last policy phase ran at a positive rate, so the auxiliary phase \
              that accompanies it must too — got {}",
             agent.policy_phase_lr
+        );
+    }
+
+    /// Behavioral companion to
+    /// [`ppg_policy_phase_lr_trails_current_learning_rate_by_one_tick`]: the
+    /// aligned rate must actually *move parameters*, not merely be positive.
+    ///
+    /// Measures a host-side weight delta across the terminal auxiliary phase —
+    /// the phase #324 turned into a bit-exact no-op. A weight delta is
+    /// `lr · step`, linear in the learning rate and here ~1e-4 against weights
+    /// of order 1e-1, so it clears `f32` resolution by several orders of
+    /// magnitude.
+    ///
+    /// This exists because the equivalent end-to-end check in
+    /// `crates/rlevo/tests/ppg_integration.rs` used to assert
+    /// `AuxPhaseStats::policy_kl > 0.0`. That also catches #324 — at `lr == 0.0`
+    /// the parameters are bitwise unchanged and every minibatch's KL is an exact
+    /// zero — but it decides the question through an `f32` mean of
+    /// log-differences between near-identical logits, measured at ~3.4×
+    /// `f32::EPSILON` on a healthy run. A backend with a different reduction
+    /// order could round a *healthy* phase to zero. The integration test now
+    /// asserts on `AuxPhaseStats::learning_rate`, which is exact, and the
+    /// "a nonzero rate moves the policy" half lives here, where the observable
+    /// has margin to spare.
+    #[test]
+    // `current_learning_rate()` landing on *exactly* 0.0 at the terminal
+    // iteration is the precondition that makes this #324's failing
+    // configuration rather than an ordinary interior phase.
+    #[allow(clippy::float_cmp)]
+    fn ppg_aux_phase_at_nonzero_lr_moves_policy_parameters() {
+        const TOTAL_ITERATIONS: usize = 4;
+        let mut agent = annealing_ppg_agent(TOTAL_ITERATIONS);
+        let mut rng = StdRng::seed_from_u64(9);
+
+        // `annealing_ppg_agent` sets `n_iteration = 1`, so an auxiliary phase
+        // fires after every policy phase; the loop keeps the last one. Mirrors
+        // the per-iteration order in `algorithms::ppg::train`.
+        let mut terminal = None;
+        for _ in 0..TOTAL_ITERATIONS {
+            collect_rollout(&mut agent, &mut rng);
+            agent.snapshot_into_aux_buffer();
+            agent.policy_phase_update(&mut rng);
+            let before = param_snapshot(agent.policy());
+            let stats = agent.maybe_aux_phase(&mut rng);
+            let after = param_snapshot(agent.policy());
+            if let Some(stats) = stats {
+                terminal = Some((before, after, stats));
+            }
+        }
+
+        let (before, after, stats) =
+            terminal.expect("with n_iteration = 1 an auxiliary phase fires every iteration");
+        assert_eq!(
+            agent.current_learning_rate(),
+            0.0,
+            "the anneal must land on exactly 0.0 at the terminal iteration, or this is not \
+             the configuration #324 broke"
+        );
+        assert!(
+            stats.learning_rate > 0.0,
+            "the terminal auxiliary phase must step at the rate of the policy phase it \
+             accompanies, got {}",
+            stats.learning_rate
+        );
+        assert_eq!(
+            before.len(),
+            after.len(),
+            "the auxiliary phase must not change the policy's parameter topology"
+        );
+        let max_delta = before
+            .iter()
+            .zip(&after)
+            .map(|(b, a)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            max_delta > 0.0,
+            "the terminal auxiliary phase left every policy parameter bit-exactly unchanged \
+             (max |Δw| = {max_delta}) — that is what stepping at lr = 0.0 does (#324)"
         );
     }
 }

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -336,41 +336,49 @@ fn ppg_final_aux_phase_steps_at_a_nonzero_learning_rate() {
     let aux = agent
         .last_aux_phase()
         .expect("the aux phase must have fired at the final iteration");
-    // Soundness precondition for `policy_kl > 0.0` below, not just a
-    // liveness check. `maybe_aux_phase` snapshots `π_old` once, before the aux
-    // epoch loop, so the *first* minibatch of the *first* epoch runs its
-    // "new" forward pass over weights the phase has not stepped yet — that
-    // minibatch's KL is structurally `0.0` at any learning rate, healthy or
-    // annealed to nothing. `policy_kl` is the mean over minibatches, so it is
-    // strictly positive only when more than one minibatch runs. A
-    // single-minibatch aux phase (`e_aux = 1` with `aux_batch_size` ≥ the total
-    // aux step count) reports `policy_kl == 0.0` at a perfectly healthy lr.
-    //
-    // This config does: `n_iteration = 2` slices × `NUM_STEPS = 128` = 256 aux
-    // steps, chunked at `aux_batch_size = 128` → 2 chunks, × `e_aux = 6`
-    // epochs = 12 minibatches.
+    // Liveness: the phase must have done real optimizer work for its reported
+    // learning rate to mean anything. This config does `n_iteration = 2` slices
+    // × `NUM_STEPS = 128` = 256 aux steps, chunked at `aux_batch_size = 128` →
+    // 2 chunks, × `e_aux = 6` epochs = 12 minibatches.
     assert!(
-        aux.minibatches > 1,
-        "`policy_kl > 0.0` is only meaningful when the aux phase runs more than one \
-         minibatch (the first minibatch's KL is structurally zero — π_old is snapshotted \
-         before the epoch loop); got {} minibatches, so shrinking `n_iteration × NUM_STEPS` \
-         or growing `aux_batch_size` into a single chunk has invalidated this test rather \
-         than regressed #324",
+        aux.minibatches > 0,
+        "the final aux phase must have run at least one minibatch for its learning rate \
+         to describe any actual step; got {}",
         aux.minibatches
+    );
+    // The load-bearing assertion, and deliberately a check on the *rate* rather
+    // than on any downstream numeric effect of it.
+    //
+    // #324 is a bit-exact defect: the terminal aux phase read
+    // `current_learning_rate()` after `policy_phase_update` had bumped
+    // `iteration`, so it ran at an anneal of exactly `0.0`. `learning_rate` is a
+    // copy of the `f64` the optimizer steps were handed, not a recomputation, so
+    // `> 0.0` decides the bug on every backend with no tolerance to tune.
+    //
+    // The previous form of this test asserted `policy_kl > 0.0` instead. That
+    // also catches the bug — at `lr == 0.0` the parameters are bitwise unchanged
+    // and every minibatch's KL is an exact zero — but it decides it through an
+    // `f32` mean of log-differences between near-identical logits. The healthy
+    // margin here measures ~4.1e-7, about 3.4× `f32::EPSILON`, so a backend with
+    // a different reduction order or fused multiply-add could round a *healthy*
+    // phase to zero and fail this test for a reason unrelated to #324. That
+    // exposure became live when the `rlevo` crate joined the PR gate (#519) and
+    // these tests started running on hardware other than the author's.
+    //
+    // The behavioral half — that a nonzero rate actually moves parameters — is
+    // asserted directly, and deterministically, by
+    // `ppg_aux_phase_at_nonzero_lr_moves_policy_parameters` in
+    // `rlevo-reinforcement-learning`, which measures a weight delta rather than
+    // a KL and so has no cancellation exposure.
+    assert!(
+        aux.learning_rate > 0.0,
+        "the final aux phase ran at lr = {}; it must step at the rate of the policy phase \
+         it accompanies, which is nonzero at every iteration (#324)",
+        aux.learning_rate
     );
     assert!(
         aux.policy_kl.is_finite(),
         "the final aux phase's distillation KL must be finite, got {}",
-        aux.policy_kl
-    );
-    // The load-bearing assertion. `policy_kl` is `KL(π_old ‖ π_new)` against a
-    // snapshot taken at the start of the phase, so at `lr == 0.0` the policy
-    // cannot move and every minibatch contributes an exact zero.
-    assert!(
-        aux.policy_kl > 0.0,
-        "the final aux phase moved the policy by exactly nothing (policy_kl = {}), which \
-         means it ran at lr = 0.0 — it must step at the rate of the policy phase it \
-         accompanies (#324)",
         aux.policy_kl
     );
 }


### PR DESCRIPTION
## Summary

Fixes a CI gap in which non-ignored tests ran in no workflow at all. `crate-tests.yml`'s test matrix is hand-maintained and named five of the eleven crates under `crates/`; nothing in cargo reports the omission, so an absent crate's tests were never compiled or run and CI was green because nothing was checked. `rlevo` was the worst case — its 22 test binaries were reachable only through `weekly-tests.yml`, which runs `-- --ignored`, a filter that *excludes* non-ignored tests rather than adding to them. 38 non-ignored tests across 16 binaries executed nowhere, including the regression tests written for #321 and #324 specifically so they would gate PRs. All eleven crates now run in the gate, and a new `test-matrix-coverage` job makes the omission itself fail the build.

The second commit is a prerequisite, not a drive-by: turning the gate on runs the #324 regression test on shared CI hardware for the first time, and its assertion was numerically fragile. See **Notes**.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Other — CI/CD change. Out of scope per the template's alpha-phase note; filed and discussed as #519 first, and the fix is the one that issue's "Suggested fix" section proposes.

## Linked Issue

Closes #519

Refs #324, #321, #391.

## What Was Changed

- `.github/workflows/crate-tests.yml` — test matrix 5 → 11 crates (adds `rlevo`, `rlevo-benchmarks-report-client`, `rlevo-examples`, `rlevo-hybrid`, `rlevo-metrics-registry`, `rlevo-test-support`); `include:` entry supplying `--features viz-report` for `rlevo`; new `test-matrix-coverage` job that fails the build when any crate under `crates/` is absent from the matrix.
- `crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs` — added `AuxPhaseStats::learning_rate: f64` (the rate both optimizer steps ran at, copied from `policy_phase_lr`, not recomputed); added a `ParamSnapshot` `ModuleVisitor` + `param_snapshot` test helper; added `ppg_aux_phase_at_nonzero_lr_moves_policy_parameters`.
- `crates/rlevo/tests/ppg_integration.rs` — `ppg_final_aux_phase_steps_at_a_nonzero_learning_rate`'s load-bearing assertion moved from `policy_kl > 0.0` to `learning_rate > 0.0`; `policy_kl` retained as `is_finite()`; `minibatches` precondition relaxed `> 1` → `> 0` (see the commit's CRITICAL note).
- `CHANGELOG.md` — `rlevo-reinforcement-learning`/**Added** and a new **Infrastructure**/**Fixed** entry.

## How It Was Tested

All three template commands, run on this branch:

```
cargo build --workspace                          # exit 0
cargo test --workspace                           # exit 0, zero FAILED
cargo clippy --all-targets --all-features        # exit 0, zero warnings
```

Also run, since `--all-features` does not reach the path this PR adds:

```
cargo test -p rlevo --features viz-report        # 54.9s wall, ~50 tests, all green
cargo fmt --all --check                          # clean
```

**Regression tests fail on the previous code.** Both new assertions were checked against a deliberately reintroduced #324 (`let lr = self.current_learning_rate()` in `maybe_aux_phase`):

| Assertion | Result against the bug |
|---|---|
| `stats.learning_rate > 0.0` (unit) | FAILED — "got 0" |
| `max \|Δw\| > 0.0` (unit) | FAILED — `max \|Δw\| = 0` exactly |
| `aux.learning_rate > 0.0` (integration) | FAILED — `ppg_integration.rs:373` |

The two unit assertions were verified independently by temporarily relaxing the learning-rate check so the weight-delta check could be reached. Mutation reverted and residue-checked before committing.

**The new CI job was tested both ways** against a scratch copy of the tree: passes as-is, and exits 1 naming `rlevo` when `rlevo` is removed from the matrix — without being falsely satisfied by the `rlevo-core` substring.

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`)
- Burn backend tested: `Flex` (`FlexAutodiff`)
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **all four files, plus the runtime measurements, the mutation testing, and this PR description.** Session transcript linked in each commit's `Claude-Session:` trailer.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [ ] This PR addresses a single concern. — **Not ticked.** Two commits, two concerns. See Notes.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Why two concerns ship together.** `test(ppg)` is a prerequisite for `fix(ci)`, not an unrelated cleanup. The #324 regression test decided the bug through `policy_kl > 0.0` — correct, since at `lr == 0.0` parameters are bitwise unchanged and every minibatch's KL is an exact zero, but routed through an `f32` mean of log-differences between near-identical logits. The healthy margin measures ~4.1e-7, about 3.4× `f32::EPSILON`. That is safe on one developer's machine and questionable the moment the gate starts running it on shared runners, which is exactly what the other commit does. No tolerance was added — the bug's signature is a structurally exact zero, so `> 0.0` already has maximal discriminating power and any positive floor would only widen the false-failure band. The observable changed instead. Landing `fix(ci)` alone would knowingly introduce a flake risk; they are reviewable as separate commits.

**Scope beyond the issue text.** #519 describes the gap as `rlevo`-only and proposes adding that one crate. Investigating found five more crates absent from the matrix with real, green, sub-second tests (114 tests between them). They are included here because the `test-matrix-coverage` job would flag them immediately, and adding a guard that knows about them while leaving them ungated would be incoherent. Happy to narrow this to `rlevo` alone if you would rather handle the others separately.

**Two corrections to the issue, both established by executing rather than reading.** #519 hedged that the two `viz-report` binaries "would skip or fail depending on wiring" — it is **fail**; neither is `#![cfg]`-gated. And `rlevo-examples` does *not* need excluding: `just test-workspace` excludes it and I initially copied that reasoning into the guard, but `cargo test -p rlevo-examples` compiles and runs 5 tests in 0.08 s. The `required-features` gating applies to the crate's *examples*, which `viz-examples.yml` already covers, not to its integration test. The exclusion list was dropped entirely.

**Follow-ups, not addressed here.**
- `just test-workspace` (`justfile:277-278`) runs `cargo test --workspace --exclude rlevo-examples` and is referenced by no workflow — the same orphaned-recipe pattern #519 spotted for `just test-ddpg`/`test-td3`/`test-sac`. A workflow calling it would have closed this gap at any point.
- `weekly-tests.yml` still runs `-- --ignored`. That is now correct by construction — the PR gate owns non-ignored tests, weekly owns the heavy runs — but the division of labour is written down nowhere.
- The per-agent and per-suite `just` recipes are now redundant with the `rlevo` matrix row. Keep as local conveniences or delete; not decided here.
- Other integration tests entering the gate for the first time have not been audited for the same class of `f32` fragility that motivated the first commit.

**One caveat on the guard job.** It greps the workflow YAML for `^ +- <crate>$` rather than parsing it. Whole-line matching prevents `rlevo` being satisfied by `rlevo-core`, and the failure path was tested — but it assumes bare list items appear only under the matrix's `crate:` key. True today (every other list in the file is a mapping) and noted in a comment.
