### PR TITLE
fix(env): Guard post-terminal step in locomotion family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **Post-terminal `step()` kept integrating the Rapier sim across the whole
+  `locomotion` family** (ADR 0044, resolves #292) — `InvertedPendulum`,
+  `InvertedDoublePendulum`, `Reacher` and `Swimmer` gated `step()` only on
+  `action.is_valid()`, so a step taken past a done snapshot ran another
+  physics tick and the observation drifted past termination.
+
+  The two pendulums are the sharp case: their healthiness predicates are live
+  reads of the current pose, not latches. A toppled pole that swings back
+  through `|θ| < 0.2` (`InvertedPendulum`) or a tip that swings back above the
+  healthy z floor (`InvertedDoublePendulum`) re-earns the alive bonus (+1,
+  +10 respectively) on a **`Running`** snapshot — a finished episode was
+  silently resurrected, not merely drifted. `Reacher` and `Swimmer` have no
+  `Terminated` path at all — their only done status is `Truncated` at `steps
+  >= max_steps` — so for them the defect was unbounded stepping past the
+  truncation boundary rather than reward re-firing.
+
+  All four now hold an `episode::EpisodeGuard`, `check()` it as the **first**
+  statement of `step()` — ahead of the `action.is_valid()` bounds check,
+  because the episode being over is a call-sequence fact independent of
+  whether the action was well-formed — and `record()` the emitted snapshot's
+  own status on a single exit. One observable side effect of the ordering: a
+  replayed malformed action taken past a terminal now reports
+  `StepAfterEpisodeEnd` rather than `InvalidAction`.
+
+  Each environment gained an `assert_rejects_post_terminal_step` conformance
+  test and a reset-reopens-the-episode test. Existing tests missed the defect
+  because none of them stepped past a done snapshot; `Reacher`'s
+  `reward_distance_is_nonpositive` and `reward_control_is_nonpositive` each
+  drive exactly 50 unconditional steps against a default `max_steps == 50` —
+  they land precisely **on** the truncation boundary, and one more iteration
+  in either would have caught it.
 - **Post-terminal `step()` kept integrating the physics sim across the whole
   `box2d` family** (ADR 0044, resolves #293) — `BipedalWalker`, `CarRacing`,
   `LunarLanderDiscrete` and `LunarLanderContinuous` checked only

--- a/crates/rlevo-core/src/environment.rs
+++ b/crates/rlevo-core/src/environment.rs
@@ -355,9 +355,9 @@ pub trait Environment<const R: usize, const SR: usize, const AR: usize> {
     /// so a rejected call leaves the environment untouched.
     ///
     /// **Migration note (alpha).** The `toy_text`, `classic` (non-bandit),
-    /// `grids`, and `box2d` families and the `TimeLimit` wrapper enforce this.
-    /// The behaviour of the remaining environments — the `classic` module's
-    /// bandits, the `locomotion` family, and `pixel_grid` — after a terminal
+    /// `grids`, `box2d`, and `locomotion` families and the `TimeLimit` wrapper
+    /// enforce this. The behaviour of the remaining environments — the
+    /// `classic` module's bandits and `pixel_grid` — after a terminal
     /// snapshot is **undefined**; see issue #289 for the family-by-family
     /// rollout. Callers must not rely on it there.
     ///

--- a/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/env.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_double_pendulum/env.rs
@@ -12,6 +12,7 @@ use rlevo_core::environment::{
 };
 use rlevo_core::reward::ScalarReward;
 
+use crate::episode::EpisodeGuard;
 use crate::locomotion::backend::{LocomotionBackend, Pose, Rapier3DBackend, Rapier3DWorld};
 use crate::locomotion::common::{LocomotionSnapshot, TerminationMode, wrap_to_pi};
 
@@ -40,6 +41,9 @@ pub const METADATA_KEY_VELOCITY: &str = "velocity";
 ///
 /// See the [module documentation](super) for the full observation layout,
 /// reward formula, and Gymnasium divergence notes.
+///
+/// A [`step`](Environment::step) taken after the episode ended is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
 #[derive(Debug)]
 pub struct InvertedDoublePendulum<B: LocomotionBackend = Rapier3DBackend> {
     world: B::World,
@@ -47,6 +51,15 @@ pub struct InvertedDoublePendulum<B: LocomotionBackend = Rapier3DBackend> {
     config: InvertedDoublePendulumConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the tip dropped (or the episode was
+    /// truncated). Neither status is a latch the physics enforces: the
+    /// healthiness test is a live read of the current tip height and the step
+    /// counter keeps climbing, so an unguarded post-terminal step integrates
+    /// another frame, ticks `steps` and pays a fresh reward — and a chaotic
+    /// double pendulum whose tip swings back above the threshold even re-earns
+    /// the `+10` alive bonus on a `Running` snapshot, silently resurrecting the
+    /// episode.
+    guard: EpisodeGuard,
     _marker: PhantomData<B>,
 }
 
@@ -75,6 +88,7 @@ impl InvertedDoublePendulum<Rapier3DBackend> {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
             _marker: PhantomData,
         })
     }
@@ -85,6 +99,10 @@ impl InvertedDoublePendulum<Rapier3DBackend> {
     /// successive episodes differ; use this when you need a *specific* episode
     /// to reproduce bit-for-bit (e.g. replaying a failure). Run-level
     /// reproducibility is already guaranteed by the construction seed.
+    ///
+    /// Delegates to [`reset`](Environment::reset) for the rebuild, so it
+    /// re-opens the [`EpisodeGuard`] on exactly the same terms — there is no
+    /// second reset path that could forget to clear it.
     ///
     /// # Errors
     ///
@@ -331,6 +349,13 @@ impl Environment<1, 1, 1> for InvertedDoublePendulum<Rapier3DBackend> {
     /// independent initial states. For deterministic replay of a specific
     /// initial state, use [`InvertedDoublePendulum::reset_with_seed`].
     ///
+    /// Re-opens the [`EpisodeGuard`], so an environment whose tip dropped (or
+    /// whose episode was truncated) becomes steppable again. The guard is
+    /// cleared only after the new world is in hand: nothing here is fallible
+    /// today, but the ordering keeps the ADR 0044 §6 rule ("clear the guard only
+    /// once the rebuild has succeeded") true by construction if `build_world`
+    /// ever becomes so.
+    ///
     /// # Errors
     ///
     /// This implementation does not currently return an error; the signature
@@ -341,6 +366,7 @@ impl Environment<1, 1, 1> for InvertedDoublePendulum<Rapier3DBackend> {
         state.last_obs = InvertedDoublePendulumObservation::default();
         self.state = state;
         self.steps = 0;
+        self.guard.reset();
 
         let obs = self.observe_reset(&self.state);
         self.state.last_obs = obs;
@@ -371,12 +397,25 @@ impl Environment<1, 1, 1> for InvertedDoublePendulum<Rapier3DBackend> {
     ///
     /// # Errors
     ///
-    /// Returns `EnvironmentError::InvalidAction` if the action value is
-    /// non-finite (`NaN` or infinity).
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended (the tip dropped, or `max_steps` was reached); call
+    /// [`reset`](Environment::reset) first. Returns
+    /// [`EnvironmentError::InvalidAction`] if the action value is non-finite
+    /// (`NaN` or infinity).
     fn step(
         &mut self,
         action: InvertedDoublePendulumAction,
     ) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — ahead of even the finiteness check: the episode being
+        // over is a fact about the *call sequence*, independent of whether the
+        // action itself is well-formed, so a caller replaying a malformed action
+        // past the terminal must hear about the finished episode, not get
+        // `InvalidAction` and the wrong diagnosis. It also runs before
+        // `step_actuated`, the `steps` tick and the observation refresh, so a
+        // rejected call leaves the physics world, the counter and the RNG stream
+        // exactly as the terminal step left them (ADR 0029).
+        self.guard.check()?;
+
         if !action.0[0].is_finite() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "InvertedDoublePendulum action must be finite, got {}",
@@ -438,12 +477,16 @@ impl Environment<1, 1, 1> for InvertedDoublePendulum<Rapier3DBackend> {
                 [obs.cart_position(), 0.0, self.config.cart_half_extents[2]],
             )
             .with_position("tip", tip);
-        Ok(LocomotionSnapshot {
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch can forget to record.
+        let snapshot = LocomotionSnapshot {
             observation: obs,
             reward: ScalarReward(total),
             status,
             metadata: Some(meta),
-        })
+        };
+        self.guard.record(snapshot.status);
+        Ok(snapshot)
     }
 }
 
@@ -484,6 +527,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::ContinuousAction;
     use rlevo_core::base::Action;
     use rlevo_core::base::Observation;
@@ -821,6 +865,246 @@ mod tests {
         assert_eq!(
             a, b,
             "reset_with_seed must reproduce the same initial state"
+        );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #292) ──────────────────────
+
+    /// Upper bound on the steps the driven pendulum may take before the test
+    /// calls it a regression. `max_steps` is set well above it so truncation
+    /// cannot pre-empt the termination the test is driving to.
+    const FALL_STEP_CAP: usize = 2000;
+
+    /// Config that lets the episode end by a genuine `Terminated`: no reset
+    /// noise (deterministic), `OnUnhealthy` termination, and a truncation budget
+    /// far beyond `FALL_STEP_CAP`.
+    fn terminating_cfg() -> InvertedDoublePendulumConfig {
+        InvertedDoublePendulumConfig {
+            seed: 7,
+            reset_noise_scale: 0.0,
+            termination: TerminationMode::OnUnhealthy,
+            max_steps: 10_000,
+            ..Default::default()
+        }
+    }
+
+    /// Drives a fresh episode to a real **`Terminated`** — not a truncation: a
+    /// sustained +1.0 cart force drops the tip below the healthy `z_range` floor
+    /// (`y_tip ≤ 1.0`), and the `OnUnhealthy` rule ends the episode through the
+    /// same physics path an agent would hit.
+    fn drive_to_tip_drop(
+        env: &mut InvertedDoublePendulum<Rapier3DBackend>,
+    ) -> LocomotionSnapshot<InvertedDoublePendulumObservation> {
+        env.reset().expect("reset must succeed");
+        for _ in 0..FALL_STEP_CAP {
+            let snap = env
+                .step(InvertedDoublePendulumAction::new(1.0))
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                assert!(
+                    snap.is_terminated(),
+                    "this fixture must end by termination, not truncation"
+                );
+                return snap;
+            }
+        }
+        panic!("a sustained +1.0 action must drop the tip within {FALL_STEP_CAP} steps");
+    }
+
+    #[test]
+    /// `InvertedDoublePendulum` satisfies the shared post-terminal conformance
+    /// check: once the tip has dropped (`Terminated`), a further step with a
+    /// *legal* action fails with `StepAfterEpisodeEnd` carrying that same
+    /// status. The replayed action is `0.0` — squarely inside the valid range —
+    /// so the rejection can only be on call-sequence grounds, never on the
+    /// action's own validity.
+    fn test_inverted_double_pendulum_rejects_post_terminal_step() {
+        let mut env =
+            InvertedDoublePendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_tip_drop,
+            InvertedDoublePendulumAction::new(0.0),
+        );
+    }
+
+    #[test]
+    /// A rejected post-terminal step must mutate nothing observable. The
+    /// healthiness test is a live read of the current tip height, not a latch,
+    /// so before the guard a further step integrated another frame, ticked the
+    /// step counter and paid a fresh reward — and a chaotic tip that swings back
+    /// above the threshold could re-earn the `+10` alive bonus on a `Running`
+    /// snapshot.
+    fn test_inverted_double_pendulum_post_terminal_step_does_not_mutate_state() {
+        let mut env =
+            InvertedDoublePendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        let terminal = drive_to_tip_drop(&mut env);
+        let ended = terminal.status();
+
+        let obs_at_end = terminal.observation().0;
+        let steps_at_end = env.steps;
+
+        let err = env
+            .step(InvertedDoublePendulumAction::new(0.0))
+            .expect_err("a step after the tip dropped must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        // Recomputed from the *live* physics world, so equality here proves the
+        // rejected call never ran `step_actuated`.
+        assert_eq!(
+            env.extract_observation().0,
+            obs_at_end,
+            "a rejected step must leave the observation byte-identical"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// The guard outranks the action check. Replaying a *malformed* action past
+    /// the terminal must still report `StepAfterEpisodeEnd`, not
+    /// `InvalidAction`: the episode being over is a fact about the call
+    /// sequence, and the finished episode is the diagnosis the caller needs.
+    fn test_inverted_double_pendulum_post_terminal_step_outranks_the_action_check() {
+        let mut env =
+            InvertedDoublePendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        drive_to_tip_drop(&mut env);
+
+        let err = env
+            .step(InvertedDoublePendulumAction::new(f32::NAN))
+            .expect_err("a NaN action after termination must still be an error");
+        assert!(
+            matches!(err, EnvironmentError::StepAfterEpisodeEnd { .. }),
+            "the finished episode must be reported before the action's validity, got {err:?}"
+        );
+    }
+
+    #[test]
+    /// A rejected step must not draw from the persistent RNG either (ADR 0029):
+    /// the episode that follows the next `reset()` must be the one the caller
+    /// would have got had the mis-sequenced call never happened.
+    fn test_inverted_double_pendulum_post_terminal_step_does_not_advance_rng() {
+        // Non-zero reset noise so the next reset actually consumes the stream.
+        let cfg = || InvertedDoublePendulumConfig {
+            seed: 7,
+            termination: TerminationMode::OnUnhealthy,
+            max_steps: 10_000,
+            ..Default::default()
+        };
+        let drive = |env: &mut InvertedDoublePendulumRapier| {
+            env.reset().unwrap();
+            for _ in 0..FALL_STEP_CAP {
+                if env
+                    .step(InvertedDoublePendulumAction::new(1.0))
+                    .unwrap()
+                    .is_done()
+                {
+                    return;
+                }
+            }
+            panic!("the tip must drop within {FALL_STEP_CAP} steps");
+        };
+
+        let with_replay = {
+            let mut env = InvertedDoublePendulumRapier::with_config(cfg()).expect("valid config");
+            drive(&mut env);
+            env.step(InvertedDoublePendulumAction::new(0.0))
+                .expect_err("the post-terminal step must be rejected");
+            env.reset().unwrap().observation().0
+        };
+        let without_replay = {
+            let mut env = InvertedDoublePendulumRapier::with_config(cfg()).expect("valid config");
+            drive(&mut env);
+            env.reset().unwrap().observation().0
+        };
+        assert_eq!(
+            with_replay, without_replay,
+            "a rejected step must leave the RNG stream untouched"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    fn test_inverted_double_pendulum_reset_reopens_terminated_episode() {
+        let mut env =
+            InvertedDoublePendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        drive_to_tip_drop(&mut env);
+        assert!(
+            env.step(InvertedDoublePendulumAction::new(0.0)).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after termination");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        let snap = env
+            .step(InvertedDoublePendulumAction::new(0.0))
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
+    }
+
+    #[test]
+    /// The truncation limb of the guard: `reset_with_seed` delegates to
+    /// `reset`, so it must clear the guard on the same terms — and a step past
+    /// a `Truncated` snapshot must report `Truncated`, not `Terminated`.
+    fn test_inverted_double_pendulum_rejects_post_truncation_step_and_reset_with_seed_reopens() {
+        let mut env = InvertedDoublePendulumRapier::with_config(InvertedDoublePendulumConfig {
+            seed: 1,
+            reset_noise_scale: 0.0,
+            max_steps: 5,
+            termination: TerminationMode::Never,
+            ..Default::default()
+        })
+        .expect("valid config");
+        env.reset().unwrap();
+        let mut last = None;
+        for _ in 0..5 {
+            last = Some(env.step(InvertedDoublePendulumAction::new(0.0)).unwrap());
+        }
+        assert_eq!(
+            last.expect("five steps were taken").status(),
+            EpisodeStatus::Truncated
+        );
+
+        let err = env
+            .step(InvertedDoublePendulumAction::new(0.0))
+            .expect_err("a step after truncation must be rejected");
+        assert!(
+            matches!(
+                err,
+                EnvironmentError::StepAfterEpisodeEnd {
+                    status: EpisodeStatus::Truncated
+                }
+            ),
+            "the error must distinguish truncation from termination, got {err:?}"
+        );
+
+        env.reset_with_seed(42)
+            .expect("reset_with_seed must succeed after truncation");
+        assert!(
+            env.step(InvertedDoublePendulumAction::new(0.0)).is_ok(),
+            "reset_with_seed must re-open the environment for a new episode"
         );
     }
 }

--- a/crates/rlevo-environments/src/locomotion/inverted_pendulum/env.rs
+++ b/crates/rlevo-environments/src/locomotion/inverted_pendulum/env.rs
@@ -11,6 +11,7 @@ use rlevo_core::environment::{
 };
 use rlevo_core::reward::ScalarReward;
 
+use crate::episode::EpisodeGuard;
 use crate::locomotion::backend::{LocomotionBackend, Rapier3DBackend, Rapier3DWorld};
 use crate::locomotion::common::{LocomotionSnapshot, TerminationMode, wrap_to_pi};
 
@@ -27,6 +28,9 @@ pub const METADATA_KEY_ALIVE: &str = "alive";
 ///
 /// Generic in the physics backend; v1 only implements `B = Rapier3DBackend`
 /// (see [`InvertedPendulumRapier`] for the default type alias).
+///
+/// A [`step`](Environment::step) taken after the episode ended is rejected with
+/// [`EnvironmentError::StepAfterEpisodeEnd`] — see the [`EpisodeGuard`] field.
 #[derive(Debug)]
 pub struct InvertedPendulum<B: LocomotionBackend = Rapier3DBackend> {
     world: B::World,
@@ -34,6 +38,14 @@ pub struct InvertedPendulum<B: LocomotionBackend = Rapier3DBackend> {
     config: InvertedPendulumConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the pole fell (or the episode was
+    /// truncated). Neither status is a latch the physics enforces: the
+    /// healthiness test is a live read of the current pole angle and the step
+    /// counter keeps climbing, so an unguarded post-terminal step integrates
+    /// another frame, ticks `steps` and emits a fresh alive bonus — a toppled
+    /// pole that swings back through `|θ| < 0.2` even re-earns `+1` on a
+    /// `Running` snapshot, silently resurrecting the episode.
+    guard: EpisodeGuard,
     _marker: PhantomData<B>,
 }
 
@@ -58,6 +70,7 @@ impl InvertedPendulum<Rapier3DBackend> {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
             _marker: PhantomData,
         })
     }
@@ -68,6 +81,10 @@ impl InvertedPendulum<Rapier3DBackend> {
     /// successive episodes differ; use this when you need a *specific* episode
     /// to reproduce bit-for-bit (e.g. replaying a failure). Run-level
     /// reproducibility is already guaranteed by the construction seed.
+    ///
+    /// Delegates to [`reset`](Environment::reset) for the rebuild, so it
+    /// re-opens the [`EpisodeGuard`] on exactly the same terms — there is no
+    /// second reset path that could forget to clear it.
     ///
     /// # Errors
     ///
@@ -255,6 +272,13 @@ impl Environment<1, 1, 1> for InvertedPendulum<Rapier3DBackend> {
     /// observation. The `METADATA_KEY_ALIVE` component is set to `0.0` on
     /// reset regardless of pole angle.
     ///
+    /// Re-opens the [`EpisodeGuard`], so an environment whose pole fell (or
+    /// whose episode was truncated) becomes steppable again. The guard is
+    /// cleared only after the new world is in hand: nothing here is fallible
+    /// today, but the ordering keeps the ADR 0044 §6 rule ("clear the guard only
+    /// once the rebuild has succeeded") true by construction if `build_world`
+    /// ever becomes so.
+    ///
     /// # Errors
     ///
     /// This implementation is currently infallible, but returns `Result` for
@@ -265,6 +289,7 @@ impl Environment<1, 1, 1> for InvertedPendulum<Rapier3DBackend> {
         state.last_obs = InvertedPendulumObservation::default();
         self.state = state;
         self.steps = 0;
+        self.guard.reset();
 
         let obs = self.observe_reset(&self.state);
         self.state.last_obs = obs;
@@ -292,12 +317,25 @@ impl Environment<1, 1, 1> for InvertedPendulum<Rapier3DBackend> {
     ///
     /// # Errors
     ///
-    /// Returns [`EnvironmentError::InvalidAction`] if the action value is
-    /// non-finite (NaN or ±infinity).
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has
+    /// already ended (the pole fell, or `max_steps` was reached); call
+    /// [`reset`](Environment::reset) first. Returns
+    /// [`EnvironmentError::InvalidAction`] if the action value is non-finite
+    /// (NaN or ±infinity).
     fn step(
         &mut self,
         action: InvertedPendulumAction,
     ) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — ahead of even the finiteness check: the episode being
+        // over is a fact about the *call sequence*, independent of whether the
+        // action itself is well-formed, so a caller replaying a malformed action
+        // past the terminal must hear about the finished episode, not get
+        // `InvalidAction` and the wrong diagnosis. It also runs before
+        // `step_actuated`, the `steps` tick and the observation refresh, so a
+        // rejected call leaves the physics world, the counter and the RNG stream
+        // exactly as the terminal step left them (ADR 0029).
+        self.guard.check()?;
+
         if !action.0[0].is_finite() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "InvertedPendulum action must be finite, got {}",
@@ -344,12 +382,16 @@ impl Environment<1, 1, 1> for InvertedPendulum<Rapier3DBackend> {
                 "cart",
                 [obs.cart_position(), 0.0, self.config.cart_half_extents[2]],
             );
-        Ok(LocomotionSnapshot {
+        // Single exit: exactly one snapshot is built, and the guard is fed that
+        // snapshot's own status, so no branch can forget to record.
+        let snapshot = LocomotionSnapshot {
             observation: obs,
             reward,
             status,
             metadata: Some(meta),
-        })
+        };
+        self.guard.record(snapshot.status);
+        Ok(snapshot)
     }
 }
 
@@ -411,6 +453,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::ContinuousAction;
     use rlevo_core::base::Action;
     use rlevo_core::base::Observation;
@@ -646,6 +689,221 @@ mod tests {
         assert_eq!(
             a, b,
             "reset_with_seed must reproduce the same initial state"
+        );
+    }
+
+    // ── post-terminal step guard (ADR 0044, issue #292) ──────────────────────
+
+    /// Upper bound on the steps the kicked pendulum may take before the test
+    /// calls it a regression. `max_steps` is set well above it so truncation
+    /// cannot pre-empt the termination the test is driving to.
+    const FALL_STEP_CAP: usize = 2000;
+
+    /// Config that lets the episode end by a genuine `Terminated`: no reset
+    /// noise (deterministic tilt), `OnUnhealthy` termination, and a truncation
+    /// budget far beyond `FALL_STEP_CAP`.
+    fn terminating_cfg() -> InvertedPendulumConfig {
+        InvertedPendulumConfig {
+            reset_noise_scale: 0.0,
+            termination: TerminationMode::OnUnhealthy,
+            max_steps: 10_000,
+            ..Default::default()
+        }
+    }
+
+    /// Drives a fresh episode to a real **`Terminated`** — not a truncation:
+    /// a short +x kick on the cart topples the pole, gravity carries `|θ|`
+    /// past the healthy band `(-0.2, 0.2)`, and the `OnUnhealthy` rule ends
+    /// the episode through the same physics path an agent would hit.
+    fn drive_to_pole_fall(
+        env: &mut InvertedPendulum<Rapier3DBackend>,
+    ) -> LocomotionSnapshot<InvertedPendulumObservation> {
+        env.reset().expect("reset must succeed");
+        for i in 0..FALL_STEP_CAP {
+            let force = if i < 20 { 3.0 } else { 0.0 };
+            let snap = env
+                .step(InvertedPendulumAction::new(force))
+                .expect("step must succeed while the episode is running");
+            if snap.is_done() {
+                assert!(
+                    snap.is_terminated(),
+                    "this fixture must end by termination, not truncation"
+                );
+                return snap;
+            }
+        }
+        panic!("a kicked pole must leave the healthy band within {FALL_STEP_CAP} steps");
+    }
+
+    #[test]
+    /// `InvertedPendulum` satisfies the shared post-terminal conformance check:
+    /// once the pole has fallen (`Terminated`), a further step with a *legal*
+    /// action fails with `StepAfterEpisodeEnd` carrying that same status. The
+    /// replayed action is `0.0` — squarely inside the valid range — so the
+    /// rejection can only be on call-sequence grounds, never on the action's own
+    /// validity.
+    fn test_inverted_pendulum_rejects_post_terminal_step() {
+        let mut env = InvertedPendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_pole_fall,
+            InvertedPendulumAction::new(0.0),
+        );
+    }
+
+    #[test]
+    /// A rejected post-terminal step must mutate nothing observable. The
+    /// healthiness test is a live read of the current pole angle, not a latch,
+    /// so before the guard a further step integrated another frame, ticked the
+    /// step counter and could hand back a fresh `+1` alive bonus on a `Running`
+    /// snapshot as the toppled pole swung back through the band.
+    fn test_inverted_pendulum_post_terminal_step_does_not_mutate_state() {
+        let mut env = InvertedPendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        let terminal = drive_to_pole_fall(&mut env);
+        let ended = terminal.status();
+
+        let obs_at_end = terminal.observation().0;
+        let steps_at_end = env.steps;
+
+        let err = env
+            .step(InvertedPendulumAction::new(0.0))
+            .expect_err("a step after the pole fell must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        // Recomputed from the *live* physics world, so equality here proves the
+        // rejected call never ran `step_actuated`.
+        assert_eq!(
+            env.extract_observation().0,
+            obs_at_end,
+            "a rejected step must leave the observation byte-identical"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    /// The guard outranks the action check. Replaying a *malformed* action past
+    /// the terminal must still report `StepAfterEpisodeEnd`, not
+    /// `InvalidAction`: the episode being over is a fact about the call
+    /// sequence, and the finished episode is the diagnosis the caller needs.
+    fn test_inverted_pendulum_post_terminal_step_outranks_the_action_check() {
+        let mut env = InvertedPendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        drive_to_pole_fall(&mut env);
+
+        let err = env
+            .step(InvertedPendulumAction::new(f32::NAN))
+            .expect_err("a NaN action after termination must still be an error");
+        assert!(
+            matches!(err, EnvironmentError::StepAfterEpisodeEnd { .. }),
+            "the finished episode must be reported before the action's validity, got {err:?}"
+        );
+    }
+
+    #[test]
+    /// A rejected step must not draw from the persistent RNG either (ADR 0029):
+    /// the episode that follows the next `reset()` must be the one the caller
+    /// would have got had the mis-sequenced call never happened.
+    fn test_inverted_pendulum_post_terminal_step_does_not_advance_rng() {
+        let with_replay = {
+            let mut env =
+                InvertedPendulumRapier::with_config(terminating_cfg()).expect("valid config");
+            drive_to_pole_fall(&mut env);
+            env.step(InvertedPendulumAction::new(0.0))
+                .expect_err("the post-terminal step must be rejected");
+            env.reset().unwrap().observation().0
+        };
+        let without_replay = {
+            let mut env =
+                InvertedPendulumRapier::with_config(terminating_cfg()).expect("valid config");
+            drive_to_pole_fall(&mut env);
+            env.reset().unwrap().observation().0
+        };
+        assert_eq!(
+            with_replay, without_replay,
+            "a rejected step must leave the RNG stream untouched"
+        );
+    }
+
+    #[test]
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    fn test_inverted_pendulum_reset_reopens_terminated_episode() {
+        let mut env = InvertedPendulumRapier::with_config(terminating_cfg()).expect("valid config");
+        drive_to_pole_fall(&mut env);
+        assert!(
+            env.step(InvertedPendulumAction::new(0.0)).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after termination");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        let snap = env
+            .step(InvertedPendulumAction::new(0.0))
+            .expect("reset() must re-open the environment for a new episode");
+        assert!(
+            !snap.is_done(),
+            "the first step of a fresh episode must not be done"
+        );
+    }
+
+    #[test]
+    /// The truncation limb of the guard: `reset_with_seed` delegates to
+    /// `reset`, so it must clear the guard on the same terms — and a step past
+    /// a `Truncated` snapshot must report `Truncated`, not `Terminated`.
+    fn test_inverted_pendulum_rejects_post_truncation_step_and_reset_with_seed_reopens() {
+        let mut env = InvertedPendulumRapier::with_config(InvertedPendulumConfig {
+            max_steps: 5,
+            termination: TerminationMode::Never,
+            reset_noise_scale: 0.0,
+            ..Default::default()
+        })
+        .expect("valid config");
+        env.reset().unwrap();
+        let mut last = None;
+        for _ in 0..5 {
+            last = Some(env.step(InvertedPendulumAction::new(0.0)).unwrap());
+        }
+        assert_eq!(
+            last.expect("five steps were taken").status(),
+            EpisodeStatus::Truncated
+        );
+
+        let err = env
+            .step(InvertedPendulumAction::new(0.0))
+            .expect_err("a step after truncation must be rejected");
+        assert!(
+            matches!(
+                err,
+                EnvironmentError::StepAfterEpisodeEnd {
+                    status: EpisodeStatus::Truncated
+                }
+            ),
+            "the error must distinguish truncation from termination, got {err:?}"
+        );
+
+        env.reset_with_seed(42)
+            .expect("reset_with_seed must succeed after truncation");
+        assert!(
+            env.step(InvertedPendulumAction::new(0.0)).is_ok(),
+            "reset_with_seed must re-open the environment for a new episode"
         );
     }
 }

--- a/crates/rlevo-environments/src/locomotion/reacher/env.rs
+++ b/crates/rlevo-environments/src/locomotion/reacher/env.rs
@@ -20,6 +20,7 @@ use rlevo_core::environment::{
 };
 use rlevo_core::reward::ScalarReward;
 
+use crate::episode::EpisodeGuard;
 use crate::locomotion::backend::{
     LocomotionBackend, Rapier3DBackend, Rapier3DJointHandle, Rapier3DWorld,
 };
@@ -38,6 +39,14 @@ pub const METADATA_KEY_REWARD_CONTROL: &str = "reward_control";
 /// Reacher — a 2-link planar arm whose fingertip must reach a randomly
 /// placed target. Generic in the physics backend; v1 only implements
 /// `B = Rapier3DBackend`.
+///
+/// # Episode lifecycle
+///
+/// The arm has no goal or failure predicate, so the episode has a single
+/// ending: `Truncated` once `steps` reaches `config.max_steps`. That ending
+/// closes the episode — a further [`step`](Environment::step) returns
+/// [`EnvironmentError::StepAfterEpisodeEnd`] until [`reset`](Environment::reset)
+/// is called (see the [`EpisodeGuard`] field).
 #[derive(Debug)]
 pub struct Reacher<B: LocomotionBackend = Rapier3DBackend> {
     world: B::World,
@@ -45,6 +54,13 @@ pub struct Reacher<B: LocomotionBackend = Rapier3DBackend> {
     config: ReacherConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the episode ended. The truncation
+    /// predicate `steps >= max_steps` is not self-limiting: past the cap it
+    /// keeps holding, so an unguarded post-terminal step would integrate the
+    /// arm for another `dt * frame_skip`, tick `steps` past the budget the
+    /// caller asked for, and re-emit `Truncated` with a fresh distance/control
+    /// reward — for as many calls as the caller makes.
+    guard: EpisodeGuard,
     _marker: PhantomData<B>,
 }
 
@@ -69,6 +85,7 @@ impl Reacher<Rapier3DBackend> {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
             _marker: PhantomData,
         })
     }
@@ -79,6 +96,9 @@ impl Reacher<Rapier3DBackend> {
     /// successive episodes differ; use this when you need a *specific* episode
     /// to reproduce bit-for-bit (e.g. replaying a failure). Run-level
     /// reproducibility is already guaranteed by the construction seed.
+    ///
+    /// This delegates to [`reset`](Environment::reset), so it also re-opens a
+    /// truncated episode: the episode guard is cleared there, not here.
     ///
     /// # Errors
     ///
@@ -295,11 +315,18 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
     /// both reward-component metadata keys are set to `0.0` to satisfy the
     /// invariant that Σ components = total reward.
     ///
+    /// The step counter and the episode guard are cleared, so a truncated
+    /// environment becomes steppable again.
+    ///
     /// # Errors
     ///
     /// This implementation never returns `Err`; the signature is required by
     /// the `Environment` trait.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        // The rebuild below is infallible, so there is no partial-reset window
+        // in which clearing the guard would re-open an episode over a world
+        // that never returned to its initial state (ADR 0044 §6).
+        self.guard.reset();
         let (world, mut state) = Self::build_world(&self.config, &mut self.rng);
         self.world = world;
         state.last_obs = ReacherObservation::default();
@@ -327,9 +354,21 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
     ///
     /// # Errors
     ///
-    /// Returns [`EnvironmentError::InvalidAction`] if either action element is
-    /// non-finite (`NaN` or ±∞).
+    /// - [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has already
+    ///   ended (`steps` reached `config.max_steps`, so the last snapshot was
+    ///   `Truncated`); call [`reset`](Environment::reset) first. Checked before
+    ///   the action itself, so a post-terminal call is diagnosed as the
+    ///   call-sequence bug it is even when the replayed action is malformed.
+    /// - [`EnvironmentError::InvalidAction`] if either action element is
+    ///   non-finite (`NaN` or ±∞).
     fn step(&mut self, action: ReacherAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — ahead of the action check, the torque application and
+        // the physics substeps. Whether the episode is over is a call-sequence
+        // fact independent of the action's validity, and a rejected step must
+        // leave the world, `steps` and the cached observation exactly as the
+        // terminal step left them.
+        self.guard.check()?;
+
         if !action.0.iter().copied().all(f32::is_finite) {
             return Err(EnvironmentError::InvalidAction(format!(
                 "Reacher action must be finite, got {:?}",
@@ -398,12 +437,16 @@ impl Environment<1, 1, 1> for Reacher<Rapier3DBackend> {
             .with(METADATA_KEY_REWARD_CONTROL, reward_control)
             .with_position("fingertip", [fx, fy, 0.0])
             .with_position("target", [tx, ty, 0.0]);
-        Ok(LocomotionSnapshot {
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status, so the two cannot disagree.
+        let snapshot = LocomotionSnapshot {
             observation: obs,
             reward: ScalarReward(total),
             status,
             metadata: Some(meta),
-        })
+        };
+        self.guard.record(snapshot.status);
+        Ok(snapshot)
     }
 }
 
@@ -416,6 +459,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::base::Action;
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
@@ -425,6 +469,175 @@ mod tests {
             seed,
             ..Default::default()
         }
+    }
+
+    // ── post-terminal step guard (issue #292) ────────────────────────────────
+    //
+    // Reacher has NO `Terminated` path: the arm has neither a goal nor a
+    // failure predicate, and `step` only ever emits `Running` or `Truncated`.
+    // Truncation at `steps >= max_steps` is therefore the only ending, and the
+    // guard tests drive to it with a deliberately tiny `max_steps` (the default
+    // is 50 physics steps, which is slow to burn through repeatedly).
+
+    /// Step budget for the guard tests.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    /// A legal no-op action: both elements are finite, which is the only
+    /// admission test `step` applies, so any rejection of it is on
+    /// call-sequence grounds alone.
+    fn idle() -> ReacherAction {
+        ReacherAction::new(0.0, 0.0)
+    }
+
+    /// Environment whose episodes truncate after [`GUARD_MAX_STEPS`] steps.
+    fn truncating_env() -> ReacherRapier {
+        ReacherRapier::with_config(ReacherConfig {
+            seed: 7,
+            reset_noise_scale: 0.0,
+            max_steps: GUARD_MAX_STEPS,
+            ..Default::default()
+        })
+        .expect("valid config")
+    }
+
+    /// Idles until the step budget runs out and returns the truncated snapshot.
+    fn drive_to_truncation(env: &mut ReacherRapier) -> LocomotionSnapshot<ReacherObservation> {
+        env.reset().expect("reset must succeed");
+        let mut snap = env.step(idle()).expect("first step must succeed");
+        while !snap.is_done() {
+            snap = env
+                .step(idle())
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    /// `Reacher` satisfies the shared post-terminal conformance check: once the
+    /// step budget is exhausted, a further `step()` with a *legal* action fails
+    /// with `StepAfterEpisodeEnd` carrying the status that ended the episode.
+    #[test]
+    fn rejects_post_terminal_step() {
+        let mut env = truncating_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_truncation, idle());
+    }
+
+    /// Regression for what the guard removes: past `max_steps` the truncation
+    /// predicate keeps holding, so an unguarded post-terminal step would
+    /// integrate the arm for another frame, tick `steps` past the caller's
+    /// budget and re-emit `Truncated` with a fresh reward. A rejected step must
+    /// mutate nothing — the step counter, the cached observation and the guard
+    /// must be exactly as the terminal step left them.
+    #[test]
+    fn post_terminal_step_does_not_mutate_state() {
+        let mut env = truncating_env();
+        let terminal = drive_to_truncation(&mut env);
+        let ended = terminal.status();
+        assert_eq!(
+            ended,
+            EpisodeStatus::Truncated,
+            "the step budget must truncate the episode"
+        );
+
+        let steps_at_end = env.steps;
+        let obs_at_end = env.state.last_obs.0;
+        let world_obs_at_end = env.extract_observation().0;
+
+        let err = env
+            .step(idle())
+            .expect_err("a step after truncation must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.state.last_obs.0, obs_at_end,
+            "a rejected step must not overwrite the cached observation"
+        );
+        // The observation is read straight out of the physics world, so an
+        // unchanged reading is direct evidence the world did not integrate.
+        assert_eq!(
+            env.extract_observation().0,
+            world_obs_at_end,
+            "a rejected step must not advance the physics world"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// The guard rejects on call-sequence grounds *before* the action's own
+    /// validity is examined: replaying a malformed action past the terminal
+    /// must still be diagnosed as `StepAfterEpisodeEnd`, not `InvalidAction`.
+    #[test]
+    fn post_terminal_step_outranks_the_action_check() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+
+        let err = env
+            .step(ReacherAction::new(f32::NAN, 0.0))
+            .expect_err("a step after truncation must return Err");
+        assert!(
+            matches!(
+                err,
+                EnvironmentError::StepAfterEpisodeEnd {
+                    status: EpisodeStatus::Truncated
+                }
+            ),
+            "the call-sequence fault outranks the action fault, got {err:?}"
+        );
+    }
+
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    #[test]
+    fn reset_reopens_finished_episode() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+        assert!(
+            env.step(idle()).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after truncation");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert!(
+            env.step(idle()).is_ok(),
+            "reset() must re-open the environment for a new episode"
+        );
+    }
+
+    /// `reset_with_seed` delegates to `reset`, so it must clear the guard too.
+    #[test]
+    fn reset_with_seed_reopens_finished_episode() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+
+        env.reset_with_seed(999)
+            .expect("reset_with_seed must succeed after truncation");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset_with_seed() must return the guard to Running"
+        );
+        assert!(
+            env.step(idle()).is_ok(),
+            "reset_with_seed() must re-open the environment for a new episode"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/locomotion/swimmer/env.rs
+++ b/crates/rlevo-environments/src/locomotion/swimmer/env.rs
@@ -20,6 +20,7 @@ use rlevo_core::environment::{
 };
 use rlevo_core::reward::ScalarReward;
 
+use crate::episode::EpisodeGuard;
 use crate::locomotion::backend::{LocomotionBackend, Rapier3DBackend, Rapier3DWorld};
 use crate::locomotion::common::{LocomotionSnapshot, ctrl_cost, wrap_to_pi};
 
@@ -43,6 +44,14 @@ pub const METADATA_KEY_CTRL: &str = "ctrl";
 ///
 /// Construct with [`ConstructableEnv::new`] (uses [`SwimmerConfig::default`])
 /// or with [`Swimmer::with_config`] for a custom configuration.
+///
+/// # Episode lifecycle
+///
+/// There is no health condition and no goal, so the episode has a single
+/// ending: `Truncated` once `steps` reaches `config.max_steps`. That ending
+/// closes the episode — a further [`step`](Environment::step) returns
+/// [`EnvironmentError::StepAfterEpisodeEnd`] until [`reset`](Environment::reset)
+/// is called (see the [`EpisodeGuard`] field).
 #[derive(Debug)]
 pub struct Swimmer<B: LocomotionBackend = Rapier3DBackend> {
     world: B::World,
@@ -50,6 +59,13 @@ pub struct Swimmer<B: LocomotionBackend = Rapier3DBackend> {
     config: SwimmerConfig,
     rng: StdRng,
     steps: usize,
+    /// Rejects a `step()` taken after the episode ended. The truncation
+    /// predicate `steps >= max_steps` is not self-limiting: past the cap it
+    /// keeps holding, so an unguarded post-terminal step would run another
+    /// `frame_skip` substeps of actuation and drag, tick `steps` past the
+    /// budget the caller asked for, and re-emit `Truncated` with a fresh
+    /// forward/ctrl reward — for as many calls as the caller makes.
+    guard: EpisodeGuard,
     _marker: PhantomData<B>,
 }
 
@@ -76,6 +92,7 @@ impl Swimmer<Rapier3DBackend> {
             config,
             rng,
             steps: 0,
+            guard: EpisodeGuard::new(),
             _marker: PhantomData,
         })
     }
@@ -86,6 +103,9 @@ impl Swimmer<Rapier3DBackend> {
     /// successive episodes differ; use this when you need a *specific* episode
     /// to reproduce bit-for-bit (e.g. replaying a failure). Run-level
     /// reproducibility is already guaranteed by the construction seed.
+    ///
+    /// This delegates to [`reset`](Environment::reset), so it also re-opens a
+    /// truncated episode: the episode guard is cleared there, not here.
     ///
     /// # Errors
     ///
@@ -353,11 +373,18 @@ impl Environment<1, 1, 1> for Swimmer<Rapier3DBackend> {
     /// The returned snapshot has `EpisodeStatus::Running`, reward `0.0`, and
     /// metadata components `forward = 0.0` and `ctrl = 0.0`.
     ///
+    /// The step counter and the episode guard are cleared, so a truncated
+    /// environment becomes steppable again.
+    ///
     /// # Errors
     ///
     /// This implementation does not currently return an error; the signature
     /// reflects the `Environment` trait contract.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        // The rebuild below is infallible, so there is no partial-reset window
+        // in which clearing the guard would re-open an episode over a world
+        // that never returned to its initial state (ADR 0044 §6).
+        self.guard.reset();
         let (world, mut state) = Self::build_world(&self.config, &mut self.rng);
         self.world = world;
         state.last_obs = SwimmerObservation::default();
@@ -392,9 +419,21 @@ impl Environment<1, 1, 1> for Swimmer<Rapier3DBackend> {
     ///
     /// # Errors
     ///
-    /// Returns [`EnvironmentError::InvalidAction`] if any element of `action`
-    /// is non-finite (`NaN` or `±∞`).
+    /// - [`EnvironmentError::StepAfterEpisodeEnd`] if the episode has already
+    ///   ended (`steps` reached `config.max_steps`, so the last snapshot was
+    ///   `Truncated`); call [`reset`](Environment::reset) first. Checked before
+    ///   the action itself, so a post-terminal call is diagnosed as the
+    ///   call-sequence bug it is even when the replayed action is malformed.
+    /// - [`EnvironmentError::InvalidAction`] if any element of `action` is
+    ///   non-finite (`NaN` or `±∞`).
     fn step(&mut self, action: SwimmerAction) -> Result<Self::SnapshotType, EnvironmentError> {
+        // Guard first — ahead of the action check, the torque application and
+        // the physics substeps. Whether the episode is over is a call-sequence
+        // fact independent of the action's validity, and a rejected step must
+        // leave the world, `steps` and the cached observation exactly as the
+        // terminal step left them.
+        self.guard.check()?;
+
         if !action.0.iter().copied().all(f32::is_finite) {
             return Err(EnvironmentError::InvalidAction(format!(
                 "Swimmer action must be finite, got {:?}",
@@ -430,12 +469,16 @@ impl Environment<1, 1, 1> for Swimmer<Rapier3DBackend> {
             .with_position("torso", torso_pos)
             .with_position("com", torso_pos)
             .with_position("main_body", torso_pos);
-        Ok(LocomotionSnapshot {
+        // Single exit: one snapshot is built, and the guard is fed that
+        // snapshot's own status, so the two cannot disagree.
+        let snapshot = LocomotionSnapshot {
             observation: obs,
             reward: ScalarReward(total),
             status,
             metadata: Some(meta),
-        })
+        };
+        self.guard.record(snapshot.status);
+        Ok(snapshot)
     }
 }
 
@@ -485,6 +528,7 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::base::Action;
     use rlevo_core::base::Observation;
     use rlevo_core::environment::Snapshot;
@@ -502,6 +546,173 @@ mod tests {
             reset_noise_scale: 0.0,
             ..Default::default()
         }
+    }
+
+    // ── post-terminal step guard (issue #292) ────────────────────────────────
+    //
+    // Swimmer has NO `Terminated` path: there is no health condition and no
+    // goal, and `step` only ever emits `Running` or `Truncated`. Truncation at
+    // `steps >= max_steps` is therefore the only ending, and the guard tests
+    // drive to it with a deliberately tiny `max_steps` (the default is 1000
+    // physics steps, which is slow to burn through repeatedly).
+
+    /// Step budget for the guard tests.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    /// A legal no-op action: both elements are finite, which is the only
+    /// admission test `step` applies, so any rejection of it is on
+    /// call-sequence grounds alone.
+    fn idle() -> SwimmerAction {
+        SwimmerAction::new(0.0, 0.0)
+    }
+
+    /// Environment whose episodes truncate after [`GUARD_MAX_STEPS`] steps.
+    fn truncating_env() -> SwimmerRapier {
+        SwimmerRapier::with_config(SwimmerConfig {
+            max_steps: GUARD_MAX_STEPS,
+            ..deterministic_cfg()
+        })
+        .expect("valid config")
+    }
+
+    /// Idles until the step budget runs out and returns the truncated snapshot.
+    fn drive_to_truncation(env: &mut SwimmerRapier) -> LocomotionSnapshot<SwimmerObservation> {
+        env.reset().expect("reset must succeed");
+        let mut snap = env.step(idle()).expect("first step must succeed");
+        while !snap.is_done() {
+            snap = env
+                .step(idle())
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    /// `Swimmer` satisfies the shared post-terminal conformance check: once the
+    /// step budget is exhausted, a further `step()` with a *legal* action fails
+    /// with `StepAfterEpisodeEnd` carrying the status that ended the episode.
+    #[test]
+    fn rejects_post_terminal_step() {
+        let mut env = truncating_env();
+        assert_rejects_post_terminal_step(&mut env, drive_to_truncation, idle());
+    }
+
+    /// Regression for what the guard removes: past `max_steps` the truncation
+    /// predicate keeps holding, so an unguarded post-terminal step would run
+    /// another `frame_skip` substeps, tick `steps` past the caller's budget and
+    /// re-emit `Truncated` with a fresh reward. A rejected step must mutate
+    /// nothing — the step counter, the cached observation and the guard must be
+    /// exactly as the terminal step left them.
+    #[test]
+    fn post_terminal_step_does_not_mutate_state() {
+        let mut env = truncating_env();
+        let terminal = drive_to_truncation(&mut env);
+        let ended = terminal.status();
+        assert_eq!(
+            ended,
+            EpisodeStatus::Truncated,
+            "the step budget must truncate the episode"
+        );
+
+        let steps_at_end = env.steps;
+        let obs_at_end = env.state.last_obs.0;
+        let world_obs_at_end = env.extract_observation().0;
+
+        let err = env
+            .step(idle())
+            .expect_err("a step after truncation must return Err, not another snapshot");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status, ended,
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.state.last_obs.0, obs_at_end,
+            "a rejected step must not overwrite the cached observation"
+        );
+        // The observation is read straight out of the physics world, so an
+        // unchanged reading is direct evidence the world did not integrate.
+        assert_eq!(
+            env.extract_observation().0,
+            world_obs_at_end,
+            "a rejected step must not advance the physics world"
+        );
+        assert_eq!(
+            env.guard.status(),
+            ended,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    /// The guard rejects on call-sequence grounds *before* the action's own
+    /// validity is examined: replaying a malformed action past the terminal
+    /// must still be diagnosed as `StepAfterEpisodeEnd`, not `InvalidAction`.
+    #[test]
+    fn post_terminal_step_outranks_the_action_check() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+
+        let err = env
+            .step(SwimmerAction::new(f32::NAN, 0.0))
+            .expect_err("a step after truncation must return Err");
+        assert!(
+            matches!(
+                err,
+                EnvironmentError::StepAfterEpisodeEnd {
+                    status: EpisodeStatus::Truncated
+                }
+            ),
+            "the call-sequence fault outranks the action fault, got {err:?}"
+        );
+    }
+
+    /// `reset()` re-opens a finished episode, so a latched guard cannot strand
+    /// the environment for the rest of the run.
+    #[test]
+    fn reset_reopens_finished_episode() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+        assert!(
+            env.step(idle()).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        let first = env.reset().expect("reset must succeed after truncation");
+        assert!(!first.is_done(), "a fresh episode must not start done");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert!(
+            env.step(idle()).is_ok(),
+            "reset() must re-open the environment for a new episode"
+        );
+    }
+
+    /// `reset_with_seed` delegates to `reset`, so it must clear the guard too.
+    #[test]
+    fn reset_with_seed_reopens_finished_episode() {
+        let mut env = truncating_env();
+        drive_to_truncation(&mut env);
+
+        env.reset_with_seed(999)
+            .expect("reset_with_seed must succeed after truncation");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset_with_seed() must return the guard to Running"
+        );
+        assert!(
+            env.step(idle()).is_ok(),
+            "reset_with_seed() must re-open the environment for a new episode"
+        );
     }
 
     #[test]

--- a/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
+++ b/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
@@ -259,12 +259,12 @@ enforce it today: the
 `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
 `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
 `grids` environments, the `box2d` family (`BipedalWalker`, `CarRacing`,
-`LunarLanderDiscrete`, `LunarLanderContinuous`), and the
-`TimeLimit` wrapper. The `classic` module's bandits, the
-`locomotion` family, and `pixel_grid` do not yet — their
-behaviour after a terminal snapshot remains **undefined**; do not depend on it,
-even by accident, until it lands for that family — the rollout is tracked
-family-by-family in
+`LunarLanderDiscrete`, `LunarLanderContinuous`), the `locomotion` family
+(`InvertedPendulum`, `InvertedDoublePendulum`, `Reacher`, `Swimmer`), and the
+`TimeLimit` wrapper. The `classic` module's bandits and `pixel_grid` do not
+yet — their behaviour after a terminal snapshot remains **undefined**; do not
+depend on it, even by accident, until it lands for that family — the rollout
+is tracked family-by-family in
 [issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). If you're
 implementing your own environment, [Bring Your Own
 Environment](../../part-2-guided-tour/99-extending-the-environment.md#step-5--guard-the-post-terminal-step)
@@ -417,8 +417,8 @@ the crate as a vocabulary anchor more than a workhorse.
 - **A `step()` taken after `is_done()` is `true` is an error, not a silent
   resume.** It returns `EnvironmentError::StepAfterEpisodeEnd { status }`; call
   `reset()` to start a new episode. The `toy_text` family, the `classic`
-  family's non-bandit environments, the `grids` family, the `box2d` family, and
-  `TimeLimit` enforce this today
+  family's non-bandit environments, the `grids` family, the `box2d` family, the
+  `locomotion` family, and `TimeLimit` enforce this today
   ([issue #289](https://github.com/anthonytorlucci/rlevo/issues/289) tracks
   the rest).
 - **`ConstructableEnv`** keeps construction off the behaviour trait so

--- a/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
+++ b/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
@@ -320,8 +320,9 @@ The rule your `step` must satisfy: once you have emitted a snapshot whose
 status is done, the *only* legal next call is `reset()`; a further `step()`
 must return `Err(EnvironmentError::StepAfterEpisodeEnd { status })`. You don't
 have to hand-write that state machine — `rlevo_environments::episode::EpisodeGuard`
-is the one-field helper the `toy_text`, `classic` (non-bandit), `grids`, and
-`box2d` families already hold for exactly this. Add it to your struct:
+is the one-field helper the `toy_text`, `classic` (non-bandit), `grids`,
+`box2d`, and `locomotion` families already hold for exactly this. Add it to
+your struct:
 
 ```rust,no_run
 use rlevo_environments::episode::EpisodeGuard;
@@ -383,12 +384,12 @@ Three details here are load-bearing, not stylistic:
 > `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
 > `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
 > `grids` environments, the `box2d` family (`BipedalWalker`, `CarRacing`,
-> `LunarLanderDiscrete`, `LunarLanderContinuous`), and the
+> `LunarLanderDiscrete`, `LunarLanderContinuous`), the `locomotion` family
+> (`InvertedPendulum`, `InvertedDoublePendulum`, `Reacher`, `Swimmer`), and the
 > `TimeLimit` wrapper all hold one. The `classic` module's bandits
 > (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
-> `AdversarialBandit`), the `locomotion` family, and
-> `pixel_grid` do not yet — their post-terminal behaviour is undefined,
-> tracked family-by-family in
+> `AdversarialBandit`) and `pixel_grid` do not yet — their post-terminal
+> behaviour is undefined, tracked family-by-family in
 > [issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). Your own
 > environment doesn't have to wait for that rollout: reach for `EpisodeGuard`
 > the same way `CliffWalking` does, and it conforms from day one.
@@ -433,10 +434,9 @@ algorithm will drive your environment correctly:
   `EnvironmentError::StepAfterEpisodeEnd` rather than silently continuing — see
   [Step 5](#step-5--guard-the-post-terminal-step) above for the `EpisodeGuard`
   recipe. (The `toy_text` family, the `classic` family's non-bandit
-  environments, the `grids` and `box2d` families, and `TimeLimit` enforce this
-  today; treat it
-  as the target for any environment you write, not yet a workspace-wide
-  guarantee.)
+  environments, the `grids`, `box2d`, and `locomotion` families, and
+  `TimeLimit` enforce this today; treat it as the target for any environment
+  you write, not yet a workspace-wide guarantee.)
 - **Neither method panics on valid input.** Return `EnvironmentError::InvalidAction`
   for out-of-range actions; reserve panics for genuine internal-logic bugs.
 - **Your config validates its own invariants.** Implement


### PR DESCRIPTION
## Summary

The four rapier3d `locomotion` environments gated `step()` only on action finiteness, so a step taken past a done snapshot ran another physics tick and emitted a fresh reward. The two pendulums are the sharp case: their healthiness predicates are **live reads of the current pose, not latches**, so the episode did not merely drift past termination — it resurrected. A toppled pole that swings back through `|θ| < 0.2` re-earns the `+1` alive bonus on a **`Running`** snapshot, and the double pendulum's tip does the same for its `+10` once it swings back above the healthy z floor. This applies the `EpisodeGuard` post-terminal contract (ADR 0044, established in #105) to all four, continuing the family-by-family rollout tracked by #289.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #292

Sub-issue of #289. Sibling of #290 (classic), #291 (grids), #293 (box2d). Remaining: #294 (pixel_grid), #295 (classic bandits).

## What Was Changed

- `crates/rlevo-environments/src/locomotion/{inverted_pendulum,inverted_double_pendulum,reacher,swimmer}/env.rs` — each env holds an `EpisodeGuard`; `self.guard.check()?` is the first statement of `step()`; `record()` of the emitted snapshot's own status on a single exit; `reset()` in `Environment::reset`; `# Errors` rustdoc now documents `StepAfterEpisodeEnd`.
- The guard is checked **ahead of the action-bounds check**, because the episode being over is a call-sequence fact independent of whether the action was well-formed. A caller replaying a malformed action past a terminal previously got `InvalidAction` — the wrong diagnosis.
- `crates/rlevo-core/src/environment.rs` — the `Environment::step` migration note moves `locomotion` from the undefined list into the enforcing list. The `classic` module's bandits and `pixel_grid` remain undefined.
- `docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md` and `docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md` — the same coverage claim appeared in five places; all updated.
- `CHANGELOG.md` — entry under `[Unreleased]` → `rlevo-environments` → `**Fixed**`.

## How It Was Tested

```
cargo build --workspace                          # clean
cargo test --workspace                           # 3041 passed, 0 failed
cargo clippy --all-targets --all-features        # 0 warnings
cargo clippy -p rlevo-environments --no-default-features --features locomotion --all-targets -- -D warnings   # clean
cargo fmt --all --check                          # clean
cd docs/user-book && mdbook build                # OK
```

`locomotion` is a default feature gating `dep:rapier3d`, so the gated combo is linted separately — `--all-features` alone would not isolate it.

**Regression tests added** — each env gains `assert_rejects_post_terminal_step` conformance plus no-mutation, guard-outranks-the-action-check, and reset-reopens tests. The pendulums drive to a genuine `Terminated`; `Reacher` and `Swimmer` have **no `Terminated` path at all** (their only done status is `Truncated` at `steps >= max_steps`, verified by grep), so theirs drive to truncation and assert the error carries `Truncated`, not `Terminated`.

**Before/after evidence.** Commenting out `check()?` in `inverted_pendulum` fails all six new tests — they are not vacuous. Separately, existing tests missed this defect because none stepped past a done snapshot; `Reacher`'s `reward_distance_is_nonpositive` and `reward_control_is_nonpositive` each drive exactly 50 unconditional steps against a default `max_steps == 50`, landing on the truncation boundary with zero margin. Extending either to 51 iterations reproduces the bug.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU); the physics path is rapier3d and backend-independent
- OS: macOS 26.5.2 (arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **implementation of the guard across all four envs, the regression tests, the doc/CHANGELOG sync, and the adversarial QA pass (including the guard-removal mutation test). Design was not AI-originated — it follows ADR 0044 and the accepted box2d precedent in 3319f7a. All output was reviewed and the verification commands re-run on the combined tree.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- **No `### Breaking changes` CHANGELOG entry**, matching the #290/#291/#293 precedent: the API-level break (`EnvironmentError::StepAfterEpisodeEnd`) was declared once when the variant was introduced, and each per-family rollout since has sat under `**Fixed**` only. Callers that stepped past a done snapshot in these four envs now get `Err` where they previously got a snapshot — but that behavior was explicitly documented as undefined.
- **Follow-ups surfaced during triage, not fixed here.** #984 and #1001 each had rows this PR delivers (the post-terminal tests, and #1001's `# Errors` doc row); both are commented with a *split* rather than closed, since their other rows — consecutive-reset test, non-finite-termination test, reset-variety doc caveat — are untouched.
- **`cargo doc -p rlevo-core --no-deps` emits 2 warnings** (`ConstraintKind::NotFinite`, `in_range`). Both are pre-existing and unrelated to this diff.
- One QA residual: the double-pendulum resurrection mechanism was confirmed by reading the health-check computation but not reproduced pre-fix in a standalone harness. The guard closes the whole class regardless of the exact mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLn6GYeiS52TpYgZfCsten
