### PR TITLE
fix(env): Guard post-terminal step() across the classic family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **Post-terminal `step()` silently resurrected a finished episode across the
+  whole `classic` family** (ADR 0044, resolves #290) — the contract #105 made
+  normative on `Environment::step` was enforced only by `toy_text` and
+  `TimeLimit`; the six `classic` environments each recomputed terminality from
+  the *current* state on every call, with no memory that the episode had already
+  ended. Because that test is a predicate and not a latch, the failure was not a
+  benign no-op: a post-terminal `step()` on `CartPole` re-emitted a fresh
+  `Terminated` snapshot and paid the `+1.0` again while advancing `steps` past
+  the true episode length, and on `MountainCarContinuous` it re-paid the `+100`
+  goal bonus on every extra call. `Acrobot` was worse still — the RK4 integrator
+  keeps running past the goal, the tip swings back *below* the height threshold,
+  and the next snapshot reads **`Running`** with reward `−1`, so a finished
+  episode came back to life with a corrupted return. `SantaFeAnt` could keep
+  eating pellets past a budget it had already exhausted. Every one of these
+  environments now holds an `episode::EpisodeGuard`, `check()`s it before any
+  state mutation or RNG draw (so a rejected step cannot desynchronise the seed
+  stream — ADR 0029), and `record()`s the emitted status on a single exit path.
+  The existing tests missed it because they all stopped at the first `is_done()`
+  snapshot — the standard rollout shape — and so never exercised the one call
+  sequence that fails; the regression tests now step deliberately past it via
+  the shared `assert_rejects_post_terminal_step` conformance helper.
+  `Pendulum` has no terminal condition and so cannot be covered by that helper;
+  it takes the guard for family uniformity, verified only to stay open, so a
+  future termination rule cannot reintroduce the hole. The remaining families
+  (`grids`, `locomotion`, `box2d`, `pixel_grid`, bandits) are still unguarded and
+  tracked by #289, so the migration note on `Environment::step` stays until they
+  land.
 - **`ContinuousAction::from_slice` now accepts exactly `COMPONENTS` values on all
   five multi-component continuous actions**, matching what the trait and
   `docs/rules.md` §3 have always documented. `ReacherAction` and `SwimmerAction`

--- a/crates/rlevo-environments/src/classic/acrobot.rs
+++ b/crates/rlevo-environments/src/classic/acrobot.rs
@@ -142,6 +142,7 @@
 //! ```
 use std::fmt;
 
+use crate::episode::EpisodeGuard;
 use rand::{SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, Uniform};
 use rlevo_core::{
@@ -653,6 +654,14 @@ pub struct Acrobot<D: AcrobotDynamicsFn = BookDynamics> {
     dynamics: D,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the swing-up terminated the episode.
+    /// Without it, the integrator would keep running past the goal: the tip
+    /// swings back down below the height threshold and the next snapshot reads
+    /// `Running` with reward `-1`, silently resurrecting a finished episode and
+    /// corrupting the return (which is defined as the negative step count to
+    /// success). The guard lives on the environment, not on `D`, so both
+    /// [`BookDynamics`] and [`NipsDynamics`] are covered by one state machine.
+    guard: EpisodeGuard,
 }
 
 impl<D: AcrobotDynamicsFn + Default> Acrobot<D> {
@@ -709,6 +718,7 @@ impl<D: AcrobotDynamicsFn> Acrobot<D> {
             dynamics,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -815,6 +825,7 @@ impl<D: AcrobotDynamicsFn + Default> Environment<1, 1, 1> for Acrobot<D> {
     ///
     /// Currently infallible; returns `Ok` in all cases.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = self.sample_init_state();
         self.steps = 0;
         Ok(SnapshotBase::running(
@@ -832,8 +843,17 @@ impl<D: AcrobotDynamicsFn + Default> Environment<1, 1, 1> for Acrobot<D> {
     ///
     /// # Errors
     ///
-    /// Currently infallible; returns `Ok` in all cases.
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode already
+    /// ended; call [`reset`](Environment::reset) first. No other failure is
+    /// possible.
     fn step(&mut self, action: AcrobotAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before the state integrates and — critically — before the
+        // torque-noise draw below, which consumes from `self.rng` whenever
+        // `torque_noise_max > 0`. A rejected call must leave both the physical
+        // state and the RNG stream untouched, or the stream would depend on how
+        // many illegal steps a caller made (ADR 0029).
+        self.guard.check()?;
+
         let mut torque = action.to_torque();
         if self.config.torque_noise_max > 0.0 {
             let noise =
@@ -851,11 +871,15 @@ impl<D: AcrobotDynamicsFn + Default> Environment<1, 1, 1> for Acrobot<D> {
 
         let terminated = Self::is_terminal(&self.state, &self.config);
         let obs = self.observe(&action, &self.state);
+        // Single exit: both branches build exactly one snapshot, and the guard is
+        // fed that snapshot's own status, so no branch can forget to record.
         let snap = if terminated {
             SnapshotBase::terminated(obs, ScalarReward(0.0))
         } else {
             SnapshotBase::running(obs, ScalarReward(-1.0))
         };
+
+        self.guard.record(snap.status);
         Ok(snap)
     }
 }
@@ -1035,9 +1059,39 @@ mod tests {
     //! determinism, and dynamics variant divergence.
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::environment::Snapshot;
 
     type DefaultAcrobot = Acrobot<BookDynamics>;
+
+    /// Swings the acrobot up until the tip clears the height threshold and
+    /// returns that terminal snapshot.
+    ///
+    /// The policy is the classic bang-bang energy pump — torque always applied
+    /// in the direction the elbow is already turning — which drives the real
+    /// dynamics through `step()` rather than hand-placing a terminal state, so
+    /// the termination the guard records is one the environment produced itself.
+    fn swing_up_to_terminal(
+        env: &mut DefaultAcrobot,
+    ) -> SnapshotBase<1, AcrobotObservation, ScalarReward> {
+        const MAX_STEPS: usize = 2_000;
+
+        env.reset().expect("reset must succeed");
+        for _ in 0..MAX_STEPS {
+            let action = if env.state.theta2_dot >= 0.0 {
+                AcrobotAction::TorquePos
+            } else {
+                AcrobotAction::TorqueNeg
+            };
+            let snap = env
+                .step(action)
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("energy-pumping policy must reach the swing-up height within {MAX_STEPS} steps");
+    }
 
     fn default_env() -> DefaultAcrobot {
         DefaultAcrobot::with_config(AcrobotConfig::default()).expect("valid config")
@@ -1267,6 +1321,161 @@ mod tests {
         assert_ne!(
             first, second,
             "successive resets must draw independent initial states"
+        );
+    }
+
+    // ── post-terminal step guard (issue #290) ────────────────────────────────
+
+    #[test]
+    /// Verifies `Acrobot` satisfies the shared post-terminal conformance check:
+    /// once the swing-up has terminated the episode, a further legal `step()`
+    /// fails with `StepAfterEpisodeEnd { status: Terminated }` instead of
+    /// integrating the tip back down and reporting `Running` again.
+    fn test_acrobot_rejects_post_terminal_step() {
+        let mut env = default_env();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            swing_up_to_terminal,
+            AcrobotAction::TorqueZero,
+        );
+    }
+
+    #[test]
+    /// Verifies a rejected post-terminal step mutates nothing: the physical
+    /// state, the step counter, and the guard all stand exactly as the terminal
+    /// snapshot left them.
+    fn test_acrobot_post_terminal_step_does_not_mutate_state() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = default_env();
+        let terminal = swing_up_to_terminal(&mut env);
+        assert!(terminal.is_terminated(), "swing-up must terminate");
+
+        let state_before = env.state;
+        let steps_before = env.steps;
+
+        env.step(AcrobotAction::TorquePos)
+            .expect_err("a step after termination must be rejected");
+
+        assert_eq!(
+            env.state, state_before,
+            "a rejected step must not integrate the dynamics"
+        );
+        assert_eq!(
+            env.steps, steps_before,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// Verifies the guard is per-environment, not per-dynamics: `NipsDynamics`
+    /// gets the same post-terminal rejection as `BookDynamics`. Termination is
+    /// forced by placing the arm upright, because the two dynamics need
+    /// different pump horizons and the guard's behaviour is independent of them.
+    fn test_acrobot_nips_dynamics_rejects_post_terminal_step() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env =
+            Acrobot::<NipsDynamics>::with_config(AcrobotConfig::default()).expect("valid config");
+        env.reset().expect("reset must succeed");
+        // Upright and at rest: height = 2 > 1, so the next step terminates.
+        env.state = AcrobotState {
+            theta1: std::f32::consts::PI,
+            theta2: 0.0,
+            theta1_dot: 0.0,
+            theta2_dot: 0.0,
+        };
+        let terminal = env
+            .step(AcrobotAction::TorqueZero)
+            .expect("the first step must succeed");
+        assert!(
+            terminal.is_terminated(),
+            "an upright acrobot must terminate on the next step"
+        );
+
+        let err = env
+            .step(AcrobotAction::TorqueZero)
+            .expect_err("a step after termination must be rejected");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                EpisodeStatus::Terminated,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    /// Verifies `reset()` re-opens a terminated environment for a new episode.
+    fn test_acrobot_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = default_env();
+        swing_up_to_terminal(&mut env);
+        assert!(
+            env.step(AcrobotAction::TorqueZero).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert!(
+            env.step(AcrobotAction::TorqueZero).is_ok(),
+            "reset() must re-open the environment for a new episode"
+        );
+    }
+
+    #[test]
+    /// Verifies a rejected post-terminal step draws no randomness: with
+    /// `torque_noise_max > 0` the torque is sampled from the persistent RNG, so
+    /// checking the guard *after* it would let illegal calls advance the stream
+    /// and desynchronise replay (ADR 0029).
+    fn test_acrobot_rejected_step_does_not_advance_rng() {
+        let noisy_env_at_terminal = || {
+            let cfg = AcrobotConfig::builder()
+                .torque_noise_max(0.1)
+                .seed(17)
+                .build();
+            let mut env = DefaultAcrobot::with_config(cfg).expect("valid config");
+            env.reset().expect("reset must succeed");
+            env.state = AcrobotState {
+                theta1: std::f32::consts::PI,
+                theta2: 0.0,
+                theta1_dot: 0.0,
+                theta2_dot: 0.0,
+            };
+            let snap = env
+                .step(AcrobotAction::TorqueZero)
+                .expect("the first step must succeed");
+            assert!(snap.is_terminated(), "an upright acrobot must terminate");
+            env
+        };
+
+        let mut rejected = noisy_env_at_terminal();
+        let mut untouched = noisy_env_at_terminal();
+
+        rejected
+            .step(AcrobotAction::TorquePos)
+            .expect_err("a step after termination must be rejected");
+
+        let draw = |env: &mut DefaultAcrobot| {
+            let u = Uniform::new_inclusive(-1.0_f32, 1.0_f32).unwrap();
+            (0..16).map(|_| u.sample(&mut env.rng)).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            draw(&mut rejected),
+            draw(&mut untouched),
+            "a rejected step must draw no randomness; the RNG stream must be identical to one that never saw the step"
         );
     }
 

--- a/crates/rlevo-environments/src/classic/cartpole.rs
+++ b/crates/rlevo-environments/src/classic/cartpole.rs
@@ -116,6 +116,13 @@
 //! There is no intrinsic step cap. Compose with [`crate::wrappers::TimeLimit`]
 //! to replicate the Gymnasium v1 500-step episode limit.
 //!
+//! ## Episode lifecycle
+//!
+//! The episode terminates as soon as the pole angle or the cart position leaves
+//! its threshold band. Once it has, a further [`Environment::step`] returns
+//! [`EnvironmentError::StepAfterEpisodeEnd`] — call [`Environment::reset`]
+//! first.
+//!
 //! ## Quick start
 //!
 //! ```no_run,ignore
@@ -132,6 +139,7 @@
 //! ```
 use std::fmt;
 
+use crate::episode::EpisodeGuard;
 use rand::{SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, Uniform};
 use rlevo_core::{
@@ -464,12 +472,23 @@ impl DiscreteAction<1> for CartPoleAction {
 ///
 /// No intrinsic step cap. Wrap with [`crate::wrappers::TimeLimit::new(env, 500)`]
 /// to replicate the Gymnasium v1 500-step episode limit.
+///
+/// Leaving either threshold band terminates the episode; a
+/// [`step`](Environment::step) taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
 #[derive(Debug)]
 pub struct CartPole {
     state: CartPoleState,
     config: CartPoleConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after a threshold ended the episode. Without it
+    /// the integrator keeps running on the fallen pole: `is_terminal` is
+    /// recomputed from scratch each step, so every post-terminal call re-emits a
+    /// fresh `Terminated` snapshot and pays out another `+1.0` (or another
+    /// `-1.0` under the Sutton-Barto schedule), inflating the episode return
+    /// without bound and advancing `steps` past the true episode length.
+    guard: EpisodeGuard,
 }
 
 impl CartPole {
@@ -487,6 +506,7 @@ impl CartPole {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -653,6 +673,7 @@ impl Environment<1, 1, 1> for CartPole {
     ///
     /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = self.sample_init_state();
         self.steps = 0;
         Ok(SnapshotBase::running(
@@ -669,8 +690,15 @@ impl Environment<1, 1, 1> for CartPole {
     ///
     /// # Errors
     ///
-    /// Currently infallible; always returns `Ok`.
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: CartPoleAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before the integrator runs, before `steps` advances, and
+        // before anything touches `self.rng`. A rejected call must leave the
+        // physics state, the step counter, and the RNG stream untouched, or the
+        // stream would depend on how many illegal steps a caller made (ADR 0029).
+        self.guard.check()?;
+
         let next = Self::step_physics(&self.state, action, &self.config);
         self.state = next;
         self.steps += 1;
@@ -686,12 +714,16 @@ impl Environment<1, 1, 1> for CartPole {
             ScalarReward(1.0)
         };
 
+        // Single exit: every path builds exactly one snapshot, and the guard is
+        // fed that snapshot's own status, so no branch can forget to record.
         let obs = self.observe(&action, &self.state);
         let snap = if terminated {
             SnapshotBase::terminated(obs, reward)
         } else {
             SnapshotBase::running(obs, reward)
         };
+
+        self.guard.record(snap.status);
         Ok(snap)
     }
 }
@@ -949,10 +981,30 @@ mod tests {
     //! episode lifecycle, reward schedules, determinism, and integrator divergence.
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::environment::Snapshot;
 
     fn default_env() -> CartPole {
         CartPole::with_config(CartPoleConfig::default()).expect("valid config")
+    }
+
+    /// Resets `env` and pushes `Right` until the pole tips past the 12° angle
+    /// threshold, returning the terminal snapshot. Pushing one direction from a
+    /// near-upright start topples the pole in a few dozen steps, so this reaches
+    /// a *real* termination rather than a hand-written terminal state.
+    fn drive_to_pole_fall(
+        env: &mut CartPole,
+    ) -> SnapshotBase<1, CartPoleObservation, ScalarReward> {
+        env.reset().expect("reset must succeed");
+        for _ in 0..1_000 {
+            let snap = env
+                .step(CartPoleAction::Right)
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("pushing Right must topple the pole within 1000 steps");
     }
 
     #[test]
@@ -1268,6 +1320,114 @@ mod tests {
         assert_eq!(
             a, b,
             "reset_with_seed must reproduce the same initial state"
+        );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #290) ──────────────────────
+
+    #[test]
+    /// Verifies `CartPole` satisfies the shared post-terminal conformance check:
+    /// once the pole has fallen past the angle threshold, a further legal
+    /// `step()` fails with `StepAfterEpisodeEnd { status: Terminated }` instead
+    /// of integrating on and paying out another `+1.0`.
+    fn test_cart_pole_rejects_post_terminal_step() {
+        let mut env = default_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_pole_fall, CartPoleAction::Right);
+    }
+
+    #[test]
+    /// Regression for the concrete defect the guard prevents: `is_terminal` is
+    /// recomputed from the current state each call, so an unguarded
+    /// post-terminal `step()` re-emitted a fresh `Terminated` snapshot, added
+    /// another `+1.0` to the return, and advanced `steps` past the true episode
+    /// length. A rejected step must mutate nothing at all.
+    fn test_cart_pole_post_terminal_step_does_not_extend_the_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = default_env();
+        let terminal = drive_to_pole_fall(&mut env);
+        assert!(terminal.is_terminated(), "the pole must have fallen");
+
+        let steps_at_end = env.steps();
+        let state_at_end = env.state;
+
+        let err = env
+            .step(CartPoleAction::Right)
+            .expect_err("a step after termination must return Err, not another +1.0 snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                EpisodeStatus::Terminated,
+                "the error must carry Terminated, the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            env.state, state_at_end,
+            "a rejected step must not advance the physics state"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// Verifies `reset()` re-opens a terminated environment, so a guard that has
+    /// latched cannot strand the environment for the rest of the run.
+    fn test_cart_pole_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = default_env();
+        drive_to_pole_fall(&mut env);
+        assert!(
+            env.step(CartPoleAction::Right).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(CartPoleAction::Right)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
+    }
+
+    #[test]
+    /// Verifies a rejected post-terminal step draws no randomness. `step()` does
+    /// not sample today, but `reset()` shares the persistent stream: checking the
+    /// guard after any future draw would let illegal calls shift every
+    /// subsequent episode's initial state and desynchronise replay (ADR 0029).
+    fn test_cart_pole_rejected_step_does_not_advance_rng() {
+        let mut rejected = default_env();
+        let mut untouched = default_env();
+        drive_to_pole_fall(&mut rejected);
+        drive_to_pole_fall(&mut untouched);
+
+        rejected
+            .step(CartPoleAction::Right)
+            .expect_err("a step after termination must be rejected");
+
+        let after = rejected.reset().unwrap().observation().to_array();
+        let baseline = untouched.reset().unwrap().observation().to_array();
+        assert_eq!(
+            after, baseline,
+            "a rejected step must draw no randomness; the next episode must start where it would have"
         );
     }
 }

--- a/crates/rlevo-environments/src/classic/mountain_car.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car.rs
@@ -53,6 +53,10 @@
 //! cost is equivalent to reaching the flag as fast as possible. The minimum
 //! achievable return depends on the initial position.
 //!
+//! Termination ends the episode: a further [`Environment::step`] returns
+//! [`EnvironmentError::StepAfterEpisodeEnd`] rather than continuing to simulate
+//! a car that has already crossed the flag — call [`Environment::reset`] first.
+//!
 //! ## Step limit
 //!
 //! This environment has **no intrinsic episode limit**. The standard
@@ -77,6 +81,7 @@
 //! ```
 use std::fmt;
 
+use crate::episode::EpisodeGuard;
 use rand::{SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, Uniform};
 use rlevo_core::{
@@ -263,12 +268,22 @@ impl DiscreteAction<1> for MountainCarAction {
 // ---------------------------------------------------------------------------
 
 /// MountainCar-v0: escape the valley by building momentum.
+///
+/// Reaching the flag terminates the episode; a [`step`](Environment::step) taken
+/// afterwards is rejected with [`EnvironmentError::StepAfterEpisodeEnd`] — see
+/// the [`EpisodeGuard`] field.
 #[derive(Debug)]
 pub struct MountainCar {
     state: MountainCarState,
     config: MountainCarConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the car crested the hill. Without it the
+    /// physics keep integrating past the flag: the car rolls on, `steps` keeps
+    /// climbing, and every extra call emits another −1 on a *`Running`*
+    /// snapshot — inflating the episode's return past the true cost of solving
+    /// it and resurrecting a finished episode.
+    guard: EpisodeGuard,
 }
 
 impl MountainCar {
@@ -290,6 +305,7 @@ impl MountainCar {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -417,6 +433,7 @@ impl Environment<1, 1, 1> for MountainCar {
     ///
     /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = self.sample_init_state();
         self.steps = 0;
         Ok(SnapshotBase::running(
@@ -434,11 +451,20 @@ impl Environment<1, 1, 1> for MountainCar {
     ///
     /// # Errors
     ///
-    /// Currently infallible; always returns `Ok`.
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first. The physics
+    /// themselves are infallible.
     fn step(&mut self, action: MountainCarAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before the physics update and before `steps` advances, so
+        // a rejected call leaves position, velocity, step count and the RNG
+        // stream exactly as the terminal step left them (ADR 0029).
+        self.guard.check()?;
+
         self.state = Self::apply_physics(self.state, action, &self.config);
         self.steps += 1;
 
+        // Single exit: both branches build exactly one snapshot, and the guard is
+        // fed that snapshot's own status, so no branch can forget to record.
         let terminated = Self::is_terminal(self.state, &self.config);
         let obs = self.observe(&action, &self.state);
         let snap = if terminated {
@@ -446,6 +472,8 @@ impl Environment<1, 1, 1> for MountainCar {
         } else {
             SnapshotBase::running(obs, ScalarReward(-1.0))
         };
+
+        self.guard.record(snap.status);
         Ok(snap)
     }
 }
@@ -642,10 +670,45 @@ mod tests {
     //! value, and determinism.
 
     use super::*;
-    use rlevo_core::environment::Snapshot;
+    use crate::episode::assert_rejects_post_terminal_step;
+    use rlevo_core::environment::{EpisodeStatus, Snapshot};
 
     fn default_env() -> MountainCar {
         MountainCar::with_config(MountainCarConfig::default()).expect("valid config")
+    }
+
+    /// Maximum steps the energy-pumping policy may take before the test calls it
+    /// a regression. Bang-bang control crests the hill in ~120 steps from any
+    /// initial position in `[-0.6, -0.4]`; the slack is generous so a legitimate
+    /// physics tweak does not turn the test flaky, but bounded so a broken
+    /// termination check fails loudly instead of hanging.
+    const PUMP_STEP_CAP: usize = 1_000;
+
+    /// Drives the car to the flag with the classic energy-pumping policy — push
+    /// in the direction the car is already moving — and returns the terminal
+    /// snapshot. This reaches the goal *legitimately*, through the real physics,
+    /// rather than by writing `state` directly, so the guard is exercised on the
+    /// same path an agent takes.
+    fn drive_to_goal(
+        env: &mut MountainCar,
+    ) -> SnapshotBase<1, MountainCarObservation, ScalarReward> {
+        let mut snap = env.reset().expect("reset must succeed");
+        for _ in 0..PUMP_STEP_CAP {
+            // Velocity 0 (the reset state) pumps right: any direction works, the
+            // hill returns the car with more energy either way.
+            let action = if snap.observation().velocity < 0.0 {
+                MountainCarAction::Left
+            } else {
+                MountainCarAction::Right
+            };
+            snap = env
+                .step(action)
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("energy pumping must crest the hill within {PUMP_STEP_CAP} steps");
     }
 
     #[test]
@@ -839,6 +902,73 @@ mod tests {
         assert_eq!(
             a, b,
             "reset_with_seed must reproduce the same initial state"
+        );
+    }
+
+    // ── post-terminal step guard (issue #290) ────────────────────────────────
+
+    #[test]
+    /// Verifies `MountainCar` satisfies the shared post-terminal conformance check:
+    /// once the car has crested the hill, a further legal `step()` fails with
+    /// `StepAfterEpisodeEnd { status: Terminated }` instead of simulating on.
+    fn test_mountain_car_rejects_post_terminal_step() {
+        let mut env = default_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_goal, MountainCarAction::Right);
+    }
+
+    #[test]
+    /// Verifies a rejected post-terminal step is a true no-op: the physics do not
+    /// advance, the step counter does not tick, and the guard stays closed. An
+    /// unguarded `step()` would silently keep integrating past the flag and add
+    /// another −1 to the return.
+    fn test_mountain_car_post_terminal_step_does_not_mutate_state() {
+        let mut env = default_env();
+        let terminal = drive_to_goal(&mut env);
+        assert!(
+            terminal.is_terminated(),
+            "the flag must terminate the episode"
+        );
+
+        let state_before = env.state;
+        let steps_before = env.steps();
+
+        env.step(MountainCarAction::Left)
+            .expect_err("a step after termination must return Err, not another -1 snapshot");
+
+        assert_eq!(
+            env.state, state_before,
+            "a rejected step must not advance the physics"
+        );
+        assert_eq!(
+            env.steps(),
+            steps_before,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// Verifies `reset()` re-opens a terminated environment, so an agent can run
+    /// a second episode without rebuilding the environment.
+    fn test_mountain_car_reset_reopens_terminated_episode() {
+        let mut env = default_env();
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(MountainCarAction::Right).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        let snap = env
+            .step(MountainCarAction::Right)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
         );
     }
 }

--- a/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
+++ b/crates/rlevo-environments/src/classic/mountain_car_continuous.rs
@@ -68,6 +68,10 @@
 //! agent must accept temporary control cost to earn the goal bonus. The two
 //! components are also exposed by the keys [`REWARD_CTRL`] and [`REWARD_GOAL`].
 //!
+//! Termination ends the episode: a further [`Environment::step`] returns
+//! [`EnvironmentError::StepAfterEpisodeEnd`] rather than paying the `$+100$`
+//! bonus a second time — call [`Environment::reset`] first.
+//!
 //! ## Step limit
 //!
 //! This environment has **no intrinsic episode limit**. The standard
@@ -95,6 +99,7 @@
 //! ```
 use std::fmt;
 
+use crate::episode::EpisodeGuard;
 use rand::{SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, Uniform};
 use rlevo_core::{
@@ -328,12 +333,22 @@ impl State<1> for MountainCarContinuousState {
 // ---------------------------------------------------------------------------
 
 /// MountainCarContinuous-v0: escape the valley with a continuous force.
+///
+/// Reaching the flag terminates the episode; a [`step`](Environment::step) taken
+/// afterwards is rejected with [`EnvironmentError::StepAfterEpisodeEnd`] — see
+/// the [`EpisodeGuard`] field.
 #[derive(Debug)]
 pub struct MountainCarContinuous {
     state: MountainCarContinuousState,
     config: MountainCarContinuousConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the car crested the hill. The goal
+    /// predicate is a position/velocity *test*, not a latch, so past the flag it
+    /// keeps holding: an unguarded post-terminal step pays the `+100` bonus
+    /// again, and again, letting a caller farm unbounded return out of a single
+    /// solved episode.
+    guard: EpisodeGuard,
 }
 
 impl MountainCarContinuous {
@@ -355,6 +370,7 @@ impl MountainCarContinuous {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -482,6 +498,7 @@ impl Environment<1, 1, 1> for MountainCarContinuous {
     ///
     /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = self.sample_init_state();
         self.steps = 0;
         Ok(SnapshotBase::running(
@@ -499,11 +516,18 @@ impl Environment<1, 1, 1> for MountainCarContinuous {
     ///
     /// # Errors
     ///
-    /// Currently infallible; always returns `Ok`.
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first. The physics
+    /// themselves are infallible.
     fn step(
         &mut self,
         action: MountainCarContinuousAction,
     ) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before the physics update and before `steps` advances, so
+        // a rejected call leaves position, velocity, step count and the RNG
+        // stream exactly as the terminal step left them (ADR 0029).
+        self.guard.check()?;
+
         let force = action.force();
         self.state = Self::apply_physics(self.state, force, &self.config);
         self.steps += 1;
@@ -513,12 +537,16 @@ impl Environment<1, 1, 1> for MountainCarContinuous {
         let goal_bonus = if terminated { 100.0 } else { 0.0 };
         let reward = ScalarReward(ctrl_cost + goal_bonus);
 
+        // Single exit: both branches build exactly one snapshot, and the guard is
+        // fed that snapshot's own status, so no branch can forget to record.
         let obs = self.observe(&action, &self.state);
         let snap = if terminated {
             SnapshotBase::terminated(obs, reward)
         } else {
             SnapshotBase::running(obs, reward)
         };
+
+        self.guard.record(snap.status);
         Ok(snap)
     }
 }
@@ -715,11 +743,49 @@ mod tests {
     //! and determinism.
 
     use super::*;
-    use rlevo_core::environment::Snapshot;
+    use crate::episode::assert_rejects_post_terminal_step;
+    use rlevo_core::environment::{EpisodeStatus, Snapshot};
 
     fn default_env() -> MountainCarContinuous {
         MountainCarContinuous::with_config(MountainCarContinuousConfig::default())
             .expect("valid config")
+    }
+
+    /// Maximum steps the energy-pumping policy may take before the test calls it
+    /// a regression. Full-throttle bang-bang crests the hill in a few hundred
+    /// steps (`power` here is 0.0015, below Gymnasium's 999-step cap); the slack
+    /// is generous so a legitimate physics tweak does not turn the test flaky,
+    /// but bounded so a broken termination check fails loudly instead of hanging.
+    const PUMP_STEP_CAP: usize = 2_000;
+
+    /// Drives the car to the flag with the classic energy-pumping policy — full
+    /// throttle in the direction the car is already moving — and returns the
+    /// terminal snapshot. This reaches the goal *legitimately*, through the real
+    /// physics, rather than by writing `state` directly, so the guard is
+    /// exercised on the same path an agent takes.
+    fn drive_to_goal(
+        env: &mut MountainCarContinuous,
+    ) -> SnapshotBase<1, MountainCarContinuousObservation, ScalarReward> {
+        let push_right = MountainCarContinuousAction::new(1.0).expect("+1.0 is in [-1, 1]");
+        let push_left = MountainCarContinuousAction::new(-1.0).expect("-1.0 is in [-1, 1]");
+
+        let mut snap = env.reset().expect("reset must succeed");
+        for _ in 0..PUMP_STEP_CAP {
+            // Velocity 0 (the reset state) pumps right: any direction works, the
+            // hill returns the car with more energy either way.
+            let action = if snap.observation().velocity < 0.0 {
+                push_left
+            } else {
+                push_right
+            };
+            snap = env
+                .step(action)
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("energy pumping must crest the hill within {PUMP_STEP_CAP} steps");
     }
 
     #[test]
@@ -908,6 +974,86 @@ mod tests {
         assert_eq!(
             a, b,
             "reset_with_seed must reproduce the same initial state"
+        );
+    }
+
+    // ── post-terminal step guard (issue #290) ────────────────────────────────
+
+    #[test]
+    /// Verifies `MountainCarContinuous` satisfies the shared post-terminal
+    /// conformance check: once the car has crested the hill, a further step with
+    /// a *legal* action fails with `StepAfterEpisodeEnd { status: Terminated }`.
+    /// The replayed action is constructed through the checked
+    /// [`MountainCarContinuousAction::new`], so the rejection can only be on
+    /// call-sequence grounds, never on the action's own validity.
+    fn test_mountain_car_continuous_rejects_post_terminal_step() {
+        let mut env = default_env();
+        let legal_action = MountainCarContinuousAction::new(0.5).expect("0.5 is in [-1, 1]");
+        assert_rejects_post_terminal_step(&mut env, drive_to_goal, legal_action);
+    }
+
+    #[test]
+    /// Regression for the payoff the guard removes: past the flag the goal
+    /// predicate still holds, so an unguarded post-terminal step would pay the
+    /// `+100` bonus a second time. The rejected step must instead leave the
+    /// physics, the step counter and the guard untouched, and emit no reward.
+    fn test_mountain_car_continuous_post_terminal_step_does_not_repay_goal_bonus() {
+        let mut env = default_env();
+        let terminal = drive_to_goal(&mut env);
+        assert!(
+            terminal.is_terminated(),
+            "the flag must terminate the episode"
+        );
+
+        let state_before = env.state;
+        let steps_before = env.steps;
+
+        let err = env
+            .step(MountainCarContinuousAction::new(1.0).expect("1.0 is in [-1, 1]"))
+            .expect_err("a step after termination must return Err, not another +100 snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                EpisodeStatus::Terminated,
+                "the error must carry Terminated, the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.state, state_before,
+            "a rejected step must not advance the physics"
+        );
+        assert_eq!(
+            env.steps, steps_before,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// Verifies `reset()` re-opens a terminated environment, so an agent can run
+    /// a second episode without rebuilding the environment.
+    fn test_mountain_car_continuous_reset_reopens_terminated_episode() {
+        let mut env = default_env();
+        let action = MountainCarContinuousAction::new(1.0).expect("1.0 is in [-1, 1]");
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(action).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        let snap = env
+            .step(action)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
         );
     }
 }

--- a/crates/rlevo-environments/src/classic/pendulum.rs
+++ b/crates/rlevo-environments/src/classic/pendulum.rs
@@ -93,6 +93,7 @@
 //! ```
 use std::fmt;
 
+use crate::episode::EpisodeGuard;
 use rand::{SeedableRng, rngs::StdRng};
 use rand_distr::{Distribution, Uniform};
 use rlevo_core::{
@@ -337,6 +338,18 @@ pub struct Pendulum {
     config: PendulumConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the episode ended — **inert in practice**,
+    /// because Pendulum has no terminal condition: every `step` emits `Running`,
+    /// so the guard never closes and never rejects anything. It is carried
+    /// anyway so the classic-control family is uniform (issue #290), and so that
+    /// a future termination rule (an upright-and-settled success criterion, say)
+    /// cannot silently reintroduce the post-terminal resurrection bug: whoever
+    /// adds a `terminated` branch gets the rejection for free from the existing
+    /// `check()`/`record()` pair rather than having to remember it.
+    ///
+    /// Episode capping lives in [`TimeLimit`](crate::wrappers::TimeLimit), which
+    /// carries its own guard; this one does not observe the wrapper's truncation.
+    guard: EpisodeGuard,
 }
 
 impl Pendulum {
@@ -357,6 +370,7 @@ impl Pendulum {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -479,6 +493,7 @@ impl Environment<1, 1, 1> for Pendulum {
     ///
     /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = self.sample_init_state();
         self.steps = 0;
         Ok(SnapshotBase::running(
@@ -496,15 +511,30 @@ impl Environment<1, 1, 1> for Pendulum {
     ///
     /// # Errors
     ///
-    /// Currently infallible; always returns `Ok`.
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended — unreachable today, since Pendulum has no terminal
+    /// condition and the [`EpisodeGuard`] therefore never closes. The variant is
+    /// documented because it is the family-wide contract a future termination
+    /// rule would activate without touching this signature.
     fn step(&mut self, action: PendulumAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before the integration step and before `steps` advances.
+        // Pendulum's dynamics draw no randomness, but `reset` does, so keeping
+        // the check ahead of every mutation is what makes a rejected call a true
+        // no-op on both the state and the RNG stream (ADR 0029).
+        self.guard.check()?;
+
         let (next_state, reward_f) = Self::step_dynamics(self.state, action.torque(), &self.config);
         self.state = next_state;
         self.steps += 1;
-        Ok(SnapshotBase::running(
-            self.observe(&action, &self.state),
-            ScalarReward(reward_f),
-        ))
+
+        // Single exit: the only status Pendulum can emit is `Running`, so the
+        // guard stays open — recording it regardless keeps the guard and the
+        // emitted snapshot in agreement no matter what branches appear later.
+        let snapshot =
+            SnapshotBase::running(self.observe(&action, &self.state), ScalarReward(reward_f));
+
+        self.guard.record(snapshot.status);
+        Ok(snapshot)
     }
 }
 
@@ -758,6 +788,55 @@ mod tests {
             assert!(!snap.is_terminated(), "should never terminate");
             assert_eq!(snap.status(), EpisodeStatus::Running);
         }
+    }
+
+    #[test]
+    /// Pendulum has no terminal condition, so the shared
+    /// `assert_rejects_post_terminal_step` conformance helper is inapplicable here —
+    /// there is no way to drive the env to a done snapshot without faking one. What
+    /// *is* checkable is the guard's other half: it must stay open forever, so
+    /// stepping never starts failing and the episode is never silently cut short.
+    /// If a termination rule is ever added, this test flips to the conformance
+    /// helper and the guard begins doing real work with no other change.
+    fn test_pendulum_guard_stays_running() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = default_env();
+        env.reset().expect("reset must succeed");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "a reset episode must start Running"
+        );
+
+        let action = PendulumAction::new(1.0).expect("torque within [-2, 2]");
+        for i in 0..1_000 {
+            let snap = env
+                .step(action)
+                .unwrap_or_else(|e| panic!("step {i} must succeed; Pendulum never ends: {e:?}"));
+            assert_eq!(
+                snap.status(),
+                EpisodeStatus::Running,
+                "snapshot at step {i} must be Running"
+            );
+            assert_eq!(
+                env.guard.status(),
+                EpisodeStatus::Running,
+                "the guard must agree with the snapshot at step {i}"
+            );
+        }
+
+        env.reset()
+            .expect("reset must succeed on a still-running episode");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must leave the guard open"
+        );
+        assert!(
+            env.step(action).is_ok(),
+            "stepping after reset must still succeed"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/classic/santa_fe_ant.rs
+++ b/crates/rlevo-environments/src/classic/santa_fe_ant.rs
@@ -56,6 +56,7 @@ use rlevo_core::state::MarkovState;
 use serde::{Deserialize, Serialize};
 
 use crate::direction::Direction;
+use crate::episode::EpisodeGuard;
 
 /// Side length of the (square, toroidal) trail grid.
 pub const GRID_SIZE: usize = 32;
@@ -382,10 +383,25 @@ impl Validate for SantaFeAntConfig {
 /// }
 /// assert!(eaten < 89.0, "a memoryless reflex cannot clear the trail (got {eaten})");
 /// ```
+///
+/// # Episode lifecycle
+///
+/// Two routes end an episode: clearing the trail *terminates* it, exhausting
+/// [`max_steps`](SantaFeAntConfig::max_steps) *truncates* it. After either, a
+/// further [`step`](Environment::step) returns
+/// [`EnvironmentError::StepAfterEpisodeEnd`] carrying the status that ended the
+/// episode — call [`reset`](Environment::reset) first.
 #[derive(Debug, Clone)]
 pub struct SantaFeAnt {
     state: SantaFeAntState,
     config: SantaFeAntConfig,
+    /// Rejects a `step()` taken after the episode ended. Without it the ant
+    /// keeps walking past the end: a post-terminal `Move` advances `steps`
+    /// beyond the budget and re-emits `Truncated` forever, and a post-truncation
+    /// `Move` can still eat pellets — scoring reward for an episode that was
+    /// already over. It also preserves the terminal/truncated distinction the
+    /// error carries back, which callers use to decide whether to bootstrap.
+    guard: EpisodeGuard,
 }
 
 impl SantaFeAnt {
@@ -400,6 +416,7 @@ impl SantaFeAnt {
         Ok(Self {
             state: Self::fresh_state(),
             config,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -493,7 +510,14 @@ impl Environment<1, 1, 1> for SantaFeAnt {
     type RewardType = ScalarReward;
     type SnapshotType = SnapshotBase<1, SantaFeAntObservation, ScalarReward>;
 
+    /// Restores the pristine trail, pose, and step counter, and re-opens the
+    /// [`EpisodeGuard`] for a new episode.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = Self::fresh_state();
         self.maybe_render();
         Ok(SnapshotBase::running(
@@ -502,7 +526,22 @@ impl Environment<1, 1, 1> for SantaFeAnt {
         ))
     }
 
+    /// Applies one motor primitive and returns the resulting snapshot.
+    ///
+    /// The episode terminates once the last pellet is eaten and truncates once
+    /// the step budget is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already terminated or truncated.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before the heading/pose mutation and the step counter, so
+        // a rejected call leaves the ant exactly where the terminal snapshot left
+        // it. The dynamics draw no randomness, but the ordering rule is the same
+        // one ADR 0029 imposes on the seeded environments.
+        self.guard.check()?;
+
         let reward: ScalarReward = match action {
             SantaFeAntAction::TurnLeft => {
                 self.state.heading = self.state.heading.left();
@@ -530,6 +569,9 @@ impl Environment<1, 1, 1> for SantaFeAnt {
 
         let obs: SantaFeAntObservation = self.observe(&action, &self.state);
         let limit: u32 = u32::try_from(self.config.max_steps).unwrap_or(u32::MAX);
+        // Single exit: all three routes build exactly one snapshot, and the guard
+        // is fed that snapshot's own status, so no branch can forget to record —
+        // and the guard cannot disagree with what the caller was handed.
         let snapshot: Self::SnapshotType = if self.state.pellets_remaining == 0 {
             // Goal reached — the whole trail is cleared.
             SnapshotBase::terminated(obs, reward)
@@ -539,6 +581,8 @@ impl Environment<1, 1, 1> for SantaFeAnt {
         } else {
             SnapshotBase::running(obs, reward)
         };
+
+        self.guard.record(snapshot.status);
         Ok(snapshot)
     }
 }
@@ -822,7 +866,8 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
-    use rlevo_core::environment::Snapshot;
+    use crate::episode::assert_rejects_post_terminal_step;
+    use rlevo_core::environment::{EpisodeStatus, Snapshot};
 
     #[test]
     fn default_config_validates() {
@@ -1031,6 +1076,106 @@ mod tests {
         assert_eq!(e.state().pellets_remaining(), 0);
         assert!(snap.is_terminated());
         assert!(snap.is_done());
+    }
+
+    // -- Post-terminal step guard (issue #290) -----------------------------
+
+    /// Clears the trail down to the single pellet directly ahead of the ant and
+    /// eats it, so the returned snapshot is `Terminated` (white-box: same module).
+    fn drive_to_last_pellet(
+        e: &mut SantaFeAnt,
+    ) -> SnapshotBase<1, SantaFeAntObservation, ScalarReward> {
+        let _ = <SantaFeAnt as Environment<1, 1, 1>>::reset(e).expect("reset");
+        e.state.food = [[false; GRID_SIZE]; GRID_SIZE];
+        e.state.food[0][1] = true;
+        e.state.pellets_remaining = 1;
+        <SantaFeAnt as Environment<1, 1, 1>>::step(e, SantaFeAntAction::Move).expect("step")
+    }
+
+    /// Spins in place until the step budget truncates the episode, so the
+    /// returned snapshot is `Truncated` (turning never eats, so the trail
+    /// cannot clear first).
+    fn drive_to_truncation(
+        e: &mut SantaFeAnt,
+    ) -> SnapshotBase<1, SantaFeAntObservation, ScalarReward> {
+        let mut snap = <SantaFeAnt as Environment<1, 1, 1>>::reset(e).expect("reset");
+        while !snap.is_done() {
+            snap = <SantaFeAnt as Environment<1, 1, 1>>::step(e, SantaFeAntAction::TurnRight)
+                .expect("step must succeed until the budget runs out");
+        }
+        snap
+    }
+
+    #[test]
+    /// Verifies `SantaFeAnt` satisfies the shared post-terminal conformance check on
+    /// its *terminating* route: once the trail is cleared, a further legal `step()`
+    /// fails with `StepAfterEpisodeEnd { status: Terminated }`.
+    fn test_santa_fe_ant_rejects_post_terminal_step() {
+        let mut e = env();
+        assert_rejects_post_terminal_step(&mut e, drive_to_last_pellet, SantaFeAntAction::Move);
+    }
+
+    #[test]
+    /// Verifies the *truncating* route is guarded too, and — the part that matters —
+    /// that the error carries `Truncated`, not `Terminated`. A caller bootstraps the
+    /// value of the final observation on truncation but not on termination, so
+    /// collapsing the two would silently corrupt its returns.
+    fn test_santa_fe_ant_rejects_post_truncation_step() {
+        let mut e = SantaFeAnt::with_config(SantaFeAntConfig {
+            max_steps: 5,
+            render: false,
+        })
+        .expect("valid config");
+        assert_rejects_post_terminal_step(&mut e, drive_to_truncation, SantaFeAntAction::Move);
+    }
+
+    #[test]
+    /// Verifies a rejected post-truncation `Move` mutates nothing: the pose, the step
+    /// counter, and the pellet count must all match the terminal snapshot's state.
+    /// Without the guard the ant would keep walking (and eating) past the budget.
+    fn test_santa_fe_ant_rejected_step_does_not_mutate_state() {
+        let mut e = SantaFeAnt::with_config(SantaFeAntConfig {
+            max_steps: 5,
+            render: false,
+        })
+        .expect("valid config");
+        let terminal = drive_to_truncation(&mut e);
+        assert!(terminal.is_truncated());
+        let frozen: SantaFeAntState = e.state().clone();
+
+        let err = <SantaFeAnt as Environment<1, 1, 1>>::step(&mut e, SantaFeAntAction::Move)
+            .expect_err("a step after truncation must return Err, not a fresh snapshot");
+        assert!(matches!(
+            err,
+            EnvironmentError::StepAfterEpisodeEnd {
+                status: EpisodeStatus::Truncated
+            }
+        ));
+        assert_eq!(
+            e.state(),
+            &frozen,
+            "a rejected step must not move the ant, eat a pellet, or advance the step counter"
+        );
+    }
+
+    #[test]
+    /// Verifies `reset()` re-opens an ended episode: the next `step()` succeeds and the
+    /// trail is pristine again.
+    fn test_santa_fe_ant_reset_reopens_ended_episode() {
+        let mut e = env();
+        drive_to_last_pellet(&mut e);
+        assert!(
+            <SantaFeAnt as Environment<1, 1, 1>>::step(&mut e, SantaFeAntAction::Move).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        <SantaFeAnt as Environment<1, 1, 1>>::reset(&mut e).expect("reset must succeed");
+        let snap = <SantaFeAnt as Environment<1, 1, 1>>::step(&mut e, SantaFeAntAction::Move)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     // -- POMDP marker ------------------------------------------------------

--- a/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
+++ b/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
@@ -253,9 +253,13 @@ tail can still build a wrapper over a rejecting environment, but a caller who
 silently absorbed a bug into a replay buffer has no way back. Reject is the
 reversible choice.
 
-**This is not yet universal — check before you rely on it.** Only the
-`toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`) and the
-`TimeLimit` wrapper enforce this rule today. Every other environment's
+**This is not yet universal — check before you rely on it.** Two of the
+built-in families enforce it today: the
+`toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
+`classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
+`MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), and the
+`TimeLimit` wrapper. The `classic` module's bandits, the `grids`,
+`locomotion`, and `box2d` families, and `pixel_grid` do not yet — their
 behaviour after a terminal snapshot remains **undefined**; do not depend on it,
 even by accident, until it lands for that family — the rollout is tracked
 family-by-family in
@@ -410,8 +414,9 @@ the crate as a vocabulary anchor more than a workhorse.
   part of the contract, and `EnvironmentError` is `#[non_exhaustive]`.
 - **A `step()` taken after `is_done()` is `true` is an error, not a silent
   resume.** It returns `EnvironmentError::StepAfterEpisodeEnd { status }`; call
-  `reset()` to start a new episode. Only `toy_text` and `TimeLimit` enforce this
-  today ([issue #289](https://github.com/anthonytorlucci/rlevo/issues/289) tracks
+  `reset()` to start a new episode. The `toy_text` family, the `classic`
+  family's non-bandit environments, and `TimeLimit` enforce this today
+  ([issue #289](https://github.com/anthonytorlucci/rlevo/issues/289) tracks
   the rest).
 - **`ConstructableEnv`** keeps construction off the behaviour trait so
   **wrappers** like `TimeLimit` compose cleanly — and that is where `Truncated`

--- a/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
+++ b/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
@@ -320,8 +320,8 @@ The rule your `step` must satisfy: once you have emitted a snapshot whose
 status is done, the *only* legal next call is `reset()`; a further `step()`
 must return `Err(EnvironmentError::StepAfterEpisodeEnd { status })`. You don't
 have to hand-write that state machine — `rlevo_environments::episode::EpisodeGuard`
-is the one-field helper every `toy_text` environment holds for exactly this.
-Add it to your struct:
+is the one-field helper the `toy_text` and `classic` (non-bandit) families
+already hold for exactly this. Add it to your struct:
 
 ```rust,no_run
 use rlevo_environments::episode::EpisodeGuard;
@@ -377,11 +377,16 @@ Three details here are load-bearing, not stylistic:
   the guard *after* the fallible work, not before — a failed reset must not
   silently re-open a finished episode.
 
-> **Scope: only four environments enforce this today.** `EpisodeGuard` ships in
-> `rlevo-environments`, and the `toy_text` family (`Blackjack`, `CliffWalking`,
-> `FrozenLake`, `Taxi`) plus the `TimeLimit` wrapper use it. The other ~44
-> built-in environments do not yet — their post-terminal behaviour is
-> undefined, tracked family-by-family in
+> **Scope: two of the built-in families enforce this today.**
+> `EpisodeGuard` ships in `rlevo-environments`, and the
+> `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
+> `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
+> `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), and the
+> `TimeLimit` wrapper all hold one. The `classic` module's bandits
+> (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
+> `AdversarialBandit`), the `grids`, `locomotion`, and `box2d` families, and
+> `pixel_grid` do not yet — their post-terminal behaviour is undefined,
+> tracked family-by-family in
 > [issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). Your own
 > environment doesn't have to wait for that rollout: reach for `EpisodeGuard`
 > the same way `CliffWalking` does, and it conforms from day one.
@@ -425,9 +430,9 @@ algorithm will drive your environment correctly:
   that is a caller error, not a fresh transition, and should be rejected with
   `EnvironmentError::StepAfterEpisodeEnd` rather than silently continuing — see
   [Step 5](#step-5--guard-the-post-terminal-step) above for the `EpisodeGuard`
-  recipe. (Only the `toy_text` family and `TimeLimit` enforce this today; treat
-  it as the target for any environment you write, not yet a workspace-wide
-  guarantee.)
+  recipe. (The `toy_text` family, the `classic` family's non-bandit
+  environments, and `TimeLimit` enforce this today; treat it as the target for
+  any environment you write, not yet a workspace-wide guarantee.)
 - **Neither method panics on valid input.** Return `EnvironmentError::InvalidAction`
   for out-of-range actions; reserve panics for genuine internal-logic bugs.
 - **Your config validates its own invariants.** Implement


### PR DESCRIPTION
## Summary

Applies the `EpisodeGuard` post-terminal contract (ADR 0044, established in #105) to the six `classic` environments. Each of them recomputed terminality from the *current* state on every `step()` — a predicate, not a latch — so none remembered the episode had already ended, and a `step()` after a terminal snapshot silently resurrected it. This was not a benign no-op: `CartPole` re-emitted a fresh `Terminated` snapshot and re-paid the `+1.0` while advancing `steps` past the true episode length; `MountainCarContinuous` re-paid the `+100` goal bonus on every extra call; and `Acrobot` was worse still, because the RK4 integrator keeps running past the goal until the tip swings back *below* the height threshold, at which point the next snapshot reads **`Running`** with reward `−1` — a finished episode brought back to life with a corrupted return. Every one of the six now holds an `EpisodeGuard`, `check()`s it before any state mutation or RNG draw, and `record()`s the emitted status on a single exit path.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #290.

Sub-issue of #289 (umbrella). Also supersedes #771, which reported the `CartPole` instance of this bug but recommended a Gymnasium-parity `terminated: bool` latch returning a zero-reward `Terminated` **snapshot** — mutually exclusive with ADR 0044's decision to return `Err`, so it is closed as *superseded*, not *fixed*.

## What Was Changed

- `classic/cartpole.rs` — added `guard: EpisodeGuard`; `check()?` first in `step()` (before `step_physics`, the step counter, and the RNG); `record(snap.status)` on the single exit. Tests: `test_cart_pole_rejects_post_terminal_step`, `..._post_terminal_step_does_not_extend_the_episode`, `..._reset_reopens_terminated_episode`, `..._rejected_step_does_not_advance_rng`.
- `classic/acrobot.rs` — same, with the guard on `Acrobot<D>` so it holds for both `BookDynamics` and `NipsDynamics`. `check()?` precedes the `torque_noise_max` sample. Tests include `test_acrobot_rejects_post_terminal_step` (termination reached by a real bang-bang swing-up through `step()`), a `NipsDynamics` variant, and an RNG-stream test.
- `classic/mountain_car.rs`, `classic/mountain_car_continuous.rs` — same shape. The continuous variant adds `test_mountain_car_continuous_post_terminal_step_does_not_repay_goal_bonus`; the `replay_action` handed to the conformance helper is built through the checked constructor so rejection can only be on call-sequence grounds.
- `classic/santa_fe_ant.rs` — all **three** snapshot paths (`terminated` / `truncated` / `running`) funnel through one `record()`. Adds `test_santa_fe_ant_rejects_post_truncation_step`, pinning that `StepAfterEpisodeEnd` carries `Truncated` rather than `Terminated` — the distinction a caller uses to decide whether to bootstrap.
- `classic/pendulum.rs` — takes the guard for family uniformity. See Notes.
- `CHANGELOG.md` — entry under `[Unreleased]` → `rlevo-environments` → `**Fixed**`.
- `docs/user-book/` — `34-environment.md` and `99-extending-the-environment.md` both asserted "only four environments enforce this today ... the other ~44 do not", which this PR falsifies. Corrected to name the conforming families, and deliberately *without* a numeral: the counts drift as the workspace grows, and #289's own "~48 impls" figure already disagrees with what is in the tree.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

All three pass with no failures and no warnings. Also run: `cargo fmt --all --check`, `cargo test -p rlevo -p rlevo-hybrid -p rlevo-test-support` (downstream consumers of the classic envs, since this changes their behavior), and `mdbook build docs/user-book`.

**Regression tests fail on the previous code — verified, not assumed.** Commenting out `self.guard.check()?` turns 4/4 of the new tests red in `cartpole.rs` and 4/4 in `santa_fe_ant.rs`; the leaked `cartpole` snapshot shows `reward: ScalarReward(1.0), status: Terminated`, i.e. the exact re-reward the guard prevents. Before this PR a post-terminal `step()` returned `Ok(snapshot)`; after it, `Err(EnvironmentError::StepAfterEpisodeEnd { status })`.

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU) — the environments are backend-independent; no tensor kernels are touched
- OS: macOS 26.5.2 (Darwin, arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full diff — guard plumbing and regression tests across the six environments, the CHANGELOG entry, and the user-book corrections — authored under maintainer direction and reviewed before commit.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Ordering is the load-bearing detail.** `guard.check()?` must precede the RNG draw, not merely the state mutation. `Acrobot` samples torque noise inside `step()`, so a check placed after it would let a *rejected* step advance the seed stream, making trajectories depend on how many illegal calls a caller made (ADR 0029). The guard call is the first statement in all six.

**`Pendulum` is a stated exception, not a silent one.** It has no terminal condition — every `step()` returns `Running` — so the shared `assert_rejects_post_terminal_step` conformance helper is **inapplicable** and is not used there. Satisfying it would mean hand-writing a terminal status the environment never emits, which tests the mock rather than the environment. `Pendulum` takes the guard for family uniformity (as #290 specifies) and is covered by the weaker `test_pendulum_guard_stays_running`, so that a future termination rule inherits the rejection instead of having to remember it.

**The migration note on `Environment::step` stays.** Deleting it is #289's acceptance criterion, not this PR's: `grids` (#291), `locomotion` (#292), `box2d` (#293), `pixel_grid` (#294) and the bandits (#295) are still unguarded. Note that `classic/bandit/` sits *inside* `classic/` but is **not** covered here — #290 scopes to the six physics envs, and the bandits' separate dead-`done`-field defect is #295.

**Follow-up.** #296 (`step()` before `reset()`) is untouched and its affected surface grows from 5 sites to 11, since `EpisodeGuard::new()` starts at `Running` and so a never-reset env still passes `check()`. Its blast radius does *not* grow: `EpisodeStatus` is unchanged and the guard's status field is private, so the `Option<EpisodeStatus>` fix sketched there still needs no `rlevo-core` change and no call-site edits.
