### PR TITLE
fix(env): Guard post-terminal step in bandit family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   form and clause 2's vacuous case already held for them. The two grid
   observation types that motivated the amendment are the `rlevo-environments`
   entries below.
+- **`Environment::step`'s post-terminal contract is now unconditional** (ADR
+  0044 §8, closes #289). The rustdoc's alpha migration note — which disclosed
+  that only some families enforced the contract and that post-terminal
+  behaviour was **undefined** everywhere else, so callers must not rely on it —
+  is deleted: with the bandit family guarded, every `Environment` implementation
+  in the workspace now holds an `EpisodeGuard` and rejects a post-terminal
+  `step()`. The normative "implementations **must** return
+  `EnvironmentError::StepAfterEpisodeEnd`" text is unchanged; what changes is
+  that it is now true of the whole workspace rather than aspirational, so
+  callers may rely on it. The same section also now says the check belongs
+  ahead of any state mutation **or RNG draw** — a rejected step must not
+  advance the environment's RNG stream either, which ADR 0029 makes persistent,
+  observable state; `EpisodeGuard`'s own docs carry the matching wording.
+
+  This is **doc-only**: no signature changes and no behavioural change in
+  `rlevo-core`. Fixture and stub environments (`rlevo-test-support`, the
+  in-crate `StubEnv`/`MockEnvironment` types) remain exempt by ADR 0044 §9 —
+  `TimeLimit`'s `StubEnv` is unguarded on purpose so the wrapper's tests
+  exercise the wrapper's own guard.
 
 ### `rlevo-environments`
 
@@ -374,6 +393,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   one the way `type_u8` did (`Color::to_u8`'s own indices are unchanged), which
   will surprise anyone porting a Minigrid baseline expecting both channels to
   move together.
+- **The inherent `KArmedBandit::is_done()` is removed** (ADR 0044, #295). It was
+  a second source of truth for episode termination, which `docs/rules.md` §10
+  forbids: done-ness is read from the snapshot, never from the environment by
+  other means. The method could not have been the real answer in any case — it
+  returned a private `done: bool` that `step()` wrote and nothing ever read, so
+  it reported termination from a field the episode's actual lifecycle had no
+  dependence on. The three sibling bandits never exposed an equivalent, so the
+  removal also ends an inconsistency inside the family.
+
+  *Migration.* Read done-ness from the snapshot: `snapshot.is_done()`
+  (`rlevo_core::environment::Snapshot::is_done`), which is what every in-tree
+  caller already did. No in-workspace caller of the inherent method existed, so
+  the break is nominal for anyone not depending on it externally.
 
 **Added**
 
@@ -504,6 +536,54 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **Post-terminal `step()` drew a fresh random reward and re-emitted
+  `Terminated` across the whole bandit family** (ADR 0044, resolves #295 and
+  closes the #289 sweep) — `KArmedBandit`, `AdversarialBandit`,
+  `ContextualBandit` and `NonStationaryBandit`. Each already carried a
+  `done: bool` that `step()` **wrote and nothing read**, so the guard was
+  half-built and inert: a call made after `max_steps` kept incrementing the
+  step counter, produced a **fresh reward** — a new draw from the arm's
+  distribution for the three stochastic bandits, a further slide along the
+  adversary's `steps`-indexed schedule for `AdversarialBandit` — and emitted a
+  **new `Terminated` snapshot** — every time, without bound. A
+  trainer that stepped one call past the budget did not get an error and did
+  not get a repeat of the terminal transition; it got fabricated experience
+  that looks indistinguishable from real experience once it is in a replay
+  buffer. This is exactly the silent data contamination ADR 0044 rejects
+  absorbing semantics to avoid, except here it was not even absorbing — the
+  reward was freshly random on each call.
+
+  All four now hold an `episode::EpisodeGuard`, `check()` it as the **first**
+  statement of `step()`, and `record()` the emitted snapshot's own
+  `EpisodeStatus` on a single exit, so the guard and the snapshot cannot drift
+  apart. The `done: bool` field is gone from all four, along with the inherent
+  `KArmedBandit::is_done()` accessor it backed (see *Breaking changes* above):
+  `EpisodeStatus` is the single source of truth (`docs/rules.md` §10), and a
+  bool could not have carried the `Terminated`/`Truncated` distinction the
+  error reports anyway.
+
+  The guard sits **ahead of** the action-validity check, because the episode
+  being over is a fact about the call sequence and is independent of whether
+  the action was well-formed. One observable consequence: an out-of-range arm
+  index replayed past a terminal snapshot now reports `StepAfterEpisodeEnd`
+  rather than `InvalidAction` — the caller is told about the sequencing bug
+  they have, not handed the wrong diagnosis.
+
+  The existing tests missed all of this for two compounding reasons. Nothing
+  asserted on post-terminal behaviour — every test stopped on the terminal call
+  and checked its status, never asking what a further step returns — and
+  because `done` was **write-only**, no test *could* have observed that the
+  lifecycle tracking was half-implemented; the field's value was correct and
+  simply never consulted. A dead field is invisible to behavioural testing by
+  construction. Each environment gained the shared
+  `assert_rejects_post_terminal_step` conformance check, a
+  rejected-before-`is_valid()` test, a reset-reopens-the-episode test, and a
+  no-mutation regression: the three stochastic bandits pin that a rejected step
+  does not advance the **RNG stream** (ADR 0029 makes that stream persistent,
+  observable state, so consuming a draw on a rejected call would desynchronise
+  every subsequent episode), and `AdversarialBandit` — whose reward is a pure
+  function of `steps` — pins the deterministic analogue, that the schedule does
+  not slide.
 - **Post-terminal `step()` kept moving the agent — and paid a *negative* goal
   reward — in `pixel_grid`** (ADR 0044, resolves #294). `PixelGridEnv::step`
   opened with `self.steps += 1; self.state.apply_move(action);` and had no

--- a/crates/rlevo-core/src/environment.rs
+++ b/crates/rlevo-core/src/environment.rs
@@ -351,15 +351,10 @@ pub trait Environment<const R: usize, const SR: usize, const AR: usize> {
     /// and is reported as one. Call [`reset`](Self::reset) to begin a new
     /// episode.
     ///
-    /// The check belongs at the **top** of `step()`, before any state mutation,
-    /// so a rejected call leaves the environment untouched.
-    ///
-    /// **Migration note (alpha).** The `toy_text`, `classic` (non-bandit),
-    /// `grids`, `box2d`, and `locomotion` families, `pixel_grid`, and the
-    /// `TimeLimit` wrapper enforce this. The behaviour of the remaining
-    /// environments — the `classic` module's bandits — after a terminal
-    /// snapshot is **undefined**; see issue #289 for the family-by-family
-    /// rollout. Callers must not rely on it there.
+    /// The check belongs at the **top** of `step()`, before any state mutation
+    /// or RNG draw, so a rejected call leaves the environment untouched — an
+    /// environment's RNG stream is a persistent, observable part of its state,
+    /// so a rejected step must not advance it either.
     ///
     /// # Errors
     ///

--- a/crates/rlevo-environments/src/classic/bandit/adversarial.rs
+++ b/crates/rlevo-environments/src/classic/bandit/adversarial.rs
@@ -47,7 +47,7 @@ use rand::rngs::StdRng;
 use rlevo_core::base::{Action, Reward};
 use rlevo_core::config::{self, ConfigError, Validate};
 use rlevo_core::environment::{
-    ConstructableEnv, Environment, EnvironmentError, Sensor, SnapshotBase,
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
@@ -56,6 +56,7 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use super::k_armed::{KArmedBanditAction, KArmedBanditObservation, KArmedBanditState};
+use crate::episode::EpisodeGuard;
 
 // ---------------------------------------------------------------------------
 // Config
@@ -193,7 +194,10 @@ impl FromStr for AdversarialBanditConfig {
 pub struct AdversarialBandit<const K: usize> {
     state: KArmedBanditState,
     steps: usize,
-    done: bool,
+    /// Episode-lifecycle guard: rejects a [`Environment::step`] taken after the
+    /// episode ended (ADR 0044). `EpisodeStatus` is the single source of truth
+    /// for done-ness (`docs/rules.md` §10).
+    guard: EpisodeGuard,
     config: AdversarialBanditConfig,
     phases: [usize; K],
 }
@@ -202,8 +206,11 @@ impl<const K: usize> Display for AdversarialBandit<K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "AdversarialBandit<{K}>(step={}/{}, period={}, done={})",
-            self.steps, self.config.max_steps, self.config.period, self.done
+            "AdversarialBandit<{K}>(step={}/{}, period={}, status={:?})",
+            self.steps,
+            self.config.max_steps,
+            self.config.period,
+            self.guard.status()
         )
     }
 }
@@ -245,7 +252,7 @@ impl<const K: usize> AdversarialBandit<K> {
         Ok(Self {
             state: KArmedBanditState,
             steps: 0,
-            done: false,
+            guard: EpisodeGuard::new(),
             config,
             phases,
         })
@@ -310,16 +317,24 @@ impl<const K: usize> Environment<1, 1, 1> for AdversarialBandit<K> {
     /// deterministic in the step index, so every episode replays the same
     /// schedule by design (host-RNG seeding convention, `docs/rules.md` §8).
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state = KArmedBanditState;
         self.steps = 0;
-        self.done = false;
         Ok(SnapshotBase::running(
             self.observe_reset(&self.state),
             ScalarReward::zero(),
         ))
     }
 
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] when the episode has
+    /// already ended — checked **first**, before the action is validated, so a
+    /// rejected call leaves the environment untouched and the reward schedule
+    /// un-advanced. Returns [`EnvironmentError::InvalidAction`] when the arm
+    /// index is out of range.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.check()?;
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "arm index {} out of range [0, {K})",
@@ -330,11 +345,11 @@ impl<const K: usize> Environment<1, 1, 1> for AdversarialBandit<K> {
         self.steps += 1;
         let obs = self.observe(&action, &self.state);
         let snap = if self.steps >= self.config.max_steps {
-            self.done = true;
             SnapshotBase::terminated(obs, reward)
         } else {
             SnapshotBase::running(obs, reward)
         };
+        self.guard.record(snap.status());
         Ok(snap)
     }
 }
@@ -374,8 +389,9 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::DiscreteAction;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::EpisodeStatus;
 
     const K: usize = 10;
 
@@ -481,6 +497,115 @@ mod tests {
         let _ = <AdversarialBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).unwrap();
         let s3 = <AdversarialBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).unwrap();
         assert!(s3.is_terminated());
+    }
+
+    // ── post-terminal step guard (issue #295, ADR 0044) ──────────────────────
+
+    /// Step budget for the guard tests: small enough to burn through quickly.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    fn guard_env() -> AdversarialBandit<K> {
+        AdversarialBandit::<K>::with_config(AdversarialBanditConfig {
+            max_steps: GUARD_MAX_STEPS,
+            seed: 7,
+            period: 4,
+            amplitude: 1.0,
+        })
+        .expect("valid config")
+    }
+
+    /// Resets, then steps arm 0 until the step budget terminates the episode.
+    fn drive_to_termination(
+        env: &mut AdversarialBandit<K>,
+    ) -> SnapshotBase<1, KArmedBanditObservation, ScalarReward> {
+        <AdversarialBandit<K> as Environment<1, 1, 1>>::reset(env).expect("reset must succeed");
+        let action = KArmedBanditAction::<K>::from_index(0);
+        let mut snap = <AdversarialBandit<K> as Environment<1, 1, 1>>::step(env, action)
+            .expect("first step must succeed");
+        while !snap.is_done() {
+            snap = <AdversarialBandit<K> as Environment<1, 1, 1>>::step(env, action)
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    #[test]
+    fn rejects_post_terminal_step() {
+        let mut env = guard_env();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_termination,
+            KArmedBanditAction::<K>::from_index(0),
+        );
+    }
+
+    #[test]
+    fn post_terminal_step_is_rejected_before_action_validity() {
+        // The call sequence is wrong independently of the action being
+        // well-formed, so StepAfterEpisodeEnd wins over InvalidAction.
+        let mut env = guard_env();
+        let terminal = drive_to_termination(&mut env);
+
+        let malformed = KArmedBanditAction::<K>::out_of_range_for_tests();
+        assert!(!malformed.is_valid(), "the replayed action is out of range");
+
+        let err = <AdversarialBandit<K> as Environment<1, 1, 1>>::step(&mut env, malformed)
+            .expect_err("a step after termination must be rejected");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                terminal.status(),
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_terminal_step_does_not_advance_the_schedule() {
+        // The adversary's reward is a pure function of `steps`, so an unguarded
+        // post-terminal step would silently slide the whole schedule. This is
+        // the deterministic analogue of the "no RNG draw" property: a rejected
+        // step must leave the next episode replaying identically.
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let steps_at_end = env.steps;
+
+        let _ = <AdversarialBandit<K> as Environment<1, 1, 1>>::step(
+            &mut env,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    fn reset_reopens_a_terminated_episode() {
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let action = KArmedBanditAction::<K>::from_index(0);
+        assert!(
+            <AdversarialBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        <AdversarialBandit<K> as Environment<1, 1, 1>>::reset(&mut env)
+            .expect("reset must succeed");
+        assert!(
+            !<AdversarialBandit<K> as Environment<1, 1, 1>>::step(&mut env, action)
+                .expect("reset() must re-open the environment")
+                .is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/classic/bandit/contextual.rs
+++ b/crates/rlevo-environments/src/classic/bandit/contextual.rs
@@ -42,7 +42,7 @@ use rlevo_core::base::{
 };
 use rlevo_core::config::{self, ConfigError, Validate};
 use rlevo_core::environment::{
-    ConstructableEnv, Environment, EnvironmentError, Sensor, SnapshotBase,
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
 use rlevo_core::state::StateError;
@@ -51,6 +51,7 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use super::k_armed::KArmedBanditAction;
+use crate::episode::EpisodeGuard;
 
 // ---------------------------------------------------------------------------
 // State / Observation
@@ -370,7 +371,10 @@ impl FromStr for ContextualBanditConfig {
 pub struct ContextualBandit<const C: usize, const K: usize> {
     state: ContextualBanditState<C>,
     steps: usize,
-    done: bool,
+    /// Episode-lifecycle guard: rejects a [`Environment::step`] taken after the
+    /// episode ended (ADR 0044). `EpisodeStatus` is the single source of truth
+    /// for done-ness (`docs/rules.md` §10).
+    guard: EpisodeGuard,
     config: ContextualBanditConfig,
     rng: StdRng,
     arm_means: [[f32; K]; C],
@@ -380,8 +384,11 @@ impl<const C: usize, const K: usize> Display for ContextualBandit<C, K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ContextualBandit<{C},{K}>(step={}/{}, context={}, done={})",
-            self.steps, self.config.max_steps, self.state.context, self.done
+            "ContextualBandit<{C},{K}>(step={}/{}, context={}, status={:?})",
+            self.steps,
+            self.config.max_steps,
+            self.state.context,
+            self.guard.status()
         )
     }
 }
@@ -417,7 +424,7 @@ impl<const C: usize, const K: usize> ContextualBandit<C, K> {
         Ok(Self {
             state: ContextualBanditState { context },
             steps: 0,
-            done: false,
+            guard: EpisodeGuard::new(),
             config,
             rng,
             arm_means,
@@ -500,16 +507,24 @@ impl<const C: usize, const K: usize> Environment<1, 1, 1> for ContextualBandit<C
     /// `docs/rules.md` §8). For a reproducible problem, construct with a fixed
     /// seed.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.state.context = self.rng.random_range(0..C);
         self.steps = 0;
-        self.done = false;
         Ok(SnapshotBase::running(
             self.observe_reset(&self.state),
             ScalarReward::zero(),
         ))
     }
 
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] when the episode has
+    /// already ended — checked **first**, before the action is validated and
+    /// before the reward draw or the next-context draw, so a rejected call
+    /// advances neither the environment nor its RNG stream. Returns
+    /// [`EnvironmentError::InvalidAction`] when the arm index is out of range.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.check()?;
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "arm index {} out of range [0, {K})",
@@ -523,11 +538,11 @@ impl<const C: usize, const K: usize> Environment<1, 1, 1> for ContextualBandit<C
         self.state.context = self.rng.random_range(0..C);
         let obs = self.observe(&action, &self.state);
         let snap = if self.steps >= self.config.max_steps {
-            self.done = true;
             SnapshotBase::terminated(obs, reward)
         } else {
             SnapshotBase::running(obs, reward)
         };
+        self.guard.record(snap.status());
         Ok(snap)
     }
 }
@@ -567,8 +582,9 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::DiscreteAction;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::EpisodeStatus;
 
     #[test]
     fn default_config_validates() {
@@ -754,6 +770,155 @@ mod tests {
         assert!(!s2.is_done());
         let s3 = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(&mut env, action).unwrap();
         assert!(s3.is_terminated());
+    }
+
+    // ── post-terminal step guard (issue #295, ADR 0044) ──────────────────────
+
+    /// Step budget for the guard tests: small enough to burn through quickly.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    fn guard_env() -> ContextualBandit<C, K> {
+        ContextualBandit::<C, K>::with_config(ContextualBanditConfig {
+            max_steps: GUARD_MAX_STEPS,
+            seed: 7,
+        })
+        .expect("valid config")
+    }
+
+    /// Resets, then steps arm 0 until the step budget terminates the episode.
+    fn drive_to_termination(
+        env: &mut ContextualBandit<C, K>,
+    ) -> SnapshotBase<1, ContextualBanditObservation<C>, ScalarReward> {
+        <ContextualBandit<C, K> as Environment<1, 1, 1>>::reset(env).expect("reset must succeed");
+        let action = KArmedBanditAction::<K>::from_index(0);
+        let mut snap = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(env, action)
+            .expect("first step must succeed");
+        while !snap.is_done() {
+            snap = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(env, action)
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    #[test]
+    fn rejects_post_terminal_step() {
+        let mut env = guard_env();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_termination,
+            KArmedBanditAction::<K>::from_index(0),
+        );
+    }
+
+    #[test]
+    fn post_terminal_step_is_rejected_before_action_validity() {
+        // The call sequence is wrong independently of the action being
+        // well-formed, so StepAfterEpisodeEnd wins over InvalidAction.
+        let mut env = guard_env();
+        let terminal = drive_to_termination(&mut env);
+
+        let malformed = KArmedBanditAction::<K>::out_of_range_for_tests();
+        assert!(!malformed.is_valid(), "the replayed action is out of range");
+
+        let err = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(&mut env, malformed)
+            .expect_err("a step after termination must be rejected");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                terminal.status(),
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_terminal_step_does_not_advance_the_step_counter() {
+        let mut env = guard_env();
+        let terminal = drive_to_termination(&mut env);
+        let steps_at_end = env.steps;
+        let context_at_end = env.current_context();
+
+        let _ = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(
+            &mut env,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.current_context(),
+            context_at_end,
+            "a rejected step must not reveal a fresh context"
+        );
+        assert_eq!(
+            env.guard.status(),
+            terminal.status(),
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    fn rejected_step_does_not_advance_the_rng_stream() {
+        // ADR 0029: the env's RNG is persistent, observable state and drives
+        // both the reward draw and the context draw. A rejected step must draw
+        // no randomness, so the next episode must replay identically to a
+        // same-seed env that never made the illegal call.
+        let mut rejected = guard_env();
+        let mut untouched = guard_env();
+        drive_to_termination(&mut rejected);
+        drive_to_termination(&mut untouched);
+
+        let _ = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(
+            &mut rejected,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        let replay = |env: &mut ContextualBandit<C, K>| -> Vec<(f32, usize)> {
+            <ContextualBandit<C, K> as Environment<1, 1, 1>>::reset(env).unwrap();
+            let action = KArmedBanditAction::<K>::from_index(0);
+            (0..GUARD_MAX_STEPS)
+                .map(|_| {
+                    let snap = <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(env, action)
+                        .unwrap();
+                    (f32::from(*snap.reward()), snap.observation().context())
+                })
+                .collect()
+        };
+        assert_eq!(
+            replay(&mut rejected),
+            replay(&mut untouched),
+            "a rejected step must draw no randomness; the next episode must replay identically"
+        );
+    }
+
+    #[test]
+    fn reset_reopens_a_terminated_episode() {
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let action = KArmedBanditAction::<K>::from_index(0);
+        assert!(
+            <ContextualBandit<C, K> as Environment<1, 1, 1>>::step(&mut env, action).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        <ContextualBandit<C, K> as Environment<1, 1, 1>>::reset(&mut env)
+            .expect("reset must succeed");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert!(
+            !<ContextualBandit<C, K> as Environment<1, 1, 1>>::step(&mut env, action)
+                .expect("reset() must re-open the environment")
+                .is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/classic/bandit/k_armed.rs
+++ b/crates/rlevo-environments/src/classic/bandit/k_armed.rs
@@ -37,12 +37,14 @@ use rlevo_core::base::{
 };
 use rlevo_core::config::{self, ConfigError, Validate};
 use rlevo_core::environment::{
-    ConstructableEnv, Environment, EnvironmentError, Sensor, SnapshotBase,
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+
+use crate::episode::EpisodeGuard;
 
 // ---------------------------------------------------------------------------
 // State
@@ -188,6 +190,18 @@ impl<const K: usize> KArmedBanditAction<K> {
     #[must_use]
     pub fn arm(&self) -> usize {
         self.selected_arm
+    }
+
+    /// Forges an action whose arm index is out of range (`selected_arm == K`).
+    ///
+    /// Test-only, and shared with the sibling bandit modules: every public
+    /// constructor rejects an out-of-range index, so this is the only way to
+    /// obtain the malformed action needed to prove that
+    /// [`Environment::step`] consults the episode guard **before** it validates
+    /// the action (ADR 0044 §5).
+    #[cfg(test)]
+    pub(super) fn out_of_range_for_tests() -> Self {
+        Self { selected_arm: K }
     }
 }
 
@@ -400,7 +414,10 @@ impl FromStr for KArmedBanditConfig {
 pub struct KArmedBandit<const K: usize> {
     state: KArmedBanditState,
     steps: usize,
-    done: bool,
+    /// Episode-lifecycle guard: rejects a [`Environment::step`] taken after the
+    /// episode ended (ADR 0044). `EpisodeStatus` is the single source of truth
+    /// for done-ness (`docs/rules.md` §10).
+    guard: EpisodeGuard,
     config: KArmedBanditConfig,
     rng: StdRng,
     arm_means: [f32; K],
@@ -410,8 +427,10 @@ impl<const K: usize> Display for KArmedBandit<K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "KArmedBandit<{K}>(step={}/{}, done={})",
-            self.steps, self.config.max_steps, self.done
+            "KArmedBandit<{K}>(step={}/{}, status={:?})",
+            self.steps,
+            self.config.max_steps,
+            self.guard.status()
         )
     }
 }
@@ -454,7 +473,7 @@ impl<const K: usize> KArmedBandit<K> {
         Ok(Self {
             state: KArmedBanditState,
             steps: 0,
-            done: false,
+            guard: EpisodeGuard::new(),
             config,
             rng,
             arm_means,
@@ -474,16 +493,29 @@ impl<const K: usize> KArmedBandit<K> {
     /// discards the snapshot return value. Prefer the
     /// [`Environment::reset`] trait method for new code — it returns a
     /// [`SnapshotBase`] for composition with wrappers.
+    ///
+    /// The episode guard is re-opened here, so both reset lanes (this one and
+    /// [`Environment::reset`], which delegates to it) agree.
     pub fn reset(&mut self) {
+        self.guard.reset();
         self.state = KArmedBanditState;
         self.steps = 0;
-        self.done = false;
     }
 
     /// Pull `arm` and return a sampled reward from `N(q*(arm), 1)`.
     ///
-    /// Advances the internal step counter and marks the episode `done` when
-    /// `steps == max_steps`.
+    /// Advances the internal step counter and, like [`Environment::step`],
+    /// records the resulting episode status on the guard: `Terminated` once
+    /// `steps >= max_steps`, `Running` before that. Both entry points funnel
+    /// through the same private `advance` helper, so the guard and the step
+    /// counter can never disagree about where the episode is — pulling to the
+    /// step budget closes the episode for the trait `step` too.
+    ///
+    /// Unlike [`Environment::step`], `pull` is **infallible and unguarded on
+    /// entry**: it does not reject a post-terminal call. It is a bespoke
+    /// non-trait entry point kept for `rlevo-benchmarks`, and making it
+    /// fallible would be an unrelated API break. Callers that need the
+    /// post-terminal contract of ADR 0044 must use [`Environment::step`].
     ///
     /// # Panics
     ///
@@ -492,17 +524,30 @@ impl<const K: usize> KArmedBandit<K> {
     pub fn pull(&mut self, arm: usize) -> f32 {
         let action = KArmedBanditAction::<K>::new(arm).expect("arm index in range");
         let reward = self.sample_reward(action.arm());
-        self.steps += 1;
-        if self.steps >= self.config.max_steps {
-            self.done = true;
-        }
+        let _ = self.advance(action, ScalarReward(reward));
         reward
     }
 
-    /// `true` when the episode has reached `max_steps`.
-    #[must_use]
-    pub fn is_done(&self) -> bool {
-        self.done
+    /// Ticks the step counter, builds the snapshot for this transition, and
+    /// records **that snapshot's own status** on the guard.
+    ///
+    /// The single place the episode advances: shared by [`Environment::step`]
+    /// and [`Self::pull`] so the guard cannot drift from the emitted snapshot
+    /// (ADR 0044 §5).
+    fn advance(
+        &mut self,
+        action: KArmedBanditAction<K>,
+        reward: ScalarReward,
+    ) -> SnapshotBase<1, KArmedBanditObservation, ScalarReward> {
+        self.steps += 1;
+        let obs = self.observe(&action, &self.state);
+        let snap = if self.steps >= self.config.max_steps {
+            SnapshotBase::terminated(obs, reward)
+        } else {
+            SnapshotBase::running(obs, reward)
+        };
+        self.guard.record(snap.status());
+        snap
     }
 
     /// Read-only view of the true arm means.
@@ -567,7 +612,15 @@ impl<const K: usize> Environment<1, 1, 1> for KArmedBandit<K> {
         ))
     }
 
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] when the episode has
+    /// already ended — checked **first**, before the action is validated and
+    /// before any RNG draw, so a rejected call leaves the environment (and its
+    /// reward stream) untouched. Returns
+    /// [`EnvironmentError::InvalidAction`] when the arm index is out of range.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.check()?;
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "arm index {} out of range [0, {K})",
@@ -575,15 +628,7 @@ impl<const K: usize> Environment<1, 1, 1> for KArmedBandit<K> {
             )));
         }
         let reward = ScalarReward(self.sample_reward(action.arm()));
-        self.steps += 1;
-        let obs = self.observe(&action, &self.state);
-        let snap = if self.steps >= self.config.max_steps {
-            self.done = true;
-            SnapshotBase::terminated(obs, reward)
-        } else {
-            SnapshotBase::running(obs, reward)
-        };
-        Ok(snap)
+        Ok(self.advance(action, reward))
     }
 }
 
@@ -658,7 +703,8 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
-    use rlevo_core::environment::Snapshot;
+    use crate::episode::assert_rejects_post_terminal_step;
+    use rlevo_core::environment::EpisodeStatus;
 
     #[test]
     fn default_config_validates() {
@@ -758,7 +804,11 @@ mod tests {
     fn environment_new_constructs() {
         let env = <KArmedBandit<K> as ConstructableEnv>::new(false);
         assert_eq!(env.steps, 0);
-        assert!(!env.done);
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "a freshly constructed bandit must be steppable"
+        );
     }
 
     #[test]
@@ -784,6 +834,192 @@ mod tests {
         assert!(!s2.is_done());
         let s3 = <KArmedBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).unwrap();
         assert!(s3.is_terminated());
+    }
+
+    // ── post-terminal step guard (issue #295, ADR 0044) ──────────────────────
+
+    /// Step budget for the guard tests: small enough to burn through quickly.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    fn guard_env() -> KArmedBandit<K> {
+        KArmedBandit::<K>::with_config(KArmedBanditConfig {
+            max_steps: GUARD_MAX_STEPS,
+            seed: 7,
+        })
+        .expect("valid config")
+    }
+
+    /// Resets, then steps arm 0 until the step budget terminates the episode.
+    fn drive_to_termination(
+        env: &mut KArmedBandit<K>,
+    ) -> SnapshotBase<1, KArmedBanditObservation, ScalarReward> {
+        <KArmedBandit<K> as Environment<1, 1, 1>>::reset(env).expect("reset must succeed");
+        let action = KArmedBanditAction::<K>::from_index(0);
+        let mut snap = <KArmedBandit<K> as Environment<1, 1, 1>>::step(env, action)
+            .expect("first step must succeed");
+        while !snap.is_done() {
+            snap = <KArmedBandit<K> as Environment<1, 1, 1>>::step(env, action)
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    #[test]
+    fn rejects_post_terminal_step() {
+        let mut env = guard_env();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_termination,
+            KArmedBanditAction::<K>::from_index(0),
+        );
+    }
+
+    #[test]
+    fn post_terminal_step_is_rejected_before_action_validity() {
+        // Being past the end of the episode is a call-sequence fact that does
+        // not depend on the action being well-formed: replaying a malformed
+        // action past a terminal must report StepAfterEpisodeEnd, not
+        // InvalidAction.
+        let mut env = guard_env();
+        let terminal = drive_to_termination(&mut env);
+
+        let malformed = KArmedBanditAction::<K>::out_of_range_for_tests();
+        assert!(!malformed.is_valid(), "the replayed action is out of range");
+
+        let err = <KArmedBandit<K> as Environment<1, 1, 1>>::step(&mut env, malformed)
+            .expect_err("a step after termination must be rejected");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                terminal.status(),
+                "the call-sequence error wins over the action's own validity"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_terminal_step_does_not_advance_the_step_counter() {
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let steps_at_end = env.steps;
+
+        let _ = <KArmedBandit<K> as Environment<1, 1, 1>>::step(
+            &mut env,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    fn rejected_step_does_not_advance_the_rng_stream() {
+        // ADR 0029: the env's RNG is persistent, observable state. A rejected
+        // step must draw no randomness, so the next episode's rewards must be
+        // exactly those of a same-seed env that never made the illegal call.
+        let mut rejected = guard_env();
+        let mut untouched = guard_env();
+        drive_to_termination(&mut rejected);
+        drive_to_termination(&mut untouched);
+
+        let _ = <KArmedBandit<K> as Environment<1, 1, 1>>::step(
+            &mut rejected,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        let after: Vec<f32> = {
+            <KArmedBandit<K> as Environment<1, 1, 1>>::reset(&mut rejected).unwrap();
+            (0..GUARD_MAX_STEPS).map(|_| rejected.pull(0)).collect()
+        };
+        let baseline: Vec<f32> = {
+            <KArmedBandit<K> as Environment<1, 1, 1>>::reset(&mut untouched).unwrap();
+            (0..GUARD_MAX_STEPS).map(|_| untouched.pull(0)).collect()
+        };
+        assert_eq!(
+            after, baseline,
+            "a rejected step must draw no randomness; the next episode must replay identically"
+        );
+    }
+
+    #[test]
+    fn reset_reopens_a_terminated_episode() {
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let action = KArmedBanditAction::<K>::from_index(0);
+        assert!(
+            <KArmedBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        <KArmedBandit<K> as Environment<1, 1, 1>>::reset(&mut env).expect("reset must succeed");
+        assert!(
+            !<KArmedBandit<K> as Environment<1, 1, 1>>::step(&mut env, action)
+                .expect("reset() must re-open the environment")
+                .is_done(),
+            "the first step of a fresh episode must not be done"
+        );
+    }
+
+    #[test]
+    fn inherent_reset_reopens_a_terminated_episode() {
+        // `KArmedBandit::reset` is the bespoke benchmark lane; it must clear the
+        // guard too, or the two reset paths disagree.
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+
+        KArmedBandit::reset(&mut env);
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "the inherent reset must re-open the guard as well"
+        );
+        assert!(
+            <KArmedBandit<K> as Environment<1, 1, 1>>::step(
+                &mut env,
+                KArmedBanditAction::<K>::from_index(0)
+            )
+            .is_ok(),
+            "the inherent reset must leave the environment steppable"
+        );
+    }
+
+    #[test]
+    fn pull_records_the_same_status_the_trait_step_would() {
+        // `pull` is unguarded on entry but shares `advance`, so it closes the
+        // episode at exactly the same step count the trait `step` does.
+        let mut env = guard_env();
+        for _ in 0..GUARD_MAX_STEPS - 1 {
+            let _ = env.pull(0);
+            assert_eq!(
+                env.guard.status(),
+                EpisodeStatus::Running,
+                "the episode is still inside its step budget"
+            );
+        }
+        let _ = env.pull(0);
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "pulling to max_steps must terminate the episode for the trait step too"
+        );
+        assert!(
+            <KArmedBandit<K> as Environment<1, 1, 1>>::step(
+                &mut env,
+                KArmedBanditAction::<K>::from_index(0)
+            )
+            .is_err(),
+            "the guard and the step counter must not disagree across the two entry points"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/classic/bandit/non_stationary.rs
+++ b/crates/rlevo-environments/src/classic/bandit/non_stationary.rs
@@ -38,7 +38,7 @@ use rand_distr::{Distribution, Normal};
 use rlevo_core::base::{Action, Reward};
 use rlevo_core::config::{self, ConfigError, Validate};
 use rlevo_core::environment::{
-    ConstructableEnv, Environment, EnvironmentError, Sensor, SnapshotBase,
+    ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
 use serde::{Deserialize, Serialize};
@@ -48,6 +48,7 @@ use std::str::FromStr;
 use super::k_armed::{
     KArmedBanditAction, KArmedBanditObservation, KArmedBanditState, sample_arm_means,
 };
+use crate::episode::EpisodeGuard;
 
 // ---------------------------------------------------------------------------
 // Config
@@ -173,7 +174,10 @@ impl FromStr for NonStationaryBanditConfig {
 pub struct NonStationaryBandit<const K: usize> {
     state: KArmedBanditState,
     steps: usize,
-    done: bool,
+    /// Episode-lifecycle guard: rejects a [`Environment::step`] taken after the
+    /// episode ended (ADR 0044). `EpisodeStatus` is the single source of truth
+    /// for done-ness (`docs/rules.md` §10).
+    guard: EpisodeGuard,
     config: NonStationaryBanditConfig,
     rng: StdRng,
     arm_means: [f32; K],
@@ -186,8 +190,11 @@ impl<const K: usize> Display for NonStationaryBandit<K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "NonStationaryBandit<{K}>(step={}/{}, sigma_walk={}, done={})",
-            self.steps, self.config.max_steps, self.config.sigma_walk, self.done
+            "NonStationaryBandit<{K}>(step={}/{}, sigma_walk={}, status={:?})",
+            self.steps,
+            self.config.max_steps,
+            self.config.sigma_walk,
+            self.guard.status()
         )
     }
 }
@@ -222,7 +229,7 @@ impl<const K: usize> NonStationaryBandit<K> {
         Ok(Self {
             state: KArmedBanditState,
             steps: 0,
-            done: false,
+            guard: EpisodeGuard::new(),
             config,
             rng,
             arm_means,
@@ -296,17 +303,25 @@ impl<const K: usize> Environment<1, 1, 1> for NonStationaryBandit<K> {
     /// convention, `docs/rules.md` §8). For a reproducible problem, construct
     /// with a fixed seed.
     fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.reset();
         self.arm_means = self.initial_arm_means;
         self.state = KArmedBanditState;
         self.steps = 0;
-        self.done = false;
         Ok(SnapshotBase::running(
             self.observe_reset(&self.state),
             ScalarReward::zero(),
         ))
     }
 
+    /// # Errors
+    ///
+    /// Returns [`EnvironmentError::StepAfterEpisodeEnd`] when the episode has
+    /// already ended — checked **first**, before the action is validated and
+    /// before the reward draw or the random-walk drift, so a rejected call
+    /// advances neither the arm means nor the RNG stream. Returns
+    /// [`EnvironmentError::InvalidAction`] when the arm index is out of range.
     fn step(&mut self, action: Self::ActionType) -> Result<Self::SnapshotType, EnvironmentError> {
+        self.guard.check()?;
         if !action.is_valid() {
             return Err(EnvironmentError::InvalidAction(format!(
                 "arm index {} out of range [0, {K})",
@@ -318,11 +333,11 @@ impl<const K: usize> Environment<1, 1, 1> for NonStationaryBandit<K> {
         self.steps += 1;
         let obs = self.observe(&action, &self.state);
         let snap = if self.steps >= self.config.max_steps {
-            self.done = true;
             SnapshotBase::terminated(obs, reward)
         } else {
             SnapshotBase::running(obs, reward)
         };
+        self.guard.record(snap.status());
         Ok(snap)
     }
 }
@@ -359,8 +374,9 @@ mod tests {
     #![allow(clippy::float_cmp)]
 
     use super::*;
+    use crate::episode::assert_rejects_post_terminal_step;
     use rlevo_core::action::DiscreteAction;
-    use rlevo_core::environment::Snapshot;
+    use rlevo_core::environment::EpisodeStatus;
 
     const K: usize = 10;
 
@@ -402,6 +418,158 @@ mod tests {
         let _ = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).unwrap();
         let s3 = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).unwrap();
         assert!(s3.is_terminated());
+    }
+
+    // ── post-terminal step guard (issue #295, ADR 0044) ──────────────────────
+
+    /// Step budget for the guard tests: small enough to burn through quickly.
+    const GUARD_MAX_STEPS: usize = 3;
+
+    fn guard_env() -> NonStationaryBandit<K> {
+        NonStationaryBandit::<K>::with_config(NonStationaryBanditConfig {
+            max_steps: GUARD_MAX_STEPS,
+            seed: 7,
+            sigma_walk: 0.1,
+        })
+        .expect("valid config")
+    }
+
+    /// Resets, then steps arm 0 until the step budget terminates the episode.
+    fn drive_to_termination(
+        env: &mut NonStationaryBandit<K>,
+    ) -> SnapshotBase<1, KArmedBanditObservation, ScalarReward> {
+        <NonStationaryBandit<K> as Environment<1, 1, 1>>::reset(env).expect("reset must succeed");
+        let action = KArmedBanditAction::<K>::from_index(0);
+        let mut snap = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(env, action)
+            .expect("first step must succeed");
+        while !snap.is_done() {
+            snap = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(env, action)
+                .expect("step must succeed while the episode is running");
+        }
+        snap
+    }
+
+    #[test]
+    fn rejects_post_terminal_step() {
+        let mut env = guard_env();
+        assert_rejects_post_terminal_step(
+            &mut env,
+            drive_to_termination,
+            KArmedBanditAction::<K>::from_index(0),
+        );
+    }
+
+    #[test]
+    fn post_terminal_step_is_rejected_before_action_validity() {
+        // The call sequence is wrong independently of the action being
+        // well-formed, so StepAfterEpisodeEnd wins over InvalidAction.
+        let mut env = guard_env();
+        let terminal = drive_to_termination(&mut env);
+
+        let malformed = KArmedBanditAction::<K>::out_of_range_for_tests();
+        assert!(!malformed.is_valid(), "the replayed action is out of range");
+
+        let err = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(&mut env, malformed)
+            .expect_err("a step after termination must be rejected");
+        match err {
+            EnvironmentError::StepAfterEpisodeEnd { status } => assert_eq!(
+                status,
+                terminal.status(),
+                "the error must carry the status that ended the episode"
+            ),
+            other => panic!("expected StepAfterEpisodeEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_terminal_step_does_not_drift_the_arm_means() {
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let steps_at_end = env.steps;
+        let means_at_end = *env.arm_means();
+
+        let _ = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(
+            &mut env,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        assert_eq!(
+            env.steps, steps_at_end,
+            "a rejected step must not tick the step counter"
+        );
+        assert_eq!(
+            means_at_end,
+            *env.arm_means(),
+            "a rejected step must not random-walk the arm means"
+        );
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Terminated,
+            "a rejected step must not reopen the episode"
+        );
+    }
+
+    #[test]
+    fn rejected_step_does_not_advance_the_rng_stream() {
+        // ADR 0029: the env's RNG is persistent, observable state and drives
+        // both the reward draw and the drift. A rejected step must draw no
+        // randomness, so the next episode must replay identically to a
+        // same-seed env that never made the illegal call.
+        let mut rejected = guard_env();
+        let mut untouched = guard_env();
+        drive_to_termination(&mut rejected);
+        drive_to_termination(&mut untouched);
+
+        let _ = <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(
+            &mut rejected,
+            KArmedBanditAction::<K>::from_index(0),
+        )
+        .expect_err("a step after termination must be rejected");
+
+        let replay = |env: &mut NonStationaryBandit<K>| -> Vec<f32> {
+            <NonStationaryBandit<K> as Environment<1, 1, 1>>::reset(env).unwrap();
+            let action = KArmedBanditAction::<K>::from_index(0);
+            (0..GUARD_MAX_STEPS)
+                .map(|_| {
+                    f32::from(
+                        *<NonStationaryBandit<K> as Environment<1, 1, 1>>::step(env, action)
+                            .unwrap()
+                            .reward(),
+                    )
+                })
+                .collect()
+        };
+        assert_eq!(
+            replay(&mut rejected),
+            replay(&mut untouched),
+            "a rejected step must draw no randomness; the next episode must replay identically"
+        );
+    }
+
+    #[test]
+    fn reset_reopens_a_terminated_episode() {
+        let mut env = guard_env();
+        drive_to_termination(&mut env);
+        let action = KArmedBanditAction::<K>::from_index(0);
+        assert!(
+            <NonStationaryBandit<K> as Environment<1, 1, 1>>::step(&mut env, action).is_err(),
+            "the episode has ended; a step must be rejected before reset()"
+        );
+
+        <NonStationaryBandit<K> as Environment<1, 1, 1>>::reset(&mut env)
+            .expect("reset must succeed");
+        assert_eq!(
+            env.guard.status(),
+            EpisodeStatus::Running,
+            "reset() must return the guard to Running"
+        );
+        assert!(
+            !<NonStationaryBandit<K> as Environment<1, 1, 1>>::step(&mut env, action)
+                .expect("reset() must re-open the environment")
+                .is_done(),
+            "the first step of a fresh episode must not be done"
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/episode.rs
+++ b/crates/rlevo-environments/src/episode.rs
@@ -15,9 +15,11 @@
 //! # Usage
 //!
 //! Hold a guard in the environment struct, `check()` at the very top of `step()`
-//! (before any state mutation, so a rejected call leaves the environment
-//! untouched), `record()` the status of every snapshot you emit, and `reset()`
-//! the guard in `Environment::reset`:
+//! (before any state mutation or RNG draw, so a rejected call leaves the
+//! environment untouched — including its RNG stream, which ADR 0029 makes a
+//! persistent, observable part of the environment's state), `record()` the
+//! status of every snapshot you emit, and `reset()` the guard in
+//! `Environment::reset`:
 //!
 //! ```rust,ignore
 //! fn reset(&mut self) -> Result<Self::SnapshotType, EnvironmentError> {
@@ -100,7 +102,9 @@ impl EpisodeGuard {
     ///
     /// Call at the **top** of
     /// [`Environment::step`](rlevo_core::environment::Environment::step), before
-    /// any state mutation, so a rejected call leaves the environment untouched.
+    /// any state mutation or RNG draw, so a rejected call leaves the environment
+    /// untouched — including its RNG stream, which ADR 0029 makes a persistent,
+    /// observable part of the environment's state.
     ///
     /// # Errors
     ///

--- a/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
+++ b/docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md
@@ -253,20 +253,19 @@ tail can still build a wrapper over a rejecting environment, but a caller who
 silently absorbed a bug into a replay buffer has no way back. Reject is the
 reversible choice.
 
-**This is not yet universal — check before you rely on it.** The following
-enforce it today: the
-`toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
-`classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
-`MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
-`grids` environments, the `box2d` family (`BipedalWalker`, `CarRacing`,
-`LunarLanderDiscrete`, `LunarLanderContinuous`), the `locomotion` family
-(`InvertedPendulum`, `InvertedDoublePendulum`, `Reacher`, `Swimmer`),
-`pixel_grid`, and the
-`TimeLimit` wrapper. The `classic` module's bandits do not
-yet — their behaviour after a terminal snapshot remains **undefined**; do not
-depend on it, even by accident, until it lands for that family — the rollout
-is tracked family-by-family in
-[issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). If you're
+**This is universal — you can rely on it.** Every environment we ship enforces
+it: the `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`),
+the whole `classic` family — both its six non-bandit environments (`CartPole`,
+`Acrobot`, `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`)
+and its four bandits (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
+`AdversarialBandit`) — all twelve `grids` environments, the `box2d` family
+(`BipedalWalker`, `CarRacing`, `LunarLanderDiscrete`, `LunarLanderContinuous`),
+the `locomotion` family (`InvertedPendulum`, `InvertedDoublePendulum`,
+`Reacher`, `Swimmer`), `pixel_grid`, and the `TimeLimit` wrapper. So you can
+write one rollout loop that treats a post-terminal `step()` as a caller bug —
+matching on `StepAfterEpisodeEnd` rather than defending against a snapshot that
+might quietly come back to life — and every built-in environment will agree with
+it. If you're
 implementing your own environment, [Bring Your Own
 Environment](../../part-2-guided-tour/99-extending-the-environment.md#step-5--guard-the-post-terminal-step)
 shows the `EpisodeGuard` helper that gets you this behaviour without hand-rolling
@@ -417,11 +416,10 @@ the crate as a vocabulary anchor more than a workhorse.
   part of the contract, and `EnvironmentError` is `#[non_exhaustive]`.
 - **A `step()` taken after `is_done()` is `true` is an error, not a silent
   resume.** It returns `EnvironmentError::StepAfterEpisodeEnd { status }`; call
-  `reset()` to start a new episode. The `toy_text` family, the `classic`
-  family's non-bandit environments, the `grids` family, the `box2d` family, the
-  `locomotion` family, and `TimeLimit` enforce this today
-  ([issue #289](https://github.com/anthonytorlucci/rlevo/issues/289) tracks
-  the rest).
+  `reset()` to start a new episode. Every environment in the workspace enforces
+  this — the `toy_text`, `classic` (bandits included), `grids`, `box2d`, and
+  `locomotion` families, `pixel_grid`, and the `TimeLimit` wrapper — so it is a
+  guarantee you can code against, not a per-environment habit to check.
 - **`ConstructableEnv`** keeps construction off the behaviour trait so
   **wrappers** like `TimeLimit` compose cleanly — and that is where `Truncated`
   comes from.

--- a/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
+++ b/docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md
@@ -378,22 +378,20 @@ Three details here are load-bearing, not stylistic:
   the guard *after* the fallible work, not before — a failed reset must not
   silently re-open a finished episode.
 
-> **Scope: most, but not all, of the built-in families enforce this today.**
-> `EpisodeGuard` ships in `rlevo-environments`, and the
+> **Scope: every built-in family enforces this.** `EpisodeGuard` ships in
+> `rlevo-environments`, and the
 > `toy_text` family (`Blackjack`, `CliffWalking`, `FrozenLake`, `Taxi`), the
-> `classic` family's six non-bandit environments (`CartPole`, `Acrobot`,
-> `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`), all twelve
+> `classic` family — its six non-bandit environments (`CartPole`, `Acrobot`,
+> `MountainCar`, `MountainCarContinuous`, `Pendulum`, `SantaFeAnt`) and its four
+> bandits (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
+> `AdversarialBandit`) — all twelve
 > `grids` environments, the `box2d` family (`BipedalWalker`, `CarRacing`,
 > `LunarLanderDiscrete`, `LunarLanderContinuous`), the `locomotion` family
 > (`InvertedPendulum`, `InvertedDoublePendulum`, `Reacher`, `Swimmer`),
 > `pixel_grid`, and the
-> `TimeLimit` wrapper all hold one. The `classic` module's bandits
-> (`KArmedBandit`, `NonStationaryBandit`, `ContextualBandit`,
-> `AdversarialBandit`) do not yet — their post-terminal
-> behaviour is undefined, tracked family-by-family in
-> [issue #289](https://github.com/anthonytorlucci/rlevo/issues/289). Your own
-> environment doesn't have to wait for that rollout: reach for `EpisodeGuard`
-> the same way `CliffWalking` does, and it conforms from day one.
+> `TimeLimit` wrapper all hold one. Reach for `EpisodeGuard` the same way
+> `CliffWalking` does and your environment joins that guarantee rather than
+> becoming the one exception a caller has to special-case.
 
 ## Step 6 — construction
 
@@ -434,10 +432,10 @@ algorithm will drive your environment correctly:
   that is a caller error, not a fresh transition, and should be rejected with
   `EnvironmentError::StepAfterEpisodeEnd` rather than silently continuing — see
   [Step 5](#step-5--guard-the-post-terminal-step) above for the `EpisodeGuard`
-  recipe. (The `toy_text` family, the `classic` family's non-bandit
-  environments, the `grids`, `box2d`, and `locomotion` families, and
-  `TimeLimit` enforce this today; treat it as the target for any environment
-  you write, not yet a workspace-wide guarantee.)
+  recipe. (Every environment in the workspace enforces this — the `toy_text`,
+  `classic` (bandits included), `grids`, `box2d`, and `locomotion` families,
+  `pixel_grid`, and `TimeLimit` — so callers already treat it as a
+  workspace-wide guarantee; yours is expected to honour it too.)
 - **Neither method panics on valid input.** Return `EnvironmentError::InvalidAction`
   for out-of-range actions; reserve panics for genuine internal-logic bugs.
 - **Your config validates its own invariants.** Implement


### PR DESCRIPTION
## Summary

Closes the last gap in the #289 post-terminal `step()` guard sweep. All four bandits (`KArmedBandit`, `AdversarialBandit`, `ContextualBandit`, `NonStationaryBandit`) carried a `done: bool` that `step()` **wrote and nothing ever read** — a half-built, inert guard. A `step()` made after `max_steps` kept incrementing the counter, produced a fresh reward, and emitted a **new `Terminated` snapshot**, without bound. A trainer that stepped one call past the budget got neither an error nor a repeat of the terminal transition; it got fabricated experience, indistinguishable from real experience once it is in a replay buffer. All four now hold an `EpisodeGuard` and return `EnvironmentError::StepAfterEpisodeEnd`. Bandits were the last unguarded family, so the alpha migration note is deleted from `Environment::step`'s rustdoc — the contract is now true of every shipped environment rather than aspirational.

## Change Type

- [x] Bug fix (non-breaking, includes regression test) — *behaviourally non-breaking; see the API note below*
- [x] Other — one **public API removal**: the inherent `KArmedBandit::is_done()`. Justified in scope: it is a second source of truth for done-ness, which `docs/rules.md` §10 forbids, and it was backed by the same dead `bool` this PR removes. Migration is `snapshot.is_done()`; there were no in-workspace callers.

## Linked Issue

Closes #295
Closes #289

## What Was Changed

- `crates/rlevo-environments/src/classic/bandit/{k_armed,adversarial,contextual,non_stationary}.rs` — replaced `done: bool` with `guard: EpisodeGuard`; `self.guard.check()?` is the literal first statement of `Environment::step`; `self.guard.record(snap.status())` on a single exit, taken from the emitted snapshot rather than hand-written; `self.guard.reset()` in `Environment::reset`. `Display` now renders `status={:?}` from the guard instead of the removed `done={}`.
- `k_armed.rs` — removed the public inherent `is_done()`. Added a private `advance()` shared by `Environment::step` and the bespoke `pull()` so the guard cannot drift from the step counter. The inherent `reset()` (the `rlevo-benchmarks` lane, which the trait `reset` delegates to) also resets the guard, so there is exactly one reset site.
- `crates/rlevo-core/src/environment.rs` — **deleted the alpha migration note** (#289 acceptance criterion 3). The check-placement sentence now says "before any state mutation **or RNG draw**", which ADR 0044 always required and the prose omitted.
- `crates/rlevo-environments/src/episode.rs` — same "or RNG draw" wording in the module doc and `EpisodeGuard::check`'s rustdoc.
- `docs/user-book/src/part-1-foundations/reinforcement-learning/34-environment.md` and `docs/user-book/src/part-2-guided-tour/99-extending-the-environment.md` — both carried the now-false "not yet universal / behaviour is undefined" disclaimer in two places each. The pedagogy for *why* the rule exists is unchanged; only the caveat is gone.
- `CHANGELOG.md` — `**Breaking changes**` (the `is_done()` removal, with migration), `**Fixed**` (the bandit defect), and a `rlevo-core` `**Changed**` entry for the doc-only contract change.

## How It Was Tested

```
cargo build --workspace                        # Finished, exit 0
cargo test --workspace                         # exit 0 — 62 suites, 0 failed
cargo clippy --all-targets --all-features      # Finished, no warnings
```

17 regression tests added. Per environment: `rejects_post_terminal_step` (via the shared `episode::assert_rejects_post_terminal_step` conformance helper), `post_terminal_step_is_rejected_before_action_validity`, `reset_reopens_a_terminated_episode`, and a no-mutation test. The three stochastic bandits pin `rejected_step_does_not_advance_the_rng_stream`; `AdversarialBandit`, whose reward is a pure function of `steps`, pins the deterministic analogue that the schedule does not slide. `KArmedBandit` additionally has `inherent_reset_reopens_a_terminated_episode` and `pull_records_the_same_status_the_trait_step_would`.

**Before/after, verified by mutation rather than by reading.** Moving `check()?` in `k_armed.rs::step` to below the action-validity check and the reward draw makes `post_terminal_step_is_rejected_before_action_validity` fail with `InvalidAction` instead of `StepAfterEpisodeEnd`, and makes `rejected_step_does_not_advance_the_rng_stream` fail on a divergent reward sequence. Both tests are load-bearing, not vacuous. On the pre-fix code, a post-terminal `step()` returned `Ok` with a freshly sampled reward and a new `Terminated` snapshot; it now returns `Err(StepAfterEpisodeEnd { status: Terminated })` and mutates nothing.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU) — the default for the test suite; no backend-specific code paths are touched
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change** — implementation, tests, rustdoc and user-book prose, changelog, and the linked-issue triage, under maintainer direction and review. The `Claude-Session:` trailer on the commit links the authoring session.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**`KArmedBandit::pull()` stays unguarded on entry, deliberately.** It is an infallible, non-`Environment` entry point used by `rlevo-benchmarks`; making it fallible would be an unrequested API break. It shares `advance()` with `step()`, so the guard can never disagree with the step counter — the only effect of a post-terminal `pull()` is `steps` growing past `max_steps`, which is documented and benign. #289's acceptance criteria are scoped to `Environment` impls, so this satisfies them; flagging it so nobody "fixes" it later.

**#295's "Audit required" section is wrong, and the commit body corrects it for the record.** It claimed in-crate bandit tests step past `max_steps` and "will start failing", citing `adversarial.rs:447-450` and `non_stationary.rs:370-373`. Those lines are a 32-step-of-64 seed test and `rejects_zero_max_steps`, which never steps at all. Two independent sweeps of all four **pre-fix** test modules found no test anywhere exceeding its own `max_steps`. The guard landed with zero test breakage — one test changed, and only because it read the removed field.

**Follow-ups, filed separately, not addressed here.** #1037 — ADR 0044 §9's fixture exemption is written as a *list of named types* rather than a predicate, so four newer test-only envs are exempt in spirit but not by the letter; now that this PR deletes the migration note, every future conformance audit will re-litigate them by hand. #905 was closed as refuted during this work (ADR 0044 §9 exempts `MockEnvironment` by name). #296 (step-before-reset) got a scope update and stays open: the `Option<EpisodeStatus>` migration is now confined to `episode.rs` workspace-wide rather than with four exceptions.
