### PR TITLE
fix(qrdqn): Reject kappa outside the loss domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -764,6 +764,55 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **QR-DQN's Huber threshold κ is now required to be finite and strictly
+  positive, closing two NaN paths that `validate()` waved through** (resolves
+  #345). `QrDqnTrainingConfig::validate` checked κ with
+  `config::in_range("kappa", 0.0, f64::INFINITY, …)`, and `config::in_range` is
+  inclusive at *both* ends — so the one value that must never reach the loss was
+  the one the check explicitly admitted. κ is the divisor of Dabney et al.
+  (2018) Eq. (10), `ρ^κ_τ(u) = |τ − 𝟙{u<0}| · L_κ(u) / κ`, which
+  `quantile_loss.rs` implements literally as `(weight * huber_u).div_scalar(κ)`.
+  Correcting the issue as filed: κ = 0 does **not** produce `inf`. `huber()`
+  returns exactly `0.0` at κ = 0 (the `|u| ≤ 0` mask is false for nonzero `u`,
+  leaving the linear branch `(|u| − 0)·0`), so the division is `0/0` and the
+  loss is `NaN` — verified by execution, not by reading. The inclusive *upper*
+  bound was the second hole and went unreported: the Huber mask selects the
+  quadratic branch everywhere, but the masked-out linear branch `(|u| − 0.5κ)·κ`
+  is still evaluated eagerly, so once it overflows f32 the blend computes
+  `0 · (−inf)` = `NaN` in **every** element, including at `u = 0`. That happens
+  at κ = `+∞` and also at any κ large enough that `0.5·κ²` exceeds `f32::MAX`,
+  so an `is_finite` check alone is not sufficient. `NaN` itself was never
+  reachable — `NaN >= lo` is false, so `in_range` already rejected it.
+  Also correcting the severity this issue was filed under: an invalid κ does
+  **not** corrupt weights. `FiniteLossGuard` (ADR 0056, #318) checks the loss
+  scalar in `qrdqn_agent.rs` before `backward()`, skips the optimizer step, and
+  fires a one-shot `tracing::warn!` — so the actual pre-fix consequence was a
+  QR-DQN run that *silently stalled*, every update a no-op while the step
+  counter advanced, discoverable only from a single warn line. That is a milder
+  and quite different failure from the silent poisoning the issue describes, and
+  it is what makes the config-boundary rejection the right fix: fail fast with a
+  named field error instead of leaning on a downstream generic guard and a
+  stalled run. Validation now uses `config::positive` plus an explicit
+  finiteness-and-overflow guard, and the fix sits at the config boundary rather
+  than inside the loss: both
+  `QrDqnTrainingConfigBuilder::build` and `QrDqnAgent::new` call `validate()`,
+  so a hand-constructed config with `pub` fields cannot route around it. No
+  behavior changes for any valid κ, and no call site in the repo moved — every
+  one already passed `1.0`. The existing tests missed this because the config
+  suite covered `num_quantiles == 0` and the τ/cadence cross-field case but had
+  no κ boundary test at all; the new `rejects_*_kappa` tests fence the whole
+  invalid domain, and were confirmed to fail against the pre-fix validator
+  before the fix landed. The root cause of the upper-bound half lives in
+  `huber()`'s eagerly-evaluated masked-out branch, not in κ — that pattern is
+  filed separately, since it is reachable through the public
+  `quantile_huber_loss_per_sample` regardless of what the config accepts. Note
+  for anyone expecting the paper's κ = 0 variant: QR-DQN-0 is *not* Eq. (10)
+  evaluated at zero. The paper's "as κ → 0 the quantile Huber loss reverts to
+  the quantile regression loss" is a limit statement, and its κ = 0 experiments
+  substitute the separate unsmoothed Eq. (8), `ρ_τ(u) = u(τ − 𝟙{u<0})`, which
+  this crate does not implement — so `kappa = 0.0` was never a way to select it.
+  The field docs and the crate README now say so.
+
 - **PPG's auxiliary phase no longer anneals one iteration ahead of the policy
   phase it accompanies** (resolves #324). `maybe_aux_phase` read
   `current_learning_rate()`, but `policy_phase_update` had already incremented

--- a/crates/rlevo-reinforcement-learning/README.md
+++ b/crates/rlevo-reinforcement-learning/README.md
@@ -107,6 +107,16 @@ Distributional-specific hyperparameters:
 | `num_quantiles` | 200 | Dabney et al. (2018) |
 | `kappa` (Huber threshold) | 1.0 | Dabney et al. (2018) |
 
+`kappa` must be **strictly positive and small enough that `0.5·κ²` stays finite
+in `f32`** (κ ⩽ √(2·`f32::MAX`) ≈ 2.6e19) — Eq. (10) divides by κ, and the Huber
+loss evaluates its `−0.5·κ²` linear branch eagerly before masking it out, so
+`validate()` rejects `0.0`, negatives, `NaN`, `±∞`, and any overflowing κ. An
+invalid κ does not corrupt weights: `FiniteLossGuard` skips the update, so
+training stalls silently instead. The paper's κ = 0
+variant (QR-DQN-0) is the *unsmoothed* Eq. (8) quantile loss, a separate
+formula that is not implemented here; it is not reachable by setting
+`kappa = 0.0`.
+
 **References**
 
 - W. Dabney, M. Rowland, M. G. Bellemare, and R. Munos, "Distributional reinforcement learning with quantile regression," in Proc. Thirty-Second AAAI Conf. Artif. Intell., vol. 32, no. 1, Feb. 2018, doi: 10.1609/aaai.v32i1.11791. [arXiv](https://arxiv.org/abs/1710.10044)

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
@@ -14,7 +14,7 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use burn::tensor::backend::Backend;
 use burn::tensor::{Tensor, TensorData};
-use rlevo_core::config::{self, ConfigError, Validate};
+use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
 use crate::replay::PrioritizedReplaySettings;
 use crate::target::TargetUpdate;
@@ -97,6 +97,59 @@ pub struct QrDqnTrainingConfig {
 
     /// Huber threshold `κ` used by the quantile Huber loss. Values below
     /// `κ` are treated quadratically, above `κ` linearly. Default `1.0`.
+    ///
+    /// # Valid domain: strictly positive, with `0.5 · κ²` finite in `f32`
+    ///
+    /// [`validate`](Validate::validate) rejects `κ ≤ 0`, `NaN`, and every κ
+    /// large enough that `0.5 · κ²` overflows `f32` — the last accepted value
+    /// is `≈ 2.6087635e19` (`√(2 · f32::MAX)`), which also excludes `+∞`.
+    ///
+    /// Two independent `NaN` sources motivate the bounds. Dabney et al. (2018)
+    /// Eq. (10) is `ρ^κ_τ(u) = |τ − 𝟙{u<0}| · L_κ(u) / κ`, so κ is a
+    /// **divisor** and κ = 0 evaluates `0/0`. Separately, `huber` evaluates
+    /// *both* branches eagerly and selects with a multiplicative mask:
+    /// `linear = (|u| − 0.5·κ)·κ ≈ −0.5·κ²` for the small-residual elements
+    /// the mask is about to discard. Once `0.5 · κ²` overflows to `−∞`, the
+    /// discard is `0 · (−∞) = NaN` — so a huge-but-finite κ poisons every
+    /// element even though the mask selects the quadratic branch everywhere.
+    /// The upper bound is therefore the precondition of that eager branch, not
+    /// a magic constant; it is verified against the measured boundary in
+    /// `rejects_overflowing_kappa`.
+    ///
+    /// # What an invalid κ actually costs
+    ///
+    /// It does **not** corrupt the weights. Every QR-DQN update reads its loss
+    /// scalar host-side and passes it through `FiniteLossGuard` (ADR 0056,
+    /// issue #318) *before* `backward()`, so a `NaN` loss skips the backward
+    /// pass, the optimizer step, the target update, and the PER writeback. The
+    /// failure mode is quieter than corruption and harder to spot: every
+    /// update becomes a no-op while `gradient_updates` keeps advancing, so
+    /// training runs to completion, reports its cadence faithfully, and learns
+    /// nothing — discoverable only from a single one-shot `tracing::warn!`.
+    /// Rejecting κ here fails fast with a named-field [`ConfigError`] instead
+    /// of relying on a downstream generic guard and a silent stall.
+    ///
+    /// # Tiny κ is accepted and is not a `NaN`, but is not useful
+    ///
+    /// Subnormal κ (~`1e-45`) validates and produces a finite loss, because
+    /// `L_κ(u)` underflows to `0.0` before the division does any damage. The
+    /// measured loss is then exactly `0.0` for ordinary residuals: the
+    /// gradient signal is flushed away by `f32` precision loss rather than by
+    /// any modelled behaviour. This is documented, not rejected — the boundary
+    /// is unrepresentable as a clean threshold and depends on the residual
+    /// magnitudes. Values below ~`1e-20` should be treated as a modelling
+    /// mistake.
+    ///
+    /// # κ = 0 (QR-DQN-0) is not representable here
+    ///
+    /// The paper notes that "as κ → 0 the quantile Huber loss reverts to the
+    /// quantile regression loss" — a **limit** statement, not an evaluation.
+    /// The paper's own κ = 0 variant, QR-DQN-0, is the strict quantile loss of
+    /// Eq. (8), `ρ_τ(u) = u(τ − 𝟙{u<0})`, a separate unsmoothed formula
+    /// substituted for Eq. (10) rather than Eq. (10) at κ = 0. That unsmoothed
+    /// path is not implemented in this crate, so QR-DQN-0 cannot be selected by
+    /// setting this field to `0.0`. The default `1.0` is the paper's
+    /// recommended QR-DQN-1, which outperformed QR-DQN-0 on Atari-57.
     pub kappa: f32,
 
     /// Optional gradient-norm / gradient-value clipping.
@@ -190,7 +243,35 @@ impl Validate for QrDqnTrainingConfig {
         config::nonzero(C, "train_frequency", self.train_frequency)?;
         config::nonzero(C, "steps_per_episode", self.steps_per_episode)?;
         config::nonzero(C, "num_quantiles", self.num_quantiles)?;
-        config::in_range(C, "kappa", 0.0, f64::INFINITY, f64::from(self.kappa))?;
+        // κ is the *divisor* of Dabney et al. (2018) Eq. (10), so the whole
+        // open interval is required — not the closed `[0, ∞]` an `in_range`
+        // would accept. κ = 0 makes the loss evaluate `0/0` → NaN. This half
+        // also catches NaN and −∞.
+        config::positive(C, "kappa", f64::from(self.kappa))?;
+        // The upper bound is not a range check but the precondition of
+        // `huber`'s eagerly-evaluated linear branch: it computes
+        // `(|u| − 0.5·κ)·κ` for *every* element and then discards the
+        // small-residual ones by multiplying by a 0.0 mask. Once `0.5·κ²`
+        // overflows f32 to `−∞`, that discard is `0 · (−∞) = NaN`, so a
+        // huge-but-finite κ poisons the whole loss even though the mask
+        // selects the quadratic branch everywhere. Expressing the guard as
+        // "the branch must not overflow" rather than a hardcoded threshold
+        // keeps it correct if `huber` changes; the resulting cutoff is
+        // `√(2 · f32::MAX) ≈ 2.6087635e19`, measured to be exact to the ULP
+        // (see `rejects_overflowing_kappa`). `+∞` fails here too.
+        if !(0.5 * self.kappa * self.kappa).is_finite() {
+            return Err(ConfigError {
+                config: C,
+                field: "kappa",
+                kind: ConstraintKind::Custom(
+                    "the Huber threshold is too large: the quantile Huber \
+                     loss evaluates its linear branch `(|u| − 0.5·κ)·κ` for \
+                     every element before masking, so `0.5·κ²` must stay \
+                     finite in f32 (κ ≤ √(2·f32::MAX) ≈ 2.6e19) or the \
+                     masked-out elements become `0 · (−∞)` = NaN",
+                ),
+            });
+        }
         if let Some(per) = &self.prioritized_replay {
             per.validate()?;
         }
@@ -329,6 +410,12 @@ impl QrDqnTrainingConfigBuilder {
     }
 
     /// Sets [`QrDqnTrainingConfig::kappa`] (Huber loss threshold κ).
+    ///
+    /// κ must be strictly positive and small enough that `0.5 · κ²` stays
+    /// finite in `f32`; [`build`](Self::build) rejects anything else, because
+    /// the quantile Huber loss divides by κ and evaluates a `−0.5·κ²` branch
+    /// eagerly. See [`QrDqnTrainingConfig::kappa`] for the derivation and for
+    /// why κ = 0 is not QR-DQN-0.
     #[must_use]
     pub fn kappa(mut self, kappa: f32) -> Self {
         self.config.kappa = kappa;
@@ -367,8 +454,10 @@ impl QrDqnTrainingConfigBuilder {
     /// # Errors
     ///
     /// Returns a [`ConfigError`] if the assembled config violates any invariant
-    /// checked by [`QrDqnTrainingConfig::validate`] (e.g. zero `num_quantiles`
-    /// or a negative `kappa`).
+    /// checked by [`QrDqnTrainingConfig::validate`] — e.g. zero
+    /// `num_quantiles`, or a `kappa` that is not strictly positive or is large
+    /// enough to overflow the Huber loss's linear branch (see
+    /// [`QrDqnTrainingConfig::kappa`]).
     pub fn build(self) -> Result<QrDqnTrainingConfig, ConfigError> {
         self.config.validate()?;
         Ok(self.config)
@@ -424,6 +513,127 @@ mod tests {
         let cfg = QrDqnTrainingConfig::default();
         assert_eq!(cfg.target_update, TargetUpdate::polyak(0.005, 1));
         assert_eq!(cfg.target_update.every(), 1);
+    }
+
+    /// κ = 0 makes Dabney et al. (2018) Eq. (10) evaluate `0/0`: the loss
+    /// divides by κ, so the config boundary — not the loss — must reject it.
+    #[test]
+    fn rejects_zero_kappa() {
+        let err = QrDqnTrainingConfigBuilder::new()
+            .kappa(0.0)
+            .build()
+            .expect_err("kappa = 0 divides by zero in the quantile Huber loss");
+        assert_eq!(err.field, "kappa", "the error must name the kappa field");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::NotPositive { got: 0.0 },
+            "κ = 0 must be rejected by the strict-positivity half of the guard, \
+             not incidentally by the overflow half"
+        );
+    }
+
+    /// Regression guard: a negative Huber threshold was already rejected and
+    /// must stay rejected.
+    #[test]
+    fn rejects_negative_kappa() {
+        let err = QrDqnTrainingConfigBuilder::new()
+            .kappa(-1.0)
+            .build()
+            .expect_err("a negative Huber threshold is meaningless");
+        assert_eq!(err.field, "kappa", "the error must name the kappa field");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::NotPositive { got: -1.0 },
+            "a negative κ must be rejected as NotPositive"
+        );
+    }
+
+    /// `NaN` and `−∞` fail `got > 0.0`, so they are caught by `config::positive`
+    /// — the *same* branch as κ = 0, not by the overflow guard. Asserted per
+    /// value rather than in one loop with `+∞`, which lands in a different
+    /// branch (see `rejects_overflowing_kappa`).
+    #[test]
+    fn rejects_non_finite_kappa() {
+        for bad in [f32::NAN, f32::NEG_INFINITY] {
+            let err = QrDqnTrainingConfigBuilder::new()
+                .kappa(bad)
+                .build()
+                .expect_err("kappa must be finite");
+            assert_eq!(err.field, "kappa", "the error must name the kappa field");
+            match err.kind {
+                ConstraintKind::NotPositive { got } => assert_eq!(
+                    got.is_nan(),
+                    bad.is_nan(),
+                    "NotPositive must carry the offending value verbatim, got {got}"
+                ),
+                other => panic!("{bad} must be rejected as NotPositive, got {other:?}"),
+            }
+        }
+    }
+
+    /// A huge-but-*finite* κ is as fatal as κ = 0 and was the hole the first
+    /// `is_finite` guard left open. `huber` evaluates its linear branch
+    /// `(|u| − 0.5·κ)·κ` for every element before masking, so once `0.5·κ²`
+    /// overflows f32 to `−∞` the masked-out elements become `0 · (−∞)` = NaN,
+    /// even though the mask selects the quadratic branch everywhere.
+    ///
+    /// The rejected values below bracket the measured NaN boundary: on the
+    /// `Flex` backend `quantile_huber_loss_per_sample` returns a finite loss at
+    /// κ = `2.608_763_5e19` and `NaN` at the very next `f32`,
+    /// `2.608_763_7e19` — i.e. the guard `!(0.5·κ²).is_finite()` is exact to
+    /// the ULP, not merely conservative.
+    #[test]
+    fn rejects_overflowing_kappa() {
+        // Bit-search the exact f32 boundary rather than transcribing a
+        // literal: `√(2 · f32::MAX)` is not representable by a computation
+        // that stays in f32, and a transcribed decimal could land on either
+        // side of the true cutoff as the rounding of the literal drifts.
+        // f32 bit patterns of positive finite values are monotonic, so a
+        // plain binary search over `to_bits` finds it.
+        let (mut lo, mut hi) = (1.0_f32.to_bits(), f32::MAX.to_bits());
+        while lo + 1 < hi {
+            let mid = lo + (hi - lo) / 2;
+            let k = f32::from_bits(mid);
+            if (0.5 * k * k).is_finite() {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let last_ok = f32::from_bits(lo);
+        assert!(
+            (2.608_763e19..2.608_764e19).contains(&last_ok),
+            "the cutoff must be √(2·f32::MAX) ≈ 2.6087635e19, got {last_ok:e}"
+        );
+
+        for bad in [
+            f32::from_bits(lo + 1),
+            2.7e19,
+            1e20,
+            f32::MAX,
+            f32::INFINITY,
+        ] {
+            let err = QrDqnTrainingConfigBuilder::new()
+                .kappa(bad)
+                .build()
+                .expect_err("kappa whose 0.5·κ² overflows f32 makes the loss NaN");
+            assert_eq!(err.field, "kappa", "the error must name the kappa field");
+            assert!(
+                matches!(err.kind, ConstraintKind::Custom(_)),
+                "{bad} overflows the Huber linear branch and must be rejected by \
+                 the Custom overflow guard, not as NotPositive; got {:?}",
+                err.kind
+            );
+        }
+
+        // The bound must not be over-tight: κ far above any sane setting, but
+        // whose linear branch still fits in f32, stays accepted.
+        for good in [1.0_f32, 1e9, 1e18, last_ok] {
+            QrDqnTrainingConfigBuilder::new()
+                .kappa(good)
+                .build()
+                .expect("a κ whose 0.5·κ² is finite must validate");
+        }
     }
 
     /// Replaces `rejects_frozen_target_when_tau_and_frequency_are_both_zero`.


### PR DESCRIPTION
## Summary

`QrDqnTrainingConfig::validate()` checked the Huber threshold κ with `config::in_range(C, "kappa", 0.0, f64::INFINITY, …)`, which is inclusive at **both** ends — so the values the quantile Huber loss cannot survive were exactly the ones the check admitted. κ is the divisor of Dabney et al. (2018) Eq. (10), and `quantile_loss.rs` implements that literally as `(weight * huber_u).div_scalar(κ)`. This tightens validation to κ's actual defined domain: strictly positive, and small enough that `huber()`'s eagerly-evaluated linear branch stays finite in f32. No behavior changes for any valid κ.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #345

## What Was Changed

- `crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs`
  - `Validate::validate` — replaced the inclusive `config::in_range(0.0, f64::INFINITY)` with `config::positive` (rejects κ ≤ 0, `NaN`, `−∞`) plus a `!(0.5 * kappa * kappa).is_finite()` guard emitting `ConstraintKind::Custom` (rejects `+∞` and huge finite κ). No new `ConstraintKind` variant — the enum is not `#[non_exhaustive]`, and `Custom` exists for exactly this.
  - Rewrote the `kappa` field doc: valid domain, Eq. (10) citation, why κ = 0 is *not* QR-DQN-0, and a note that subnormal κ (~1e-45) is accepted but flushes the loss to `0.0` through precision loss.
  - Corrected the `build()` `# Errors` doc (previously said "a negative `kappa`") and the builder `kappa()` setter doc.
  - Added regression tests `rejects_zero_kappa`, `rejects_negative_kappa`, `rejects_non_finite_kappa`, `rejects_overflowing_kappa`. All assert `err.kind`, not just `err.field`, matching the `rlevo-core/src/config.rs` convention.
- `crates/rlevo-reinforcement-learning/README.md` — κ domain paragraph after the distributional defaults table.
- `CHANGELOG.md` — entry under `[Unreleased]` → `rlevo-reinforcement-learning` → **Fixed**.

`quantile_loss.rs` and `rlevo-core` are **unchanged** — the guard belongs at the config boundary.

## How It Was Tested

```
cargo build --workspace                      # Finished, no errors
cargo test --workspace                       # 2782 passed; 0 failed
cargo clippy --all-targets --all-features    # no warnings, no errors
cargo fmt --all --check                      # clean
```

**Regression tests, before/after.** Reverting `validate()` to the original `in_range` line and re-running:

```
rejects_zero_kappa        ... FAILED   (build() returned Ok)
rejects_overflowing_kappa ... FAILED   (at κ = 2.6087637e19)
rejects_non_finite_kappa  ... ok       (NaN/−∞ were already caught by in_range)
rejects_negative_kappa    ... ok       (pure regression guard, documented as such)
```

Two of the four genuinely fail on the previous code and pass on this PR. The other two are honest regression guards for behavior that was already correct, and their doc comments say so.

**Measured κ sweep** through `quantile_huber_loss_per_sample`, establishing that the new bound tracks reality rather than algebra:

| κ | loss | finite? |
|---|---|---|
| 1e-45 | 0e0 | yes (precision flush) |
| 1.0 | 2.7083334e-1 | yes |
| 1e18 | 2.7833335e-19 | yes |
| 2.6087635e19 | 1.0669165e-20 | yes |
| **2.6087637e19** (next `f32`) | **NaN** | no |
| 1e20 / `f32::MAX` | NaN | no |

The cutoff is `√(2·f32::MAX) = 2.6087636e19`, exact to the ULP by bit-level binary search. `rejects_overflowing_kappa` bit-searches the boundary in-test rather than hardcoding a decimal literal that could round to either side.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: `Flex` (CPU)
- OS: macOS 26.5.2, arm64 (Apple Silicon)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change — validation logic, tests, doc comments, README paragraph, and CHANGELOG entry — plus the literature check against the QR-DQN paper and the κ-sweep measurements. Reviewed and verified by the maintainer before merge.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Three of #345's claims did not survive execution.** They are corrected in the docs, the commit message, and a comment on the issue:

1. **κ = 0 produces `NaN`, not `inf`.** `huber()` returns exactly `0.0` at κ = 0 (the `|u| ≤ 0` mask is false for nonzero `u`), so the division is `0/0`. The issue's "verified by execution" table mirrored the validator and computed `1/κ` separately — it never ran the loss.
2. **The lower bound was not the only hole.** The inclusive *upper* bound admitted `+∞` and every finite κ above `2.6087636e19`. `config::positive` alone — the fix #345 recommends — would have closed neither.
3. **The severity was overstated.** #345 says the bad value "propagates into `backward()` and poisons the parameters." It does not: `FiniteLossGuard` (ADR 0056, #318) checks the loss at `qrdqn_agent.rs:573` and returns before `backward()` on the next line. The real symptom was a *silently stalled* run — every update a no-op, weights untouched — and it was well camouflaged, because `gradient_updates += 1` sits before the guard (ADR 0059 §4), so the target-update cadence kept firing on a frozen network.

That third point is why the config boundary is the right place for this: not to prevent corruption, but to fail fast with a named field error instead of leaning on a downstream generic guard and leaving the user to find one warn line in a run that looks like it is training.

**Literature.** Rejecting κ = 0 is faithful to the paper, not a deviation. Dabney et al.'s "as κ → 0 the quantile Huber loss reverts to the quantile regression loss" is a *limit* statement — Eq. (10) evaluates `0/0` at κ = 0 — and their own κ = 0 variant (QR-DQN-0) substitutes the separate unsmoothed Eq. (8), `ρ_τ(u) = u(τ − 𝟙{u<0})`, which this crate does not implement. So `kappa = 0.0` was never a way to select QR-DQN-0; the field docs now say so.

**Follow-up — the coupling is load-bearing.** The upper bound encodes a precondition of `huber()`'s *current implementation*, not a property of κ: `huber()` blends its branches by multiplying by a 0/1 mask, so the untaken branch is still evaluated and `0 · (−inf)` is `NaN`. That root cause is reachable through the **public** `quantile_huber_loss_per_sample` regardless of what the config accepts, and is filed as **#888** with a reproducer and a `mask_where` remedy (in-repo precedent: `ppo/losses.rs:173-181`). **If #888 lands, this guard becomes unnecessary and must be relaxed** — otherwise it silently over-rejects. Flagged in the code comment and in the commit's `CRITICAL:` line.

**Scope note for the reviewer.** #345 asks only for `config::positive` and explicitly warns against generalizing the fix. I stayed inside `kappa` — `entropy_coef`, `value_coef`, `exploration_noise`, and `beta_clone` are untouched, and zero remains legitimate for all of them. But rejecting `+∞` and the overflow region is more than the issue asked for. The reasoning: same field, same `validate()` line, same NaN class, and the prescribed fix demonstrably leaves both open. Happy to split the upper bound onto #888 if you would rather keep this PR to the letter of the issue.
