### PR TITLE
chore(deps): Update spin to 0.10.1, unyank pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7156,9 +7156,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
  "portable-atomic",


### PR DESCRIPTION
## Summary

`Cargo.lock` pinned `spin v0.10.0`, pulled in transitively via `burn-autodiff` → `burn` → all `rlevo-*` crates. That version was yanked by its maintainer on crates.io. `spin 0.10.1` satisfies the same `^0.10.0` requirement from `burn-autodiff` and is not yanked, so `cargo update -p spin` resolves it with no other dependency changes.

## Change Type

- [x] Other — _lockfile-only bump of a transitive dependency to replace a yanked version; not a new dependency, no `Cargo.toml` changes, no API surface touched_

## Linked Issue

Closes #1057

## What Was Changed

- `Cargo.lock`: `spin` `0.10.0` → `0.10.1` (transitive dep of `burn-autodiff`, no other packages affected)

## How It Was Tested

```
cargo update -p spin --dry-run   # confirmed clean resolution to 0.10.1, 169 other deps unchanged
cargo check --workspace          # passed
cargo test --workspace           # all passed (0 failed)
cargo clippy --all-targets --all-features   # passed, no warnings
```

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (active, via rustup)
- Burn backend tested: default (CPU/ndarray via workspace default features)
- OS: macOS (Darwin 25.5.0, arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code. Scope: verified the yank claim and dependency chain against the live repo (registry index cache, `cargo tree -i spin`), applied `cargo update -p spin`, ran the verification commands above, and authored this PR.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*. — N/A, no public API changed
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR. — N/A, dependency version bump only
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).
