### PR TITLE
fix(env): Guard post-terminal step in box2d family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,55 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **Post-terminal `step()` kept integrating the physics sim across the whole
+  `box2d` family** (ADR 0044, resolves #293) — `BipedalWalker`, `CarRacing`,
+  `LunarLanderDiscrete` and `LunarLanderContinuous` checked only
+  `action.is_valid()`, so a `step()` taken past a done snapshot ran another
+  Rapier tick and emitted a fresh reward. The four terminal predicates are live
+  tests over the world, not latches, and every one of them keeps holding after
+  the episode ends, so the environments did not merely drift — they re-fired.
+
+  `LunarLander` is the sharp case, and the one #122 left exposed. That issue
+  made the terminal reward *overwritten* rather than accumulated: a crash sets
+  `reward = -100.0` exactly, discarding the shaping delta. A crashed hull stays
+  in ground contact, so `hull_in_contact()` was still `true` on the next call
+  and the unguarded environment re-emitted `Terminated` with a **fresh −100
+  every time**. Measured on the default config at `seed = 0`, free fall,
+  `DoNothing`: terminal at step 135 with −100, then −100 on each of five further
+  steps — **−600 banked for a single crash**, identically for both the discrete
+  and continuous variants, and unbounded because the contact never clears. A
+  rollout loop that steps once more before checking `is_done()` pays that
+  penalty again with no signal that anything went wrong. `BipedalWalker` had the
+  same shape one level deeper: a fallen hull re-pays the −100 fall penalty into
+  `total_reward`, which is itself the accumulator its `total_reward < -100.0`
+  termination rule reads.
+
+  All four now hold an `episode::EpisodeGuard`, `check()` it as the **first**
+  statement of `step()` — ahead of the `action.is_valid()` bounds check, because
+  the episode being over is a call-sequence fact independent of whether the
+  action was well-formed, and ahead of `world.step()`, the step counter and
+  `prev_shaping` — and `record()` the emitted snapshot's own status on a single
+  exit. Ordering the guard first also matters for `LunarLander`'s
+  `WindMode::Stochastic`: `step_common` calls `apply_wind` before anything else,
+  which draws from `wind_rng`, and ADR 0029 requires a rejected step to leave
+  every seed stream where it was. `BipedalWalker::reset` clears the guard only
+  *after* its fallible `rebuild_world()?` succeeds (ADR 0044 §6, the
+  `TimeLimit::reset` precedent); `LunarLander` clears it in the infallible
+  `LunarLanderCore::rebuild`, the single point both variants' `reset` funnels
+  through, so a future third variant cannot forget.
+
+  Each environment gained a `assert_rejects_post_terminal_step` conformance
+  test, a reset-reopens-the-episode test, and a state-untouched test that
+  compares the observation across the rejected call — for `CarRacing` that is
+  the full 96×96×3 frame, which is the direct evidence the world did not
+  integrate. `LunarLander` additionally pins the #122 regression on both
+  variants. Existing tests missed all of this because none of them stepped past
+  a terminal snapshot — they unwrapped every call and never asked what the
+  status was. `test_joint_obs_not_dead` is the one that shows it: it drove 30
+  unconditional `.unwrap()`ed steps with an asymmetric action that topples the
+  walker inside those 30, and only the absence of the guard kept it green. It
+  now breaks on `is_done()`, with both assertions intact on the terminal
+  snapshot.
 - **Post-terminal `step()` was an unbounded reward pump across the whole `grids`
   family** (ADR 0044, resolves #291) — all twelve gridworlds derived termination
   from a predicate over the *current* board rather than latching it, and the

--- a/crates/rlevo-core/src/environment.rs
+++ b/crates/rlevo-core/src/environment.rs
@@ -354,10 +354,12 @@ pub trait Environment<const R: usize, const SR: usize, const AR: usize> {
     /// The check belongs at the **top** of `step()`, before any state mutation,
     /// so a rejected call leaves the environment untouched.
     ///
-    /// **Migration note (alpha).** Only the `toy_text` family and the `TimeLimit`
-    /// wrapper currently enforce this. The behaviour of every other environment
-    /// after a terminal snapshot is **undefined** — see issue #289 for the
-    /// family-by-family rollout. Callers must not rely on it.
+    /// **Migration note (alpha).** The `toy_text`, `classic` (non-bandit),
+    /// `grids`, and `box2d` families and the `TimeLimit` wrapper enforce this.
+    /// The behaviour of the remaining environments — the `classic` module's
+    /// bandits, the `locomotion` family, and `pixel_grid` — after a terminal
+    /// snapshot is **undefined**; see issue #289 for the family-by-family
+    /// rollout. Callers must not rely on it there.
     ///
     /// # Errors
     ///

--- a/crates/rlevo-environments/src/box2d/bipedal_walker/env.rs
+++ b/crates/rlevo-environments/src/box2d/bipedal_walker/env.rs
@@ -28,6 +28,7 @@ use rlevo_core::environment::{
 use rlevo_core::reward::ScalarReward;
 
 use crate::box2d::physics::RapierWorld;
+use crate::episode::EpisodeGuard;
 
 use super::action::BipedalWalkerAction;
 use super::config::{BipedalTerrain, BipedalWalkerConfig};
@@ -73,6 +74,9 @@ const GROUND_Y: f32 = -1.0;
 /// `[hip1, knee1, hip2, knee2]` motor velocity targets. Components outside
 /// the valid range or containing non-finite values cause `step()` to return
 /// `Err(InvalidAction)`.
+///
+/// A [`step`](Environment::step) taken after the episode ended is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
 #[derive(Debug)]
 pub struct BipedalWalker {
     world: RapierWorld,
@@ -84,6 +88,13 @@ pub struct BipedalWalker {
     steps: usize,
     /// Running sum of rewards (for the < −100 termination check).
     total_reward: f32,
+    /// Rejects a `step()` taken after the walker fell (or the episode was
+    /// truncated). Neither termination condition is a latch the physics
+    /// enforces: the fallen hull stays in contact with the ground, so an
+    /// unguarded post-terminal step keeps re-applying the −100 fall penalty and
+    /// keeps driving `total_reward` further down, while the world, the step
+    /// counter and the motors advance past the episode the agent actually ran.
+    guard: EpisodeGuard,
 }
 
 impl BipedalWalker {
@@ -155,6 +166,7 @@ impl BipedalWalker {
             rng,
             steps: 0,
             total_reward: 0.0,
+            guard: EpisodeGuard::new(),
         };
         env.rebuild_world()?;
         Ok(env)
@@ -518,12 +530,22 @@ impl Environment<1, 1, 1> for BipedalWalker {
     /// Rebuild the physics world, reset counters, and return the initial
     /// observation with reward 0 and status `Running`.
     ///
+    /// Re-opens the [`EpisodeGuard`], so an environment whose walker fell (or
+    /// whose episode was truncated) becomes steppable again.
+    ///
     /// # Errors
     ///
     /// Returns [`EnvironmentError::Config`] if the active terrain generator
-    /// violates its output contract (ADR 0040) when the world is rebuilt.
+    /// violates its output contract (ADR 0040) when the world is rebuilt. On
+    /// that path the guard is deliberately left **latched**: the sole fallible
+    /// call runs first, and the guard is cleared only once a whole new world is
+    /// in hand. Clearing it first would re-open a finished episode over the
+    /// *old* physics world — the environment would happily step a state it never
+    /// returned to its initial condition (ADR 0044 §6, the same rule
+    /// `TimeLimit::reset` follows).
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
         self.rebuild_world()?;
+        self.guard.reset();
         self.steps = 0;
         self.total_reward = 0.0;
         self.state.leg1_contact = false;
@@ -543,9 +565,24 @@ impl Environment<1, 1, 1> for BipedalWalker {
     ///
     /// # Errors
     ///
-    /// Returns [`EnvironmentError::InvalidAction`] if any component of `action`
-    /// is outside `[-1, 1]` or is non-finite.
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended; call [`reset`](Environment::reset) first. Returns
+    /// [`EnvironmentError::InvalidAction`] if any component of `action` is
+    /// outside `[-1, 1]` or is non-finite.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — ahead of even the action-validity check: the episode
+        // being over is a fact about the *call sequence*, independent of whether
+        // the action itself is well-formed, so the caller must hear about the
+        // finished episode first. It also runs before `apply_motors`,
+        // `world.step()`, the `steps` tick and the `total_reward` accumulation,
+        // so a rejected call leaves the physics world, the step counter, the
+        // running reward and the RNG stream exactly as the terminal step left
+        // them (ADR 0029). `total_reward` is the specific state a post-terminal
+        // step would corrupt: it is a monotone accumulator that itself drives
+        // the `total_reward < -100.0` termination, so stepping past the end
+        // rewrites the very quantity that ended the episode.
+        self.guard.check()?;
+
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "BipedalWalkerAction components must be in [-1, 1], got {:?}",
@@ -587,12 +624,16 @@ impl Environment<1, 1, 1> for BipedalWalker {
 
         // Apply fall penalty
         let final_reward = if hull_down { reward - 100.0 } else { reward };
-        Ok(SnapshotBase {
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch can forget to record.
+        let snapshot = SnapshotBase {
             observation: obs,
             reward: ScalarReward(final_reward),
             status,
             metadata: None,
-        })
+        };
+        self.guard.record(snapshot.status);
+        Ok(snapshot)
     }
 }
 
@@ -683,6 +724,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
 
@@ -805,12 +847,20 @@ mod tests {
         let reset_snap = env.reset().unwrap();
         let reset_obs = reset_snap.observation().values;
 
-        // Drive asymmetric motor targets so joints move differently.
+        // Drive asymmetric motor targets so joints move differently. The
+        // asymmetric drive topples the walker well inside 30 steps, and since
+        // ADR 0044 a step past that terminal is rejected — so stop at the
+        // terminal snapshot and assert on it. The joints have already moved by
+        // then; the invariant under test is "the dims are live", not "the walker
+        // survived 30 steps".
         let mut moved_obs = reset_obs;
         for _ in 0..30 {
             let action = BipedalWalkerAction([1.0, -1.0, -1.0, 1.0]);
             let snap = env.step(action).unwrap();
             moved_obs = snap.observation().values;
+            if snap.is_done() {
+                break;
+            }
         }
 
         let joint_dims = [4usize, 5, 6, 7, 9, 10, 11, 12];
@@ -1035,6 +1085,124 @@ mod tests {
                 "hardcore reset obs must be finite for seed {seed}"
             );
         }
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #293) ──────────────────────
+
+    /// Upper bound on the steps the zero-action walker may take before the test
+    /// calls it a regression. Measured on the default flat-terrain config: the
+    /// unactuated walker's hull hits the ground on step 154 (`Terminated`, via
+    /// hull contact — `total_reward` is only ≈ −9.9 there, so it is the fall,
+    /// not the `< −100` rule, that ends it, and 1600-step truncation never comes
+    /// into play). The slack is generous so a legitimate physics tweak does not
+    /// turn the test flaky, but bounded so a broken termination check fails
+    /// loudly instead of hanging.
+    const FALL_STEP_CAP: usize = 800;
+
+    /// Drives a fresh episode to a real terminal by doing nothing: an
+    /// unactuated walker topples and the hull contacts the ground. The episode
+    /// ends through the genuine physics path an agent would hit, not by writing
+    /// state directly.
+    fn drive_to_fall(
+        env: &mut BipedalWalker,
+    ) -> SnapshotBase<1, BipedalWalkerObservation, ScalarReward> {
+        env.reset().expect("reset must succeed");
+        for _ in 0..FALL_STEP_CAP {
+            let snap = env
+                .step(BipedalWalkerAction([0.0; 4]))
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("an unactuated walker must fall within {FALL_STEP_CAP} steps");
+    }
+
+    #[test]
+    /// `BipedalWalker` satisfies the shared post-terminal conformance check:
+    /// once the walker has fallen, a further step with a *legal* action fails
+    /// with `StepAfterEpisodeEnd` carrying the status that ended the episode.
+    /// The replayed action is all-zeros — squarely inside `[-1, 1]` — so the
+    /// rejection can only be on call-sequence grounds, never on the action's own
+    /// validity.
+    fn test_bipedal_walker_rejects_post_terminal_step() {
+        let mut env = make_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_fall, BipedalWalkerAction([0.0; 4]));
+    }
+
+    #[test]
+    /// A rejected post-terminal step must mutate nothing observable. The fallen
+    /// hull stays in contact with the ground, so before the guard a further step
+    /// advanced the physics world and the step counter and kept accumulating
+    /// into `total_reward` — the very quantity the `< −100` termination reads.
+    fn test_bipedal_walker_post_terminal_step_does_not_mutate_state() {
+        let mut env = make_env();
+        let terminal = drive_to_fall(&mut env);
+        assert!(terminal.is_done(), "the fall must end the episode");
+        let ended = terminal.status();
+
+        let obs_at_end = terminal.observation().values;
+        let steps_at_end = env.steps;
+        let total_reward_at_end = env.total_reward;
+
+        let err = env
+            .step(BipedalWalkerAction([0.0; 4]))
+            .expect_err("a step after the fall must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.total_reward, total_reward_at_end,
+            "a rejected step must not accumulate into the running reward"
+        );
+        // Recomputed from the *live* physics world, so equality here proves the
+        // rejected call never ran `world.step()`.
+        assert_eq!(
+            env.compute_observation(env.state_for_test()).values,
+            obs_at_end,
+            "a rejected step must leave the observation byte-identical"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    fn test_bipedal_walker_reset_reopens_terminated_episode() {
+        let mut env = make_env();
+        drive_to_fall(&mut env);
+        assert!(
+            env.step(BipedalWalkerAction([0.0; 4])).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after termination");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        let snap = env
+            .step(BipedalWalkerAction([0.0; 4]))
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/car_racing/env.rs
+++ b/crates/rlevo-environments/src/box2d/car_racing/env.rs
@@ -56,6 +56,7 @@ use rlevo_core::environment::{
 use rlevo_core::reward::ScalarReward;
 
 use crate::box2d::physics::RapierWorld;
+use crate::episode::EpisodeGuard;
 
 use super::action::CarRacingAction;
 use super::config::CarRacingConfig;
@@ -82,6 +83,9 @@ const CAR_H: f32 = 4.0 / 30.0;
 /// - `step(action)` applies car controls and advances physics.
 /// - `Terminated` when the car visits ≥ 95% of track tiles.
 /// - `Truncated` after `config.max_steps` steps.
+/// - Either ending closes the episode: a further [`step`](Environment::step)
+///   returns [`EnvironmentError::StepAfterEpisodeEnd`] until [`reset`](Environment::reset)
+///   is called — see the [`EpisodeGuard`] field.
 ///
 /// # Observation (96×96×3)
 ///
@@ -98,6 +102,13 @@ pub struct CarRacing {
     config: CarRacingConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the episode ended. Neither ending is
+    /// self-limiting: `lap_complete` is a latched flag that stays set, so an
+    /// unguarded post-terminal step keeps re-emitting `Terminated`, and
+    /// `steps >= max_steps` keeps holding, so past the cap every further step
+    /// re-emits `Truncated` while still advancing the physics world and the step
+    /// counter past the budget the caller asked for.
+    guard: EpisodeGuard,
 }
 
 impl CarRacing {
@@ -126,6 +137,7 @@ impl CarRacing {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         };
         env.build_world();
         Ok(env)
@@ -379,7 +391,20 @@ impl Environment<3, 3, 1> for CarRacing {
     type RewardType = ScalarReward;
     type SnapshotType = SnapshotBase<3, CarRacingObservation, ScalarReward>;
 
+    /// Generates a fresh procedural track, rebuilds the physics world, and
+    /// returns the first snapshot of a new episode.
+    ///
+    /// The track is drawn from the environment's persistent RNG, so the stream
+    /// **advances** across resets and successive episodes race different tracks.
+    /// Tile-visit bookkeeping, the step counter and the episode guard are all
+    /// cleared, so a terminated or truncated environment becomes steppable again.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; always returns `Ok`. Track generation and world
+    /// construction cannot fail once the config has validated.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.track = Track::generate(&self.config, &mut self.rng);
         self.state.total_tiles = self.track.tiles.len();
         self.build_world();
@@ -391,7 +416,32 @@ impl Environment<3, 3, 1> for CarRacing {
         Ok(SnapshotBase::running(obs, ScalarReward(0.0)))
     }
 
+    /// Applies the car controls, advances the physics world by one fixed
+    /// timestep, and returns the resulting snapshot.
+    ///
+    /// Gas, brake, steer and lateral friction are turned into forces on the car
+    /// body, the world is integrated by `config.dt`, then the tile-visit sweep
+    /// marks newly covered tiles and pays `lap_reward / total_tiles` for each.
+    /// The step reward is that tile reward plus the constant `frame_penalty`.
+    /// The episode is `Terminated` once `tiles_visited` reaches
+    /// `lap_complete_percent × total_tiles`, and `Truncated` once `steps`
+    /// reaches `config.max_steps`.
+    ///
+    /// # Errors
+    ///
+    /// - [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has already
+    ///   ended (lap completed or step budget exhausted); call
+    ///   [`reset`](Environment::reset) first.
+    /// - [`EnvironmentError::InvalidAction`] if `action` violates the asymmetric
+    ///   bounds `steer ∈ [−1, 1]`, `gas ∈ [0, 1]`, `brake ∈ [0, 1]`.
     fn step(&mut self, action: CarRacingAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — ahead of the action check, the force application, the
+        // world integration, the step counter and the tile-visit sweep. Whether
+        // the episode is over is a call-sequence fact independent of the action's
+        // validity, and a rejected step must leave the physics world, `steps` and
+        // the tile bookkeeping exactly as the terminal step left them.
+        self.guard.check()?;
+
         // D5: validate asymmetric bounds
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
@@ -422,12 +472,16 @@ impl Environment<3, 3, 1> for CarRacing {
             self.state.is_valid(),
             "CarRacingState invariant violated after step"
         );
-        Ok(SnapshotBase {
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status, so the two cannot disagree.
+        let snap = SnapshotBase {
             observation: obs,
             reward: ScalarReward(reward),
             status,
             metadata: None,
-        })
+        };
+        self.guard.record(snap.status);
+        Ok(snap)
     }
 }
 
@@ -552,12 +606,185 @@ fn sweep_visits(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
+    use std::sync::Arc;
 
     /// Creates a default seeded `CarRacing` environment for use in tests.
     fn make_env() -> CarRacing {
         CarRacing::with_config(CarRacingConfig::default()).expect("valid config")
+    }
+
+    // ── post-terminal step guard (issue #293) ────────────────────────────────
+
+    /// Step budget for the guard tests. Each step rasterizes a 96×96×3 frame, so
+    /// the budget is kept tiny; truncation is a pure step-counter fact and does
+    /// not depend on how far the car actually gets.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    /// A legal no-op action: `steer = 0`, `gas = 0`, `brake = 0` all sit inside
+    /// the D5 asymmetric bounds, so any rejection of it is on call-sequence
+    /// grounds alone.
+    fn coast() -> CarRacingAction {
+        CarRacingAction::new(0.0, 0.0, 0.0)
+    }
+
+    /// Environment whose episodes truncate after [`GUARD_MAX_STEPS`] steps.
+    ///
+    /// Truncation is the terminal these tests drive to: `Terminated` needs
+    /// `lap_complete`, which under the real physics is not reachable by any
+    /// constant-control policy (the stiff wheel fixed-joints diverge to `NaN`
+    /// within a few steps and the car covers 2 of 60 tiles in 20 000 steps). The
+    /// lap-complete path is covered separately by
+    /// [`lap_completes_via_scripted_contiguous_sweep`], which teleports rather
+    /// than drives.
+    fn truncating_env() -> CarRacing {
+        let config = CarRacingConfig::builder()
+            .max_steps(GUARD_MAX_STEPS)
+            .build()
+            .expect("valid config");
+        CarRacing::with_config(config).expect("valid config")
+    }
+
+    /// Coasts until the step budget runs out and returns the truncated snapshot.
+    fn drive_to_truncation(
+        env: &mut CarRacing,
+    ) -> SnapshotBase<3, CarRacingObservation, ScalarReward> {
+        env.reset().expect("reset must succeed");
+        let mut snap = env.step(coast()).expect("first step must succeed");
+        while !snap.is_done() {
+            snap = env
+                .step(coast())
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    #[test]
+    /// `CarRacing` satisfies the shared post-terminal conformance check: once the
+    /// step budget is exhausted, a further `step()` with a *legal* action fails
+    /// with `StepAfterEpisodeEnd` carrying the status that ended the episode.
+    fn rejects_post_terminal_step() {
+        let mut env = truncating_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_truncation, coast());
+    }
+
+    #[test]
+    /// The same contract on the other terminal: a completed lap latches
+    /// `lap_complete`, so an unguarded post-terminal step would keep re-emitting
+    /// `Terminated`. The lap is reached by teleporting the car across the tile
+    /// centres in order — the physics cannot carry it round — and the sweep runs
+    /// through the real `update_tile_visits`.
+    fn rejects_post_terminal_step_after_lap_completion() {
+        let mut env = make_env();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            |env| {
+                env.reset().expect("reset must succeed");
+                let total = env.state_for_test().total_tiles();
+                let car = env.state_for_test().car_handle();
+                for i in 0..total {
+                    let centre = env.track.tiles[i].centre;
+                    if let Some(body) = env.world.bodies_mut().get_mut(car) {
+                        body.set_translation(Vector::new(centre[0], centre[1]), true);
+                    }
+                    env.update_tile_visits();
+                }
+                env.step(coast())
+                    .expect("the lap-closing step must succeed")
+            },
+            coast(),
+        );
+    }
+
+    #[test]
+    /// Regression for what the guard removes: past `max_steps` the truncation
+    /// predicate keeps holding, so an unguarded post-terminal step would advance
+    /// the physics world and the step counter past the budget the caller asked
+    /// for while re-emitting `Truncated`. A rejected step must mutate nothing —
+    /// the step counter, the tile bookkeeping, the guard, and the rendered frame
+    /// (all 96×96×3 bytes of it) must be exactly as the terminal step left them.
+    fn post_terminal_step_does_not_mutate_state() {
+        let mut env = truncating_env();
+        let terminal = drive_to_truncation(&mut env);
+        let ended = terminal.status();
+        assert_eq!(
+            ended,
+            EpisodeStatus::Truncated,
+            "the step budget must truncate the episode"
+        );
+
+        let steps_at_end = env.steps;
+        let visited_at_end = env.state_for_test().tiles_visited();
+        let tile_at_end = env.state_for_test().current_tile();
+        let frame_at_end = Arc::clone(&terminal.observation().pixels);
+
+        let err = env
+            .step(coast())
+            .expect_err("a step after truncation must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.state_for_test().tiles_visited(),
+            visited_at_end,
+            "a rejected step must not mark further tiles"
+        );
+        assert_eq!(
+            env.state_for_test().current_tile(),
+            tile_at_end,
+            "a rejected step must not advance the current tile"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+        // The frame is a pure function of the world pose and the tile colours, so
+        // an unchanged frame is direct evidence the physics world did not step.
+        let frame_after = env.observe_reset(&env.state);
+        assert!(
+            *frame_after.pixels == *frame_at_end,
+            "a rejected step must not advance the physics world (frame changed)"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    fn reset_reopens_finished_episode() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+        assert!(
+            env.step(coast()).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after truncation");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+
+        let snap = env
+            .step(coast())
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/box2d/lunar_lander/env.rs
+++ b/crates/rlevo-environments/src/box2d/lunar_lander/env.rs
@@ -42,6 +42,7 @@ use rlevo_core::environment::{
 use rlevo_core::reward::ScalarReward;
 
 use crate::box2d::physics::RapierWorld;
+use crate::episode::EpisodeGuard;
 
 use super::action_continuous::LunarLanderContinuousAction;
 use super::action_discrete::LunarLanderDiscreteAction;
@@ -76,6 +77,21 @@ struct LunarLanderCore {
     rng: StdRng,
     wind_rng: Option<StdRng>,
     steps: usize,
+    /// Rejects a `step()` taken after the episode already ended.
+    ///
+    /// Both variants own their own `LunarLanderCore`, so one guard per
+    /// environment instance covers `LunarLanderDiscrete` and
+    /// `LunarLanderContinuous` without duplicating the field.
+    ///
+    /// The guard is load-bearing here because the terminal predicates in
+    /// [`Self::step_common`] are *tests over the live world*, not latches: a
+    /// crashed hull stays on the ground, so `hull_in_contact()` (and the
+    /// out-of-bounds check) keeps holding, and every further step re-runs the
+    /// Gym reward **overwrite** and re-emits a fresh `Terminated` snapshot
+    /// paying another −100. Measured before this guard: a seed-0 free fall
+    /// crashes at step 135 with −100, then re-emits −100 on each of five
+    /// further steps (running total −600 for a single crash).
+    guard: EpisodeGuard,
 }
 
 impl LunarLanderCore {
@@ -102,12 +118,23 @@ impl LunarLanderCore {
             rng,
             wind_rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
         };
         core.rebuild();
         Ok(core)
     }
 
+    /// Tears down and rebuilds the physics world, starting a fresh episode.
+    ///
+    /// The [`EpisodeGuard`] is cleared **here** rather than in each variant's
+    /// `Environment::reset`: `rebuild` is the single place the episode actually
+    /// begins (both `reset` impls and `new` funnel through it), and it is
+    /// infallible, so there is no partial-reset window in which the world is
+    /// fresh but the guard still reads `Terminated`. Clearing it in the two
+    /// `reset` impls instead would put the invariant one copy-paste away from
+    /// being broken by a third variant.
     fn rebuild(&mut self) {
+        self.guard.reset();
         self.world = RapierWorld::new(Vector::new(0.0, self.config.gravity), self.config.dt);
 
         // Ground
@@ -379,8 +406,10 @@ impl LunarLanderCore {
 ///
 /// [`SnapshotBase`]: rlevo_core::environment::SnapshotBase
 ///
-/// Actions never return an error; all four [`LunarLanderDiscreteAction`] variants
-/// are always valid.
+/// All four [`LunarLanderDiscreteAction`] variants are always valid, so the only
+/// error [`step`](Environment::step) can return is
+/// [`EnvironmentError::StepAfterEpisodeEnd`], raised once the episode has ended
+/// — see the [`EpisodeGuard`] field on the shared core.
 #[derive(Debug)]
 pub struct LunarLanderDiscrete {
     core: LunarLanderCore,
@@ -462,11 +491,24 @@ impl Environment<1, 1, 1> for LunarLanderDiscrete {
     ///   of bounds (reward −100), or landed softly (reward +100).
     /// - `Truncated` — `config.max_steps` reached without a terminal event.
     ///
-    /// This variant never returns `Err`; the result is always `Ok`.
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended (crash, landing, or step-limit truncation); call
+    /// [`reset`](Environment::reset) first. All four
+    /// [`LunarLanderDiscreteAction`] variants are always valid, so this is the
+    /// only error this variant can return.
     fn step(
         &mut self,
         action: LunarLanderDiscreteAction,
     ) -> Result<LunarLanderSnapshot, EnvironmentError> {
+        // Guard first: before `step_common` touches the Rapier world, `steps`,
+        // `prev_shaping`, or the stochastic-wind stream. `step_common` calls
+        // `apply_wind` as its first act, which under `WindMode::Stochastic`
+        // draws from `wind_rng` — and ADR 0029 requires a rejected step to
+        // leave every seed stream where it was.
+        self.core.guard.check()?;
+
         let (main, lateral) = match action {
             LunarLanderDiscreteAction::DoNothing => (0.0, 0.0),
             LunarLanderDiscreteAction::LeftEngine => (0.0, -1.0),
@@ -475,12 +517,16 @@ impl Environment<1, 1, 1> for LunarLanderDiscrete {
         };
         let (obs, reward, status) = self.core.step_common(main, lateral);
         let meta = shaping_metadata(self.core.shaping_value());
+        // Single exit: every branch builds exactly one snapshot, and the guard
+        // is fed that snapshot's own status, so no branch can forget to record.
         let snap = match status {
             EpisodeStatus::Running => LunarLanderSnapshot::running(obs, ScalarReward(reward)),
             EpisodeStatus::Terminated => LunarLanderSnapshot::terminated(obs, ScalarReward(reward)),
             EpisodeStatus::Truncated => LunarLanderSnapshot::truncated(obs, ScalarReward(reward)),
         }
         .with_metadata(meta);
+
+        self.core.guard.record(snap.status);
         Ok(snap)
     }
 }
@@ -491,7 +537,10 @@ impl Environment<1, 1, 1> for LunarLanderDiscrete {
 ///
 /// Each action is a `[f32; 2]` vector wrapped in [`LunarLanderContinuousAction`].
 /// Both components must lie in `[-1, 1]` and be finite; `step` returns
-/// `Err(EnvironmentError::InvalidAction)` otherwise (design decision D5).
+/// `Err(EnvironmentError::InvalidAction)` otherwise (design decision D5). Once
+/// the episode has ended, `step` returns
+/// [`EnvironmentError::StepAfterEpisodeEnd`] instead — that check precedes the
+/// bounds check, since episode-over does not depend on the action.
 ///
 /// The main-engine component maps as follows: values in `[-1, 0]` are treated as
 /// off (no thrust); values in `(0, 1]` scale the main engine linearly. The lateral
@@ -579,6 +628,12 @@ impl Environment<1, 1, 1> for LunarLanderContinuous {
     ///
     /// # Errors
     ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended (crash, landing, or step-limit truncation); call
+    /// [`reset`](Environment::reset) first. This check runs **before** the
+    /// action check below, so a post-terminal step is rejected on
+    /// call-sequence grounds even when the action is also out of range.
+    ///
     /// Returns `Err(EnvironmentError::InvalidAction)` if either component of
     /// `action` is outside `[-1, 1]` or is non-finite (design decision D5).
     ///
@@ -588,6 +643,16 @@ impl Environment<1, 1, 1> for LunarLanderContinuous {
         &mut self,
         action: LunarLanderContinuousAction,
     ) -> Result<LunarLanderSnapshot, EnvironmentError> {
+        // Guard first — ahead of the D5 bounds check. Episode-over is a fact
+        // about the call *sequence*, independent of whether this particular
+        // action is well-formed, so it is the stronger and earlier rejection.
+        // Placing it first also keeps a rejected step from touching the Rapier
+        // world, `steps`, `prev_shaping`, or the stochastic-wind stream:
+        // `step_common` calls `apply_wind` first thing, which under
+        // `WindMode::Stochastic` draws from `wind_rng`, and ADR 0029 requires a
+        // rejected step to leave every seed stream exactly where it was.
+        self.core.guard.check()?;
+
         // D5: validate action bounds
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
@@ -600,12 +665,16 @@ impl Environment<1, 1, 1> for LunarLanderContinuous {
         let main = main_raw.max(0.0);
         let (obs, reward, status) = self.core.step_common(main, lateral);
         let meta = shaping_metadata(self.core.shaping_value());
+        // Single exit: every branch builds exactly one snapshot, and the guard
+        // is fed that snapshot's own status, so no branch can forget to record.
         let snap = match status {
             EpisodeStatus::Running => LunarLanderSnapshot::running(obs, ScalarReward(reward)),
             EpisodeStatus::Terminated => LunarLanderSnapshot::terminated(obs, ScalarReward(reward)),
             EpisodeStatus::Truncated => LunarLanderSnapshot::truncated(obs, ScalarReward(reward)),
         }
         .with_metadata(meta);
+
+        self.core.guard.record(snap.status);
         Ok(snap)
     }
 }
@@ -818,6 +887,7 @@ mod tests {
 
     use super::super::snapshot::METADATA_KEY_SHAPING;
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::DiscreteAction;
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
@@ -1093,6 +1163,223 @@ mod tests {
     // hand-written script without flakiness, so the landing branch is left to
     // integration-level policy tests. Tests 1 and 2 above are deterministic and
     // directly exercise the truncation and (newly live) hull-crash branches.
+
+    // ── post-terminal step guard (issue #293, regression for #122) ───────────
+
+    /// Deterministic config shared by the guard tests: seed 0 free-falls into
+    /// the hull-crash terminal at step 135, well inside `max_steps` (1000).
+    fn guard_cfg() -> LunarLanderConfig {
+        LunarLanderConfig::builder()
+            .seed(0)
+            .build()
+            .expect("valid config")
+    }
+
+    /// Upper bound on the free-fall drive; `guard_cfg`'s own `max_steps` is
+    /// 1000 and the crash lands at 135, so this only fires if termination
+    /// regressed.
+    const FREE_FALL_CAP: usize = 1_000;
+
+    /// Drives a discrete lander to its terminal snapshot by free fall (no
+    /// thrust) and returns it. The terminal is a *crash*: the hull contacts the
+    /// ground and the reward is overwritten to −100.
+    ///
+    /// The `+100` **landing** terminal is not driven here. As the note above
+    /// `render_styled_matches_ascii` records, a soft landing needs a control
+    /// policy that nulls out velocity and angle and lets both legs settle, and
+    /// no fixed hand-written action script achieves it without flakiness. The
+    /// guard is status-based, not reward-based — it records
+    /// `snap.status()`, which is `Terminated` on both paths — so covering the
+    /// crash terminal covers the landing terminal's guard behaviour too.
+    fn crash_discrete(env: &mut LunarLanderDiscrete) -> LunarLanderSnapshot {
+        env.reset().expect("reset must succeed");
+        for _ in 0..FREE_FALL_CAP {
+            let snap = env
+                .step(LunarLanderDiscreteAction::DoNothing)
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("free fall must reach the hull-crash terminal within {FREE_FALL_CAP} steps");
+    }
+
+    /// Continuous counterpart of [`crash_discrete`]; a zero action is the
+    /// continuous no-op, so the trajectory is the same free fall.
+    fn crash_continuous(env: &mut LunarLanderContinuous) -> LunarLanderSnapshot {
+        env.reset().expect("reset must succeed");
+        for _ in 0..FREE_FALL_CAP {
+            let snap = env
+                .step(LunarLanderContinuousAction([0.0, 0.0]))
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                return snap;
+            }
+        }
+        panic!("free fall must reach the hull-crash terminal within {FREE_FALL_CAP} steps");
+    }
+
+    /// Conformance: once the lander has crashed, a further step with an always
+    /// valid action fails with `StepAfterEpisodeEnd { status: Terminated }`.
+    #[test]
+    fn test_lunar_lander_discrete_rejects_post_terminal_step() {
+        let mut env = LunarLanderDiscrete::with_config(guard_cfg()).expect("valid config");
+        assert_rejects_post_terminal_step(
+            &mut env,
+            crash_discrete,
+            LunarLanderDiscreteAction::DoNothing,
+        );
+    }
+
+    /// Conformance for the continuous variant. The replayed action is `[0, 0]`,
+    /// squarely inside the D5 bounds, so the rejection can only be on
+    /// call-sequence grounds — never on the action's own validity.
+    #[test]
+    fn test_lunar_lander_continuous_rejects_post_terminal_step() {
+        let mut env = LunarLanderContinuous::with_config(guard_cfg()).expect("valid config");
+        assert_rejects_post_terminal_step(
+            &mut env,
+            crash_continuous,
+            LunarLanderContinuousAction([0.0, 0.0]),
+        );
+    }
+
+    /// Regression for the reward pump behind issue #122.
+    ///
+    /// `step_common` **overwrites** a terminal step's reward with −100,
+    /// discarding the shaping delta. The crash predicate is a live test —
+    /// `hull_in_contact()` — not a latch, and a crashed hull stays on the
+    /// ground, so before the guard every further step re-ran the physics,
+    /// re-satisfied the predicate and re-emitted a fresh `Terminated` snapshot
+    /// paying another −100. Measured against the pre-guard code (seed 0, free
+    /// fall, both variants): terminal at step 135 with reward −100, then −100
+    /// on each of five further steps — running total −600 for a single crash.
+    ///
+    /// The guard closes it: each of those five calls is now an `Err`, and no
+    /// further reward is emitted at all.
+    #[test]
+    fn test_lunar_lander_discrete_post_terminal_step_does_not_repay_crash_penalty() {
+        let mut env = LunarLanderDiscrete::with_config(guard_cfg()).expect("valid config");
+        let terminal = crash_discrete(&mut env);
+        assert!(
+            terminal.is_terminated(),
+            "free fall must crash the hull, got {:?}",
+            terminal.status()
+        );
+        approx::assert_relative_eq!(terminal.reward().0, -100.0, epsilon = 1e-4);
+
+        for i in 1..=5 {
+            let err = env
+                .step(LunarLanderDiscreteAction::DoNothing)
+                .expect_err("post-terminal step must Err, not re-emit another -100 snapshot");
+            match err {
+                EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                    status,
+                    EpisodeStatus::Terminated,
+                    "post-terminal step {i} must carry the status that ended the episode"
+                ),
+                other => {
+                    panic!("post-terminal step {i}: expected StepAfterEpisodeEnd, got {other:?}")
+                }
+            }
+        }
+    }
+
+    /// Continuous counterpart of the #122 reward-pump regression; the pre-guard
+    /// numbers were identical (−100 at step 135, then −100 per post-terminal
+    /// step, total −600 over five).
+    #[test]
+    fn test_lunar_lander_continuous_post_terminal_step_does_not_repay_crash_penalty() {
+        let mut env = LunarLanderContinuous::with_config(guard_cfg()).expect("valid config");
+        let terminal = crash_continuous(&mut env);
+        assert!(terminal.is_terminated(), "free fall must crash the hull");
+        approx::assert_relative_eq!(terminal.reward().0, -100.0, epsilon = 1e-4);
+
+        for i in 1..=5 {
+            let err = env
+                .step(LunarLanderContinuousAction([0.0, 0.0]))
+                .expect_err("post-terminal step must Err, not re-emit another -100 snapshot");
+            assert!(
+                matches!(
+                    err,
+                    EnvironmentError::StepAfterEpisodeEnd {
+                        status: EpisodeStatus::Terminated
+                    }
+                ),
+                "post-terminal step {i}: expected StepAfterEpisodeEnd(Terminated), got {err:?}"
+            );
+        }
+    }
+
+    /// A rejected post-terminal step must be a true no-op: the physics world,
+    /// the step counter, the shaping potential (and hence the snapshot
+    /// metadata) and the guard itself all read exactly as the terminal step
+    /// left them.
+    #[test]
+    fn test_lunar_lander_rejected_post_terminal_step_leaves_state_untouched() {
+        let mut env = LunarLanderDiscrete::with_config(guard_cfg()).expect("valid config");
+        let terminal = crash_discrete(&mut env);
+        let terminal_shaping = terminal
+            .metadata()
+            .expect("the terminal snapshot carries shaping metadata")
+            .components[METADATA_KEY_SHAPING];
+
+        let obs_before = env.core.compute_obs().values;
+        let steps_before = env.core.steps;
+
+        env.step(LunarLanderDiscreteAction::MainEngine)
+            .expect_err("the episode has ended; this step must be rejected");
+
+        assert_eq!(
+            env.core.compute_obs().values,
+            obs_before,
+            "a rejected step must not advance the Rapier world"
+        );
+        assert_eq!(
+            env.core.steps, steps_before,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            shaping_metadata(env.core.shaping_value()).components[METADATA_KEY_SHAPING],
+            terminal_shaping,
+            "a rejected step must not move the shaping potential"
+        );
+        assert_eq!(
+            env.core.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// `reset()` re-opens a terminated environment for a second episode —
+    /// `LunarLanderCore::rebuild` clears the guard, so both variants inherit
+    /// this without their own `reset` remembering to do anything.
+    #[test]
+    fn test_lunar_lander_reset_reopens_terminated_episode() {
+        let mut env = LunarLanderDiscrete::with_config(guard_cfg()).expect("valid config");
+        crash_discrete(&mut env);
+        assert!(
+            env.step(LunarLanderDiscreteAction::DoNothing).is_err(),
+            "the episode has terminated; a step must be rejected before reset()"
+        );
+
+        env.reset().expect("reset must succeed after termination");
+        let snap = env
+            .step(LunarLanderDiscreteAction::DoNothing)
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
+
+        let mut env = LunarLanderContinuous::with_config(guard_cfg()).expect("valid config");
+        crash_continuous(&mut env);
+        env.reset().expect("reset must succeed after termination");
+        assert!(
+            env.step(LunarLanderContinuousAction([0.0, 0.0])).is_ok(),
+            "reset() must re-open the continuous variant too"
+        );
+    }
 
     #[test]
     fn render_styled_matches_ascii() {

--- a/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
+++ b/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
@@ -258,9 +258,10 @@ enforce it today: the
 `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
 `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
 `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
-`grids` environments, and the
+`grids` environments, the `box2d` family (`BipedalWalker`, `CarRacing`,
+`LunarLanderDiscrete`, `LunarLanderContinuous`), and the
 `TimeLimit` wrapper. The `classic` module's bandits, the
-`locomotion` and `box2d` families, and `pixel_grid` do not yet — their
+`locomotion` family, and `pixel_grid` do not yet — their
 behaviour after a terminal snapshot remains **undefined**; do not depend on it,
 even by accident, until it lands for that family — the rollout is tracked
 family-by-family in
@@ -416,8 +417,8 @@ the crate as a vocabulary anchor more than a workhorse.
 - **A `step()` taken after `is_done()` is `true` is an error, not a silent
   resume.** It returns `EnvironmentError::StepAfterEpisodeEnd { status }`; call
   `reset()` to start a new episode. The `toy_text` family, the `classic`
-  family's non-bandit environments, the `grids` family, and `TimeLimit` enforce
-  this today
+  family's non-bandit environments, the `grids` family, the `box2d` family, and
+  `TimeLimit` enforce this today
   ([issue #289](https://github.com/anthonytorlucci/rlevo/issues/289) tracks
   the rest).
 - **`ConstructableEnv`** keeps construction off the behaviour trait so

--- a/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
+++ b/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
@@ -320,8 +320,8 @@ The rule your `step` must satisfy: once you have emitted a snapshot whose
 status is done, the *only* legal next call is `reset()`; a further `step()`
 must return `Err(EnvironmentError::StepAfterEpisodeEnd { status })`. You don't
 have to hand-write that state machine — `rlevo_environments::episode::EpisodeGuard`
-is the one-field helper the `toy_text` and `classic` (non-bandit) families
-already hold for exactly this. Add it to your struct:
+is the one-field helper the `toy_text`, `classic` (non-bandit), `grids`, and
+`box2d` families already hold for exactly this. Add it to your struct:
 
 ```rust,no_run
 use rlevo_environments::episode::EpisodeGuard;
@@ -382,10 +382,11 @@ Three details here are load-bearing, not stylistic:
 > `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
 > `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
 > `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
-> `grids` environments, and the
+> `grids` environments, the `box2d` family (`BipedalWalker`, `CarRacing`,
+> `LunarLanderDiscrete`, `LunarLanderContinuous`), and the
 > `TimeLimit` wrapper all hold one. The `classic` module's bandits
 > (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
-> `AdversarialBandit`), the `locomotion` and `box2d` families, and
+> `AdversarialBandit`), the `locomotion` family, and
 > `pixel_grid` do not yet — their post-terminal behaviour is undefined,
 > tracked family-by-family in
 > [issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). Your own
@@ -432,7 +433,8 @@ algorithm will drive your environment correctly:
   `EnvironmentError::StepAfterEpisodeEnd` rather than silently continuing — see
   [Step 5](#step-5--guard-the-post-terminal-step) above for the `EpisodeGuard`
   recipe. (The `toy_text` family, the `classic` family's non-bandit
-  environments, the `grids` family, and `TimeLimit` enforce this today; treat it
+  environments, the `grids` and `box2d` families, and `TimeLimit` enforce this
+  today; treat it
   as the target for any environment you write, not yet a workspace-wide
   guarantee.)
 - **Neither method panics on valid input.** Return `EnvironmentError::InvalidAction`


### PR DESCRIPTION
## Summary

Applies the `EpisodeGuard` post-terminal `step()` contract (ADR 0044, established in #105) to the `box2d` family. All four environments — `BipedalWalker`, `CarRacing`, `LunarLanderDiscrete`, `LunarLanderContinuous` — checked only `action.is_valid()`, so a `step()` taken past a done snapshot ran another Rapier tick and emitted a fresh reward. Their terminal predicates are live tests over the physics world rather than latches, and every one keeps holding after the episode ends, so the environments did not merely drift — they re-fired. `LunarLander` is the sharp case: because #122 made the terminal reward *overwritten* rather than accumulated (`reward = -100.0` exactly on a crash) and a crashed hull stays in ground contact, an unguarded post-terminal step re-emitted `Terminated` with a **fresh −100 every call** — measured at −600 for a single crash, and unbounded.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #293

Sub-issue of #289 (family-by-family rollout). Related: #122, whose overwrite semantics are what made the re-emission cost a full −100 per call.

## What Was Changed

- `crates/rlevo-environments/src/box2d/bipedal_walker/env.rs` — `guard: EpisodeGuard` field; `guard.check()?` as the first statement of `step()`, ahead of the `[-1,1]` action-bounds check; `guard.record(snapshot.status)` on a single exit; `reset()` clears the guard **only after** `rebuild_world()?` succeeds (ADR 0044 §6, matching `TimeLimit::reset`); `# Errors` rustdoc documents `StepAfterEpisodeEnd`.
- `crates/rlevo-environments/src/box2d/car_racing/env.rs` — same guard shape; `check()?` ahead of the D5 asymmetric-bounds check; `step()` rustdoc brought up to the `classic`-family standard.
- `crates/rlevo-environments/src/box2d/lunar_lander/env.rs` — guard lives on the shared `LunarLanderCore` (one per environment instance) and is cleared in the infallible `LunarLanderCore::rebuild`, the single point both variants' `reset()` funnels through. Both `step()` impls guard first. `LunarLanderDiscrete::step`'s rustdoc claim *"This variant never returns `Err`; the result is always `Ok`"* was false after this change and is now a proper `# Errors` section.
- `crates/rlevo-core/src/environment.rs` — the `Environment::step` migration note is **refreshed, not deleted**. It had drifted to claiming only `toy_text` and `TimeLimit` enforce the contract, two families out of date; it now names the enforcing set and the outstanding one. #289's third acceptance criterion (delete it) is not met until #292, #294 and #295 land.
- `docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md`, `docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md` — the "which families enforce this today" lists move `box2d` from the outstanding side to the enforcing side, in all four places they appear.
- `CHANGELOG.md` — entry under `[Unreleased]` → `### rlevo-environments` → **Fixed**.

## How It Was Tested

```
cargo build --workspace                      # Finished, no errors
cargo test --workspace                       # 3019 passed, 0 failed
cargo clippy --all-targets --all-features    # Finished, zero warnings
cargo fmt --all --check                      # clean
cd docs/user-book && mdbook build            # ok
```

**Regression tests added.** Each environment gained a conformance test via the shared `episode::assert_rejects_post_terminal_step` helper, a reset-reopens-the-episode test, and a state-untouched test that compares the observation across the rejected call — for `CarRacing` that is the full 96×96×3 frame, rendered independently rather than cloned from the terminal snapshot's `Arc`, which is the direct evidence the world did not integrate. `LunarLander` additionally pins the #122 regression on both variants (`test_lunar_lander_{discrete,continuous}_post_terminal_step_does_not_repay_crash_penalty`).

**Before/after, measured rather than inferred** — `LunarLander`, default config, `seed = 0`, free fall, `DoNothing`:

```
TERMINAL at step 135, reward -100
post-terminal step 1: status=Terminated reward=-100 running_total=-200
post-terminal step 2: status=Terminated reward=-100 running_total=-300
post-terminal step 3: status=Terminated reward=-100 running_total=-400
post-terminal step 4: status=Terminated reward=-100 running_total=-500
post-terminal step 5: status=Terminated reward=-100 running_total=-600
```

Identical for `LunarLanderContinuous`. After the fix, each of those five calls is `Err(StepAfterEpisodeEnd { status: Terminated })`.

**The new tests were verified to be load-bearing**, not decorative: deleting each `guard.check()?` in turn and re-running the suite fails 3/3 of the new `bipedal_walker` tests, 4/4 of `car_racing`'s, and the discrete and continuous `lunar_lander` guards fail independently of each other.

**One pre-existing test changed.** `test_joint_obs_not_dead` drove 30 unconditional `.unwrap()`ed steps with an asymmetric action that topples the walker inside those 30 — only the guard's absence kept it green. It now breaks on `is_done()`, with both assertions intact and evaluated on the terminal snapshot. No assertion was weakened.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`), `rustc 1.94.1 (e408947bf 2026-03-25)`
- Burn backend tested: n/a — this change is confined to `rlevo-environments` and `rlevo-core`; no tensor or backend code is touched
- OS: macOS 26.5.2 (aarch64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change — implementation, tests, changelog and user-book edits — authored by delegated agents under my direction and reviewed by me before commit. The measured reward-pump figures and the guard-removal test-adequacy check are executed output, not model claims.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- **Ordering matters, and it is the one thing to check in review.** The guard must precede the action-validity check: the episode being over is a call-sequence fact independent of whether the action was well-formed, and validating first means a caller who replays a malformed action past a terminal gets `InvalidAction` — the wrong diagnosis. Sharper still for `LunarLander` under `WindMode::Stochastic`, which draws from `wind_rng` inside `apply_wind`, the first thing `step_common` does: ADR 0029 requires a rejected step to leave every seed stream untouched. The same trap applies to `locomotion` (#292).
- **Unrelated defect found on the way past, filed as #1033.** `CarRacing`'s wheel `FixedJoint` solver diverges to NaN within 8–18 steps under **any** action including a strict no-op (linvel `1e-13 → 708 → 78708 → NaN` with zero applied force), and `CarRacingState::is_valid()` has no finiteness predicate, so `step()` returns `Ok` with garbage frames indefinitely. Orthogonal to this change — the guard neither causes nor papers over it — but it is why the `CarRacing` conformance test here drives to `Truncated` rather than to a completed lap. Note the tile-sweep logic is *not* at fault: a lap does complete through the ordinary `step()` path at a threshold reachable before divergence.
- **Follow-up on #289.** Four of six sub-issues are now closed; #292 (`locomotion`), #294 (`pixel_grid`) and #295 (bandits) remain, and whoever lands the last of them deletes the `Environment::step` migration note.
