### PR TITLE
fix(env): Guard post-terminal step in grids family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,57 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **Post-terminal `step()` was an unbounded reward pump across the whole `grids`
+  family** (ADR 0044, resolves #291) — all twelve gridworlds derived termination
+  from a predicate over the *current* board rather than latching it, and the
+  shared dynamics consume nothing on success: `step_forward` moves the agent
+  **onto** `Entity::Goal` and leaves the cell intact. So a finished episode was
+  re-enterable. Stepping off the goal and back on re-raised
+  `StepOutcome::ReachedGoal` and paid `success_reward` again, on a loop as short
+  as two steps. Measured, not inferred: `EmptyEnv` banked `0.955 + 0.901 = 1.856`
+  for a single goal; `GoToDoorEnv` returned **5.649 on a task whose maximum is
+  1.0** (one win plus five replayed `Done`s). Because `success_reward` is
+  step-count-discounted and deliberately unclamped, replays past `max_steps` go
+  **negative** — a below-zero reward on a snapshot the caller reads as a win.
+  The intermediate calls emitted **`Running`** snapshots *after* a `Terminated`
+  one, so any rollout loop watching `is_done()` simply kept collecting.
+
+  Several envs lost a task-defining property rather than just reward hygiene. A
+  `LavaGapEnv` / `CrossingEnv` death was reversible — the agent stands *on* the
+  lava, and one more `Forward` walks it off and re-emits `Running`, converting a
+  `0.0` death into a positive-return episode. In `MemoryEnv` a wrong commit could
+  be retracted and the other object taken for full reward, making guessing free
+  and dissolving the recall property the 11-cell layout exists to enforce; the
+  same retry defeated `GoToDoorEnv`'s 25% cap on a mission-blind policy.
+  `UnlockEnv` was farmable because `toggle` maps `Open -> Closed` with no key
+  check, and `UnlockPickupEnv` because `Drop` returned the box and flipped
+  `has_target()` false. `DynamicObstaclesEnv` is the one that broke a documented
+  *invariant*: a collision-terminal step leaves an obstacle tracked on the
+  agent's cell with no `Ball` drawn, so re-entering `move_obstacles` violates its
+  SOUNDNESS premise and obstacles merge — reproduced at `seed = 37`,
+  `size = 5`, `num_obstacles = 4`, where `[(2,2),(2,1),(1,1),(1,3)]` becomes
+  `[(1,2),(1,1),(1,1),(2,3)]` on the *first* post-terminal step. #125 shipped
+  with that caveat documented rather than fixed; the guard now makes the
+  invariant unconditional, and the hedged prose on `obstacles()` and
+  `move_obstacles` has been tightened accordingly.
+
+  Every one of the twelve now holds an `episode::EpisodeGuard`, `check()`s it as
+  the first statement of `step()` — before the step counter, before
+  `apply_action`, and before `move_obstacles` draws (ADR 0029: a rejected step
+  must not advance the seed stream) — and `record()`s the emitted snapshot's own
+  status on a single exit. `DynamicObstaclesEnv`'s three return paths were
+  collapsed to one to make that reachable. Where `reset()` runs a fallible
+  `Self::build(..)?` (`FourRoomsEnv`, `DoorKeyEnv`, `UnlockPickupEnv`) the guard
+  is cleared **only on success**, per ADR 0044 §6 and the `TimeLimit::reset`
+  precedent: clearing first would re-open a finished episode over a board that
+  never returned to its initial state.
+
+  Note the guard is orthogonal to #1028, still open: `build_snapshot` maps a
+  step-limit cutoff to `Terminated` rather than `Truncated`, so the grids family
+  still disagrees with `SantaFeAnt`, which emits `Truncated` for its time limit.
+  The new conformance tests deliberately end their episodes on a task terminal
+  (goal, lava, mission, collision) rather than the step limit, so fixing #1028
+  will not require rewriting them.
 - **Post-terminal `step()` silently resurrected a finished episode across the
   whole `classic` family** (ADR 0044, resolves #290) — the contract #105 made
   normative on `Environment::step` was enforced only by `toy_text` and

--- a/crates/rlevo-environments/src/grids/crossing.rs
+++ b/crates/rlevo-environments/src/grids/crossing.rs
@@ -107,9 +107,15 @@ use rand::seq::SliceRandom;
 // `Rng` is the trait bound (rules.md §8); `RngExt` carries `random_range`,
 // which rand 0.10 moved out of `Rng` into a blanket extension implemented for
 // every `R: Rng + ?Sized`. Imported anonymously — only its methods are wanted.
+use crate::episode::EpisodeGuard;
 use rand::{Rng, RngExt as _, SeedableRng};
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+// `Snapshot` is imported anonymously: `step()` needs its `status()` method to
+// feed the guard, but re-exporting the name through this module's `use super::*`
+// in the test module would shadow the test module's own explicit import.
+use rlevo_core::environment::{
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot as _,
+};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -385,6 +391,30 @@ pub struct CrossingEnv {
     render: bool,
     layout: CrossingLayout,
     rng: StdRng,
+    /// Rejects a `step()` taken after the episode already ended.
+    ///
+    /// Termination here is derived from the *outcome of the current action*
+    /// (`ReachedGoal` / `HitLava`), never from a stored flag, and neither
+    /// terminal cell is consumed: the goal stays [`Entity::Goal`] on the grid and
+    /// the agent is left standing **on** the lava tile it died on. Unguarded,
+    /// that made both endings reversible.
+    ///
+    /// - **Lava.** After a `HitLava` snapshot the agent is on the lava cell. A
+    ///   `TurnLeft`/`TurnRight`, or a `Forward` onto any ordinary cell, yields
+    ///   `NoOp`/`Moved` — `done` is then just `steps >= max_steps`, i.e. `false`
+    ///   — so the very next call emitted a **`Running`** snapshot and the agent
+    ///   walked off the lava as if it had never burned. It could then go on to
+    ///   reach the goal and be paid `success_reward`, turning a 0.0 lava death
+    ///   into a positive-return episode.
+    /// - **Goal.** The goal cell is not cleared on arrival, so backing off it and
+    ///   stepping in again re-raised `ReachedGoal` and re-paid
+    ///   `success_reward(self.steps, max_steps)` — a second, third, … positive
+    ///   reward on one episode.
+    /// - **Both.** `self.steps` kept advancing on every illegal call, so it no
+    ///   longer measured the episode's true length and each replayed
+    ///   `success_reward` was discounted by steps taken after the episode was
+    ///   over.
+    guard: EpisodeGuard,
 }
 
 impl CrossingEnv {
@@ -441,6 +471,7 @@ impl CrossingEnv {
             render,
             layout,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -715,7 +746,16 @@ impl Environment<3, 3, 1> for CrossingEnv {
     type RewardType = ScalarReward;
     type SnapshotType = GridSnapshot;
 
+    /// Samples a fresh layout and returns the first snapshot of a new episode.
+    ///
+    /// Re-opens the [`EpisodeGuard`], so an episode that ended on lava or on the
+    /// goal becomes steppable again — the only way it does.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         let (state, layout) = Self::build(&self.config, &mut self.rng);
         self.state = state;
         self.layout = layout;
@@ -724,7 +764,21 @@ impl Environment<3, 3, 1> for CrossingEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies one grid action and returns the resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended (goal reached, lava entered, or the step budget spent);
+    /// call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances, before the grid or the agent is
+        // touched, and before any draw from `self.rng`. A rejected call must
+        // leave the board, the step counter and the RNG stream exactly as they
+        // were, or the layout of the *next* episode would depend on how many
+        // illegal steps a caller made (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -736,7 +790,12 @@ impl Environment<3, 3, 1> for CrossingEnv {
             }
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so the two cannot drift apart.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -1361,6 +1420,149 @@ mod tests {
             checked,
             "the traced river set never came up in {EPISODES} episodes"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Post-terminal step guard (ADR 0044, issue #291).
+    //
+    // Both drivers reach the terminal through real `step()` calls, and both end
+    // the episode on a *task* terminal — the goal, or lava — never by spending
+    // the step budget. `grids/core/mod.rs::build_snapshot` currently stamps a
+    // step-limit cutoff `Terminated` rather than `Truncated` (#1028, out of
+    // scope here); driving through the budget would bake that bug into these
+    // assertions and force #1028's fix to rewrite them.
+    // -----------------------------------------------------------------------
+
+    /// Reset, then walk the planned safe path to the goal with real `step()`s.
+    ///
+    /// Returns the terminal snapshot. The layout is sampled fresh every reset,
+    /// so the route is re-planned from the board rather than scripted.
+    fn drive_to_goal(env: &mut CrossingEnv) -> GridSnapshot {
+        env.reset().expect("reset");
+        let path = safe_path(env.state()).expect("every sampled board is solvable");
+        let mut last = None;
+        for action in actions_along(&path, env.state().agent.direction) {
+            last = Some(env.step(action).expect("step must succeed until the goal"));
+        }
+        last.expect("the plan must contain at least one action")
+    }
+
+    /// Reset until lava sits directly south of the start, then walk into it.
+    ///
+    /// Returns the terminal snapshot.
+    fn drive_into_lava(env: &mut CrossingEnv) -> GridSnapshot {
+        assert!(
+            reset_until_blocker_south(env, 512),
+            "no episode in 512 put lava directly south of the start"
+        );
+        env.step(GridAction::TurnRight).expect("turn");
+        env.step(GridAction::Forward).expect("step onto lava")
+    }
+
+    #[test]
+    fn test_crossing_rejects_post_terminal_step_after_reaching_goal() {
+        let mut env = default_env(CrossingKind::Lava);
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_goal,
+            GridAction::TurnLeft,
+        );
+    }
+
+    #[test]
+    fn test_crossing_rejects_post_terminal_step_after_hitting_lava() {
+        // The lava ending is the one this env is *about*, and it was the more
+        // damaging leak: the agent is left standing on the lava tile, so an
+        // unguarded turn or side-step re-emitted a `Running` snapshot and the
+        // episode carried on from a death.
+        let mut env = default_env(CrossingKind::Lava);
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_into_lava,
+            GridAction::TurnLeft,
+        );
+    }
+
+    #[test]
+    fn test_crossing_rejected_step_does_not_mutate_state() {
+        // The guard must reject *before* `steps += 1`, before `apply_action`
+        // touches the grid or the agent, and before any RNG draw (ADR 0029).
+        let mut env = default_env(CrossingKind::Lava);
+        let terminal = drive_into_lava(&mut env);
+        assert!(terminal.is_done(), "the drive must end the episode");
+
+        let steps = env.steps();
+        let agent = env.state().agent;
+        let board = env.ascii();
+
+        env.step(GridAction::Forward)
+            .expect_err("a post-terminal step must be rejected");
+
+        assert_eq!(
+            env.steps(),
+            steps,
+            "a rejected step must not advance `steps`"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (agent.x, agent.y),
+            "a rejected step must not move the agent"
+        );
+        assert_eq!(
+            env.state().agent.direction,
+            agent.direction,
+            "a rejected step must not turn the agent"
+        );
+        assert_eq!(
+            env.ascii(),
+            board,
+            "a rejected step must not touch the grid"
+        );
+    }
+
+    #[test]
+    fn test_crossing_rejected_step_does_not_advance_the_rng() {
+        // The sharper half of the ADR 0029 claim: two envs seeded alike, one of
+        // which is asked for an illegal step, must still sample the *same* next
+        // board. Only a guard that runs before every draw can deliver that.
+        let mut guarded = default_env(CrossingKind::Lava);
+        let mut clean = default_env(CrossingKind::Lava);
+
+        for env in [&mut guarded, &mut clean] {
+            let terminal = drive_to_goal(env);
+            assert!(terminal.is_done(), "the drive must end the episode");
+        }
+        for _ in 0..3 {
+            guarded
+                .step(GridAction::Forward)
+                .expect_err("post-terminal steps must be rejected");
+        }
+
+        guarded.reset().expect("reset");
+        clean.reset().expect("reset");
+        assert_eq!(
+            guarded.ascii(),
+            clean.ascii(),
+            "rejected steps drew from the RNG: the next episode's board diverged"
+        );
+    }
+
+    #[test]
+    fn test_crossing_reset_reopens_a_terminated_episode() {
+        let mut env = default_env(CrossingKind::Lava);
+        let terminal = drive_into_lava(&mut env);
+        assert!(terminal.is_done(), "the drive must end the episode");
+        env.step(GridAction::TurnLeft)
+            .expect_err("the episode has ended; a further step must be rejected");
+
+        let snapshot = env.reset().expect("reset");
+        assert!(
+            !snapshot.is_done(),
+            "reset() must hand back a running snapshot"
+        );
+        assert_eq!(env.steps(), 0, "reset() must clear the step counter");
+        env.step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
     }
 
     /// Occlusion hides the **goal** from a cell on the solution corridor — and

--- a/crates/rlevo-environments/src/grids/dist_shift.rs
+++ b/crates/rlevo-environments/src/grids/dist_shift.rs
@@ -63,8 +63,9 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -251,6 +252,28 @@ pub struct DistShiftEnv {
     config: DistShiftConfig,
     steps: usize,
     render: bool,
+    /// Rejects a `step()` taken after the goal or the lava ended the episode.
+    ///
+    /// Termination here is recomputed from the current cell on every call and
+    /// nothing consumes the terminal cell, so without the guard the board stays
+    /// fully playable after the episode is over:
+    ///
+    /// - **The goal pays out again.** `step_forward` moves the agent onto `(7,
+    ///   1)` but leaves `Entity::Goal` in the grid. Two `TurnLeft`s, a
+    ///   `Forward` off the goal and a `Forward` back onto it produce a second
+    ///   `StepOutcome::ReachedGoal`, and `success_reward(self.steps,
+    ///   max_steps)` is paid a second time — still positive for any `steps <
+    ///   max_steps`, and repeatable until the step limit, so a single episode's
+    ///   return can be inflated by roughly `max_steps / 4` extra goal payouts.
+    /// - **The lava death is undone.** After `StepOutcome::HitLava` the agent
+    ///   is standing on the lava strip; the next `Forward` steps off it, scores
+    ///   `StepOutcome::Moved`, and emits a fresh `Running` snapshot — the agent
+    ///   walks out of the lava it just died in and the terminated episode is
+    ///   resurrected.
+    /// - **`self.steps` keeps advancing** past the true episode length, so the
+    ///   reported episode length is wrong and every replayed goal payout is
+    ///   discounted by steps the episode never legitimately took.
+    guard: EpisodeGuard,
 }
 
 impl DistShiftEnv {
@@ -300,6 +323,7 @@ impl DistShiftEnv {
             config,
             steps: 0,
             render,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -400,14 +424,35 @@ impl Environment<3, 3, 1> for DistShiftEnv {
     type RewardType = ScalarReward;
     type SnapshotType = GridSnapshot;
 
+    /// Rebuilds the fixed board, re-opens the episode, and returns the initial
+    /// observation.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = Self::build(&self.config);
         self.steps = 0;
         let observation = self.observe_reset(&self.state);
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies `action` to the grid and returns the resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended (goal reached, lava entered, or step limit hit); call
+    /// [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances and before `apply_action` touches
+        // the grid or the agent, so a rejected call leaves the environment
+        // bit-for-bit unchanged. This env draws no randomness, but the guard
+        // still precedes every effect so the ordering matches ADR 0029's rule
+        // that a rejected step never advances a seed stream.
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -419,7 +464,12 @@ impl Environment<3, 3, 1> for DistShiftEnv {
             }
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch can forget to record.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -438,7 +488,6 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
-    use rlevo_core::environment::Snapshot;
 
     #[test]
     fn default_config_validates() {
@@ -575,5 +624,155 @@ mod tests {
     #[test]
     fn unknown_variant_errors() {
         assert!("variant=wat".parse::<DistShiftConfig>().is_err());
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+    //
+    // Both drivers end the episode on a *task* outcome — the goal or the lava —
+    // never on the step limit. `build_snapshot` currently reports a step-limit
+    // cutoff as `Terminated` rather than `Truncated` (#1028); routing these
+    // tests around it keeps them correct either way.
+
+    /// Drives a default env to the goal at `(7, 1)` with six `Forward`s, through
+    /// real `step()` calls only.
+    fn drive_to_goal(env: &mut DistShiftEnv) -> GridSnapshot {
+        env.reset().expect("reset must succeed");
+        let mut snapshot = env
+            .step(GridAction::Forward)
+            .expect("the first step must succeed");
+        while !snapshot.is_done() {
+            snapshot = env
+                .step(GridAction::Forward)
+                .expect("stepping east along the safe corridor must succeed until the goal");
+        }
+        snapshot
+    }
+
+    /// Drives a default env (variant One, lava at row 3) onto the lava strip at
+    /// `(3, 3)`, through real `step()` calls only.
+    fn drive_into_lava(env: &mut DistShiftEnv) -> GridSnapshot {
+        env.reset().expect("reset must succeed");
+        for action in [
+            GridAction::Forward,   // (2, 1)
+            GridAction::Forward,   // (3, 1)
+            GridAction::TurnRight, // face South
+            GridAction::Forward,   // (3, 2)
+        ] {
+            let snapshot = env
+                .step(action)
+                .expect("the approach must not end the episode");
+            assert!(
+                !snapshot.is_done(),
+                "the approach to the lava must stay running"
+            );
+        }
+        env.step(GridAction::Forward)
+            .expect("stepping onto the lava must succeed")
+    }
+
+    #[test]
+    /// `DistShiftEnv` satisfies the shared post-terminal conformance check: once
+    /// the agent is on the goal, a further legal `Forward` fails with
+    /// `StepAfterEpisodeEnd` instead of stepping on.
+    fn test_dist_shift_rejects_post_terminal_step() {
+        let mut env =
+            DistShiftEnv::with_config(DistShiftConfig::default(), false).expect("valid config");
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_goal,
+            GridAction::Forward,
+        );
+    }
+
+    #[test]
+    /// The same conformance check for the other terminal route: dying in lava
+    /// must latch the episode just as reaching the goal does.
+    fn test_dist_shift_rejects_post_terminal_step_after_lava() {
+        let mut env =
+            DistShiftEnv::with_config(DistShiftConfig::default(), false).expect("valid config");
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_into_lava,
+            GridAction::Forward,
+        );
+    }
+
+    #[test]
+    /// Regression for the concrete defect the guard prevents on the goal cell:
+    /// nothing consumes `Entity::Goal`, so an unguarded agent could turn around,
+    /// step off the goal and back onto it for a second `success_reward` payout
+    /// while `steps` ran past the true episode length. A rejected step must
+    /// mutate nothing at all.
+    fn test_dist_shift_post_terminal_step_does_not_mutate_state() {
+        let mut env =
+            DistShiftEnv::with_config(DistShiftConfig::default(), false).expect("valid config");
+        let terminal = drive_to_goal(&mut env);
+        let ended = terminal.status();
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+
+        let err = env
+            .step(GridAction::TurnLeft)
+            .expect_err("a step after the goal must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (agent_at_end.x, agent_at_end.y),
+            "a rejected step must not move the agent"
+        );
+        assert_eq!(
+            env.state().agent.direction,
+            agent_at_end.direction,
+            "a rejected TurnLeft must not rotate the agent"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a terminated episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    fn test_dist_shift_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env =
+            DistShiftEnv::with_config(DistShiftConfig::default(), false).expect("valid config");
+        drive_into_lava(&mut env);
+        assert!(
+            env.step(GridAction::Forward).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert_eq!(env.steps(), 0, "reset() must clear the step counter");
+
+        let snapshot = env
+            .step(GridAction::Forward)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snapshot.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 }

--- a/crates/rlevo-environments/src/grids/door_key.rs
+++ b/crates/rlevo-environments/src/grids/door_key.rs
@@ -97,10 +97,11 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt as _, SeedableRng};
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -284,6 +285,10 @@ struct Layout {
 /// Construct via [`DoorKeyEnv::with_config`] for full control or via
 /// [`ConstructableEnv::new`] for default settings (size 5, 100 steps, seed 0).
 ///
+/// Reaching the goal (or lava) ends the episode; a [`step`](Environment::step)
+/// taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
+///
 /// # Examples
 ///
 /// ```rust
@@ -306,6 +311,32 @@ pub struct DoorKeyEnv {
     split_col: i32,
     door_row: i32,
     rng: StdRng,
+    /// Rejects a `step()` taken after the episode already ended.
+    ///
+    /// Without it the goal cell is a reward faucet, because nothing here is
+    /// consumed on success: `Forward` leaves `Entity::Goal` in the grid and the
+    /// agent standing on it, so the agent can walk off the goal and back on and
+    /// `apply_action` reports `ReachedGoal` again, paying `success_reward` a
+    /// second time on a second `Terminated` snapshot. Measured on
+    /// `size = 5, max_steps = 100, reset_with_seed(3)`: the episode terminates
+    /// at step 11 with reward `0.901`, then five further steps (`TurnRight`,
+    /// `TurnRight`, `Forward`, `TurnRight` ×2, `Forward`) re-terminate at step
+    /// 17 with another `0.847` — and the five snapshots in between come back
+    /// `Running`, so a finished episode is silently resumed.
+    ///
+    /// The re-payment also *decays*, because `self.steps` never stops
+    /// advancing: it is the numerator of `success_reward(steps, max_steps)`, so
+    /// each replay is worth less than the last, and once `steps` passes
+    /// `max_steps` the formula goes negative — the case `reward::success_reward`
+    /// documents as "no env should call it past termination".
+    ///
+    /// The key/door mechanic keeps running too. The agent still carries the
+    /// yellow key after the goal, and `Pickup` / `Drop` / `Toggle` stay live: in
+    /// the same seed-3 rollout a post-terminal `Drop` at step 15 dumps the key
+    /// at `(3, 1)` inside the goal room and empties the hand. The board the
+    /// terminal snapshot described is then no longer the board the environment
+    /// holds.
+    guard: EpisodeGuard,
 }
 
 impl DoorKeyEnv {
@@ -371,6 +402,7 @@ impl DoorKeyEnv {
             split_col: layout.split_col,
             door_row: layout.door_row,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -565,8 +597,28 @@ impl Environment<3, 3, 1> for DoorKeyEnv {
     type RewardType = ScalarReward;
     type SnapshotType = GridSnapshot;
 
+    /// Draws a fresh layout and re-opens the episode.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`PlacementError`] from [`build`](Self::build) if the left
+    /// room has no free cell for the agent or the key. No legal
+    /// [`DoorKeyConfig`] reaches that path.
+    ///
+    /// A failed reset is a **total no-op**: the board, the step counter, and the
+    /// guard all keep the previous episode's values, so a finished episode stays
+    /// finished and a later `step()` is still rejected. Clearing the guard before
+    /// the draw would instead re-open a finished episode on a board that never
+    /// returned to an initial state. This follows ADR 0044 §6 and the
+    /// [`TimeLimit::reset`](crate::wrappers::TimeLimit) precedent, which clears
+    /// its guard only after the delegated reset succeeds.
+    ///
+    /// That `Err` path is unreachable for any config this crate accepts (see
+    /// [`build`](Self::build)), so it carries no test — only this ordering.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Draw first: only a *successful* build actually starts a new episode.
         let layout = Self::build(&self.config, &mut self.rng)?;
+        self.guard.reset();
         self.state = layout.state;
         self.split_col = layout.split_col;
         self.door_row = layout.door_row;
@@ -575,7 +627,21 @@ impl Environment<3, 3, 1> for DoorKeyEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies `action` to the board and returns the resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances (it is the numerator of
+        // `success_reward`, so an illegal call would silently discount every
+        // later payout) and before `apply_action` touches the grid or the
+        // agent's hand. `step()` draws no randomness today, but `reset()` shares
+        // the persistent stream, so checking any later would let rejected calls
+        // reorder future episodes (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -587,7 +653,12 @@ impl Environment<3, 3, 1> for DoorKeyEnv {
             }
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+
+        // Single exit: the guard is fed the emitted snapshot's own status, so
+        // the two cannot disagree about whether the episode is over.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -607,10 +678,11 @@ mod tests {
 
     use super::*;
     use crate::direction::Direction;
+    use crate::episode::assert_rejects_post_terminal_step;
     use crate::grids::core::UNSEEN_TYPE;
     use crate::grids::core::agent::AgentState;
     use rlevo_core::config::ConstraintKind;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::EpisodeStatus;
     use std::collections::{HashSet, VecDeque};
 
     /// Every seed loop runs at the `MIN_SIZE` floor and at one larger board.
@@ -1210,5 +1282,170 @@ mod tests {
             Visibility::Occluded,
             "doorkey.py omits see_through_walls, so MiniGridEnv's False default applies"
         );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// A 5×5 board whose seed-3 layout the module docs pin, so the scripted
+    /// solution below is written against a board that cannot silently move —
+    /// `module_doc_snapshot_is_current` fails first if the generator changes.
+    fn env_seed_3() -> DoorKeyEnv {
+        let mut env = env_5x5();
+        env.reset_with_seed(3).expect("reset");
+        env
+    }
+
+    /// Solves the seed-3 board through **real `step()` calls** and returns the
+    /// terminal snapshot.
+    ///
+    /// Termination is by *reaching the goal*, not by exhausting `max_steps`:
+    /// `grids/core/mod.rs`'s `build_snapshot` currently maps a step-limit cutoff
+    /// to `Terminated` rather than `Truncated` (#1028), so a step-limit ending
+    /// would pin the wrong status through this guard.
+    ///
+    /// The board (see the module docs) is agent `(1, 1)` facing North, key
+    /// `(1, 2)`, locked door `(2, 1)`, goal `(3, 3)`.
+    fn drive_to_goal(env: &mut DoorKeyEnv) -> GridSnapshot {
+        let plan = [
+            GridAction::TurnRight, // North → East
+            GridAction::TurnRight, // East → South, now facing the key
+            GridAction::Pickup,    // take the yellow key
+            GridAction::TurnLeft,  // South → East, now facing the locked door
+            GridAction::Toggle,    // Locked → Closed
+            GridAction::Toggle,    // Closed → Open
+            GridAction::Forward,   // (1,1) → (2,1), through the door
+            GridAction::Forward,   // (2,1) → (3,1)
+            GridAction::TurnRight, // East → South
+            GridAction::Forward,   // (3,1) → (3,2)
+            GridAction::Forward,   // (3,2) → (3,3), the goal
+        ];
+        let mut snapshot = None;
+        for action in plan {
+            let snap = env
+                .step(action)
+                .expect("the scripted solution must be legal");
+            snapshot = Some(snap);
+        }
+        let terminal = snapshot.expect("the plan is non-empty");
+        assert!(
+            terminal.is_done(),
+            "the scripted plan must reach the goal; the board or the dynamics moved"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (3, 3),
+            "the agent must finish on the goal cell"
+        );
+        terminal
+    }
+
+    #[test]
+    /// Verifies `DoorKeyEnv` satisfies the shared post-terminal conformance
+    /// check: once the agent reaches the goal, a further *legal* action fails
+    /// with `StepAfterEpisodeEnd { status: Terminated }`. `Drop` is chosen as the
+    /// replay because the agent is still holding the key — the rejection must be
+    /// on call-sequence grounds, never on the action's own validity.
+    fn test_door_key_rejects_post_terminal_step() {
+        let mut env = env_5x5();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            |env| {
+                env.reset_with_seed(3).expect("reset");
+                drive_to_goal(env)
+            },
+            GridAction::Drop,
+        );
+    }
+
+    #[test]
+    /// Regression for the concrete defect the guard prevents. Nothing is
+    /// consumed on success — the goal entity stays in the grid, the agent stays
+    /// on it, and the key stays in its hand — so an unguarded post-terminal step
+    /// resumed the episode: `steps` advanced past the true episode length
+    /// (discounting the `success_reward` of any goal re-entry), the agent turned
+    /// and walked off the goal, and a later `Drop` emptied the hand.
+    ///
+    /// A rejected step must mutate none of the three.
+    fn test_door_key_post_terminal_step_mutates_nothing() {
+        let mut env = env_seed_3();
+        let terminal = drive_to_goal(&mut env);
+        assert!(
+            terminal.is_terminated(),
+            "the agent must have reached the goal"
+        );
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+        assert_eq!(
+            agent_at_end.carrying,
+            Some(Entity::Key(DOOR_COLOR)),
+            "the agent finishes the episode still holding the key"
+        );
+
+        let err = env
+            .step(GridAction::TurnRight)
+            .expect_err("a step after the goal must return Err, not another Running snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                EpisodeStatus::Terminated,
+                "the error must carry Terminated, the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (agent_at_end.x, agent_at_end.y),
+            "a rejected step must not move the agent off the goal"
+        );
+        assert_eq!(
+            env.state().agent.direction,
+            agent_at_end.direction,
+            "a rejected TurnRight must not turn the agent"
+        );
+        assert_eq!(
+            env.state().agent.carrying,
+            Some(Entity::Key(DOOR_COLOR)),
+            "a rejected step must leave the key in the agent's hand"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// Verifies `reset()` re-opens a terminated episode, so a guard that has
+    /// latched cannot strand the environment for the rest of the run.
+    fn test_door_key_reset_reopens_terminated_episode() {
+        let mut env = env_seed_3();
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(GridAction::TurnRight).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(GridAction::TurnRight)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "a turn on the first step of a fresh episode cannot end it"
+        );
+        assert_eq!(env.steps(), 1, "the step counter must restart at the reset");
     }
 }

--- a/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
+++ b/crates/rlevo-environments/src/grids/dynamic_obstacles.rs
@@ -72,10 +72,13 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot as _,
+};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -268,6 +271,22 @@ pub struct DynamicObstaclesEnv {
     render: bool,
     obstacles: Vec<(i32, i32)>,
     rng: StdRng,
+    /// Rejects a `step()` taken after the episode ended.
+    ///
+    /// Load-bearing for a correctness invariant here, not merely for step-count
+    /// hygiene. On a collision-terminal step `move_obstacles` moves the winning
+    /// obstacle's *tracked* position onto the agent's cell but deliberately
+    /// draws no [`Ball`](Entity::Ball) there, so `self.obstacles` holds one
+    /// entry the grid does not back with a ball. A further `step()` would run
+    /// `move_obstacles` against that ghost entry, breaking its SOUNDNESS
+    /// premise — every obstacle's old cell reads as `Ball` on entry — and
+    /// obstacles then **duplicate**: with `size = 5`, `num_obstacles = 4`,
+    /// `seed = 37`, one post-terminal step turns
+    /// `[(2, 2), (2, 1), (1, 1), (1, 3)]` into
+    /// `[(1, 2), (1, 1), (1, 1), (2, 3)]` — two obstacles on `(1, 1)`. The
+    /// guard makes that call an error, which is what keeps
+    /// [`obstacles`](Self::obstacles) unconditionally pairwise distinct.
+    guard: EpisodeGuard,
 }
 
 impl DynamicObstaclesEnv {
@@ -324,6 +343,7 @@ impl DynamicObstaclesEnv {
             render,
             obstacles,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -366,17 +386,14 @@ impl DynamicObstaclesEnv {
     /// slice length equals `num_obstacles` (or fewer if there were not enough
     /// free cells at spawn time).
     ///
-    /// Throughout any episode driven per the [`Environment`] contract
-    /// (`reset` → `step` until `done` → `reset`), the returned positions are
-    /// **pairwise distinct** — including on the terminal step where an obstacle
-    /// collides with the agent. Obstacles that would otherwise merge are
-    /// resolved by `move_obstacles`: the first claimant
-    /// of a cell keeps it and the loser stays put.
-    ///
-    /// Calling [`step`](Environment::step) again *after* a terminal snapshot,
-    /// without an intervening [`reset`](Environment::reset), leaves the
-    /// contract and may break the invariant — see the note on
-    /// `move_obstacles`.
+    /// The returned positions are **pairwise distinct** in every observable
+    /// state — including on the terminal step where an obstacle collides with
+    /// the agent. Obstacles that would otherwise merge are resolved by
+    /// `move_obstacles`: the first claimant of a cell keeps it and the loser
+    /// stays put. The invariant is unconditional because
+    /// [`step`](Environment::step) cannot be called after a terminal snapshot:
+    /// it returns [`EnvironmentError::StepAfterEpisodeEnd`] until
+    /// [`reset`](Environment::reset) re-opens the episode.
     #[must_use]
     pub fn obstacles(&self) -> &[(i32, i32)] {
         &self.obstacles
@@ -440,22 +457,21 @@ impl DynamicObstaclesEnv {
     /// wins, and any later obstacle whose draw lands on an already-claimed cell
     /// stays at its old position. The agent's cell is claimed like any other, so
     /// at most one obstacle can reach the agent on a given step. Obstacle
-    /// positions are consequently pairwise distinct in every state reachable
-    /// through the documented [`Environment`] contract (`reset` → `step` until
-    /// `done` → `reset`).
+    /// positions are consequently pairwise distinct in every observable state.
     ///
     /// # Stepping past a terminal snapshot
     ///
     /// On a collision-terminal step the winning obstacle's tracked position is
     /// set to the agent's cell, but no [`Ball`](Entity::Ball) is *drawn* there —
     /// the episode is over. `self.obstacles` is therefore deliberately desynced
-    /// from the grid, which is harmless only because the contract requires a
-    /// [`reset`](Environment::reset) next. Calling [`step`](Environment::step)
-    /// again instead violates the contract: the stale entry's cell no longer
-    /// reads as `Ball`, the SOUNDNESS premise below fails, and obstacles can
-    /// merge. That is the grids family's known missing post-terminal `step`
-    /// guard (the ADR 0044 / #105 sweep covered `toy_text` only), not a property
-    /// of this function; `Environment` claims nothing about post-terminal steps.
+    /// from the grid for exactly as long as the terminal snapshot is the latest
+    /// one. Re-entering this function with that stale entry would break the
+    /// SOUNDNESS premise below (the entry's cell no longer reads as `Ball`) and
+    /// obstacles could merge — so it cannot happen:
+    /// [`step`](Environment::step) checks its [`EpisodeGuard`] first and returns
+    /// [`EnvironmentError::StepAfterEpisodeEnd`] rather than calling this
+    /// function again. [`reset`](Environment::reset) rebuilds the grid and the
+    /// obstacle list together, so the next episode starts in sync.
     fn move_obstacles(&mut self) -> bool {
         let mut collision = false;
         let agent_pos = (self.state.agent.x, self.state.agent.y);
@@ -471,11 +487,12 @@ impl DynamicObstaclesEnv {
         // *other* obstacle can have that old cell among its candidates: each
         // old position is uniquely reserved for its own occupant.
         //
-        // The premise holds in every state reachable through the documented
-        // `Environment` contract (`reset` -> `step` until `done` -> `reset`).
-        // It does *not* hold if a caller steps past a terminal snapshot without
-        // resetting — see the "Stepping past a terminal snapshot" section on
-        // this function.
+        // The premise holds in every state this function can be entered from:
+        // `reset` draws the balls and the tracked list from one another, each
+        // non-terminal pass below restores the correspondence, and the one pass
+        // that does not — the collision-terminal step — is never followed by
+        // another, because `step`'s `EpisodeGuard` rejects the call. See the
+        // "Stepping past a terminal snapshot" section on this function.
         let mut claimed: HashSet<(i32, i32)> = HashSet::with_capacity(self.obstacles.len());
         let mut new_positions: Vec<(i32, i32)> = Vec::with_capacity(self.obstacles.len());
         for &pos in &self.obstacles {
@@ -588,7 +605,14 @@ impl Environment<3, 3, 1> for DynamicObstaclesEnv {
     type RewardType = ScalarReward;
     type SnapshotType = GridSnapshot;
 
+    /// Rebuilds the grid, respawns the obstacles, and re-opens the
+    /// [`EpisodeGuard`] for a new episode.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         let (state, obstacles) = Self::build(&self.config, &mut self.rng);
         self.state = state;
         self.obstacles = obstacles;
@@ -597,26 +621,42 @@ impl Environment<3, 3, 1> for DynamicObstaclesEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies the agent's action, then random-walks every obstacle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Self::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — before the step counter, before `apply_action`, and
+        // critically before `move_obstacles` draws from `self.rng`. ADR 0029
+        // makes the persistent RNG an observable part of this environment's
+        // state, so a rejected step must not advance the seed stream.
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
 
-        // Terminal state from agent step takes priority over obstacle motion.
-        if let StepOutcome::ReachedGoal = outcome {
-            let observation = self.observe(&action, &self.state);
-            let reward = success_reward(self.steps, self.config.max_steps);
-            return Ok(self.emit(observation, reward, true));
-        }
-        if let StepOutcome::HitLava = outcome {
-            let observation = self.observe(&action, &self.state);
-            return Ok(self.emit(observation, 0.0, true));
-        }
+        // A terminal outcome from the agent's own step takes priority over
+        // obstacle motion: on those routes the obstacles do not move at all.
+        let (reward, done) = match outcome {
+            StepOutcome::ReachedGoal => (success_reward(self.steps, self.config.max_steps), true),
+            StepOutcome::HitLava => (0.0, true),
+            _ => {
+                let collided = self.move_obstacles();
+                let reward = if collided { COLLISION_REWARD } else { 0.0 };
+                (reward, collided || self.steps >= self.config.max_steps)
+            }
+        };
 
-        let collided = self.move_obstacles();
-        let done = collided || self.steps >= self.config.max_steps;
-        let reward = if collided { COLLISION_REWARD } else { 0.0 };
+        // Single exit: all three routes build exactly one snapshot, and the
+        // guard is fed that snapshot's own status, so no branch can forget to
+        // record — and the guard cannot disagree with what the caller was
+        // handed.
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -985,6 +1025,150 @@ mod tests {
         assert_eq!(env.state().grid.get(3, 3), Entity::Ball(OBSTACLE_COLOR));
         assert_eq!(env.state().grid.get(3, 1), Entity::Empty);
         assert_eq!(count_balls(&env), 2);
+    }
+
+    // -- Post-terminal step guard (issue #291) -----------------------------
+
+    /// A configuration whose `TurnLeft` rollout ends in a **collision**, and
+    /// whose very next (illegal) step used to duplicate an obstacle.
+    ///
+    /// Pinned deliberately: collision endings are the interesting terminal
+    /// route here, and step-limit endings are avoided because `build_snapshot`
+    /// labels truncation as `Terminated` (#1028, out of scope).
+    const COLLISION_CFG: DynamicObstaclesConfig = DynamicObstaclesConfig::new(5, 4, 200, 37);
+
+    /// Drives a fresh episode to its **collision**-terminal snapshot through
+    /// real `step()` calls, and asserts the ending really was a collision (the
+    /// `−1.0` reward) rather than the step budget running out.
+    fn drive_to_collision(env: &mut DynamicObstaclesEnv) -> GridSnapshot {
+        let cfg = *env.config();
+        env.reset().expect("reset must succeed");
+        for _ in 1..=cfg.max_steps {
+            let snapshot = env
+                .step(GridAction::TurnLeft)
+                .expect("step must succeed until the episode ends");
+            if snapshot.is_done() {
+                let reward: f32 = (*snapshot.reward()).into();
+                assert_eq!(
+                    reward, COLLISION_REWARD,
+                    "this fixture must end by collision, not by exhausting the step budget"
+                );
+                return snapshot;
+            }
+        }
+        panic!("the episode never ended within max_steps");
+    }
+
+    #[test]
+    fn rejects_post_terminal_step() {
+        // The shared conformance check: a collision-terminal snapshot reached
+        // through real `step()` calls, then one more legal action.
+        let mut env = DynamicObstaclesEnv::with_config(COLLISION_CFG, false).expect("valid config");
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_collision,
+            GridAction::TurnLeft,
+        );
+    }
+
+    #[test]
+    fn post_terminal_step_is_rejected_rather_than_duplicating_an_obstacle() {
+        // Regression for the desync recorded on #291. On a collision-terminal
+        // step the winning obstacle's tracked position moves onto the agent's
+        // cell with no ball drawn there, so a further `move_obstacles` pass ran
+        // against a ghost entry and merged two obstacles. With this exact
+        // config the pre-guard result of the illegal step was
+        // `[(1, 2), (1, 1), (1, 1), (2, 3)]` — a duplicate at (1, 1).
+        let mut env = DynamicObstaclesEnv::with_config(COLLISION_CFG, false).expect("valid config");
+        let terminal = drive_to_collision(&mut env);
+        assert!(terminal.is_done());
+        let frozen = env.obstacles().to_vec();
+
+        let err = env
+            .step(GridAction::TurnLeft)
+            .expect_err("a step after the collision must return Err, not move the obstacles");
+        assert!(
+            matches!(err, EnvironmentError::StepAfterEpisodeEnd { .. }),
+            "expected StepAfterEpisodeEnd, got {err:?}"
+        );
+
+        assert_eq!(
+            env.obstacles(),
+            frozen.as_slice(),
+            "a rejected step must not move any obstacle"
+        );
+        let unique: std::collections::HashSet<(i32, i32)> =
+            env.obstacles().iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            env.obstacles().len(),
+            "obstacles must remain pairwise distinct after a rejected post-terminal step, got {:?}",
+            env.obstacles()
+        );
+    }
+
+    #[test]
+    fn rejected_step_does_not_advance_the_rng_stream() {
+        // ADR 0029: the persistent RNG is observable state, so a rejected step
+        // must draw nothing. `move_obstacles` is the only RNG consumer inside
+        // `step`, and `reset` re-draws the spawn layout from the same stream —
+        // so an identical post-reset layout is the evidence that no draw
+        // happened.
+        let mut rejected =
+            DynamicObstaclesEnv::with_config(COLLISION_CFG, false).expect("valid config");
+        let mut clean =
+            DynamicObstaclesEnv::with_config(COLLISION_CFG, false).expect("valid config");
+
+        drive_to_collision(&mut rejected);
+        drive_to_collision(&mut clean);
+        assert_eq!(
+            rejected.obstacles(),
+            clean.obstacles(),
+            "the two identically seeded runs must agree before the illegal call"
+        );
+
+        rejected
+            .step(GridAction::TurnLeft)
+            .expect_err("the post-terminal step must be rejected");
+
+        rejected.reset().expect("reset must succeed");
+        clean.reset().expect("reset must succeed");
+        assert_eq!(
+            rejected.obstacles(),
+            clean.obstacles(),
+            "the rejected step must not have consumed a draw from the seed stream"
+        );
+
+        for _ in 0..5 {
+            let a = rejected.step(GridAction::TurnLeft).expect("step");
+            let b = clean.step(GridAction::TurnLeft).expect("step");
+            assert_eq!(a.is_done(), b.is_done());
+            assert_eq!(
+                rejected.obstacles(),
+                clean.obstacles(),
+                "the two streams must stay in lockstep after the rejected call"
+            );
+            if a.is_done() {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn reset_reopens_an_ended_episode() {
+        let mut env = DynamicObstaclesEnv::with_config(COLLISION_CFG, false).expect("valid config");
+        drive_to_collision(&mut env);
+        assert!(
+            env.step(GridAction::TurnLeft).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed");
+        // Only that the step is *accepted* is asserted: this fixture is dense
+        // enough (4 obstacles in a 3x3 interior) that a fresh episode can end
+        // by collision on its very first step.
+        env.step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/empty.rs
+++ b/crates/rlevo-environments/src/grids/empty.rs
@@ -58,9 +58,10 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rlevo_core::config::{self, ConfigError, Validate};
 use rlevo_core::environment::{
-    ConstructableEnv, Environment, EnvironmentError, Sensor, SnapshotBase,
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
@@ -233,6 +234,19 @@ pub struct EmptyEnv {
     config: EmptyConfig,
     steps: usize,
     render: bool,
+    /// Rejects a `step()` taken after the episode ended. Reaching the goal does
+    /// not consume the [`Goal`] tile or freeze the agent, and `done` is
+    /// recomputed from the *current* outcome each call, so without this guard a
+    /// post-terminal `step()` emitted a fresh **`Running`** snapshot — silently
+    /// resurrecting a finished episode — while `steps` kept advancing past the
+    /// true episode length. Worse, the agent stands *on* the goal: stepping off
+    /// and back on re-triggers `StepOutcome::ReachedGoal` and pays
+    /// [`success_reward`] a second time. On a 5×5 grid with `max_steps = 100`
+    /// the optimal rollout terminates at step 5 with `0.955`, then six more
+    /// steps re-pay `0.901` — an episode return of `1.856` for one goal, and
+    /// unbounded under repetition. The inflated `steps` also deflates every
+    /// later payout, since `success_reward` divides by the step count.
+    guard: EpisodeGuard,
 }
 
 impl EmptyEnv {
@@ -275,6 +289,9 @@ impl EmptyEnv {
     /// )
     /// .expect("valid config");
     /// ```
+    /// This is the only constructor that builds an `EmptyEnv` value —
+    /// [`ConstructableEnv::new`] delegates here — so it is also the single
+    /// place the [`EpisodeGuard`] is initialized.
     pub fn with_config(config: EmptyConfig, render: bool) -> Result<Self, ConfigError> {
         config.validate()?;
         let (grid, agent) = Self::build(&config);
@@ -283,6 +300,7 @@ impl EmptyEnv {
             config,
             steps: 0,
             render,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -385,7 +403,14 @@ impl Environment<3, 3, 1> for EmptyEnv {
     type RewardType = ScalarReward;
     type SnapshotType = SnapshotBase<3, GridObservation, ScalarReward>;
 
+    /// Rebuilds the fixed layout, clears the step counter, and re-opens the
+    /// episode guard so a terminated environment becomes steppable again.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         let (grid, agent) = Self::build(&self.config);
         self.state = GridState::new(grid, agent);
         self.steps = 0;
@@ -393,7 +418,21 @@ impl Environment<3, 3, 1> for EmptyEnv {
         Ok(self.snapshot(observation, 0.0, false))
     }
 
+    /// Applies `action`, then maps the resulting [`StepOutcome`] to reward and
+    /// termination.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances and before `apply_action` touches
+        // the grid or the agent. A rejected call must leave the environment
+        // bit-identical — and this env draws no randomness, but the ordering is
+        // the same one ADR 0029 requires of the envs that do, so a rejected step
+        // can never shift a seed stream.
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -405,7 +444,12 @@ impl Environment<3, 3, 1> for EmptyEnv {
             }
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.snapshot(observation, reward, done))
+
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status, so the two cannot drift apart.
+        let snapshot = self.snapshot(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -424,10 +468,11 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::base::Observation;
     use rlevo_core::config::ConstraintKind;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::EpisodeStatus;
 
     #[test]
     fn default_config_validates() {
@@ -619,6 +664,121 @@ mod tests {
                 break;
             }
         }
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// Drives a fresh 5×5 episode to the goal with real `step()` calls.
+    ///
+    /// The termination is a **goal arrival**, deliberately not a step-limit
+    /// cutoff: `grids::core::build_snapshot` currently reports a timeout as
+    /// `Terminated` (issue #1028), and these tests must not bake that in.
+    fn drive_to_goal(env: &mut EmptyEnv) -> SnapshotBase<3, GridObservation, ScalarReward> {
+        env.reset().expect("reset must succeed");
+        // Agent at (1,1) facing East, goal at (3,3).
+        let script = [
+            GridAction::Forward,
+            GridAction::Forward,
+            GridAction::TurnRight,
+            GridAction::Forward,
+            GridAction::Forward,
+        ];
+        let mut last = None;
+        for action in script {
+            last = Some(env.step(action).expect("scripted step must succeed"));
+        }
+        last.expect("the script is non-empty")
+    }
+
+    fn goal_env() -> EmptyEnv {
+        EmptyEnv::with_config(EmptyConfig::new(5, 100, 0), false).expect("valid config")
+    }
+
+    #[test]
+    /// `EmptyEnv` satisfies the shared post-terminal conformance check: once the
+    /// agent has reached the goal, a further legal `step()` fails with
+    /// `StepAfterEpisodeEnd` carrying the status that ended the episode.
+    fn rejects_post_terminal_step() {
+        let mut env = goal_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_goal, GridAction::TurnLeft);
+    }
+
+    #[test]
+    /// Regression for the concrete defect the guard prevents. Reaching the goal
+    /// neither consumes the `Goal` tile nor freezes the agent, so an unguarded
+    /// post-terminal `step()` advanced `steps`, moved the agent, and emitted a
+    /// fresh `Running` snapshot — and walking off the goal and back on re-paid
+    /// `success_reward` (measured: `0.955` then another `0.901` on this 5×5).
+    /// A rejected step must mutate nothing at all.
+    fn post_terminal_step_does_not_mutate_state() {
+        let mut env = goal_env();
+        let terminal = drive_to_goal(&mut env);
+        assert!(terminal.is_done(), "reaching the goal must end the episode");
+        let ended = terminal.status();
+
+        let steps_at_end = env.steps();
+        let pos_at_end = (env.state().agent.x, env.state().agent.y);
+        let dir_at_end = env.state().agent.direction;
+
+        let err = env
+            .step(GridAction::TurnLeft)
+            .expect_err("a step after the goal must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            pos_at_end,
+            "a rejected step must not move the agent"
+        );
+        assert_eq!(
+            env.state().agent.direction,
+            dir_at_end,
+            "a rejected step must not turn the agent"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    fn reset_reopens_terminated_episode() {
+        let mut env = goal_env();
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(GridAction::TurnLeft).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after termination");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/four_rooms.rs
+++ b/crates/rlevo-environments/src/grids/four_rooms.rs
@@ -92,10 +92,13 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt as _, SeedableRng};
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot as _,
+};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -322,6 +325,10 @@ impl FromStr for FourRoomsConfig {
 /// Construct via [`FourRoomsEnv::with_config`] for full control or via
 /// [`ConstructableEnv::new`] for default settings (size 11, seed 0).
 ///
+/// Reaching the goal (or lava) ends the episode; a [`step`](Environment::step)
+/// taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
+///
 /// # Examples
 ///
 /// ```rust
@@ -345,6 +352,23 @@ pub struct FourRoomsEnv {
     /// documents.
     openings: [(i32, i32); OPENING_COUNT],
     rng: StdRng,
+    /// Rejects a `step()` taken after the goal (or lava) ended the episode.
+    ///
+    /// Without it the goal cell stays `Entity::Goal` under the agent and
+    /// `apply_action` re-classifies it on every visit, so a finished episode was
+    /// not merely resumed — it was *farmable*. Measured on `size = 11`,
+    /// `max_steps = 484`, seed 3 before this guard existed: the derived route
+    /// reached the goal on step 17 and paid `success_reward(17, 484) = 0.968`;
+    /// the next `step()` re-emitted a **`Running`** snapshot (the episode came
+    /// back to life), five more steps walked the agent off the goal and back on,
+    /// and step 23 paid `success_reward(23, 484) = 0.957` a second time. Because
+    /// the payout is step-count-discounted rather than one-shot, each re-entry
+    /// pays again at a slightly smaller discount — a two-step oscillation on and
+    /// off the goal adds ≈0.95 to the episode return per cycle, for as many
+    /// cycles as `max_steps` allows, while `steps` runs past the true episode
+    /// length and the zero-reward `Running` snapshots in between enter the
+    /// replay buffer as ordinary transitions.
+    guard: EpisodeGuard,
 }
 
 impl FourRoomsEnv {
@@ -410,6 +434,7 @@ impl FourRoomsEnv {
             render,
             openings,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -615,8 +640,22 @@ impl Environment<3, 3, 1> for FourRoomsEnv {
     /// Samples a fresh board — four openings, agent pose, goal — from the
     /// persistent RNG, letting the stream advance (ADR 0029). Never re-seeds;
     /// [`FourRoomsEnv::reset_with_seed`] is the replay hatch.
+    ///
+    /// Re-opens the [`EpisodeGuard`], so an episode ended at the goal (or in
+    /// lava) becomes steppable again.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`PlacementError`] from [`FourRoomsEnv::build`] as an
+    /// [`EnvironmentError`]. On that path the guard is deliberately left
+    /// **latched**: the sole fallible call runs first, and the guard is cleared
+    /// only once a whole new episode is in hand. Clearing it first would re-open
+    /// a finished episode over the *old* board — the environment would happily
+    /// step a state it never returned to its initial condition (ADR 0044 §6,
+    /// the same rule `TimeLimit::reset` follows).
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
         let (state, openings) = Self::build(&self.config, &mut self.rng)?;
+        self.guard.reset();
         self.state = state;
         self.openings = openings;
         self.steps = 0;
@@ -624,7 +663,17 @@ impl Environment<3, 3, 1> for FourRoomsEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances, before `apply_action` touches
+        // the grid or the agent pose, and before any RNG draw. A rejected call
+        // must leave the board, the counter, and the stream untouched, or the
+        // stream would depend on how many illegal steps a caller made (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -635,8 +684,12 @@ impl Environment<3, 3, 1> for FourRoomsEnv {
                 (0.0, done)
             }
         };
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch can forget to record.
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -658,6 +711,7 @@ mod tests {
     // needs it at file scope for the parity `Custom` variant.
     use super::*;
     use crate::direction::Direction;
+    use crate::episode::assert_rejects_post_terminal_step;
     use crate::grids::core::UNSEEN_TYPE;
     use crate::grids::core::agent::AgentState;
     use rlevo_core::environment::Snapshot;
@@ -1319,6 +1373,159 @@ mod tests {
         assert_eq!(env.steps(), 2);
         env.reset().unwrap();
         assert_eq!(env.steps(), 0);
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// Drives `env` to a **goal** termination through real `step()` calls.
+    ///
+    /// Ends the episode by reaching the goal rather than by exhausting
+    /// `max_steps`: the step-limit path currently maps a cutoff to `Terminated`
+    /// rather than `Truncated` (`grids/core/mod.rs`, `build_snapshot`; GitHub
+    /// #1028), and no guard test should be written against a status that a bug
+    /// fix is expected to change. The route is derived from the board the env
+    /// actually drew, so this does not encode one seed's geometry.
+    fn drive_to_goal(env: &mut FourRoomsEnv) -> GridSnapshot {
+        env.reset_with_seed(3).expect("reset must succeed");
+        let agent = env.state().agent;
+        let goal = goal_of(&env.state().grid);
+        let route = cell_route(&env.state().grid, (agent.x, agent.y), goal)
+            .expect("every sampled board is connected");
+        let actions = route_actions(&route, agent.direction);
+        assert!(
+            !actions.is_empty(),
+            "the agent must not start on the goal, or there is nothing to drive"
+        );
+
+        let mut last = None;
+        for action in actions {
+            last = Some(env.step(action).expect("every step en route must succeed"));
+        }
+        let snapshot = last.expect("the route is non-empty");
+        assert!(
+            snapshot.is_done(),
+            "walking the derived route must end the episode at the goal"
+        );
+        snapshot
+    }
+
+    /// The shared post-terminal conformance check: once the agent has walked
+    /// onto the goal, a further legal action fails with `StepAfterEpisodeEnd`
+    /// carrying the status that ended the episode.
+    ///
+    /// `TurnLeft` is the replayed action precisely because it is always legal
+    /// and never blocked — the rejection has to come from the call sequence, not
+    /// from the action.
+    #[test]
+    fn test_four_rooms_rejects_post_terminal_step() {
+        let mut env = env_11();
+        assert_rejects_post_terminal_step(&mut env, drive_to_goal, GridAction::TurnLeft);
+    }
+
+    /// Regression for the measured defect: the goal cell keeps its
+    /// `Entity::Goal` under the agent, so before the guard a post-terminal step
+    /// re-emitted a **`Running`** snapshot and walking back onto the goal paid
+    /// `success_reward` a second time (seed 3: `0.968` on step 17, then `0.957`
+    /// on step 23). A rejected step must mutate nothing at all.
+    #[test]
+    fn test_four_rooms_post_terminal_step_does_not_resume_the_episode() {
+        let mut env = env_11();
+        let terminal = drive_to_goal(&mut env);
+        let ended = terminal.status();
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+        let openings_at_end = *env.openings();
+
+        let err = env
+            .step(GridAction::Forward)
+            .expect_err("a step after the goal must return Err, not a resurrected episode");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (
+                env.state().agent.x,
+                env.state().agent.y,
+                env.state().agent.direction
+            ),
+            (agent_at_end.x, agent_at_end.y, agent_at_end.direction),
+            "a rejected step must not move or turn the agent"
+        );
+        assert_eq!(
+            *env.openings(),
+            openings_at_end,
+            "a rejected step must not redraw the board"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// `reset()` re-opens a terminated environment, so a latched guard cannot
+    /// strand it for the rest of the run.
+    #[test]
+    fn test_four_rooms_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = env_11();
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(GridAction::TurnLeft).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "a single turn on a fresh board must not end the episode"
+        );
+    }
+
+    /// A rejected step draws no randomness. `step()` does not sample today, but
+    /// `reset()` shares the persistent stream: checking the guard after any
+    /// future draw would let illegal calls shift every subsequent episode's
+    /// board and desynchronise replay (ADR 0029).
+    #[test]
+    fn test_four_rooms_rejected_step_does_not_advance_rng() {
+        let mut rejected = env_11();
+        let mut untouched = env_11();
+        drive_to_goal(&mut rejected);
+        drive_to_goal(&mut untouched);
+
+        rejected
+            .step(GridAction::TurnLeft)
+            .expect_err("a step after the goal must be rejected");
+
+        rejected.reset().expect("reset");
+        untouched.reset().expect("reset");
+        assert_eq!(
+            layout_of(&rejected),
+            layout_of(&untouched),
+            "a rejected step must draw no randomness; the next episode must be the board it \
+             would have been"
+        );
     }
 
     /// Occlusion is not decoration here: a cell that encoded a real entity under

--- a/crates/rlevo-environments/src/grids/go_to_door.rs
+++ b/crates/rlevo-environments/src/grids/go_to_door.rs
@@ -85,13 +85,14 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use burn::tensor::{Tensor, backend::Backend};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rlevo_core::base::{HostRow, Observation, TensorConversionError, TensorConvertible};
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 use rlevo_core::environment::{
-    ConstructableEnv, Environment, EnvironmentError, Sensor, SnapshotBase,
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot as _, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
@@ -543,6 +544,12 @@ impl FromStr for GoToDoorConfig {
 /// Implements [`Environment<3, 3, 1>`] with [`GridState`] /
 /// [`GoToDoorObservation`] / [`GridAction`] / [`ScalarReward`].
 ///
+/// [`GridAction::Done`] ends the episode either way — at a target-colored door
+/// for [`success_reward`], anywhere else for `0.0` — and a
+/// [`step`](Environment::step) taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`]; see the `guard` field for what
+/// that rejection prevents.
+///
 /// # Examples
 ///
 /// ```rust
@@ -564,6 +571,31 @@ pub struct GoToDoorEnv {
     /// North / East / South / West wall order.
     doors: [(i32, i32, Color); DOOR_COUNT],
     rng: StdRng,
+    /// Rejects a `step()` taken after `Done` already ended the episode.
+    ///
+    /// Two concrete defects, both measured on the unguarded code:
+    ///
+    /// - **The success reward was re-paid, once per replayed `Done`.** `Done`
+    ///   leaves the agent where it stands ([`apply_action`] returns
+    ///   [`StepOutcome::DoneAction`] without moving it), and the mission is only
+    ///   re-sampled at [`reset`](Environment::reset) — so after a winning `Done`
+    ///   the target-colored door is *still* in front and every further `Done`
+    ///   re-satisfied the win condition. On seed 31 a 4-step win paid `0.964`,
+    ///   then five replayed `Done`s paid `0.955, 0.946, 0.937, 0.928, 0.919`,
+    ///   for an episode return of `5.649` on a task whose maximum is `1.0`. The
+    ///   payments shrink only because [`success_reward`] discounts by
+    ///   `self.steps`, which the replays also kept advancing (4 → 9, past
+    ///   `max_steps` given enough calls — at which point `success_reward` goes
+    ///   negative and the replays start *charging* the agent).
+    /// - **A failed mission became retryable inside the same episode.** A
+    ///   *wrong*-color `Done` also ends the episode (`0.0`), but the next
+    ///   non-`Done` action took the `else` branch and emitted a **`Running`**
+    ///   snapshot: on seed 6 a wrong-door `Done` at step 5 was followed by a
+    ///   `TurnLeft` that resurrected the episode at step 6. The agent could then
+    ///   walk to the correct door and collect the full success reward, which
+    ///   destroys the 25% cap on a mission-blind policy that this environment
+    ///   exists to enforce.
+    guard: EpisodeGuard,
 }
 
 impl GoToDoorEnv {
@@ -625,6 +657,7 @@ impl GoToDoorEnv {
             mission,
             doors,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -835,6 +868,13 @@ impl Environment<3, 3, 1> for GoToDoorEnv {
     /// independent door colors and missions. Use
     /// [`reset_with_seed`](Self::reset_with_seed) for deterministic replay.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Re-open the episode first, so no later statement can return early and
+        // strand a latched guard. `build` is infallible and this body has no `?`,
+        // so `reset` never leaves here on an `Err` path today; should `build`
+        // ever become fallible, move this below the commit of the new episode —
+        // a reset that failed to produce a snapshot must not re-open stepping on
+        // the *old*, already-terminated state.
+        self.guard.reset();
         let (state, doors, mission) = Self::build(&self.config, &mut self.rng);
         self.state = state;
         self.doors = doors;
@@ -844,7 +884,22 @@ impl Environment<3, 3, 1> for GoToDoorEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies `action`, then pays [`success_reward`] iff it was
+    /// [`GridAction::Done`] with a target-colored door in front.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances, before `apply_action` touches
+        // the grid or the agent pose, and before anything reads `self.rng`. A
+        // rejected call must leave the environment bit-identical — `step` draws
+        // no randomness today, but `reset` shares the persistent stream, so
+        // checking any later would let illegal calls shift every subsequent
+        // episode's doors and mission and desynchronise replay (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = if outcome == StepOutcome::DoneAction {
@@ -857,8 +912,12 @@ impl Environment<3, 3, 1> for GoToDoorEnv {
             let done = self.steps >= self.config.max_steps;
             (0.0, done)
         };
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch above can disagree with it.
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -880,7 +939,7 @@ mod tests {
     // The env no longer cuts the raw window itself (it goes through `mask_view`),
     // but the encoding tests still compare against the *unoccluded* view.
     use crate::grids::core::grid::egocentric_view;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::{EpisodeStatus, Snapshot};
     use std::collections::HashSet;
 
     /// Wall order used by `GoToDoorEnv::doors` and by the scripts below.
@@ -1485,6 +1544,183 @@ mod tests {
         assert_eq!(env.steps(), 1);
         env.reset().expect("reset must succeed");
         assert_eq!(env.steps(), 0, "reset must zero the step counter");
+    }
+
+    // ─────────────── post-terminal step guard (ADR 0044, issue #291) ─────────
+
+    /// Reset, read the target wall out of the observation's mission channel,
+    /// walk to that door and issue `Done` — returning the terminal snapshot.
+    ///
+    /// Drives to termination through real `step()` calls only: no hand-written
+    /// snapshot, no poking at `env.state`. Mission completion is deliberately
+    /// preferred over exhausting `max_steps`, because a step-limit ending is
+    /// currently mislabelled `Terminated` rather than `Truncated` (issue #1028,
+    /// out of scope here) — the conformance check must not be written against
+    /// a status the env is known to be reporting wrongly.
+    fn drive_to_mission_done(env: &mut GoToDoorEnv) -> GoToDoorSnapshot {
+        let snap = env.reset().expect("reset must succeed");
+        let wall = target_wall(env, snap.observation());
+        let mut last = None;
+        for &a in script_for(wall) {
+            last = Some(env.step(a).expect("the scripted route must step cleanly"));
+        }
+        last.expect("script_for is never empty")
+    }
+
+    /// Asserts every cell of `obs` carries `expected` in the mission channel.
+    fn assert_mission_channel_is(obs: &GoToDoorObservation, expected: u8, context: &str) {
+        for (r, row) in obs.view.iter().enumerate() {
+            for (c, cell) in row.iter().enumerate() {
+                assert_eq!(
+                    cell[MISSION_CHANNEL], expected,
+                    "{context}: cell ({r}, {c}) must carry the mission color byte"
+                );
+            }
+        }
+    }
+
+    #[test]
+    /// The shared conformance check: once the mission-completing `Done` has
+    /// ended the episode, a further legal action fails with
+    /// `StepAfterEpisodeEnd` carrying the status that ended it.
+    fn test_go_to_door_rejects_post_terminal_step() {
+        let mut env = env_6x6(31);
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_mission_done,
+            GridAction::Done,
+        );
+    }
+
+    #[test]
+    /// Regression for the defect the guard prevents: because `Done` does not
+    /// move the agent and the mission is only re-sampled at `reset`, a replayed
+    /// `Done` used to find the target door still in front, re-pay
+    /// `success_reward`, and advance `steps` — five replays turned a `0.964`
+    /// win into a `5.649` return. A rejected step must mutate nothing at all.
+    fn test_go_to_door_post_terminal_done_neither_pays_nor_advances() {
+        let mut env = env_6x6(31);
+        let terminal = drive_to_mission_done(&mut env);
+        assert!(
+            terminal.is_terminated(),
+            "the scripted route must end on the mission-completing Done"
+        );
+        let won: f32 = (*terminal.reward()).into();
+        assert!(won > 0.9, "the oracle must be paid for the win, got {won}");
+
+        let steps_at_end = env.steps();
+        let pose_at_end = (
+            env.state().agent.x,
+            env.state().agent.y,
+            env.state().agent.direction,
+        );
+
+        let err = env
+            .step(GridAction::Done)
+            .expect_err("a replayed Done must be rejected, not paid a second time");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                EpisodeStatus::Terminated,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (
+                env.state().agent.x,
+                env.state().agent.y,
+                env.state().agent.direction
+            ),
+            pose_at_end,
+            "a rejected step must not move or re-orient the agent"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// The second half of the defect: a *wrong*-color `Done` also ends the
+    /// episode, and the next non-`Done` action used to emit a `Running`
+    /// snapshot — resurrecting the episode so the agent could walk on to the
+    /// correct door and collect the win it had just forfeited.
+    fn test_wrong_door_done_cannot_be_retried_within_the_episode() {
+        let mut env = env_6x6(6);
+        let snap = env.reset().expect("reset must succeed");
+        let target = target_wall(&env, snap.observation());
+        let wrong = (target + 1) % DOOR_COUNT;
+        let forfeit = run(&mut env, script_for(wrong));
+        assert_eq!(forfeit, 0.0, "a wrong-color Done pays nothing");
+
+        let err = env
+            .step(GridAction::TurnLeft)
+            .expect_err("a forfeited mission must not be retryable within the episode");
+        assert!(
+            matches!(
+                err,
+                EnvironmentError::StepAfterEpisodeEnd {
+                    status: EpisodeStatus::Terminated
+                }
+            ),
+            "expected StepAfterEpisodeEnd {{ Terminated }}, got {err:?}"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a terminated episode — a latched guard must not
+    /// strand the environment — and the fresh episode's mission channel agrees
+    /// with the freshly sampled mission on every cell, on the reset snapshot
+    /// and on the first step's snapshot alike.
+    fn test_reset_reopens_terminated_episode_with_a_coherent_mission() {
+        let mut env = env_6x6(31);
+        drive_to_mission_done(&mut env);
+        assert!(
+            env.step(GridAction::Done).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let snap = env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert!(!snap.is_done(), "a reset snapshot is not done");
+        assert_mission_channel_is(
+            snap.observation(),
+            env.mission().color_u8(),
+            "reset snapshot",
+        );
+
+        let stepped = env
+            .step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !stepped.is_done(),
+            "a turn on the first step of a fresh episode must not end it"
+        );
+        assert_mission_channel_is(
+            stepped.observation(),
+            env.mission().color_u8(),
+            "first step of the new episode",
+        );
+        assert_eq!(
+            env.doors()
+                .iter()
+                .filter(|&&(_, _, c)| c == env.mission().target_color)
+                .count(),
+            1,
+            "the re-opened episode must still have exactly one target-colored door"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/lava_gap.rs
+++ b/crates/rlevo-environments/src/grids/lava_gap.rs
@@ -93,9 +93,10 @@ use super::core::{
 // `Rng` is the object-safe core trait in rand 0.10; the `random_range` sugar
 // lives on the blanket-implemented `RngExt`. The public bound stays
 // `R: Rng + ?Sized` per `rules.md` §8.
+use crate::episode::EpisodeGuard;
 use rand::{Rng, RngExt as _, SeedableRng, rngs::StdRng};
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -261,6 +262,10 @@ impl FromStr for LavaGapConfig {
 /// [`reset`](Environment::reset)** from a persistent RNG stream (ADR 0029/0062);
 /// see the module docs for the ranges and for what stays fixed.
 ///
+/// Reaching the goal, burning in the lava, or exhausting the step budget ends
+/// the episode; a [`step`](Environment::step) taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
+///
 /// Implements [`Environment<3, 3, 1>`] with [`GridState`] /
 /// [`GridObservation`](super::core::GridObservation) / [`GridAction`] / [`ScalarReward`].
 ///
@@ -285,6 +290,33 @@ pub struct LavaGapEnv {
     /// Row of the current episode's single gap in that strip.
     gap_row: i32,
     rng: StdRng,
+    /// Rejects a `step()` taken after the episode already ended.
+    ///
+    /// Termination here is derived from the *current* action's
+    /// [`StepOutcome`] alone — nothing in the state records that the episode is
+    /// over — so before this guard existed a post-terminal `step()` simply ran
+    /// the dynamics again, with two concrete defects:
+    ///
+    /// - **A lava death was reversible.** `step_forward` moves the agent *onto*
+    ///   the lava cell and leaves the cell as [`Entity::Lava`], so the dead
+    ///   agent was still standing on a normal, passable board. One more
+    ///   `Forward` (or a turn plus `Forward`) walked it straight back off the
+    ///   lava onto an empty cell, whose outcome is `Moved` — reward `0.0`,
+    ///   `done = false`. The env emitted a fresh **`Running`** snapshot and the
+    ///   episode continued as if the agent had never burned.
+    /// - **The goal payout could be collected repeatedly.** `ReachedGoal`
+    ///   leaves [`Entity::Goal`] in place under the agent, so stepping off the
+    ///   goal and back onto it paid `success_reward(self.steps,
+    ///   self.config.max_steps)` a *second* time, and again for every further
+    ///   round trip — inflating the episode return without bound. Meanwhile
+    ///   `self.steps` kept advancing past the true episode length, so those
+    ///   extra payouts shrank and, once `steps > max_steps`, went **negative**:
+    ///   a "success" reward below zero on a snapshot the caller reads as a win.
+    ///
+    /// [`StepOutcome`]: super::core::dynamics::StepOutcome
+    /// [`Entity::Lava`]: super::core::entity::Entity::Lava
+    /// [`Entity::Goal`]: super::core::entity::Entity::Goal
+    guard: EpisodeGuard,
 }
 
 impl LavaGapEnv {
@@ -346,6 +378,11 @@ impl LavaGapEnv {
             lava_col,
             gap_row,
             rng,
+            // Sole construction chokepoint: `ConstructableEnv::new` and every
+            // test fixture route through here, so the guard cannot be missed on
+            // one path. `reset_with_seed` re-seeds and delegates to `reset`,
+            // which clears the guard itself.
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -520,6 +557,7 @@ impl Environment<3, 3, 1> for LavaGapEnv {
     /// independent lava columns and gap rows. Use
     /// [`reset_with_seed`](Self::reset_with_seed) for deterministic replay.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         let (state, lava_col, gap_row) = Self::build(&self.config, &mut self.rng);
         self.state = state;
         self.lava_col = lava_col;
@@ -529,7 +567,20 @@ impl Environment<3, 3, 1> for LavaGapEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies `action`, then maps the outcome to reward and termination.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `self.steps` advances, before the dynamics move
+        // the agent, and before anything can touch `self.rng`. A rejected call
+        // must leave the board, the step counter and the RNG stream untouched,
+        // or the stream would depend on how many illegal steps a caller made
+        // and every later episode's layout would shift (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -541,7 +592,11 @@ impl Environment<3, 3, 1> for LavaGapEnv {
             }
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        // Single exit: the guard is fed the emitted snapshot's own status, so
+        // the two cannot drift apart.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -565,9 +620,11 @@ mod tests {
     // `test_lava_gap_occlusion_masks_only_the_world_outside_the_room`.
     use super::super::core::grid::egocentric_view;
     use super::super::core::{UNSEEN_TYPE, VIEW_SIZE, mask_view};
+    use crate::episode::assert_rejects_post_terminal_step;
     use crate::grids::core::is_free;
     use rlevo_core::config::ConstraintKind;
-    use rlevo_core::environment::Snapshot;
+    // `Snapshot` arrives through `use super::*` — `step()` needs it for
+    // `snapshot.status()`, so importing it again here is redundant.
     use std::collections::HashSet;
 
     /// The four facings, for the occlusion sweep.
@@ -1157,6 +1214,181 @@ mod tests {
         assert_eq!(env.steps(), 2);
         env.reset().unwrap();
         assert_eq!(env.steps(), 0);
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// A script that walks the agent into the lava strip on whatever board
+    /// `env` is **currently** holding, derived the same way
+    /// [`stepping_into_lava_terminates_with_zero_reward`] derives it.
+    fn route_into_lava(env: &LavaGapEnv) -> Vec<GridAction> {
+        // Row 1 is the agent's own row and works unless the gap landed there;
+        // row 2 is interior at every size >= MIN_SIZE.
+        let blocked_row = if env.gap_row() == 1 { 2 } else { 1 };
+        let mut script = Vec::new();
+        if blocked_row > 1 {
+            script.push(GridAction::TurnRight); // face South
+            for _ in 1..blocked_row {
+                script.push(GridAction::Forward);
+            }
+            script.push(GridAction::TurnLeft); // face East again
+        }
+        // x: 1 -> lava_col; the last Forward enters the strip.
+        for _ in 1..env.lava_col() {
+            script.push(GridAction::Forward);
+        }
+        script
+    }
+
+    /// Reset to a known board and walk the derived route to the **goal**,
+    /// returning the terminal snapshot.
+    ///
+    /// Terminating on the goal rather than on the step budget is deliberate:
+    /// `grids/core::build_snapshot` currently maps a step-limit cutoff to
+    /// `Terminated` rather than `Truncated` (#1028, out of scope here), so a
+    /// budget-driven ending would bake that bug into these assertions.
+    fn drive_to_goal(env: &mut LavaGapEnv) -> GridSnapshot {
+        env.reset_with_seed(0).expect("reset");
+        let script = route_to_goal(env);
+        run_to_completion(env, &script)
+    }
+
+    /// Reset to a known board and walk the derived route **into the lava**,
+    /// returning the terminal snapshot.
+    fn drive_into_lava(env: &mut LavaGapEnv) -> GridSnapshot {
+        env.reset_with_seed(0).expect("reset");
+        let script = route_into_lava(env);
+        run_to_completion(env, &script)
+    }
+
+    /// The shared conformance check: once the agent has reached the goal, a
+    /// further legal action fails with `StepAfterEpisodeEnd` carrying the status
+    /// that ended the episode, rather than re-running the dynamics.
+    #[test]
+    fn test_lava_gap_rejects_post_terminal_step() {
+        let mut env = env_5x5();
+        assert_rejects_post_terminal_step(&mut env, drive_to_goal, GridAction::TurnLeft);
+    }
+
+    /// The same conformance check driven by a lava death, the other terminal
+    /// this environment owns.
+    #[test]
+    fn test_lava_gap_rejects_post_terminal_step_after_lava() {
+        let mut env = env_5x5();
+        assert_rejects_post_terminal_step(&mut env, drive_into_lava, GridAction::TurnLeft);
+    }
+
+    /// Regression for the concrete defect the guard prevents: nothing in the
+    /// state records that the agent burned, so an unguarded `Forward` walked it
+    /// straight back off the lava cell onto an empty one and emitted a fresh
+    /// `Running` snapshot. A rejected step must mutate nothing at all — not the
+    /// step counter, not the agent's pose, not the guard.
+    #[test]
+    fn test_lava_gap_post_terminal_step_does_not_resurrect_the_agent() {
+        let mut env = env_5x5();
+        let terminal = drive_into_lava(&mut env);
+        assert!(terminal.is_done(), "the agent must have died in the lava");
+        let ended = terminal.status();
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+        let board_at_end = env.ascii();
+
+        // `Forward` is the action that used to undo the death: the lava cell is
+        // ordinary and passable, so the agent simply moved off it.
+        let err = env
+            .step(GridAction::Forward)
+            .expect_err("a step after the episode ended must return Err, not a Running snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (agent_at_end.x, agent_at_end.y),
+            "a rejected step must leave the agent on the lava cell it died on"
+        );
+        assert_eq!(
+            env.state().agent.direction,
+            agent_at_end.direction,
+            "a rejected step must not turn the agent"
+        );
+        assert_eq!(
+            env.ascii(),
+            board_at_end,
+            "a rejected step must not change the board"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    #[test]
+    fn test_lava_gap_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = env_5x5();
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(GridAction::TurnLeft).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset()
+            .expect("reset must succeed after the episode ended");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "a turn on the first step of a fresh episode must not end it"
+        );
+    }
+
+    /// A rejected step draws no randomness. `step()` never samples today, but
+    /// `reset()` shares the persistent stream: checking the guard after any
+    /// future draw would let illegal calls shift every subsequent episode's
+    /// board and desynchronise replay (ADR 0029).
+    #[test]
+    fn test_lava_gap_rejected_step_does_not_advance_rng() {
+        let mut rejected = env_5x5();
+        let mut untouched = env_5x5();
+        drive_to_goal(&mut rejected);
+        drive_to_goal(&mut untouched);
+
+        for _ in 0..3 {
+            rejected
+                .step(GridAction::TurnLeft)
+                .expect_err("a step after the episode ended must be rejected");
+        }
+
+        rejected.reset().expect("reset");
+        untouched.reset().expect("reset");
+        assert_eq!(
+            rejected.ascii(),
+            untouched.ascii(),
+            "rejected steps must draw no randomness; the next board must be the one \
+             the stream would have produced anyway"
+        );
     }
 
     /// Occlusion is live here, but **nothing it hides is task-relevant**: every

--- a/crates/rlevo-environments/src/grids/memory.rs
+++ b/crates/rlevo-environments/src/grids/memory.rs
@@ -237,10 +237,11 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -549,6 +550,10 @@ impl FromStr for MemoryConfig {
 /// [`GridObservation`](super::core::GridObservation) / [`GridAction`] /
 /// [`ScalarReward`].
 ///
+/// The episode ends on the first [`GridAction::Done`] (or at the step budget);
+/// a [`step`](Environment::step) taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
+///
 /// # Examples
 ///
 /// ```rust
@@ -571,6 +576,33 @@ pub struct MemoryEnv {
     /// World coordinates of the fork object whose type equals [`Self::cue`].
     match_pos: (i32, i32),
     rng: StdRng,
+    /// Rejects a `step()` taken after the agent has already answered.
+    ///
+    /// This environment is a *matching* task that is supposed to end the instant
+    /// the agent commits to one of the two fork objects — one commitment, one
+    /// payout. Nothing in the state made that true: `GridAction::Done` returns
+    /// [`StepOutcome::DoneAction`] without touching the grid or the agent, so
+    /// [`facing_match`](Self::facing_match) is recomputed, unchanged, on every
+    /// later call. Without the guard, an unguarded post-terminal `step()` let
+    /// the agent:
+    ///
+    /// - **re-answer correctly, repeatedly.** Standing at the decision cell
+    ///   facing the matching object, each further `Done` re-entered the
+    ///   `facing_match()` branch and paid another
+    ///   `success_reward(self.steps, max_steps)` — an unbounded episode return
+    ///   from a single act of recall, decaying only because `self.steps` kept
+    ///   climbing.
+    /// - **retract a wrong answer and take the other object.** A `Done` facing
+    ///   the distractor pays `0.0` and ends the episode; unguarded, the agent
+    ///   could then turn around, walk to the *other* fork object, and `Done`
+    ///   again for the full success reward. Guessing became free, which destroys
+    ///   the recall property the whole layout (Invariant M) exists to protect.
+    ///
+    /// It also kept `self.steps` advancing past `max_steps`, so a timed-out
+    /// episode reported a length longer than its own budget.
+    ///
+    /// [`StepOutcome::DoneAction`]: super::core::dynamics::StepOutcome::DoneAction
+    guard: EpisodeGuard,
 }
 
 impl MemoryEnv {
@@ -637,6 +669,7 @@ impl MemoryEnv {
             cue,
             match_pos,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -846,6 +879,7 @@ impl Environment<3, 3, 1> for MemoryEnv {
     /// reactive policy the answer for free. Use
     /// [`reset_with_seed`](Self::reset_with_seed) for deterministic replay.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         let (state, cue, match_pos) = Self::build(self.layout, &mut self.rng);
         self.state = state;
         self.cue = cue;
@@ -855,7 +889,21 @@ impl Environment<3, 3, 1> for MemoryEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Advances one step and returns the resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended — the agent has answered, or the step budget ran out. Call
+    /// [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances, before the action is applied,
+        // and before anything can touch `self.rng`. A rejected call must leave
+        // the grid, the agent, and the step counter untouched — and must not
+        // advance the persistent stream, or the cue of every subsequent episode
+        // would depend on how many illegal steps a caller made (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = if outcome == StepOutcome::DoneAction {
@@ -869,7 +917,12 @@ impl Environment<3, 3, 1> for MemoryEnv {
             (0.0, done)
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch can record something the caller
+        // was not handed.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -895,7 +948,9 @@ mod tests {
     // Test-only: the byte a masked cell carries, asserted directly by
     // `test_memory_env_masked_empty_cells_are_encoded_as_unseen`.
     use super::super::core::UNSEEN_TYPE;
-    use rlevo_core::environment::Snapshot;
+    use crate::episode::assert_rejects_post_terminal_step;
+    // `Snapshot` arrives through `use super::*` — the module now imports the
+    // trait itself, for `snapshot.status()` in `step`.
     use std::collections::HashSet;
 
     const KEY: Entity = Entity::Key(OBJECT_COLOR);
@@ -1859,6 +1914,137 @@ mod tests {
         assert!(
             s.contains("0/845"),
             "Display must report the budget, got {s}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Post-terminal step guard (ADR 0044, issue #291)
+    // ---------------------------------------------------------------------
+
+    /// Reset, walk to the junction, commit to a fork object, and answer.
+    ///
+    /// Drives the whole episode through real `step()` calls — no hand-written
+    /// terminal snapshot, no poking at `env.state`. With `correct = true` the
+    /// agent turns toward the matching object (success terminal); with `false`
+    /// it turns toward the distractor (failure terminal). Both are genuine
+    /// `Done` terminations, so neither depends on the step-limit status bug
+    /// (GitHub #1028) that maps a budget cutoff to `Terminated`.
+    fn drive_to_commit(env: &mut MemoryEnv, correct: bool) -> GridSnapshot {
+        env.reset().expect("reset");
+        drive_to_junction(env);
+        let turn = match (oracle_turn(env), correct) {
+            (t, true) => t,
+            (GridAction::TurnLeft, false) => GridAction::TurnRight,
+            (_, false) => GridAction::TurnLeft,
+        };
+        env.step(turn).expect("turn");
+        env.step(GridAction::Forward).expect("forward");
+        let snap = env.step(GridAction::Done).expect("done");
+        assert!(snap.is_done(), "Done at the fork must end the episode");
+        snap
+    }
+
+    /// Conformance: after a **correct** commit the episode is over, and a
+    /// further legal `Done` must be refused rather than paying out again.
+    #[test]
+    fn test_memory_env_rejects_post_terminal_step_after_correct_answer() {
+        let mut env = env_default();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            |env| drive_to_commit(env, true),
+            GridAction::Done,
+        );
+    }
+
+    /// Conformance for the other terminal: a **wrong** commit ends the episode
+    /// too, and the guard must reject afterwards just as firmly. This is the
+    /// half that matters most here — unguarded, the agent could retract a wrong
+    /// answer and go take the other object.
+    #[test]
+    fn test_memory_env_rejects_post_terminal_step_after_wrong_answer() {
+        let mut env = env_default();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            |env| drive_to_commit(env, false),
+            GridAction::Done,
+        );
+    }
+
+    /// Regression for the concrete defect: `Done` leaves the grid and the agent
+    /// untouched, so `facing_match()` stayed true and every further `Done`
+    /// re-paid `success_reward` while `steps` climbed. A rejected step must
+    /// change nothing at all.
+    #[test]
+    fn test_memory_env_post_terminal_step_pays_nothing_and_mutates_nothing() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = env_default();
+        let terminal = drive_to_commit(&mut env, true);
+        let paid: f32 = (*terminal.reward()).into();
+        assert!(paid > 0.0, "the correct answer must have been paid once");
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+
+        let err = env
+            .step(GridAction::Done)
+            .expect_err("a second Done must be refused, not paid a second success_reward");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, terminal.status,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (agent_at_end.x, agent_at_end.y),
+            "a rejected step must not move the agent"
+        );
+        assert_eq!(
+            env.state().agent.direction,
+            agent_at_end.direction,
+            "a rejected step must not turn the agent"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// `reset()` re-opens a terminated episode, so a latched guard cannot strand
+    /// the environment for the rest of a run.
+    #[test]
+    fn test_memory_env_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = env_default();
+        drive_to_commit(&mut env, false);
+        assert!(
+            env.step(GridAction::Done).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(GridAction::Forward)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
         );
     }
 

--- a/crates/rlevo-environments/src/grids/multi_room.rs
+++ b/crates/rlevo-environments/src/grids/multi_room.rs
@@ -71,8 +71,9 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -278,6 +279,10 @@ impl FromStr for MultiRoomConfig {
 /// Implements [`Environment<3, 3, 1>`] with [`GridState`] /
 /// [`GridObservation`](super::core::GridObservation) / [`GridAction`] / [`ScalarReward`].
 ///
+/// Reaching the goal (or exhausting `max_steps`) ends the episode; a
+/// [`step`](Environment::step) taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
+///
 /// # Examples
 ///
 /// ```rust
@@ -294,6 +299,28 @@ pub struct MultiRoomEnv {
     config: MultiRoomConfig,
     steps: usize,
     render: bool,
+    /// Rejects a `step()` taken after the episode ended. Without it the strip
+    /// keeps walking, and two things go wrong — both measured on the default
+    /// 3-room board, whose optimal rollout terminates on step 15 with reward
+    /// `0.955`:
+    ///
+    /// 1. **The goal is never consumed.** `step_forward` moves the agent *onto*
+    ///    the `Entity::Goal` cell but leaves the entity in the grid, so
+    ///    `TurnLeft, TurnLeft, Forward` (off the goal) then `TurnLeft, TurnLeft,
+    ///    Forward` (back onto it) re-raises `StepOutcome::ReachedGoal` and pays
+    ///    `success_reward` a second time — a further `0.934` at step 22, taking
+    ///    the episode return to `1.889` for a task worth at most `1.0`. The goal
+    ///    can be farmed indefinitely until `max_steps` drives the payout
+    ///    negative.
+    /// 2. **`steps` keeps advancing.** Every post-terminal call increments the
+    ///    counter (15 → 22 above), so `steps()` no longer reports the true
+    ///    episode length *and* it is the numerator of
+    ///    `success_reward(steps, max_steps)`, discounting every later payout.
+    ///
+    /// The unguarded intermediate calls are worse than merely extra: they emit
+    /// `Running` snapshots after a `Terminated` one, silently resurrecting the
+    /// episode for any rollout loop that watches `is_done()`.
+    guard: EpisodeGuard,
 }
 
 impl MultiRoomEnv {
@@ -346,6 +373,7 @@ impl MultiRoomEnv {
             config,
             steps: 0,
             render,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -482,14 +510,33 @@ impl Environment<3, 3, 1> for MultiRoomEnv {
     type RewardType = ScalarReward;
     type SnapshotType = GridSnapshot;
 
+    /// Rebuilds the fixed strip, re-closes every door, and re-opens the episode.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = Self::build(&self.config);
         self.steps = 0;
         let observation = self.observe_reset(&self.state);
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies one grid action and returns the resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances and before `apply_action` touches
+        // the grid or the agent. A rejected call must leave the environment
+        // bit-identical — and it must precede any future random draw, or the
+        // seed stream would depend on how many illegal steps a caller made
+        // (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let outcome = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = match outcome {
@@ -501,7 +548,11 @@ impl Environment<3, 3, 1> for MultiRoomEnv {
             }
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        // Single exit: the guard is fed the emitted snapshot's own status, so it
+        // cannot disagree with what the caller received.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -524,11 +575,48 @@ mod tests {
     // carries, both read by
     // `test_multi_room_occlusion_hides_the_goal_behind_the_next_closed_door`.
     use super::super::core::{UNSEEN_TYPE, VIEW_SIZE, mask_view};
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::config::ConstraintKind;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::EpisodeStatus;
 
     fn default_env() -> MultiRoomEnv {
         MultiRoomEnv::with_config(MultiRoomConfig::default(), false).expect("valid config")
+    }
+
+    /// The optimal rollout on the default 3-room board: open door one, cross,
+    /// open door two, cross, step onto the goal at (14, 2).
+    const OPTIMAL_ROLLOUT: [GridAction; 15] = [
+        GridAction::Forward, // (2, 2)
+        GridAction::Forward, // (3, 2)
+        GridAction::Forward, // (4, 2)
+        GridAction::Toggle,  // open door at (5, 2)
+        GridAction::Forward, // (5, 2)
+        GridAction::Forward, // (6, 2)
+        GridAction::Forward, // (7, 2)
+        GridAction::Forward, // (8, 2)
+        GridAction::Forward, // (9, 2)
+        GridAction::Toggle,  // open door at (10, 2)
+        GridAction::Forward, // (10, 2)
+        GridAction::Forward, // (11, 2)
+        GridAction::Forward, // (12, 2)
+        GridAction::Forward, // (13, 2)
+        GridAction::Forward, // (14, 2) goal
+    ];
+
+    /// Drives `env` to termination **by reaching the goal**, through real
+    /// `step()` calls only, and returns the terminal snapshot.
+    ///
+    /// Deliberately not the step-limit ending: `build_snapshot` maps a
+    /// `max_steps` cutoff to `Terminated` rather than `Truncated` (issue #1028,
+    /// out of scope here), so a timeout-driven test would bake that bug into an
+    /// assertion.
+    fn drive_to_goal(env: &mut MultiRoomEnv) -> GridSnapshot {
+        env.reset().expect("reset must succeed");
+        let mut last = None;
+        for action in OPTIMAL_ROLLOUT {
+            last = Some(env.step(action).expect("the optimal rollout must succeed"));
+        }
+        last.expect("the rollout is non-empty")
     }
 
     #[test]
@@ -840,6 +928,109 @@ mod tests {
             MultiRoomEnv::VISIBILITY,
             Visibility::Occluded,
             "multiroom.py omits see_through_walls, so MiniGridEnv's False default applies"
+        );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// Verifies `MultiRoomEnv` satisfies the shared post-terminal conformance
+    /// check: once the agent has stepped onto the goal, a further legal `step()`
+    /// fails with `StepAfterEpisodeEnd` carrying the status that ended the
+    /// episode.
+    #[test]
+    fn test_multi_room_rejects_post_terminal_step() {
+        let mut env = default_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_goal, GridAction::Forward);
+    }
+
+    /// Regression for the concrete defect the guard prevents.
+    ///
+    /// `step_forward` moves the agent onto the goal cell but never clears
+    /// `Entity::Goal`, so an unguarded rollout could turn around, step off, and
+    /// step back on to re-raise `StepOutcome::ReachedGoal` and collect
+    /// `success_reward` again — measured at `+0.934` on top of the terminal
+    /// `0.955`, a return of `1.889` on a task worth at most `1.0`. Each of those
+    /// calls also advanced `steps` (15 → 22), which is both the reported episode
+    /// length and the numerator of `success_reward`. A rejected step must mutate
+    /// nothing at all.
+    #[test]
+    fn test_multi_room_post_terminal_step_does_not_refarm_the_goal() {
+        let mut env = default_env();
+        let terminal = drive_to_goal(&mut env);
+        assert!(terminal.is_done(), "reaching the goal must end the episode");
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+        assert_eq!(
+            env.state().grid.get(14, 2),
+            Entity::Goal,
+            "the goal entity survives arrival — that is what made re-farming possible"
+        );
+
+        // The first move of the off-and-back-on re-farm loop.
+        let err = env
+            .step(GridAction::TurnLeft)
+            .expect_err("a step after the goal must return Err, not another payout");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                terminal.status(),
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (
+                env.state().agent.x,
+                env.state().agent.y,
+                env.state().agent.direction
+            ),
+            (agent_at_end.x, agent_at_end.y, agent_at_end.direction),
+            "a rejected step must not move or turn the agent"
+        );
+        assert_eq!(
+            env.guard.status(),
+            terminal.status(),
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// Verifies `reset()` re-opens a terminated episode, so a guard that has
+    /// latched cannot strand the environment for the rest of the run.
+    #[test]
+    fn test_multi_room_reset_reopens_terminated_episode() {
+        let mut env = default_env();
+        drive_to_goal(&mut env);
+        assert!(
+            env.step(GridAction::TurnLeft).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(GridAction::Forward)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
+        assert_eq!(env.steps(), 1, "reset() must restart the step counter");
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (2, 2),
+            "the fresh episode starts back at (1, 2) and the first Forward advances one cell"
         );
     }
 }

--- a/crates/rlevo-environments/src/grids/unlock.rs
+++ b/crates/rlevo-environments/src/grids/unlock.rs
@@ -73,8 +73,9 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -245,6 +246,26 @@ pub struct UnlockEnv {
     steps: usize,
     render: bool,
     door_pos: (i32, i32),
+    /// Rejects a `step()` taken after the door opened (or the step budget ran
+    /// out).
+    ///
+    /// Termination here is recomputed from the live grid every call —
+    /// `door_is_open()` reads `self.state.grid` — so nothing latched the episode
+    /// as over. Without this guard, a post-terminal step re-read an open door
+    /// and paid `success_reward(self.steps, max_steps)` **again**, once per
+    /// call, while `self.steps` kept advancing past the true episode length and
+    /// decayed each successive payout; past `max_steps` the formula goes
+    /// negative (`success_reward` deliberately does not clamp, "no env should
+    /// call it past termination"), so the same finished episode could keep
+    /// billing the agent.
+    ///
+    /// Worse, the door is re-toggleable: `dynamics::toggle` maps
+    /// `Open -> Closed` unconditionally and `Closed -> Open` without needing the
+    /// key. So after the winning `Toggle`, an unguarded agent could shut the
+    /// door and re-open it, collecting the unlock reward a second, third, and
+    /// n-th time from a single unlock — an unbounded return farmed out of one
+    /// solved episode.
+    guard: EpisodeGuard,
 }
 
 impl UnlockEnv {
@@ -295,6 +316,7 @@ impl UnlockEnv {
             steps: 0,
             render,
             door_pos,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -407,7 +429,13 @@ impl Environment<3, 3, 1> for UnlockEnv {
     type RewardType = ScalarReward;
     type SnapshotType = GridSnapshot;
 
+    /// Rebuilds the fixed board and re-opens the episode.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         let (state, door_pos) = Self::build(&self.config);
         self.state = state;
         self.door_pos = door_pos;
@@ -416,7 +444,23 @@ impl Environment<3, 3, 1> for UnlockEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies `action`, then ends the episode if the door is now open or the
+    /// step budget is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances and before `apply_action` touches
+        // the grid, so a rejected call leaves the board, the step counter, and
+        // the door state exactly as the terminal snapshot described them. Making
+        // termination re-derivable from a mutated grid is precisely how the
+        // unlock reward became farmable (ADR 0044); this env draws no
+        // randomness, but the same ordering keeps a future draw off a rejected
+        // path (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let _ = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = if self.door_is_open() {
@@ -427,7 +471,11 @@ impl Environment<3, 3, 1> for UnlockEnv {
             (0.0, false)
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status rather than a re-derived literal.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -445,8 +493,9 @@ mod tests {
     // `test_unlock_occlusion_is_carried_entirely_by_the_locked_door`.
     use super::super::core::grid::egocentric_view;
     use super::super::core::{UNSEEN_TYPE, VIEW_SIZE, mask_view};
+    // `Snapshot` arrives through `super::*`: `step()` reads `status()` off the
+    // snapshot it emits, so the trait is now in scope crate-side.
     use rlevo_core::config::ConstraintKind;
-    use rlevo_core::environment::Snapshot;
 
     /// The four facings, for the occlusion sweep.
     const DIRECTIONS: [Direction; 4] = [
@@ -800,6 +849,144 @@ mod tests {
             UnlockEnv::VISIBILITY,
             Visibility::Occluded,
             "Unlock derives from RoomGrid, which passes see_through_walls=False"
+        );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// Drives a fresh episode to the winning terminal snapshot the honest way:
+    /// through real `step()` calls, ending by **unlocking and opening the door**
+    /// rather than by exhausting `max_steps`.
+    ///
+    /// The step-limit ending is deliberately avoided: `build_snapshot` maps a
+    /// budget cutoff to `Terminated` rather than `Truncated` (issue #1028), so a
+    /// timeout-driven conformance test would bake in a status the environment
+    /// gets wrong. Opening the door is a genuine termination.
+    fn drive_to_open_door(env: &mut UnlockEnv) -> GridSnapshot {
+        env.reset().expect("reset must succeed");
+        let script = [
+            GridAction::Pickup,   // grab the key
+            GridAction::TurnLeft, // face north toward the door
+            GridAction::Toggle,   // unlock (Locked -> Closed)
+            GridAction::Toggle,   // open   (Closed -> Open)
+        ];
+        let mut last = None;
+        for a in script {
+            last = Some(env.step(a).expect("the winning script must be steppable"));
+        }
+        last.expect("the script is non-empty")
+    }
+
+    /// Conformance with the shared post-terminal contract: once the door is
+    /// open, a further legal `step()` fails with `StepAfterEpisodeEnd` carrying
+    /// the status that ended the episode.
+    #[test]
+    fn test_unlock_rejects_post_terminal_step() {
+        let mut env = test_env();
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_open_door,
+            GridAction::Toggle,
+        );
+    }
+
+    /// Regression for the concrete defect the guard prevents.
+    ///
+    /// Termination is recomputed from the live grid (`door_is_open()`), so an
+    /// unguarded post-terminal step advanced `self.steps`, re-ran
+    /// `apply_action`, and paid `success_reward` again on the still-open door —
+    /// and a replayed `Toggle` shut the door (`Open -> Closed`, no key needed),
+    /// so the very next `Toggle` re-opened it and billed the unlock reward a
+    /// second time. A rejected step must mutate nothing: not the counter, not
+    /// the agent's pose, not the door.
+    #[test]
+    fn test_unlock_post_terminal_step_cannot_re_pay_the_unlock_reward() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = test_env();
+        let terminal = drive_to_open_door(&mut env);
+        assert!(terminal.is_done(), "opening the door must terminate");
+        let paid: f32 = (*terminal.reward()).into();
+        assert!(paid > 0.0, "the unlock reward was {paid}");
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+        let door_at_end = env.state().grid.get(env.door_pos().0, env.door_pos().1);
+        assert_eq!(
+            door_at_end,
+            Entity::Door(DOOR_COLOR, DoorState::Open),
+            "the episode ended with the door open"
+        );
+
+        let err = env
+            .step(GridAction::Toggle)
+            .expect_err("a step after the door opened must return Err, not another payout");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                terminal.status(),
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (
+                env.state().agent.x,
+                env.state().agent.y,
+                env.state().agent.direction
+            ),
+            (agent_at_end.x, agent_at_end.y, agent_at_end.direction),
+            "a rejected step must not move or turn the agent"
+        );
+        assert_eq!(
+            env.state().grid.get(env.door_pos().0, env.door_pos().1),
+            door_at_end,
+            "a rejected Toggle must not shut the door and re-arm another unlock reward"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    #[test]
+    fn test_unlock_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = test_env();
+        drive_to_open_door(&mut env);
+        assert!(
+            env.step(GridAction::Toggle).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert_eq!(
+            env.state().grid.get(1, 0),
+            Entity::Door(DOOR_COLOR, DoorState::Locked),
+            "reset() must re-lock the door for the new episode"
+        );
+
+        let snap = env
+            .step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
         );
     }
 

--- a/crates/rlevo-environments/src/grids/unlock_pickup.rs
+++ b/crates/rlevo-environments/src/grids/unlock_pickup.rs
@@ -95,10 +95,11 @@ use super::core::{
     reward::success_reward,
     state::GridState,
 };
+use crate::episode::EpisodeGuard;
 use rand::rngs::StdRng;
 use rand::{Rng, RngExt, SeedableRng};
 use rlevo_core::config::{self, ConfigError, Validate};
-use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor};
+use rlevo_core::environment::{ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot};
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -302,6 +303,10 @@ struct Layout {
 /// cell, and agent pose — see the module docs for the draw order and
 /// [`UnlockPickupConfig::seed`] for the reproducibility contract.
 ///
+/// Carrying the target box terminates the episode; a [`step`](Environment::step)
+/// taken afterwards is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
+///
 /// Implements [`Environment<3, 3, 1>`] with [`GridState`] /
 /// [`GridObservation`](super::core::GridObservation) / [`GridAction`] / [`ScalarReward`].
 ///
@@ -323,6 +328,24 @@ pub struct UnlockPickupEnv {
     render: bool,
     layout: Layout,
     rng: StdRng,
+    /// Rejects a `step()` taken after the box was picked up. Termination here is
+    /// [`has_target`](Self::has_target) — "is the agent carrying the target box
+    /// *right now*" — recomputed from the live state on every call, never
+    /// latched. Without the guard a post-terminal `step()` therefore re-ran the
+    /// whole predicate on a finished episode, and both of its answers were
+    /// defects:
+    ///
+    /// - **Still carrying** (any action but `Drop`): the env emitted another
+    ///   `Terminated` snapshot paying `success_reward(self.steps, max_steps)`
+    ///   *again*, once per call, while `self.steps` kept advancing past the true
+    ///   episode length — so the extra payouts also decayed, silently
+    ///   contaminating any per-episode return or step-count metric.
+    /// - **`Drop`**: the box goes back on the board, `has_target()` turns
+    ///   `false`, and the env emitted a **`Running`** snapshot — a finished
+    ///   episode resurrected, `done → not done`. A following `Pickup` re-satisfied
+    ///   `has_target()` and paid the success reward a second time, so
+    ///   `Drop`/`Pickup` cycling was an unbounded reward pump on a single box.
+    guard: EpisodeGuard,
 }
 
 impl UnlockPickupEnv {
@@ -386,6 +409,7 @@ impl UnlockPickupEnv {
             render,
             layout,
             rng,
+            guard: EpisodeGuard::new(),
         })
     }
 
@@ -637,8 +661,21 @@ impl Environment<3, 3, 1> for UnlockPickupEnv {
     /// the target box is part of the draw, so leaving
     /// [`target`](UnlockPickupEnv::target) behind would score the episode against
     /// an object that is not on the board.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a [`PlacementError`] from [`build`](Self::build) as an
+    /// [`EnvironmentError::Config`] if the fresh layout cannot be placed. On that
+    /// path the whole reset is a no-op — board, step counter *and*
+    /// [`EpisodeGuard`] are left exactly as they were. The guard is deliberately
+    /// cleared only **after** the fallible build, for the reason ADR 0044 gives
+    /// for `TimeLimit::reset`: clearing first would re-open a finished episode
+    /// even though the environment never returned to an initial state, leaving
+    /// `step()` willing to run on the stale terminal board — the very board that
+    /// still has the target box in the agent's hands.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
         let (state, layout) = Self::build(&self.config, &mut self.rng)?;
+        self.guard.reset();
         self.state = state;
         self.layout = layout;
         self.steps = 0;
@@ -646,7 +683,20 @@ impl Environment<3, 3, 1> for UnlockPickupEnv {
         Ok(self.emit(observation, 0.0, false))
     }
 
+    /// Applies one [`GridAction`] and returns the resulting snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first: before `steps` advances, before `apply_action` touches the
+        // grid or the agent's hands, and before anything could draw from the
+        // persistent stream. A rejected call must leave the environment
+        // bit-identical, or the layouts of every later episode would depend on
+        // how many illegal steps a caller made (ADR 0029).
+        self.guard.check()?;
+
         self.steps += 1;
         let _ = apply_action(&mut self.state.grid, &mut self.state.agent, action);
         let (reward, done) = if self.has_target() {
@@ -657,7 +707,11 @@ impl Environment<3, 3, 1> for UnlockPickupEnv {
             (0.0, false)
         };
         let observation = self.observe(&action, &self.state);
-        Ok(self.emit(observation, reward, done))
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch above can forget to record.
+        let snapshot = self.emit(observation, reward, done);
+        self.guard.record(snapshot.status());
+        Ok(snapshot)
     }
 }
 
@@ -683,7 +737,8 @@ mod tests {
     use crate::direction::Direction;
     use crate::grids::core::AgentState;
     use rlevo_core::config::ConstraintKind;
-    use rlevo_core::environment::Snapshot;
+    // `Snapshot` arrives through `use super::*`: `step()` now needs it in the
+    // parent module to read `snapshot.status()` for the guard.
     use std::collections::{HashSet, VecDeque};
 
     /// Every seed loop runs at the enforced floor **and** at a larger board, so
@@ -1512,6 +1567,161 @@ mod tests {
             UnlockPickupEnv::VISIBILITY,
             Visibility::Occluded,
             "UnlockPickup derives from RoomGrid, which passes see_through_walls=False"
+        );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #291) ──────────────────────
+
+    /// Drive a fresh episode to its terminal snapshot **by picking up the box**,
+    /// through real `step()` calls only.
+    ///
+    /// The task's own terminal, not the step-limit one: `build_snapshot` maps a
+    /// timeout to `Terminated` rather than `Truncated` (GitHub #1028, out of
+    /// scope here), so a step-limit ending would pin the guard to a status this
+    /// environment is expected to stop emitting.
+    ///
+    /// The route is planned from the board the env actually drew — seed 3's
+    /// layout, the same one `a_planned_rollout_takes_the_key_then_the_box`
+    /// solves — because a sampled layout has no fixed action script.
+    fn drive_to_box_pickup(env: &mut UnlockPickupEnv) -> GridSnapshot {
+        env.reset_with_seed(3).expect("reset");
+        let target = env.target();
+        let route = plan(env.state(), &|agent| agent.carrying == Some(target))
+            .unwrap_or_else(|| panic!("seed 3 must be solvable:\n{}", env.ascii()));
+        let snapshot = run(env, &route);
+        assert!(
+            snapshot.is_done(),
+            "carrying the target box must end the episode"
+        );
+        assert_eq!(
+            env.state().agent.carrying,
+            Some(target),
+            "the plan must end with the box in hand"
+        );
+        snapshot
+    }
+
+    /// `UnlockPickupEnv` satisfies the shared post-terminal conformance check:
+    /// once the box is in hand, a further legal `step()` fails with
+    /// `StepAfterEpisodeEnd` carrying the status that ended the episode.
+    #[test]
+    fn test_unlock_pickup_rejects_post_terminal_step() {
+        let mut env = env_7x7();
+        crate::episode::assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_box_pickup,
+            GridAction::TurnLeft,
+        );
+    }
+
+    /// Regression for the concrete defect the guard prevents.
+    ///
+    /// `has_target()` is recomputed from the live state each call, so an
+    /// unguarded post-terminal `Drop` put the box back on the board, flipped the
+    /// predicate to `false`, and emitted a **`Running`** snapshot — resurrecting
+    /// a finished episode and arming a second `Pickup` to pay the success reward
+    /// all over again. A rejected step must mutate nothing at all: not the step
+    /// counter, not the agent's pose, not what it is carrying, not the board.
+    #[test]
+    fn test_unlock_pickup_post_terminal_step_does_not_reopen_the_episode() {
+        let mut env = env_7x7();
+        let terminal = drive_to_box_pickup(&mut env);
+        let ended = terminal.status();
+
+        let steps_at_end = env.steps();
+        let agent_at_end = env.state().agent;
+        let board_at_end = env.ascii();
+
+        let err = env.step(GridAction::Drop).expect_err(
+            "dropping the box after termination must return Err, not a Running snapshot",
+        );
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps(),
+            steps_at_end,
+            "a rejected step must not advance the step counter"
+        );
+        assert_eq!(
+            (env.state().agent.x, env.state().agent.y),
+            (agent_at_end.x, agent_at_end.y),
+            "a rejected step must not move the agent"
+        );
+        assert_eq!(
+            env.state().agent.carrying,
+            agent_at_end.carrying,
+            "a rejected Drop must leave the box in the agent's hands"
+        );
+        assert_eq!(
+            env.ascii(),
+            board_at_end,
+            "a rejected step must not put the box back on the board"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not re-open the episode"
+        );
+    }
+
+    /// `reset()` re-opens a terminated environment, so a latched guard cannot
+    /// strand the env for the rest of a run.
+    #[test]
+    fn test_unlock_pickup_reset_reopens_terminated_episode() {
+        use rlevo_core::environment::EpisodeStatus;
+
+        let mut env = env_7x7();
+        drive_to_box_pickup(&mut env);
+        assert!(
+            env.step(GridAction::TurnLeft).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert_eq!(env.steps(), 0, "reset() must clear the step counter");
+
+        let snapshot = env
+            .step(GridAction::TurnLeft)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snapshot.is_done(),
+            "a turn on a fresh board must not end the episode"
+        );
+    }
+
+    /// A rejected post-terminal step draws no randomness. `step()` does not
+    /// sample today, but `reset()` shares the persistent stream: checking the
+    /// guard after any future draw would let illegal calls shift every
+    /// subsequent episode's layout and desynchronise replay (ADR 0029).
+    #[test]
+    fn test_unlock_pickup_rejected_step_does_not_advance_rng() {
+        let mut rejected = env_7x7();
+        let mut untouched = env_7x7();
+        drive_to_box_pickup(&mut rejected);
+        drive_to_box_pickup(&mut untouched);
+
+        rejected
+            .step(GridAction::Toggle)
+            .expect_err("a step after termination must be rejected");
+
+        rejected.reset().expect("reset");
+        untouched.reset().expect("reset");
+        assert_eq!(
+            fingerprint(&rejected),
+            fingerprint(&untouched),
+            "a rejected step must draw no randomness; the next episode must be the board \
+             it would have been"
         );
     }
 }

--- a/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
+++ b/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
@@ -253,13 +253,14 @@ tail can still build a wrapper over a rejecting environment, but a caller who
 silently absorbed a bug into a replay buffer has no way back. Reject is the
 reversible choice.
 
-**This is not yet universal — check before you rely on it.** Two of the
-built-in families enforce it today: the
+**This is not yet universal — check before you rely on it.** The following
+enforce it today: the
 `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
 `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
-`MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), and the
-`TimeLimit` wrapper. The `classic` module's bandits, the `grids`,
-`locomotion`, and `box2d` families, and `pixel_grid` do not yet — their
+`MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
+`grids` environments, and the
+`TimeLimit` wrapper. The `classic` module's bandits, the
+`locomotion` and `box2d` families, and `pixel_grid` do not yet — their
 behaviour after a terminal snapshot remains **undefined**; do not depend on it,
 even by accident, until it lands for that family — the rollout is tracked
 family-by-family in
@@ -415,7 +416,8 @@ the crate as a vocabulary anchor more than a workhorse.
 - **A `step()` taken after `is_done()` is `true` is an error, not a silent
   resume.** It returns `EnvironmentError::StepAfterEpisodeEnd { status }`; call
   `reset()` to start a new episode. The `toy_text` family, the `classic`
-  family's non-bandit environments, and `TimeLimit` enforce this today
+  family's non-bandit environments, the `grids` family, and `TimeLimit` enforce
+  this today
   ([issue #289](https://github.com/anthonytorlucci/rlevo/issues/289) tracks
   the rest).
 - **`ConstructableEnv`** keeps construction off the behaviour trait so

--- a/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
+++ b/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
@@ -377,14 +377,15 @@ Three details here are load-bearing, not stylistic:
   the guard *after* the fallible work, not before — a failed reset must not
   silently re-open a finished episode.
 
-> **Scope: two of the built-in families enforce this today.**
+> **Scope: most, but not all, of the built-in families enforce this today.**
 > `EpisodeGuard` ships in `rlevo-environments`, and the
 > `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
 > `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
-> `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), and the
+> `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
+> `grids` environments, and the
 > `TimeLimit` wrapper all hold one. The `classic` module's bandits
 > (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
-> `AdversarialBandit`), the `grids`, `locomotion`, and `box2d` families, and
+> `AdversarialBandit`), the `locomotion` and `box2d` families, and
 > `pixel_grid` do not yet — their post-terminal behaviour is undefined,
 > tracked family-by-family in
 > [issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). Your own
@@ -431,8 +432,9 @@ algorithm will drive your environment correctly:
   `EnvironmentError::StepAfterEpisodeEnd` rather than silently continuing — see
   [Step 5](#step-5--guard-the-post-terminal-step) above for the `EpisodeGuard`
   recipe. (The `toy_text` family, the `classic` family's non-bandit
-  environments, and `TimeLimit` enforce this today; treat it as the target for
-  any environment you write, not yet a workspace-wide guarantee.)
+  environments, the `grids` family, and `TimeLimit` enforce this today; treat it
+  as the target for any environment you write, not yet a workspace-wide
+  guarantee.)
 - **Neither method panics on valid input.** Return `EnvironmentError::InvalidAction`
   for out-of-range actions; reserve panics for genuine internal-logic bugs.
 - **Your config validates its own invariants.** Implement


### PR DESCRIPTION
> **Stacked PR.** Based on `290-env-post-terminal-step-guard-classic-family` (#1031), not `main`. Both branches edit the same `CHANGELOG.md` block and the same two user-book paragraphs, so basing on `main` would have guaranteed conflicts. The diff below is #291's work only. **Merge #1031 first**; GitHub will retarget this to `main` automatically.

## Summary

Applies the `EpisodeGuard` post-terminal contract (ADR 0044, established in #105) to all twelve `grids` environments. Each derived termination from a *predicate over the current board* rather than latching it — and the shared dynamics consume nothing on success: `step_forward` moves the agent **onto** `Entity::Goal` and leaves the cell intact. A finished episode was therefore fully re-enterable, and stepping off the goal and back on re-raised `StepOutcome::ReachedGoal` and re-paid `success_reward`, on a loop as short as two steps.

This was measured, not inferred. `EmptyEnv` banked `0.955 + 0.901 = 1.856` for a single goal; `GoToDoorEnv` returned **5.649 on a task whose maximum is 1.0** (one legitimate win plus five replayed `Done`s). Because `success_reward` is step-count-discounted and deliberately unclamped, replays past `max_steps` pay a **negative** reward on a snapshot the caller reads as a win. Worse, the intermediate calls emitted **`Running`** snapshots *after* a `Terminated` one, so any rollout loop watching `is_done()` simply kept collecting.

Several environments lost a task-defining property, not merely reward hygiene:

- **`LavaGapEnv` / `CrossingEnv`** — a lava death was reversible. The agent stands *on* the lava; one more `Forward` walks it off and re-emits `Running`, converting a `0.0` death into a positive-return episode.
- **`MemoryEnv`** — a wrong commit could be retracted and the *other* object taken for full reward. Guessing became free, dissolving the recall property the entire 11-cell layout exists to enforce.
- **`GoToDoorEnv`** — the same retry defeated the 25% cap on a mission-blind policy.
- **`UnlockEnv`** — `dynamics::toggle` maps `Open -> Closed` with no key check, so the door was re-farmable.
- **`UnlockPickupEnv`** — `Drop` returned the box and flipped `has_target()` false, making `Drop`/`Pickup` an unbounded reward pump on one box.
- **`DynamicObstaclesEnv`** — broke a documented **invariant**, not just reward accounting. See below.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #291. Sub-issue of #289 (umbrella).

## What Was Changed

Each of the twelve gained a `guard: EpisodeGuard` field (initialized at the single `with_config` chokepoint), `self.guard.check()?` as the literal first statement of `step()`, `self.guard.record(snapshot.status())` on a single exit, and the guard cleared in `Environment::reset`.

- **`dynamic_obstacles.rs`** — the one that matters most. `move_obstacles` deliberately does not draw a `Ball` on the agent's cell on a collision-terminal step, so `self.obstacles` retains a position the grid does not back. Re-entering violates the SOUNDNESS premise that every obstacle's old cell holds `Entity::Ball`, and obstacles merge. Reproduced by sweeping 300 seeds × 5 layouts: at `seed = 37`, `size = 5`, `num_obstacles = 4`, `[(2,2),(2,1),(1,1),(1,3)]` becomes `[(1,2),(1,1),(1,1),(2,3)]` on the **first** post-terminal step. That seed is now pinned as a regression test. #125 shipped with this scoped honestly in the docs rather than fixed; the four hedged doc comments on `obstacles()` and `move_obstacles` are now tightened to state the invariant unconditionally. This env's three return paths were collapsed to one, and it is the only one drawing RNG inside `step()`.
- **`go_to_door.rs`** — the odd one out: bespoke 7×7×4 mission-carrying snapshot, bypasses `build_snapshot`. The shared conformance helper turned out to apply unchanged.
- **`crossing.rs`, `dist_shift.rs`, `door_key.rs`, `empty.rs`, `four_rooms.rs`, `lava_gap.rs`, `memory.rs`, `multi_room.rs`, `unlock.rs`, `unlock_pickup.rs`** — same shape, each with a doc comment naming its own concrete defect rather than a generic sentence.
- **`CHANGELOG.md`** — entry under `[Unreleased]` → `rlevo-environments` → `**Fixed**`.
- **`docs/user-book/`** — `34-environment.md` and `99-extending-the-environment.md` both listed `grids` among the families that do *not* enforce this. Corrected. Kept deliberately numeral-free: the counts drift as the workspace grows, and #289's own figure already disagrees with the tree.

### Design note: `grids/core` was considered and rejected

#291 suggests threading the guard "through the shared step template" in `grids/core/`. There is no shared step template — `grids/core/` holds shared *data* helpers, and each env writes its own `Environment::step`. The one plausible chokepoint, `build_snapshot`, covers only **10 of 12** (`empty.rs` and `go_to_door.rs` construct `SnapshotBase` inline). Decisively, no arrangement removes the twelve `check()?` call sites, because `check()` must be the literal first statement of `step()` — so the abstraction would save nothing while hiding a mutation inside a function `reset()` also calls. Per-env repetition matches `classic` and `toy_text` and needs no new ADR.

### Fallible `reset` ordering

Where `reset()` runs a fallible `Self::build(..)?` — `FourRoomsEnv`, `DoorKeyEnv`, `UnlockPickupEnv` — the guard is cleared **only on success**, per ADR 0044 §6 and the `TimeLimit::reset` precedent (`wrappers/time_limit.rs:127-133`). Clearing first would re-open a finished episode over a board that never returned to its initial state, leaving `step()` willing to run on stale terminal state. `GoToDoorEnv`'s `build` returns a plain tuple, so the question does not arise there; a comment records what to do if that ever changes.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

All three pass, no failures, no warnings. Also run: `cargo fmt --all --check`, `cargo clippy -p rlevo-environments --all-targets -- -D warnings`, `cargo test -p rlevo-environments` (1284 unit tests + all integration targets), and `mdbook build docs/user-book`.

**Non-vacuity was executed for all twelve, not argued.** `self.guard.check()?` was commented out in each environment one at a time and that module's tests re-run; every one went red — 3 to 5 tests per file, minimum 3, maximum 5. In particular the two tests most likely to pass vacuously, `..._does_not_mutate_state` and `..._reset_reopens_terminated_episode`, went red in **all twelve**. `dynamic_obstacles` regressed to exactly the `(1,1)` duplication pinned in its doc comment. Every file was restored from backup and the tree confirmed clean by `git diff --stat` afterward.

Every conformance test reaches its terminal through **real `step()` calls** — no hand-written terminal snapshots, no poking `env.guard`.

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU) — these environments are backend-independent; no tensor kernels are touched
- OS: macOS 26.5.2 (Darwin, arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full diff — guard plumbing and regression tests across the twelve environments, the `dynamic_obstacles` doc tightening, the CHANGELOG entry, and the user-book corrections — authored under maintainer direction and reviewed before commit.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Ordering is the load-bearing detail.** `check()?` must precede the RNG draw, not merely the state mutation. `DynamicObstaclesEnv` draws inside `step()` via `move_obstacles`, so a check placed after it would let a *rejected* step advance the seed stream and make trajectories depend on how many illegal calls a caller made (ADR 0029). The guard call is the first statement in all twelve.

**This does not fix #1028, and deliberately does not entrench it.** `grids/core/mod.rs::build_snapshot` still maps a step-limit cutoff to `Terminated` rather than `Truncated`, so the grids family still disagrees with `SantaFeAnt`, which emits `Truncated` for its time limit. `build_snapshot` is untouched here. Every new conformance test ends its episode on a *task* terminal — goal, lava, mission, collision — rather than the step limit, and none hard-codes `Terminated` for a step-limit ending, so fixing #1028 will not require rewriting any of them.

**The migration note on `Environment::step` stays.** Deleting it is #289's acceptance criterion, not this PR's: `locomotion` (#292), `box2d` (#293), `pixel_grid` (#294) and the `classic` bandits (#295) were each verified still unguarded.

**#125 stays closed.** Its pairwise-distinctness invariant was scoped in the docs precisely because a post-terminal step could still merge obstacles; that scoping is now removed. The rewritten prose was reviewed for the opposite failure — overclaiming — and holds: `move_obstacles` is private with exactly one call site, `step()`, strictly after `guard.check()?`.
