### PR TITLE
fix(env)!: Enforce grid size floors at the construction chokepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,29 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `GoToDoorEnv` implements `Sensor` for its goal-conditioned observation.
   `pixel_grid` keeps `Observable<3>` and delegates its `Sensor` to `project()`.
   Behaviour (observations, rewards, termination) is unchanged.
+- **Nine grid environments now reject sub-minimum configs at construction**
+  (#106): `CrossingEnv`, `DoorKeyEnv`, `DynamicObstaclesEnv`, `EmptyEnv`,
+  `FourRoomsEnv`, `LavaGapEnv`, `MultiRoomEnv`, `UnlockEnv`, `UnlockPickupEnv`.
+  Each declared a minimum but enforced it only in `FromStr`, so `with_config` and
+  `ConstructableEnv::new` accepted values that `from_str` refused. Configs that
+  previously built — `EmptyConfig { size: 3, .. }`, `MultiRoomConfig { num_rooms:
+  1, .. }`, and every other sub-floor value — now return `Err(ConfigError)`.
+
+  *Migration.* Raise the offending field to the environment's documented minimum:
+  `Empty`/`Unlock` 4, `DoorKey`/`DynamicObstacles`/`LavaGap` 5,
+  `Crossing`/`UnlockPickup` 7, `FourRooms` 11 **and odd**, `MultiRoom`
+  `num_rooms ≥ 2`, `room_width ≥ 3`, `height ≥ 5`. Every `Default` config already
+  satisfies its floor, so `ConstructableEnv::new` is unaffected. No persisted data
+  is involved — `Deserialize` remains non-validating by design (ADR 0026 §2), and
+  the constructor is where the rejection now happens for a deserialized config too.
+- **`ConfigError::kind` for a zero-valued grid dimension changes from
+  `ConstraintKind::Zero` to `ConstraintKind::TooSmall { min, got }`** on the same
+  nine environments, because a single `config::at_least` guard replaces the
+  `config::nonzero` it subsumes. Code matching on `Zero` for these fields must
+  match `TooSmall` instead; the new variant carries strictly more information.
+  `max_steps` keeps `nonzero`/`Zero` throughout — it has no floor above 1.
+  `FromStr`'s `String` error text changes correspondingly, from
+  `"size must be >= 5, got 1"` to `ConfigError`'s `Display` form.
 
 **Added**
 
@@ -247,6 +270,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   asserted only `len() >= COMPONENTS` and so accepted (and truncated) a long
   slice. All five now `assert_eq!` and carry a matching `# Panics` line. No
   in-workspace caller passed a non-exact slice, so nothing else changes.
+- **Grid construction no longer panics or silently builds a corrupt board for an
+  undersized config** (#106). The nine environments above split their invariant
+  across two doors: `FromStr` checked the minimum, `Validate::validate` — the one
+  the ADR 0026 chokepoint actually calls — checked only `nonzero`. Anything
+  reaching `with_config` by struct literal, `..Default::default()`, or
+  `Deserialize` therefore skipped the guard entirely and ran `build()` on a size
+  the layout code cannot express. The failure was inconsistent, which is why it
+  survived: `EmptyEnv`/`LavaGapEnv` at `size = 1` panicked with a `usize`
+  underflow, `DoorKeyEnv`/`UnlockEnv`/`UnlockPickupEnv` panicked on an
+  out-of-bounds `Grid::set`, and the rest built quietly broken boards —
+  `UnlockPickupEnv` at `size = 3` produced a board with **no door at all** (the
+  key overwrote it), `FourRoomsEnv` at `size = 7` punched a hole through all four
+  perimeter walls, and `MultiRoomEnv` at `num_rooms = 1` returned a single-room
+  environment. The floors now live in `Validate`, so all four construction paths
+  share one guard, and `FourRoomsEnv` gained `const _` assertions pinning the
+  derivation of its bound at compile time.
+
+  The existing conformance test could not have caught this: every grid case in
+  `tests/config_validation_chokepoint.rs` used a **zero** value, which trips the
+  generic `nonzero` guard and so cannot distinguish a real minimum from an
+  incidental one. Each environment now also has a non-zero below-floor case,
+  which is the input that actually pins the constraint.
 
 ### `rlevo-reinforcement-learning`
 

--- a/crates/rlevo-environments/src/grids/crossing.rs
+++ b/crates/rlevo-environments/src/grids/crossing.rs
@@ -180,9 +180,21 @@ impl Default for CrossingConfig {
 }
 
 impl Validate for CrossingConfig {
+    /// Rejects any `size` below `MIN_SIZE` (7) and a zero `max_steps`.
+    ///
+    /// The `size` floor lives **here**, not only in [`FromStr`]: `CrossingConfig`
+    /// derives `Deserialize`, so a config loaded from a file is user-supplied
+    /// runtime data that never passes through `from_str` (rules.md §4 — "if an
+    /// invalid value can arrive via `Deserialize`, it must be an `Err`").
+    /// Struct-update syntax on [`Default`] bypasses `from_str` just as freely.
+    ///
+    /// [`config::at_least`] subsumes a `nonzero` check for `size`, so the zero
+    /// case reports [`TooSmall`](rlevo_core::config::ConstraintKind::TooSmall)
+    /// rather than [`Zero`](rlevo_core::config::ConstraintKind::Zero);
+    /// `max_steps` keeps `nonzero` because its only floor is 1.
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "CrossingConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -191,6 +203,14 @@ impl Validate for CrossingConfig {
 impl FromStr for CrossingConfig {
     type Err = String;
 
+    /// Parses `"size=9,max_steps=324,seed=0,kind=wall"` (keys in any order) or
+    /// the positional form `"9,324,0,wall"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`CrossingEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -220,9 +240,8 @@ impl FromStr for CrossingConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -283,8 +302,11 @@ impl CrossingEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (7) — zero included — or a zero `max_steps`. This is the
+    /// construction chokepoint (rules.md §4), so it also rejects a config that
+    /// arrived by `Deserialize` or struct-update syntax without passing through
+    /// [`FromStr`].
     pub fn with_config(config: CrossingConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -447,6 +469,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn default_env(kind: CrossingKind) -> CrossingEnv {
@@ -465,6 +488,32 @@ mod tests {
             ..Default::default()
         };
         assert!(CrossingEnv::with_config(bad, false).is_err());
+    }
+
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        // The floor must be enforced at the construction chokepoint, not only in
+        // `FromStr`: a `Deserialize`d or struct-updated config skips the parser
+        // entirely, and used to reach `build` unchecked. The assertion is on the
+        // *policy* (`size >= MIN_SIZE`), not on a geometric claim — some
+        // sub-MIN_SIZE boards do build successfully, which is exactly why the
+        // floor has to be stated rather than inferred from a build failure.
+        let bad = CrossingConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = CrossingEnv::with_config(bad, false)
+            .expect_err("a sub-MIN_SIZE grid must be refused at construction");
+        assert_eq!(err.config, "CrossingConfig", "the config must be named");
+        assert_eq!(err.field, "size", "the offending field must be named");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            },
+            "the structured kind carries the bound; assert it, not the message"
+        );
     }
 
     /// Optimal rollout that works for both lava and wall variants.

--- a/crates/rlevo-environments/src/grids/door_key.rs
+++ b/crates/rlevo-environments/src/grids/door_key.rs
@@ -138,9 +138,21 @@ impl Default for DoorKeyConfig {
 }
 
 impl Validate for DoorKeyConfig {
+    /// Rejects any `size` below `MIN_SIZE` (5) and a zero `max_steps`.
+    ///
+    /// The `size` floor lives **here**, not only in [`FromStr`]: `DoorKeyConfig`
+    /// derives `Deserialize`, so a config loaded from a file is user-supplied
+    /// runtime data that never passes through `from_str` (rules.md §4 — "if an
+    /// invalid value can arrive via `Deserialize`, it must be an `Err`").
+    /// Struct-update syntax on [`Default`] bypasses `from_str` just as freely.
+    ///
+    /// [`config::at_least`] subsumes a `nonzero` check for `size`, so the zero
+    /// case reports [`TooSmall`](rlevo_core::config::ConstraintKind::TooSmall)
+    /// rather than [`Zero`](rlevo_core::config::ConstraintKind::Zero);
+    /// `max_steps` keeps `nonzero` because its only floor is 1.
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "DoorKeyConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -149,6 +161,14 @@ impl Validate for DoorKeyConfig {
 impl FromStr for DoorKeyConfig {
     type Err = String;
 
+    /// Parses `"size=7,max_steps=196,seed=0"` (keys in any order) or the
+    /// positional form `"7,196,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`DoorKeyEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -176,9 +196,8 @@ impl FromStr for DoorKeyConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -243,8 +262,11 @@ impl DoorKeyEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (5) — zero included — or a zero `max_steps`. This is the
+    /// construction chokepoint (rules.md §4), so it also rejects a config that
+    /// arrived by `Deserialize` or struct-update syntax without passing through
+    /// [`FromStr`].
     pub fn with_config(config: DoorKeyConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -404,6 +426,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn env_5x5() -> DoorKeyEnv {
@@ -422,6 +445,29 @@ mod tests {
             ..Default::default()
         };
         assert!(DoorKeyEnv::with_config(bad, false).is_err());
+    }
+
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        // The floor must be enforced at the construction chokepoint, not only in
+        // `FromStr`. Before this guard, size 4 built a board whose goal at (2,2)
+        // overwrote the locked door, making the episode trivially winnable.
+        let bad = DoorKeyConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = DoorKeyEnv::with_config(bad, false)
+            .expect_err("a sub-MIN_SIZE grid must be refused at construction");
+        assert_eq!(err.config, "DoorKeyConfig", "the config must be named");
+        assert_eq!(err.field, "size", "the offending field must be named");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            },
+            "the structured kind carries the bound; assert it, not the message"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
+++ b/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
@@ -154,9 +154,26 @@ impl Default for DynamicObstaclesConfig {
 }
 
 impl Validate for DynamicObstaclesConfig {
+    /// Rejects any `size` below `MIN_SIZE` (5) and a zero `max_steps`.
+    ///
+    /// The `size` floor lives **here**, not only in [`FromStr`]:
+    /// `DynamicObstaclesConfig` derives `Deserialize`, so a config loaded from a
+    /// file is user-supplied runtime data that never passes through `from_str`
+    /// (rules.md §4 — "if an invalid value can arrive via `Deserialize`, it must
+    /// be an `Err`"). Struct-update syntax on [`Default`] bypasses `from_str`
+    /// just as freely.
+    ///
+    /// [`config::at_least`] subsumes a `nonzero` check for `size`, so the zero
+    /// case reports [`TooSmall`](rlevo_core::config::ConstraintKind::TooSmall)
+    /// rather than [`Zero`](rlevo_core::config::ConstraintKind::Zero);
+    /// `max_steps` keeps `nonzero` because its only floor is 1.
+    ///
+    /// `num_obstacles` is deliberately unchecked here: `0` is a supported
+    /// configuration, and the cross-field ceiling relating it to `size` is
+    /// tracked separately.
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "DynamicObstaclesConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -165,6 +182,14 @@ impl Validate for DynamicObstaclesConfig {
 impl FromStr for DynamicObstaclesConfig {
     type Err = String;
 
+    /// Parses `"size=8,num_obstacles=4,max_steps=256,seed=0"` (keys in any
+    /// order) or the positional form `"8,4,256,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`DynamicObstaclesEnv::with_config`] applies, so this parser cannot
+    /// admit a config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -202,9 +227,8 @@ impl FromStr for DynamicObstaclesConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -253,8 +277,11 @@ impl DynamicObstaclesEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (5) — zero included — or a zero `max_steps`. This is the
+    /// construction chokepoint (rules.md §4), so it also rejects a config that
+    /// arrived by `Deserialize` or struct-update syntax without passing through
+    /// [`FromStr`].
     ///
     /// # Examples
     ///
@@ -567,6 +594,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn env_no_obstacles() -> DynamicObstaclesEnv {
@@ -586,6 +614,33 @@ mod tests {
             ..Default::default()
         };
         assert!(DynamicObstaclesEnv::with_config(bad, false).is_err());
+    }
+
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        // The floor must be enforced at the construction chokepoint, not only in
+        // `FromStr`. Before this guard, sizes 2 and 3 built a board on which
+        // *none* of the requested obstacles were placed, silently turning a
+        // stochastic env into a static one.
+        let bad = DynamicObstaclesConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = DynamicObstaclesEnv::with_config(bad, false)
+            .expect_err("a sub-MIN_SIZE grid must be refused at construction");
+        assert_eq!(
+            err.config, "DynamicObstaclesConfig",
+            "the config must be named"
+        );
+        assert_eq!(err.field, "size", "the offending field must be named");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            },
+            "the structured kind carries the bound; assert it, not the message"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/empty.rs
+++ b/crates/rlevo-environments/src/grids/empty.rs
@@ -82,7 +82,8 @@ const MIN_SIZE: usize = 4;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EmptyConfig {
-    /// Grid side length in cells (including perimeter walls).
+    /// Grid side length in cells (including perimeter walls); must be ≥
+    /// `MIN_SIZE` (4).
     pub size: usize,
     /// Maximum number of steps before the episode times out.
     pub max_steps: usize,
@@ -125,9 +126,21 @@ impl Default for EmptyConfig {
 }
 
 impl Validate for EmptyConfig {
+    /// Rejects any `size` below `MIN_SIZE` (4) and a zero `max_steps`.
+    ///
+    /// The `size` guard lives **here**, not only in [`FromStr`]: `EmptyConfig`
+    /// derives `Deserialize`, so a config loaded from a file is user-supplied
+    /// runtime data that never passes through `from_str` (rules.md §4 — "if an
+    /// invalid value can arrive via `Deserialize`, it must be an `Err`").
+    /// The layout builder subtracts 2 from `size` to place the goal, which
+    /// underflows for `size < 2`.
+    ///
+    /// `at_least` subsumes the previous `nonzero` check — `MIN_SIZE >= 1`, so a
+    /// zero `size` is still rejected, now as
+    /// [`ConstraintKind::TooSmall`](rlevo_core::config::ConstraintKind::TooSmall).
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "EmptyConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -139,8 +152,13 @@ impl FromStr for EmptyConfig {
     /// Parse a config from a comma-separated list.
     ///
     /// Accepts positional values (`"5"`, `"5,100"`, `"5,100,42"`) and
-    /// `key=value` pairs (`"size=5,max_steps=100,seed=42"`). Unknown keys
-    /// and sizes below the minimum produce an error.
+    /// `key=value` pairs (`"size=5,max_steps=100,seed=42"`).
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`EmptyEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (i, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -153,9 +171,8 @@ impl FromStr for EmptyConfig {
                 apply_positional(&mut cfg, i, raw)?;
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -225,8 +242,10 @@ impl EmptyEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (4) or a zero `max_steps`. This is the construction chokepoint
+    /// (rules.md §4), so it also rejects a config that arrived by `Deserialize`
+    /// or struct-update syntax without passing through [`FromStr`].
     ///
     /// # Examples
     ///
@@ -369,6 +388,7 @@ mod tests {
     use super::*;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::base::Observation;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     #[test]
@@ -418,8 +438,34 @@ mod tests {
 
     #[test]
     fn fromstr_rejects_small_size() {
+        // `from_str` delegates to `Validate`, so the text is the `ConfigError`
+        // rendering plus the parsed size. Substrings only: the structured
+        // assertion lives in `with_config_rejects_size_below_min`.
         let err = "2".parse::<EmptyConfig>().unwrap_err();
-        assert!(err.contains("size must be"));
+        assert!(err.contains("EmptyConfig.size"), "was {err}");
+        assert!(err.contains("at least 4"), "was {err}");
+    }
+
+    /// Issue #106: `MIN_SIZE` was enforced only in [`FromStr`], so a config
+    /// built by `Deserialize` or struct-update syntax reached `build`, where
+    /// `size - 2` underflowed and panicked. The guard now lives in
+    /// [`Validate`], which `with_config` runs (ADR 0026 chokepoint).
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        let bad = EmptyConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = EmptyEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "EmptyConfig");
+        assert_eq!(err.field, "size");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            }
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/four_rooms.rs
+++ b/crates/rlevo-environments/src/grids/four_rooms.rs
@@ -65,7 +65,7 @@ use super::core::{
 };
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rlevo_core::config::{self, ConfigError, Validate};
+use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
@@ -73,7 +73,35 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 /// Minimum side length; we need at least three interior cells per quadrant.
+///
+/// `11` is an `rlevo` convention, not a value inherited from upstream: Sutton,
+/// Precup & Singh (1999) do not parameterize four-rooms by size at all, and
+/// Farama Minigrid `v3.1.0` hardcodes `self.size = 19` with no `size`
+/// constructor argument. It is deliberately *above* the smallest geometrically
+/// clean size — the openings land inside the border from `9` up — so changing it
+/// is a policy decision, not a bug fix.
 const MIN_SIZE: usize = 11;
+
+// The two invariants `build` silently assumed. Its four openings are written at
+// `mid ± 3` where `mid = size / 2`, with no bounds check of their own; when they
+// fall outside the interior they land on the *border* and punch holes in it.
+// Measured before the guard existed: `size = 7` perforated all four perimeter
+// walls — holes at (0,3), (3,0), (3,6), (6,3) — and `size = 8` perforated two,
+// at (4,7) and (7,4). Written as `const _` so lowering `MIN_SIZE` breaks the
+// build instead of the board.
+//
+//   `mid - 3 >= 1`         (top / left opening stays off the border) → mid >= 4
+//   `mid + 3 <= size - 2`  (bottom / right opening stays off the border)
+const _: () = assert!(MIN_SIZE % 2 == 1, "MIN_SIZE must be odd");
+const _: () = assert!(
+    MIN_SIZE / 2 + 3 <= MIN_SIZE - 2 && MIN_SIZE / 2 >= 4,
+    "the mid±3 openings must land strictly inside the border"
+);
+
+/// Rejection text for an even `size`. Unlike the floor, the parity requirement
+/// has no `at_least` analogue, so it is a `Custom` invariant.
+const SIZE_NOT_ODD: &str =
+    "FourRoomsEnv requires an odd size so the interior cross has a single centre row and column";
 
 /// Configuration for [`FourRoomsEnv`].
 ///
@@ -136,9 +164,32 @@ impl Default for FourRoomsConfig {
 }
 
 impl Validate for FourRoomsConfig {
+    /// Rejects any `size` below `MIN_SIZE` (11), an even `size`, and a zero
+    /// `max_steps`.
+    ///
+    /// Both `size` guards live **here**, not only in [`FromStr`]:
+    /// `FourRoomsConfig` derives `Deserialize`, so a config loaded from a file is
+    /// user-supplied runtime data that never passes through `from_str`
+    /// (rules.md §4 — "if an invalid value can arrive via `Deserialize`, it must
+    /// be an `Err`"). Measured below the floor: `size` 1 through 6 panic inside
+    /// `Grid::set` (out of bounds), and `size` 7 and 8 build a board whose
+    /// `mid ± 3` openings are punched through the *perimeter* wall rather than
+    /// the interior cross. Enforcing parity anywhere but here would recreate,
+    /// for one env, exactly the split enforcement this guard removes.
+    ///
+    /// `at_least` subsumes the previous `nonzero` check — `MIN_SIZE >= 1`, so a
+    /// zero `size` is still rejected, now as
+    /// [`ConstraintKind::TooSmall`].
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "FourRoomsConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
+        if self.size.is_multiple_of(2) {
+            return Err(ConfigError {
+                config: C,
+                field: "size",
+                kind: ConstraintKind::Custom(SIZE_NOT_ODD),
+            });
+        }
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -147,6 +198,14 @@ impl Validate for FourRoomsConfig {
 impl FromStr for FourRoomsConfig {
     type Err = String;
 
+    /// Parses `"size=11,max_steps=484,seed=0"` (keys in any order) or the
+    /// positional form `"11,484,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`FourRoomsEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -174,12 +233,8 @@ impl FromStr for FourRoomsConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
-        if cfg.size % 2 == 0 {
-            return Err(format!("size must be odd, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -245,8 +300,11 @@ impl FourRoomsEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (11), an even `size`, or a zero `max_steps`. This is the
+    /// construction chokepoint (rules.md §4), so it also rejects a config that
+    /// arrived by `Deserialize` or struct-update syntax without passing through
+    /// [`FromStr`].
     pub fn with_config(config: FourRoomsConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -393,6 +451,8 @@ mod tests {
     // regression pass. Reviewed as a class, not site-by-site.
     #![allow(clippy::float_cmp)]
 
+    // `ConstraintKind` arrives via `super::*` — this module's `Validate` impl
+    // needs it at file scope for the parity `Custom` variant.
     use super::*;
     use rlevo_core::environment::Snapshot;
 
@@ -429,6 +489,74 @@ mod tests {
     #[test]
     fn fromstr_rejects_small_size() {
         assert!("9".parse::<FourRoomsConfig>().is_err());
+    }
+
+    /// Issue #106: `MIN_SIZE` was enforced only in [`FromStr`], so a config
+    /// built by `Deserialize` or struct-update syntax reached `build`. Measured
+    /// consequences: `size` 1–6 panicked in `Grid::set`; `size = 7` punched a
+    /// hole in all four perimeter walls and `size = 8` in two, because `build`
+    /// writes its openings at `mid ± 3` without checking where they land. The
+    /// guard now lives in [`Validate`], which `with_config` runs (ADR 0026
+    /// chokepoint).
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        let bad = FourRoomsConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = FourRoomsEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "FourRoomsConfig");
+        assert_eq!(err.field, "size");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            }
+        );
+    }
+
+    /// `9` builds a geometrically clean board — the `mid ± 3` openings land
+    /// inside the border — and is still refused. The floor is `rlevo` policy for
+    /// this env, not the smallest size the layout code survives.
+    #[test]
+    fn with_config_rejects_clean_but_sub_floor_size() {
+        let bad = FourRoomsConfig {
+            size: 9,
+            ..Default::default()
+        };
+        let err = FourRoomsEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.field, "size");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: 9,
+            }
+        );
+    }
+
+    /// The parity rule the `size` field doc already published. It was enforced
+    /// only in [`FromStr`] before #106, so `Deserialize` could hand `build` an
+    /// even size whose interior cross has two centre rows.
+    ///
+    /// The value is `14`, not `MIN_SIZE + 1` (12), and must **not** be a
+    /// multiple of 3. `12` is divisible by both 2 and 3, so it cannot tell the
+    /// guard's modulus apart: mutating `is_multiple_of(2)` to
+    /// `is_multiple_of(3)` in [`FourRoomsConfig::validate`] left this test — and
+    /// the whole suite — green. `14` is even, above the floor, and `14 % 3 == 2`,
+    /// so it pins the modulus as well as the parity intent. Do not "tidy" it back
+    /// to `MIN_SIZE + 1`.
+    #[test]
+    fn with_config_rejects_even_size() {
+        let bad = FourRoomsConfig {
+            size: 14,
+            ..Default::default()
+        };
+        let err = FourRoomsEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "FourRoomsConfig");
+        assert_eq!(err.field, "size");
+        assert_eq!(err.kind, ConstraintKind::Custom(SIZE_NOT_ODD));
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/lava_gap.rs
+++ b/crates/rlevo-environments/src/grids/lava_gap.rs
@@ -119,9 +119,24 @@ impl Default for LavaGapConfig {
 }
 
 impl Validate for LavaGapConfig {
+    /// Rejects any `size` below `MIN_SIZE` (5) and a zero `max_steps`.
+    ///
+    /// The `size` guard lives **here**, not only in [`FromStr`]:
+    /// `LavaGapConfig` derives `Deserialize`, so a config loaded from a file is
+    /// user-supplied runtime data that never passes through `from_str`
+    /// (rules.md §4 — "if an invalid value can arrive via `Deserialize`, it
+    /// must be an `Err`"). At `size = 1` the layout builder's `size - 2` goal
+    /// placement underflows and panics; sizes between that and `MIN_SIZE` build
+    /// without panicking but are outside the supported range this env
+    /// documents, so the floor is enforced as policy rather than only as a
+    /// crash guard.
+    ///
+    /// `at_least` subsumes the previous `nonzero` check — `MIN_SIZE >= 1`, so a
+    /// zero `size` is still rejected, now as
+    /// [`ConstraintKind::TooSmall`](rlevo_core::config::ConstraintKind::TooSmall).
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "LavaGapConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -130,6 +145,14 @@ impl Validate for LavaGapConfig {
 impl FromStr for LavaGapConfig {
     type Err = String;
 
+    /// Parses `"size=5,max_steps=100,seed=0"` (keys in any order) or the
+    /// positional form `"5,100,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`LavaGapEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -157,9 +180,8 @@ impl FromStr for LavaGapConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -218,8 +240,10 @@ impl LavaGapEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (5) or a zero `max_steps`. This is the construction chokepoint
+    /// (rules.md §4), so it also rejects a config that arrived by `Deserialize`
+    /// or struct-update syntax without passing through [`FromStr`].
     pub fn with_config(config: LavaGapConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -377,6 +401,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn env_5x5() -> LavaGapEnv {
@@ -414,6 +439,30 @@ mod tests {
     #[test]
     fn fromstr_rejects_small_size() {
         assert!("3".parse::<LavaGapConfig>().is_err());
+    }
+
+    /// Issue #106: `MIN_SIZE` was enforced only in [`FromStr`], so a config
+    /// built by `Deserialize` or struct-update syntax reached `build`, where
+    /// `size - 2` underflowed and panicked at `size = 1`. The guard now lives
+    /// in [`Validate`], which `with_config` runs (ADR 0026 chokepoint), and it
+    /// rejects the whole sub-`MIN_SIZE` range — including sizes that happen to
+    /// build a well-formed board.
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        let bad = LavaGapConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = LavaGapEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "LavaGapConfig");
+        assert_eq!(err.field, "size");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            }
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/multi_room.rs
+++ b/crates/rlevo-environments/src/grids/multi_room.rs
@@ -68,7 +68,15 @@ use std::str::FromStr;
 /// Minimum per-room width; needs at least one interior column in each room.
 const MIN_ROOM_WIDTH: usize = 3;
 /// Minimum number of rooms.
+///
+/// Below this the env has no dividing wall and therefore no door to toggle —
+/// the task it exists to pose disappears.
 const MIN_NUM_ROOMS: usize = 2;
+/// Minimum strip height.
+///
+/// Was a bare `5` literal in [`FromStr`] before it became a [`Validate`] guard;
+/// named so the floor is stated once and reachable from the field docs.
+const MIN_HEIGHT: usize = 5;
 const DOOR_COLOR: Color = Color::Grey;
 
 /// Configuration for [`MultiRoomEnv`].
@@ -87,7 +95,7 @@ pub struct MultiRoomConfig {
     pub num_rooms: usize,
     /// Width of each individual room, including its right-hand wall; must be ≥ `MIN_ROOM_WIDTH` (3).
     pub room_width: usize,
-    /// Height of the strip in cells; must be ≥ 5.
+    /// Height of the strip in cells; must be ≥ `MIN_HEIGHT` (5).
     pub height: usize,
     /// Maximum steps before the episode times out with reward `0.0`.
     pub max_steps: usize,
@@ -146,11 +154,29 @@ impl Default for MultiRoomConfig {
 }
 
 impl Validate for MultiRoomConfig {
+    /// Rejects `num_rooms` below `MIN_NUM_ROOMS` (2), `room_width` below
+    /// `MIN_ROOM_WIDTH` (3), `height` below `MIN_HEIGHT` (5), and a zero
+    /// `max_steps`.
+    ///
+    /// The three floors live **here**, not only in [`FromStr`]: `MultiRoomConfig`
+    /// derives `Deserialize`, so a config loaded from a file is user-supplied
+    /// runtime data that never passes through `from_str` (rules.md §4 — "if an
+    /// invalid value can arrive via `Deserialize`, it must be an `Err`").
+    /// Measured below the floors: `num_rooms = 1` silently built a
+    /// **single-room** env with no dividing wall and no door at all
+    /// (`wall_columns()` returned `[]`); `room_width = 2` built rooms of a single
+    /// interior column; `height = 2` put the corridor row, its doors and the goal
+    /// on the bottom border wall.
+    ///
+    /// `at_least` subsumes the previous `nonzero` checks — every floor is `>= 1`,
+    /// so zeros are still rejected, now as
+    /// [`ConstraintKind::TooSmall`](rlevo_core::config::ConstraintKind::TooSmall).
+    /// `max_steps` keeps `nonzero`: it has no floor above 1.
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "MultiRoomConfig";
-        config::nonzero(C, "num_rooms", self.num_rooms)?;
-        config::nonzero(C, "room_width", self.room_width)?;
-        config::nonzero(C, "height", self.height)?;
+        config::at_least(C, "num_rooms", self.num_rooms, MIN_NUM_ROOMS)?;
+        config::at_least(C, "room_width", self.room_width, MIN_ROOM_WIDTH)?;
+        config::at_least(C, "height", self.height, MIN_HEIGHT)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -159,6 +185,14 @@ impl Validate for MultiRoomConfig {
 impl FromStr for MultiRoomConfig {
     type Err = String;
 
+    /// Parses `"num_rooms=3,room_width=5,height=5,max_steps=300,seed=0"` (keys in
+    /// any order) or the positional form `"3,5,5,300,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`MultiRoomEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -202,21 +236,10 @@ impl FromStr for MultiRoomConfig {
                 }
             }
         }
-        if cfg.num_rooms < MIN_NUM_ROOMS {
-            return Err(format!(
-                "num_rooms must be >= {MIN_NUM_ROOMS}, got {}",
-                cfg.num_rooms
-            ));
-        }
-        if cfg.room_width < MIN_ROOM_WIDTH {
-            return Err(format!(
-                "room_width must be >= {MIN_ROOM_WIDTH}, got {}",
-                cfg.room_width
-            ));
-        }
-        if cfg.height < 5 {
-            return Err(format!("height must be >= 5, got {}", cfg.height));
-        }
+        // Unlike the square-grid envs there is no single `size` worth appending:
+        // `ConfigError`'s own `Display` already names the config, the field and
+        // the offending count.
+        cfg.validate().map_err(|e| e.to_string())?;
         Ok(cfg)
     }
 }
@@ -276,8 +299,12 @@ impl MultiRoomEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero
-    /// `num_rooms`, `room_width`, `height`, or `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: `num_rooms`
+    /// below `MIN_NUM_ROOMS` (2), `room_width` below `MIN_ROOM_WIDTH` (3),
+    /// `height` below `MIN_HEIGHT` (5), or a zero `max_steps`. This is the
+    /// construction chokepoint (rules.md §4), so it also rejects a config that
+    /// arrived by `Deserialize` or struct-update syntax without passing through
+    /// [`FromStr`].
     pub fn with_config(config: MultiRoomConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -444,6 +471,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn default_env() -> MultiRoomEnv {
@@ -483,6 +511,69 @@ mod tests {
             "num_rooms=3,room_width=2"
                 .parse::<MultiRoomConfig>()
                 .is_err()
+        );
+    }
+
+    /// Issue #106: the three structural floors were enforced only in
+    /// [`FromStr`], so a config built by `Deserialize` or struct-update syntax
+    /// reached `build`. Measured: `num_rooms = 1` produced a silent single-room
+    /// env whose `wall_columns()` was empty — no dividing wall, no door, the
+    /// whole task gone. The guard now lives in [`Validate`], which `with_config`
+    /// runs (ADR 0026 chokepoint).
+    #[test]
+    fn with_config_rejects_num_rooms_below_min() {
+        let bad = MultiRoomConfig {
+            num_rooms: MIN_NUM_ROOMS - 1,
+            ..Default::default()
+        };
+        let err = MultiRoomEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "MultiRoomConfig");
+        assert_eq!(err.field, "num_rooms");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_NUM_ROOMS as u64,
+                got: (MIN_NUM_ROOMS - 1) as u64,
+            }
+        );
+    }
+
+    /// `room_width = 2` used to build rooms with a single interior column.
+    #[test]
+    fn with_config_rejects_room_width_below_min() {
+        let bad = MultiRoomConfig {
+            room_width: MIN_ROOM_WIDTH - 1,
+            ..Default::default()
+        };
+        let err = MultiRoomEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "MultiRoomConfig");
+        assert_eq!(err.field, "room_width");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_ROOM_WIDTH as u64,
+                got: (MIN_ROOM_WIDTH - 1) as u64,
+            }
+        );
+    }
+
+    /// `height = 2` used to build a degenerate strip whose corridor row — agent,
+    /// doors and goal — sat on the bottom border wall.
+    #[test]
+    fn with_config_rejects_height_below_min() {
+        let bad = MultiRoomConfig {
+            height: MIN_HEIGHT - 1,
+            ..Default::default()
+        };
+        let err = MultiRoomEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "MultiRoomConfig");
+        assert_eq!(err.field, "height");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_HEIGHT as u64,
+                got: (MIN_HEIGHT - 1) as u64,
+            }
         );
     }
 

--- a/crates/rlevo-environments/src/grids/unlock.rs
+++ b/crates/rlevo-environments/src/grids/unlock.rs
@@ -78,7 +78,7 @@ const DOOR_COLOR: Color = Color::Yellow;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UnlockConfig {
-    /// Side length of the room.
+    /// Side length of the room; must be ≥ `MIN_SIZE` (4).
     pub size: usize,
     /// Maximum number of steps before the episode times out.
     pub max_steps: usize,
@@ -119,9 +119,23 @@ impl Default for UnlockConfig {
 }
 
 impl Validate for UnlockConfig {
+    /// Rejects any `size` below `MIN_SIZE` (4) and a zero `max_steps`.
+    ///
+    /// The `size` guard lives **here**, not only in [`FromStr`]: `UnlockConfig`
+    /// derives `Deserialize`, so a config loaded from a file is user-supplied
+    /// runtime data that never passes through `from_str` (rules.md §4 — "if an
+    /// invalid value can arrive via `Deserialize`, it must be an `Err`"). The
+    /// layout builder writes the door at `(1, 0)` and the key at `(2, 1)` from
+    /// fixed coordinates: below this floor those land out of bounds (`size <= 2`,
+    /// a panic in `Grid::set`) or inside the perimeter wall (`size == 3`, an
+    /// unsolvable board).
+    ///
+    /// `at_least` subsumes the previous `nonzero` check — `MIN_SIZE >= 1`, so a
+    /// zero `size` is still rejected, now as
+    /// [`ConstraintKind::TooSmall`](rlevo_core::config::ConstraintKind::TooSmall).
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "UnlockConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -130,6 +144,14 @@ impl Validate for UnlockConfig {
 impl FromStr for UnlockConfig {
     type Err = String;
 
+    /// Parses `"size=5,max_steps=200,seed=0"` (keys in any order) or the
+    /// positional form `"5,200,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`UnlockEnv::with_config`] applies, so this parser cannot admit a
+    /// config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -157,9 +179,8 @@ impl FromStr for UnlockConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -221,8 +242,10 @@ impl UnlockEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (4) or a zero `max_steps`. This is the construction chokepoint
+    /// (rules.md §4), so it also rejects a config that arrived by `Deserialize`
+    /// or struct-update syntax without passing through [`FromStr`].
     pub fn with_config(config: UnlockConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -361,6 +384,7 @@ impl rlevo_core::render::payload::GridPayloadSource for UnlockEnv {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn test_env() -> UnlockEnv {
@@ -399,6 +423,30 @@ mod tests {
     #[test]
     fn fromstr_rejects_small_size() {
         assert!("2".parse::<UnlockConfig>().is_err());
+    }
+
+    /// Issue #106: `MIN_SIZE` was enforced only in [`FromStr`], so a config
+    /// built by `Deserialize` or struct-update syntax reached `build`, which
+    /// panicked in `Grid::set` placing the door at `(1, 0)` (`size = 1`) or the
+    /// key at `(2, 1)` (`size = 2`), and silently produced an unsolvable board
+    /// at `size = 3`. The guard now lives in [`Validate`], which `with_config`
+    /// runs (ADR 0026 chokepoint).
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        let bad = UnlockConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = UnlockEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "UnlockConfig");
+        assert_eq!(err.field, "size");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            }
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/unlock_pickup.rs
+++ b/crates/rlevo-environments/src/grids/unlock_pickup.rs
@@ -124,9 +124,25 @@ impl Default for UnlockPickupConfig {
 }
 
 impl Validate for UnlockPickupConfig {
+    /// Rejects any `size` below `MIN_SIZE` (7) and a zero `max_steps`.
+    ///
+    /// The `size` guard lives **here**, not only in [`FromStr`]:
+    /// `UnlockPickupConfig` derives `Deserialize`, so a config loaded from a
+    /// file is user-supplied runtime data that never passes through `from_str`
+    /// (rules.md §4 — "if an invalid value can arrive via `Deserialize`, it must
+    /// be an `Err`"). Measured behaviour below the floor: `size` 1 and 2 panic
+    /// inside `Grid::set` (out of bounds); `size = 3` builds a board with **no
+    /// door at all**, because the key written at `(1, 1)` lands on the same cell
+    /// as the door; `size = 4` puts the box on the border wall. Sizes closer to
+    /// the floor build a well-formed board, so `MIN_SIZE` is enforced as the
+    /// documented policy for this env rather than only as a crash guard.
+    ///
+    /// `at_least` subsumes the previous `nonzero` check — `MIN_SIZE >= 1`, so a
+    /// zero `size` is still rejected, now as
+    /// [`ConstraintKind::TooSmall`](rlevo_core::config::ConstraintKind::TooSmall).
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "UnlockPickupConfig";
-        config::nonzero(C, "size", self.size)?;
+        config::at_least(C, "size", self.size, MIN_SIZE)?;
         config::nonzero(C, "max_steps", self.max_steps)?;
         Ok(())
     }
@@ -135,6 +151,14 @@ impl Validate for UnlockPickupConfig {
 impl FromStr for UnlockPickupConfig {
     type Err = String;
 
+    /// Parses `"size=7,max_steps=196,seed=0"` (keys in any order) or the
+    /// positional form `"7,196,0"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending key/value, or the [`Validate`] rejection — the same
+    /// guard [`UnlockPickupEnv::with_config`] applies, so this parser cannot
+    /// admit a config that construction would refuse.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut cfg = Self::default();
         for (idx, raw) in s.trim().split(',').map(str::trim).enumerate() {
@@ -162,9 +186,8 @@ impl FromStr for UnlockPickupConfig {
                 }
             }
         }
-        if cfg.size < MIN_SIZE {
-            return Err(format!("size must be >= {MIN_SIZE}, got {}", cfg.size));
-        }
+        cfg.validate()
+            .map_err(|e| format!("{e} (got size={})", cfg.size))?;
         Ok(cfg)
     }
 }
@@ -225,8 +248,10 @@ impl UnlockPickupEnv {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConfigError`] if `config` fails [`Validate`] (zero `size` or
-    /// `max_steps`).
+    /// Returns a [`ConfigError`] if `config` fails [`Validate`]: a `size` below
+    /// `MIN_SIZE` (7) or a zero `max_steps`. This is the construction chokepoint
+    /// (rules.md §4), so it also rejects a config that arrived by `Deserialize`
+    /// or struct-update syntax without passing through [`FromStr`].
     pub fn with_config(config: UnlockPickupConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
@@ -380,6 +405,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use rlevo_core::config::ConstraintKind;
     use rlevo_core::environment::Snapshot;
 
     fn env_7x7() -> UnlockPickupEnv {
@@ -411,6 +437,32 @@ mod tests {
     #[test]
     fn fromstr_rejects_small_size() {
         assert!("5".parse::<UnlockPickupConfig>().is_err());
+    }
+
+    /// Issue #106: `MIN_SIZE` was enforced only in [`FromStr`], so a config
+    /// built by `Deserialize` or struct-update syntax reached `build`. Measured
+    /// consequences: `size` 1 and 2 panicked in `Grid::set`; `size = 3` produced
+    /// a board with no door (the key overwrote it); `size = 4` wrote the box
+    /// onto the border wall. The guard now lives in [`Validate`], which
+    /// `with_config` runs (ADR 0026 chokepoint), and it rejects the whole
+    /// sub-`MIN_SIZE` range — including sizes such as `5` that happen to build a
+    /// playable board.
+    #[test]
+    fn with_config_rejects_size_below_min() {
+        let bad = UnlockPickupConfig {
+            size: MIN_SIZE - 1,
+            ..Default::default()
+        };
+        let err = UnlockPickupEnv::with_config(bad, false).unwrap_err();
+        assert_eq!(err.config, "UnlockPickupConfig");
+        assert_eq!(err.field, "size");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooSmall {
+                min: MIN_SIZE as u64,
+                got: (MIN_SIZE - 1) as u64,
+            }
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/tests/config_validation_chokepoint.rs
+++ b/crates/rlevo-environments/tests/config_validation_chokepoint.rs
@@ -10,11 +10,46 @@
 //!
 //! Issue #326 ("all 32 config structs have `pub` fields, so struct-literal
 //! construction bypasses `validate()`") read that `pub` field as the bug. It is
-//! not: at the time of filing, all 34 environment `with_config` constructors and
-//! all 6 RL agent constructors already called `config.validate()?`. The real
+//! not: at the time of filing, every one of this crate's 35 environment
+//! `with_config` constructors — covering 34 distinct `*Config` types, since
+//! `LunarLanderDiscrete` and `LunarLanderContinuous` each have a `with_config`
+//! consuming the *same* `LunarLanderConfig` — and all 8 RL agent constructors
+//! already called `config.validate()?`. (The RL figure is the same 8/8 ADR 0055
+//! reports: `dqn`, `c51`, `qrdqn`, `ddpg`, `td3`, `sac`, `ppo`, `ppg`.) The real
 //! risk the issue was groping at is that **nothing pinned the convention** — a
 //! new environment whose `with_config` forgot `validate()?` would ship silently,
 //! and no test would fail.
+//!
+//! # The second failure mode: chokepoint present, predicate incomplete
+//!
+//! Issue #106 established that "forgot to call `validate()`" is not the only way
+//! the contract breaks, and empirically not the common one. The chokepoint can be
+//! present and running while its `validate()` is simply **incomplete** — the call
+//! returns `Ok(())` and the constructor then builds a broken (or panicking) env
+//! from a config the contract was supposed to have refused. Two measured examples
+//! from the pre-fix tree:
+//!
+//! - `EmptyEnv::with_config(EmptyConfig { size: 1, ..Default::default() }, false)`
+//!   panicked at `empty.rs:277` with a `usize` underflow — *after* its
+//!   `config.validate()` had returned `Ok(())`.
+//! - `UnlockPickupEnv::with_config(UnlockPickupConfig { size: 3, ..Default::default() }, false)`
+//!   returned `Ok`, having built a board whose cells were
+//!   `[Wall, Wall, Wall, Wall, Key(Yellow), Box(Purple), Wall, Wall, Wall]` — no
+//!   `Door` cell at all, the key having silently overwritten it.
+//!
+//! This file pins that mode too, and it is why the cases below assert a
+//! *specific* `field` and `ConstraintKind` per constraint rather than merely that
+//! some rejection happened: an incomplete predicate is invisible to any assertion
+//! that only asks whether `validate()` ran.
+//!
+//! None of this retracts the #326 refutation above — that analysis was
+//! substantially right, and the mechanism #326 named remains false. `pub` fields
+//! do not bypass anything, and `#[non_exhaustive]` would not have prevented
+//! either construction: both were **same-crate**, where the cross-crate
+//! restriction never applies, and more fundamentally the attribute restricts
+//! *construction syntax*, not *predicate completeness* — a `size = 1` arriving
+//! through a hand-written setter or builder hits the same incomplete `validate()`
+//! and panics identically.
 //!
 //! This file is that pin. For each environment config with a non-vacuous
 //! [`Validate`] impl, it hands a deliberately invalid config to the public
@@ -46,6 +81,31 @@
 //! parse failure, a physics-init failure, a different field's guard firing
 //! first), which is exactly the silent regression this file exists to catch.
 //! Assert the `field` and the `ConstraintKind`, or the test proves nothing.
+//!
+//! # Which `ConstraintKind` a size floor gets
+//!
+//! Several grid configs reject a `size` (or a room count) that is too small, and
+//! the *variant* they reject with is a deliberate distinction that these cases
+//! pin:
+//!
+//! - [`ConstraintKind::TooSmall`] — via `config::at_least` — is the variant for a
+//!   plain minimum-count floor. The nine `grids/` envs with a `MIN_SIZE`-style
+//!   constant use it, including the ones whose floor is a *policy* choice rather
+//!   than a hard geometric limit: measured on this checkout, `lava_gap` builds a
+//!   clean board at `4` (floor `5`), `crossing` at `5` (floor `7`),
+//!   `unlock_pickup` at `5` (floor `7`), `four_rooms` at `9` (floor `11`), and
+//!   `multi_room` at `height = 3` (floor `5`). A machine-readable
+//!   `TooSmall { min, got }` is the honest report for those — the caller can act
+//!   on the number.
+//! - [`ConstraintKind::Custom`] is reserved for a floor (or a shape) derived from
+//!   a non-obvious invariant, where the prose payload carries information the
+//!   `min` alone cannot: `memory.rs`'s Invariant M, `go_to_door.rs`'s
+//!   four-distinct-doors requirement, and `four_rooms`' odd-`size` parity rule.
+//!
+//! So do not "upgrade" a `TooSmall` case here to `assert_rejected_custom`: that
+//! is a strictly weaker assertion (it drops `min` and `got`) *and* it would
+//! contradict the convention. Conversely, do not fabricate a `Custom` expectation
+//! for one of the nine floors — none of them is geometry-derived.
 //!
 //! # Placement
 //!
@@ -320,7 +380,24 @@ fn test_empty_grid_with_config_rejects_zero_size() {
         EmptyEnv::with_config(cfg, false),
         "EmptyConfig",
         "size",
-        &ConstraintKind::Zero,
+        &ConstraintKind::TooSmall { min: 4, got: 0 },
+    );
+}
+
+/// `EmptyConfig` floors `size` at `MIN_SIZE` (4). `3` is deliberately *not* `0`:
+/// a zero would also be caught by any generic `nonzero` guard, so only a
+/// non-zero sub-floor value proves the real floor is enforced.
+#[test]
+fn test_empty_grid_with_config_rejects_size_below_min() {
+    let cfg = EmptyConfig {
+        size: 3,
+        ..EmptyConfig::default()
+    };
+    assert_rejected(
+        EmptyEnv::with_config(cfg, false),
+        "EmptyConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 4, got: 3 },
     );
 }
 
@@ -348,15 +425,89 @@ fn test_multi_room_with_config_rejects_zero_num_rooms() {
         MultiRoomEnv::with_config(cfg, false),
         "MultiRoomConfig",
         "num_rooms",
-        &ConstraintKind::Zero,
+        &ConstraintKind::TooSmall { min: 2, got: 0 },
     );
 }
 
-// The seven grid configs below share one `nonzero(size)` + `nonzero(max_steps)`
-// shape. The broken field is alternated on purpose: a `size` case only proves
-// the *first* guard runs, so half these tests instead zero `max_steps` (leaving
-// `size` valid) to prove the *second* guard is reached too. Do not normalize them
-// all onto the same field — that would halve what the block actually pins.
+// `MultiRoomConfig` is the only grid config with *three* independent floors —
+// `num_rooms` >= 2, `room_width` >= 3, `height` >= 5 — checked in that order.
+// Each gets its own sub-floor case, with the other two left at their defaults,
+// so a case cannot pass on the strength of an earlier guard firing.
+
+/// `num_rooms = 1` is the value that actually motivated the floor: it built a
+/// **single-room** env with no dividing wall and therefore no door to unlock.
+#[test]
+fn test_multi_room_with_config_rejects_num_rooms_below_min() {
+    let cfg = MultiRoomConfig {
+        num_rooms: 1,
+        ..MultiRoomConfig::default()
+    };
+    assert_rejected(
+        MultiRoomEnv::with_config(cfg, false),
+        "MultiRoomConfig",
+        "num_rooms",
+        &ConstraintKind::TooSmall { min: 2, got: 1 },
+    );
+}
+
+/// `room_width` floors at `MIN_ROOM_WIDTH` (3); `2` leaves each room a single
+/// interior column.
+#[test]
+fn test_multi_room_with_config_rejects_room_width_below_min() {
+    let cfg = MultiRoomConfig {
+        room_width: 2,
+        ..MultiRoomConfig::default()
+    };
+    assert_rejected(
+        MultiRoomEnv::with_config(cfg, false),
+        "MultiRoomConfig",
+        "room_width",
+        &ConstraintKind::TooSmall { min: 3, got: 2 },
+    );
+}
+
+/// `height` floors at `MIN_HEIGHT` (5). `4` is a *policy* rejection, not a
+/// geometric one — the board at `height = 3` still builds cleanly — which is
+/// exactly why the floor reports `TooSmall` and not `Custom`.
+#[test]
+fn test_multi_room_with_config_rejects_height_below_min() {
+    let cfg = MultiRoomConfig {
+        height: 4,
+        ..MultiRoomConfig::default()
+    };
+    assert_rejected(
+        MultiRoomEnv::with_config(cfg, false),
+        "MultiRoomConfig",
+        "height",
+        &ConstraintKind::TooSmall { min: 5, got: 4 },
+    );
+}
+
+// The seven grid configs below share one `at_least(size, MIN_SIZE)` +
+// `nonzero(max_steps)` shape, and the block pins it in three tiers:
+//
+//   1. `size = 0`      → `TooSmall { min: MIN_SIZE, got: 0 }`. Pins that the
+//      floor, not a leftover `nonzero`, is what rejects a zero. Before the fix
+//      these cases expected `Zero`, which is precisely the confusion the tier
+//      structure now rules out.
+//   2. `size = MIN - 1` → `TooSmall { min: MIN_SIZE, got: MIN - 1 }`. This is the
+//      tier that actually pins the defect. A `size = 0` case alone cannot
+//      distinguish a real floor from an incidental non-zero guard, because both
+//      reject `0`; only a non-zero sub-floor value can. Each `MIN_SIZE` differs
+//      per env (`empty` 4, `unlock` 4, `dynamic_obstacles` 5, `door_key` 5,
+//      `lava_gap` 5, `crossing` 7, `unlock_pickup` 7, `four_rooms` 11), so the
+//      expected `min` is per-env too — do not copy one env's number to another.
+//   3. `max_steps = 0` → `Zero`. `max_steps` has no floor above 1, so it keeps
+//      `nonzero`; it is the one field in these configs whose rejection is still
+//      `ConstraintKind::Zero`.
+//
+// The broken field stays alternated across the block, as it always was, but for
+// a restated reason: `size` is checked *before* `max_steps`, so a `size` case can
+// only ever prove the first guard runs. The envs that zero `max_steps` (leaving
+// `size` valid) are what prove the *second* guard is reached at all. Do not
+// normalize the block onto `size` — that would drop every proof that validation
+// continues past the first `?`. Every env is covered by tier 2; tiers 1 and 3 are
+// split across the block on purpose.
 
 #[test]
 fn test_crossing_with_config_rejects_zero_size() {
@@ -368,7 +519,26 @@ fn test_crossing_with_config_rejects_zero_size() {
         CrossingEnv::with_config(cfg, false),
         "CrossingConfig",
         "size",
-        &ConstraintKind::Zero,
+        &ConstraintKind::TooSmall { min: 7, got: 0 },
+    );
+}
+
+/// Tier 2 for `crossing`: `MIN_SIZE` is `7`, and `6` is non-zero, so only the
+/// floor can reject it. Measured on this checkout, `size = 5` still builds a
+/// clean board — the floor is policy, which is why `TooSmall` (with its
+/// machine-readable `min`) is the right variant rather than a `Custom` prose
+/// claim about geometry.
+#[test]
+fn test_crossing_with_config_rejects_size_below_min() {
+    let cfg = CrossingConfig {
+        size: 6,
+        ..CrossingConfig::default()
+    };
+    assert_rejected(
+        CrossingEnv::with_config(cfg, false),
+        "CrossingConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 7, got: 6 },
     );
 }
 
@@ -386,6 +556,24 @@ fn test_door_key_with_config_rejects_zero_max_steps() {
     );
 }
 
+/// Tier 2 for `door_key`: `MIN_SIZE` is `5`, so `4` is the largest rejected
+/// `size`. Reported as `TooSmall`, unlike sibling `go_to_door`'s same-valued
+/// floor, which stays `Custom` because it encodes the four-distinct-doors
+/// invariant rather than a plain count.
+#[test]
+fn test_door_key_with_config_rejects_size_below_min() {
+    let cfg = DoorKeyConfig {
+        size: 4,
+        ..DoorKeyConfig::default()
+    };
+    assert_rejected(
+        DoorKeyEnv::with_config(cfg, false),
+        "DoorKeyConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 5, got: 4 },
+    );
+}
+
 #[test]
 fn test_dynamic_obstacles_with_config_rejects_zero_size() {
     let cfg = DynamicObstaclesConfig {
@@ -396,7 +584,23 @@ fn test_dynamic_obstacles_with_config_rejects_zero_size() {
         DynamicObstaclesEnv::with_config(cfg, false),
         "DynamicObstaclesConfig",
         "size",
-        &ConstraintKind::Zero,
+        &ConstraintKind::TooSmall { min: 5, got: 0 },
+    );
+}
+
+/// Tier 2 for `dynamic_obstacles`: `MIN_SIZE` is `5`, so `4` is non-zero and
+/// still below the floor.
+#[test]
+fn test_dynamic_obstacles_with_config_rejects_size_below_min() {
+    let cfg = DynamicObstaclesConfig {
+        size: 4,
+        ..DynamicObstaclesConfig::default()
+    };
+    assert_rejected(
+        DynamicObstaclesEnv::with_config(cfg, false),
+        "DynamicObstaclesConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 5, got: 4 },
     );
 }
 
@@ -414,6 +618,53 @@ fn test_four_rooms_with_config_rejects_zero_max_steps() {
     );
 }
 
+/// Tier 2 for `four_rooms`: `MIN_SIZE` is `11`. `9` is chosen because it is
+/// **odd** — it therefore satisfies the parity guard, isolating the floor from
+/// it. (A board at `9` builds cleanly on this checkout; the floor is policy, so
+/// `TooSmall` is the honest variant.) The parity guard is exercised separately
+/// by `test_four_rooms_with_config_rejects_even_size` below.
+#[test]
+fn test_four_rooms_with_config_rejects_size_below_min() {
+    let cfg = FourRoomsConfig {
+        size: 9,
+        ..FourRoomsConfig::default()
+    };
+    assert_rejected(
+        FourRoomsEnv::with_config(cfg, false),
+        "FourRoomsConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 11, got: 9 },
+    );
+}
+
+/// `FourRoomsEnv` also requires an **odd** `size`, so the interior cross has a
+/// single centre row and column. `14` is even but comfortably above `MIN_SIZE`
+/// (11), which isolates the parity guard from the floor: the `at_least` check
+/// runs first, so any value that is *both* sub-floor and even would report
+/// `TooSmall` and prove nothing about parity.
+///
+/// `14` and not `12`, and the value must **not** be a multiple of 3: `12` is
+/// divisible by both 2 and 3, so mutating the guard's modulus
+/// (`size.is_multiple_of(2)` → `is_multiple_of(3)` in `four_rooms.rs`) left this
+/// case, and the entire suite, green. `14 % 3 == 2`, so the modulus is now pinned
+/// as well as the parity intent. Do not "simplify" this back to `12`.
+///
+/// This is the one `four_rooms` `size` case that is `Custom` rather than
+/// `TooSmall` — parity has no `min` to report, so the prose payload is the whole
+/// information content.
+#[test]
+fn test_four_rooms_with_config_rejects_even_size() {
+    let cfg = FourRoomsConfig {
+        size: 14,
+        ..FourRoomsConfig::default()
+    };
+    assert_rejected_custom(
+        FourRoomsEnv::with_config(cfg, false),
+        "FourRoomsConfig",
+        "size",
+    );
+}
+
 #[test]
 fn test_lava_gap_with_config_rejects_zero_size() {
     let cfg = LavaGapConfig {
@@ -424,7 +675,24 @@ fn test_lava_gap_with_config_rejects_zero_size() {
         LavaGapEnv::with_config(cfg, false),
         "LavaGapConfig",
         "size",
-        &ConstraintKind::Zero,
+        &ConstraintKind::TooSmall { min: 5, got: 0 },
+    );
+}
+
+/// Tier 2 for `lava_gap`: `MIN_SIZE` is `5`. Measured on this checkout a board
+/// at `4` still builds cleanly, so this rejection is a policy floor — asserted
+/// as `TooSmall`, never as a `Custom` geometric claim.
+#[test]
+fn test_lava_gap_with_config_rejects_size_below_min() {
+    let cfg = LavaGapConfig {
+        size: 4,
+        ..LavaGapConfig::default()
+    };
+    assert_rejected(
+        LavaGapEnv::with_config(cfg, false),
+        "LavaGapConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 5, got: 4 },
     );
 }
 
@@ -438,7 +706,22 @@ fn test_unlock_with_config_rejects_zero_size() {
         UnlockEnv::with_config(cfg, false),
         "UnlockConfig",
         "size",
-        &ConstraintKind::Zero,
+        &ConstraintKind::TooSmall { min: 4, got: 0 },
+    );
+}
+
+/// Tier 2 for `unlock`: `MIN_SIZE` is `4`, so `3` is the largest rejected size.
+#[test]
+fn test_unlock_with_config_rejects_size_below_min() {
+    let cfg = UnlockConfig {
+        size: 3,
+        ..UnlockConfig::default()
+    };
+    assert_rejected(
+        UnlockEnv::with_config(cfg, false),
+        "UnlockConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 4, got: 3 },
     );
 }
 
@@ -453,6 +736,24 @@ fn test_unlock_pickup_with_config_rejects_zero_max_steps() {
         "UnlockPickupConfig",
         "max_steps",
         &ConstraintKind::Zero,
+    );
+}
+
+/// Tier 2 for `unlock_pickup`: `MIN_SIZE` is `7`, twice the sibling `unlock`
+/// floor (4) because this env must host a second room plus a box. `6` is
+/// non-zero, so only the floor can reject it. Measured on this checkout a board
+/// at `5` still builds cleanly — policy floor, hence `TooSmall`.
+#[test]
+fn test_unlock_pickup_with_config_rejects_size_below_min() {
+    let cfg = UnlockPickupConfig {
+        size: 6,
+        ..UnlockPickupConfig::default()
+    };
+    assert_rejected(
+        UnlockPickupEnv::with_config(cfg, false),
+        "UnlockPickupConfig",
+        "size",
+        &ConstraintKind::TooSmall { min: 7, got: 6 },
     );
 }
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -292,6 +292,26 @@ whole-config validation — see below.
   config-consuming constructor adopting `validate()?` is not optional. Any
   invariant that must hold independently of that chokepoint belongs in a
   validated newtype (§2, ADR 0027/0031).
+- **A minimum-count constraint uses `config::at_least`, yielding
+  `ConstraintKind::TooSmall`.** An `at_least` guard **replaces** its paired
+  `nonzero` rather than sitting beside it (same rule as a validated newtype,
+  §2) — `at_least(.., min)` with `min >= 1` subsumes `nonzero`, so keeping both
+  leaves a branch that cannot fire. `ConstraintKind::Custom` is reserved for a
+  floor **derived** from a non-obvious invariant that prose must defend:
+  `MemoryConfig`'s Invariant M and `GoToDoorConfig`'s four-distinct-doors bound
+  are the reference cases. **Do not write a `Custom` message asserting a
+  mechanism that a value one below the floor does not actually violate** — most
+  grid floors are task convention, not geometry, and several build clean boards
+  below their declared minimum (#106), so cause-naming prose would be false in
+  the source. `TooSmall` states the policy, which is true.
+- **A minimum enforced only in `FromStr` is not enforced.** `validate()` is the
+  chokepoint every construction path shares; `from_str` is a second door onto
+  the same contract, so it delegates (`cfg.validate().map_err(..)?`) rather than
+  re-checking. Splitting a bound across the two doors is how #106's nine grid
+  environments admitted configs that `from_str` refused. Where a constant's
+  value is *derived* (a parity rule, a geometric offset), add a `const _: () =
+  assert!(..)` pinning the derivation so lowering it breaks the build rather
+  than the output — `memory.rs` and `four_rooms.rs` are the reference cases.
 - **No config loader exists in the workspace yet.** The first one added (run
   manifest, config file, checkpoint restore) owns the `Deserialize` half of this
   contract: call `validate()?` on the decoded value and propagate the `Err`.


### PR DESCRIPTION
## Summary

Nine grid environments declared a minimum size but enforced it **only inside `FromStr`**. `Validate::validate` — the function the ADR 0026 consumption chokepoint actually calls from `with_config` — checked only `config::nonzero`, so struct-literal, `..Default::default()`, `ConstructableEnv::new`, and `Deserialize` construction all reached `build()` with configs the layout code cannot express. This moves each floor into `Validate` (via `config::at_least`), so one guard serves all four construction paths.

The failure was inconsistent, which is why it survived so long: `empty`/`lava_gap` at `size = 1` panicked with a `usize` underflow, `door_key`/`unlock`/`unlock_pickup` panicked on an out-of-bounds `Grid::set`, and the rest built **quietly broken boards** — `unlock_pickup` at `size = 3` produced a board with *no door at all* (the key overwrote it), and `four_rooms` at `size = 7` punched holes through all four perimeter walls.

## Change Type

- [x] Bug fix (non-breaking, includes regression test) — **with one breaking consequence, see Notes**

## Linked Issue

Closes #106

## What Was Changed

- **`crates/rlevo-environments/src/grids/{crossing,door_key,dynamic_obstacles,empty,four_rooms,lava_gap,multi_room,unlock,unlock_pickup}.rs`** — in each `Validate::validate`, replaced `config::nonzero(C, "size", ..)` with `config::at_least(C, "size", .., MIN_SIZE)`. `max_steps` deliberately keeps `nonzero`. Deleted the duplicated floor check from each `FromStr`, which now delegates via `cfg.validate().map_err(..)`. Updated each `# Errors` section and field doc; added an in-source below-floor rejection test per file.
- **`four_rooms.rs`** — additionally moved the odd-size parity guard into `Validate` (as `ConstraintKind::Custom`, since *that* prose is true), and added `const _: () = assert!(..)` pinning the `mid ± 3` doorway derivation so lowering `MIN_SIZE` breaks the build rather than the board.
- **`multi_room.rs`** — named the magic `height < 5` literal as `const MIN_HEIGHT: usize = 5`; all three of `num_rooms`/`room_width`/`height` converted to `at_least`.
- **`crates/rlevo-environments/tests/config_validation_chokepoint.rs`** — migrated 6 cases from `ConstraintKind::Zero` to `TooSmall { min, got: 0 }`; added 12 new cases; rewrote the block comment for the new three-tier shape and added a section stating the `TooSmall`-vs-`Custom` convention. Also corrected the header's stale RL-agent constructor count (6 → 8) and clarified the 35-constructors/34-configs distinction.
- **`docs/rules.md` §4** — added the governing convention: `at_least`/`TooSmall` for a plain minimum, `Custom` reserved for a *derived* floor whose prose is defensible; and "a minimum enforced only in `FromStr` is not enforced".
- **`CHANGELOG.md`** — breaking-change entry with migration, plus the `**Fixed**` entry.

**No `MIN_*` constant changed value.** Enforcement placement was the defect; re-deriving floors is a separate decision.

## How It Was Tested

```
cargo build --workspace                    # clean
cargo test --workspace                     # 61 test binaries, 0 failed
cargo clippy --all-targets --all-features  # 0 warnings, 0 errors
cargo fmt --all --check                    # clean
```

Regression tests, all of which fail on the previous code:

- One in-source `with_config_rejects_*_below_min` per environment (9 files), asserting the **structured** `ConfigError` — config name, field, and `ConstraintKind` — never a stringified message.
- 12 cases in `tests/config_validation_chokepoint.rs`, each using a **non-zero** below-floor value.

**Why the existing conformance test could not have caught this:** every grid case in that file used a **zero** value, which trips the generic `nonzero` guard and therefore cannot distinguish a real minimum from an incidental one. The non-zero below-floor case is the input that actually pins the constraint.

Two adversarial checks were run and are worth recording:

- Reverting `at_least` → `nonzero` in `crossing.rs` fails 4 tests; corrupting `multi_room.rs`'s `height` check to read `room_width` fails 2. The new cases are not theatre.
- The `four_rooms` parity case originally used `size = 12`, which is divisible by both 2 **and** 3 — mutating the guard from `is_multiple_of(2)` to `is_multiple_of(3)` left the whole suite green. Changed to `14` (`14 % 3 == 2`), and the mutation now fails both test files.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: CPU (`ndarray`) — no tensor code is touched by this change
- OS: macOS 26.5.2 (Apple Silicon)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **verification sweeps, all nine source edits, the conformance-test update, and this description — reviewed and re-verified against executed output before commit.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

### Breaking: `ConstraintKind::Zero` → `TooSmall` for grid dimensions

`config::at_least` subsumes the `config::nonzero` it replaces, so keeping both would leave a branch that cannot fire. Consequently `ConfigError::kind` for a **zero** grid dimension on these nine configs changes from `ConstraintKind::Zero` to `TooSmall { min, got }`. Code matching on `Zero` for these fields must match `TooSmall`; the new variant carries strictly more information. `max_steps` keeps `nonzero`/`Zero` throughout — it has no floor above 1 — and the retained `max_steps` cases exist precisely to pin that asymmetry.

Configs that previously constructed and now return `Err`: any sub-floor value. Migration is in `CHANGELOG.md`; every `Default` config already satisfies its floor, so `ConstructableEnv::new` is unaffected. `FromStr`'s `String` error text also changes, from `"size must be >= 5, got 1"` to `ConfigError`'s `Display` form.

### Why not the remedy #106 prescribed

The issue asked for `assert!(size >= MIN_SIZE)` plus `# Panics` docs. Both parts were rejected on evidence:

1. **`assert!` is the wrong mechanism.** `with_config` already returns `Result<_, ConfigError>`, and an assert in `build` leaves the `Deserialize` bypass open (`rules.md` §4 — an invalid value that can arrive via `Deserialize` must be an `Err`). `go_to_door.rs` and `memory.rs` had already fixed this defect the right way; this brings the remaining nine into line rather than inventing a third shape.
2. **Cause-naming prose would be false.** Five of the nine build *clean* boards below their declared floor — `lava_gap` at 4 (floor 5), `crossing` at 5 (7), `unlock_pickup` at 5 (7), `four_rooms` at 9 (11), `multi_room` height 3 (5). A `Custom` message reading "smaller grids cannot host X" would have shipped as a false statement. `TooSmall` states the *policy*, which is true.

### `four_rooms`' floor is convention, not geometry — and is deliberately kept

Sweeping sizes 1–16: 1–6 panic, **7 holes all four perimeter walls** at `(0,3) (3,0) (3,6) (6,3)`, **8 holes two** at `(4,7) (7,4)`, and 9+ is clean *at both parities*. So the geometric floor is 9, and parity is irrelevant to it. `MIN_SIZE = 11` and the odd rule are `rlevo` conventions with no upstream basis — Sutton, Precup & Singh (1999) never parameterizes four-rooms by size at all, and Farama Minigrid `v3.1.0` hardcodes `self.size = 19` with no `size` constructor argument. Both were kept; the new `const _` assertions pin the derivation so the gap stays visible. Lowering to 9 is a defensible follow-up, but it is a policy decision and not this PR's.

### Follow-up filed, deliberately not fixed here

**#1016** — `DynamicObstaclesEnv` silently truncates an over-requested `num_obstacles` (`size=7, num_obstacles=200` places 23; `size=6, num_obstacles=1000` places 14). That is a cross-field invariant (`num_obstacles <= (size-2)² - 2`), not a size floor, and a `size >= 5` guard leaves the entire class untouched. **Closing #106 does not close #1016.**

Also left as-is deliberately: a minor `# Errors` phrasing split across the nine (three say "zero included", six do not). Cosmetic; belongs in a later doc pass rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFHKjtu628TyBvUjYACFRs
