### PR TITLE
fix(evolution): Close the two residual #132 fitness-hygiene defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### `rlevo-evolution`
+
+**Fixed**
+
+- **`mean_fitness` still reported `+∞` for a population of optimal
+  individuals** (resolves the metrics half of #132). ADR 0034 maps a `+∞`
+  fitness to `f32::MAX` and states that, because the clamped value is finite, it
+  "cannot blow a `mean`, `variance`, or reward to `+∞`". That guarantee did not
+  hold: `f32::MAX` passes `is_finite()` and so joins the running total, and
+  `f32::MAX + f32::MAX` saturates straight back to `f32::INFINITY`. Two
+  individuals legitimately pegging the objective in one generation were enough
+  to report an infinite mean. `StrategyMetrics::from_host_fitness` now
+  accumulates in `f64` and narrows once, after the division — the accumulator's
+  width, not the clamp, is what carries the guarantee. This also removes the
+  ~1 ULP-per-addition drift the `f32` total accrued over a large population.
+  Because the chokepoint is shared, every evolutionary strategy was affected,
+  not only the EA-root family #132 names.
+
+  The existing coverage could not have caught this: the one `+∞` regression test
+  passed a slice with a *single* infinite member, and a single `f32::MAX` in the
+  sum is exactly the case that does not overflow. The defect needed two.
+
+- **A `NaN` at index 0 permanently stranded the champion genome in GA,
+  binary GA, and EP** (resolves the champion-tracking half of #132).
+  `update_best` in `algorithms/ga.rs`, `algorithms/ga_binary.rs` and
+  `algorithms/ep.rs` seeded its scan with `best_f = fitness[0]` and compared
+  with `>`. Every comparison against a `NaN` seed is false, so the scan kept
+  index 0 and the champion-write guard `best_f > state.best_fitness` never
+  fired — while the caller advanced `state.best_fitness` from the *sanitising*
+  `StrategyMetrics`. The two fields desynchronised: `best_fitness` ratcheted up
+  to the real winner, `best_genome` stayed `None`, and because the ratchet was
+  now high, every later generation failed the guard too. `Strategy::best()`
+  returned `None` for the rest of the run. All three now sanitise into a local
+  buffer and order with `total_cmp`, matching the fix already carried by
+  `algorithms/gp_cgp.rs` and satisfying ADR 0034's requirement that every
+  champion-write site hold the per-site correctness floor.
+
+  Only callers who drive `Strategy::tell` directly could reach this —
+  `EvolutionaryHarness::step` sanitises before `tell`, so harness-driven runs
+  were never exposed. `Strategy` is public and re-exported in the umbrella
+  prelude, and the existing tests all went through the harness. `es_classical.rs`
+  and `de.rs` were checked and are unaffected: both delegate to `argmax_host`,
+  which seeds at `−∞` and is `NaN`-safe under `>`.
+
+---
+
 ## [0.4.0] – 2026-08-02
 
 Minor release: contains breaking changes since 0.3.1. See the

--- a/crates/rlevo-evolution/src/algorithms/ep.rs
+++ b/crates/rlevo-evolution/src/algorithms/ep.rs
@@ -454,15 +454,22 @@ fn update_best<B: Backend>(state: &mut EpState<B>, pop: &Tensor<B, 2>, fitness: 
     if fitness.is_empty() {
         return;
     }
+    // Sanitize (NaN → −∞) then order with `total_cmp`: the §3 correctness floor
+    // for a direct (non-harness) caller. `best_fitness` seeds at `−∞`, so a
+    // legitimately sanitized `−∞` fitness is treated as the worst, not skipped.
+    let sane: Vec<f32> = fitness
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .collect();
     let mut best_idx = 0usize;
-    let mut best_f = fitness[0];
-    for (i, &f) in fitness.iter().enumerate().skip(1) {
-        if f > best_f {
+    let mut best_f = sane[0];
+    for (i, &f) in sane.iter().enumerate().skip(1) {
+        if f.total_cmp(&best_f) == std::cmp::Ordering::Greater {
             best_f = f;
             best_idx = i;
         }
     }
-    if best_f > state.best_fitness {
+    if best_f.total_cmp(&state.best_fitness) == std::cmp::Ordering::Greater {
         let device = pop.device();
         #[allow(clippy::cast_possible_wrap)]
         let idx =
@@ -667,6 +674,67 @@ mod tests {
         assert!(
             best.is_finite(),
             "NaN fitness poisoned best_fitness_ever: {best}"
+        );
+    }
+
+    /// Direct-`tell` companion to `nan_fitness_never_becomes_best`, which drives
+    /// the *harness* path (ADR 0034 decision 3, `rules.md` §3).
+    /// `EvolutionaryHarness::step` sanitizes fitness before `tell`, but a direct
+    /// caller does not, so a raw `NaN` can arrive at index 0. Seeding the
+    /// `update_best` scan with `fitness[0]` and comparing with `>` made every
+    /// comparison against that `NaN` false, so the champion write was skipped
+    /// while `best_fitness` still ratcheted up from the sanitizing
+    /// `StrategyMetrics::from_host_fitness` — a permanent `best() == None`
+    /// desync. The winner here is row 1.
+    #[test]
+    fn direct_tell_with_nan_at_index_zero_records_champion() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let (mu, dim) = (6usize, 3usize);
+        let params = EpConfig::default_for(mu, dim);
+        let strategy = EvolutionaryProgramming::<TestBackend>::new();
+        let mut rng = StdRng::seed_from_u64(0);
+
+        // Row `i` is filled with the constant `i`, so the champion row is
+        // identifiable from its contents alone.
+        let rows: Vec<f32> = [0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
+            .iter()
+            .flat_map(|&v| vec![v; dim])
+            .collect();
+        let population =
+            Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [mu, dim]), &device);
+        // Raw (unsanitized) fitness: NaN first, clear finite winner at index 1.
+        let fitness = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NAN, 1000.0, 1.0, 2.0, 3.0, 4.0], [mu]),
+            &device,
+        );
+        let state = EpState {
+            parents: population.clone(),
+            sigmas: Tensor::<TestBackend, 1>::from_data(
+                TensorData::new(vec![params.initial_sigma; mu], [mu]),
+                &device,
+            ),
+            parent_fitness: Vec::new(),
+            best_genome: None,
+            best_fitness: f32::NEG_INFINITY,
+            generation: 0,
+        };
+
+        let (next, _m) = strategy.tell(&params, population, fitness, state, &mut rng);
+        let (genome, best_f) = strategy
+            .best(&next)
+            .expect("a finite winner exists, so the champion must be recorded");
+        approx::assert_relative_eq!(best_f, 1000.0, epsilon = 1e-6);
+        let row = genome
+            .into_data()
+            .into_vec::<f32>()
+            .expect("champion row host-read of a tensor this test just built");
+        assert_eq!(
+            row,
+            vec![1.0f32; dim],
+            "champion genome must be population row 1, the finite winner"
         );
     }
 

--- a/crates/rlevo-evolution/src/algorithms/ga.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga.rs
@@ -435,15 +435,22 @@ fn update_best<B: Backend>(state: &mut GaState<B>, pop: &Tensor<B, 2>, fitness: 
     if fitness.is_empty() {
         return;
     }
+    // Sanitize (NaN → −∞) then order with `total_cmp`: the §3 correctness floor
+    // for a direct (non-harness) caller. `best_fitness` seeds at `−∞`, so a
+    // legitimately sanitized `−∞` fitness is treated as the worst, not skipped.
+    let sane: Vec<f32> = fitness
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .collect();
     let mut best_idx = 0_usize;
-    let mut best_f = fitness[0];
-    for (i, &f) in fitness.iter().enumerate().skip(1) {
-        if f > best_f {
+    let mut best_f = sane[0];
+    for (i, &f) in sane.iter().enumerate().skip(1) {
+        if f.total_cmp(&best_f) == std::cmp::Ordering::Greater {
             best_f = f;
             best_idx = i;
         }
     }
-    if best_f > state.best_fitness {
+    if best_f.total_cmp(&state.best_fitness) == std::cmp::Ordering::Greater {
         let device = pop.device();
         #[allow(clippy::cast_possible_wrap)]
         let idx = Tensor::<B, 1, burn::tensor::Int>::from_data(
@@ -571,5 +578,61 @@ mod tests {
                 break;
             }
         }
+    }
+
+    /// Direct-`tell` regression for the `update_best` scan (ADR 0034 decision 3,
+    /// `rules.md` §3). `EvolutionaryHarness::step` sanitizes fitness before
+    /// `tell`, but a direct caller does not, so a raw `NaN` can arrive at index
+    /// 0. Seeding the scan with `fitness[0]` and comparing with `>` made every
+    /// comparison against that `NaN` false, so the champion write was skipped
+    /// while `best_fitness` still ratcheted up from the sanitizing
+    /// `StrategyMetrics::from_host_fitness` — a permanent `best() == None`
+    /// desync. The winner here is row 1.
+    #[test]
+    fn direct_tell_with_nan_at_index_zero_records_champion() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let (pop, dim) = (6usize, 3usize);
+        let params = GaConfig::default_for(pop, dim);
+        let strategy = GeneticAlgorithm::<TestBackend>::new();
+        let mut rng = StdRng::seed_from_u64(0);
+
+        // Row `i` is filled with the constant `i`, so the champion row is
+        // identifiable from its contents alone.
+        let rows: Vec<f32> = [0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
+            .iter()
+            .flat_map(|&v| vec![v; dim])
+            .collect();
+        let population =
+            Tensor::<TestBackend, 2>::from_data(TensorData::new(rows, [pop, dim]), &device);
+        // Raw (unsanitized) fitness: NaN first, clear finite winner at index 1.
+        let fitness = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NAN, 1000.0, 1.0, 2.0, 3.0, 4.0], [pop]),
+            &device,
+        );
+        let state = GaState {
+            population: population.clone(),
+            fitness: Vec::new(),
+            best_genome: None,
+            best_fitness: f32::NEG_INFINITY,
+            generation: 0,
+        };
+
+        let (next, _m) = strategy.tell(&params, population, fitness, state, &mut rng);
+        let (genome, best_f) = strategy
+            .best(&next)
+            .expect("a finite winner exists, so the champion must be recorded");
+        approx::assert_relative_eq!(best_f, 1000.0, epsilon = 1e-6);
+        let row = genome
+            .into_data()
+            .into_vec::<f32>()
+            .expect("champion row host-read of a tensor this test just built");
+        assert_eq!(
+            row,
+            vec![1.0f32; dim],
+            "champion genome must be population row 1, the finite winner"
+        );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/ga_binary.rs
+++ b/crates/rlevo-evolution/src/algorithms/ga_binary.rs
@@ -418,15 +418,22 @@ fn update_best<B: Backend>(state: &mut BinaryGaState<B>, pop: &Tensor<B, 2, Int>
     if fitness.is_empty() {
         return;
     }
+    // Sanitize (NaN → −∞) then order with `total_cmp`: the §3 correctness floor
+    // for a direct (non-harness) caller. `best_fitness` seeds at `−∞`, so a
+    // legitimately sanitized `−∞` fitness is treated as the worst, not skipped.
+    let sane: Vec<f32> = fitness
+        .iter()
+        .map(|&f| crate::fitness::sanitize_fitness(f))
+        .collect();
     let mut best_idx = 0usize;
-    let mut best_f = fitness[0];
-    for (i, &f) in fitness.iter().enumerate().skip(1) {
-        if f > best_f {
+    let mut best_f = sane[0];
+    for (i, &f) in sane.iter().enumerate().skip(1) {
+        if f.total_cmp(&best_f) == std::cmp::Ordering::Greater {
             best_f = f;
             best_idx = i;
         }
     }
-    if best_f > state.best_fitness {
+    if best_f.total_cmp(&state.best_fitness) == std::cmp::Ordering::Greater {
         let device = pop.device();
         #[allow(clippy::cast_possible_wrap)]
         let idx =
@@ -626,5 +633,60 @@ mod tests {
         assert_eq!(next.population.dims(), [pop, dim]);
         assert_eq!(next.fitness, vec![4.0, 3.0, 2.0, 10.0]);
         approx::assert_relative_eq!(m.best_fitness_ever(), 10.0, epsilon = 1e-6);
+    }
+
+    /// Direct-`tell` regression for the `update_best` scan (ADR 0034 decision 3,
+    /// `rules.md` §3). `EvolutionaryHarness::step` sanitizes fitness before
+    /// `tell`, but a direct caller does not, so a raw `NaN` can arrive at index
+    /// 0. Seeding the scan with `fitness[0]` and comparing with `>` made every
+    /// comparison against that `NaN` false, so the champion write was skipped
+    /// while `best_fitness` still ratcheted up from the sanitizing
+    /// `StrategyMetrics::from_host_fitness` — a permanent `best() == None`
+    /// desync. The winner here is row 1.
+    #[test]
+    fn direct_tell_with_nan_at_index_zero_records_champion() {
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let device = Default::default();
+        let (pop, dim) = (6usize, 3usize);
+        let params = BinaryGaConfig::default_for(pop, dim);
+        let strategy = BinaryGeneticAlgorithm::<TestBackend>::new();
+        let mut rng = StdRng::seed_from_u64(0);
+
+        // Row `i` is filled with the constant `i`, so the champion row is
+        // identifiable from its contents alone.
+        let rows: Vec<i32> = (0..pop)
+            .flat_map(|i| vec![i32::try_from(i).expect("row index fits i32"); dim])
+            .collect();
+        let population =
+            Tensor::<TestBackend, 2, Int>::from_data(TensorData::new(rows, [pop, dim]), &device);
+        // Raw (unsanitized) fitness: NaN first, clear finite winner at index 1.
+        let fitness = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NAN, 1000.0, 1.0, 2.0, 3.0, 4.0], [pop]),
+            &device,
+        );
+        let state = BinaryGaState {
+            population: population.clone(),
+            fitness: Vec::new(),
+            best_genome: None,
+            best_fitness: f32::NEG_INFINITY,
+            generation: 0,
+        };
+
+        let (next, _m) = strategy.tell(&params, population, fitness, state, &mut rng);
+        let (genome, best_f) = strategy
+            .best(&next)
+            .expect("a finite winner exists, so the champion must be recorded");
+        approx::assert_relative_eq!(best_f, 1000.0, epsilon = 1e-6);
+        let row = genome
+            .into_data()
+            .into_vec::<i32>()
+            .expect("champion row host-read of a tensor this test just built");
+        assert_eq!(
+            row,
+            vec![1i32; dim],
+            "champion genome must be population row 1, the finite winner"
+        );
     }
 }

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -243,9 +243,20 @@ impl StrategyMetrics {
     /// from the average and counted in [`broken_count`](Self::broken_count)
     /// instead (ADR 0034). This keeps a single broken individual from blanking
     /// the whole mean to `−∞` while still surfacing that the population is
-    /// unhealthy. `+∞ → f32::MAX` members are finite and *are* included, so an
-    /// optimal individual cannot blow the mean to `+∞`. If *every* member is
-    /// broken, `mean_fitness = −∞` (degenerate but well-defined).
+    /// unhealthy. `+∞ → f32::MAX` members are finite and *are* included. If
+    /// *every* member is broken, `mean_fitness = −∞` (degenerate but
+    /// well-defined).
+    ///
+    /// The mean is **accumulated in `f64`** and narrowed to `f32` once, after the
+    /// division. The clamp alone does not make the mean safe: `f32::MAX` is
+    /// finite and therefore admitted into the sum, but *two* clamped members
+    /// saturate an `f32` accumulator (`f32::MAX + f32::MAX == f32::INFINITY`),
+    /// which would report `mean_fitness = +∞` for a population of optimal
+    /// individuals. `f64` carries the widened sum (`≈ 6.8e38` per pair, far below
+    /// `f64::MAX`), so it is the accumulator width — not the clamp — that
+    /// delivers ADR 0034's "cannot blow a mean up" guarantee. Averaging in `f64`
+    /// also removes the ~1 ULP-per-addition drift an `f32` sum accrues over a
+    /// large population.
     ///
     /// # Panics
     ///
@@ -261,9 +272,14 @@ impl StrategyMetrics {
         // so all statistics agree on the crate-wide convention. The mean is taken
         // over finite members only; non-finite (`−∞`) members are counted as
         // broken rather than dragging the mean to `−∞`.
+        //
+        // `finite_sum` is `f64`, not `f32`: sanitized `+∞` arrives as `f32::MAX`,
+        // which *is* finite and so joins the sum, and two such members overflow
+        // an `f32` accumulator to `+∞` (issue #132). `f64` holds the widened sum
+        // and also avoids the ~1 ULP-per-addition drift over a large population.
         let mut best = f32::NEG_INFINITY;
         let mut worst = f32::INFINITY;
-        let mut finite_sum = 0.0_f32;
+        let mut finite_sum = 0.0_f64;
         let mut finite_n = 0_usize;
         let mut broken_count = 0_usize;
         for &f in fitnesses {
@@ -275,16 +291,21 @@ impl StrategyMetrics {
                 worst = f;
             }
             if f.is_finite() {
-                finite_sum += f;
+                finite_sum += f64::from(f);
                 finite_n += 1;
             } else {
                 broken_count += 1;
             }
         }
         let mean = if finite_n > 0 {
+            // `usize as f64` is exact for any realistic population size, and the
+            // mean of values bounded by `f32::MAX` is itself within `f32` range,
+            // so the single narrowing below cannot overflow to `±∞`.
             #[allow(clippy::cast_precision_loss)]
-            let n = finite_n as f32;
-            finite_sum / n
+            let n = finite_n as f64;
+            #[allow(clippy::cast_possible_truncation)]
+            let mean = (finite_sum / n) as f32;
+            mean
         } else {
             // Every member is broken: no finite value to average.
             f32::NEG_INFINITY
@@ -937,11 +958,43 @@ mod tests {
     #[test]
     fn from_host_fitness_pos_inf_ranks_top_but_mean_stays_finite() {
         // +∞ → f32::MAX (ADR 0034): it stays best/finite and is *included* in the
-        // mean (no −∞/broken), so an optimal individual cannot blow the mean up.
+        // mean (no −∞/broken). The clamp is only half of why the mean survives —
+        // the other half is the `f64` accumulator, which
+        // `from_host_fitness_two_pos_inf_members_keep_mean_finite` pins for the
+        // multi-member case this single-member test cannot reach.
         let m = StrategyMetrics::from_host_fitness(0, &[1.0, f32::INFINITY, 3.0], 0.0);
         approx::assert_relative_eq!(m.best_fitness(), f32::MAX);
         assert_eq!(m.broken_count(), 0);
         assert!(m.mean_fitness().is_finite());
+    }
+
+    #[test]
+    fn from_host_fitness_two_pos_inf_members_keep_mean_finite() {
+        // Regression (issue #132): ADR 0034 maps `+∞ → f32::MAX` and claims the
+        // clamped value "cannot blow a mean up". `f32::MAX` passes `is_finite()`,
+        // so it is admitted into the accumulator — and *two* such members
+        // saturate an `f32` sum: `f32::MAX + f32::MAX == f32::INFINITY`. The
+        // accumulator, not the clamp, is what has to carry the guarantee, so the
+        // sum runs in `f64` (`f32::MAX + f32::MAX ≈ 6.8e38` is nowhere near
+        // `f64::MAX`) and is narrowed back to `f32` once, after the division.
+        // The mean here is `(1 + MAX + MAX + 3) / 4 ≈ 1.7e38`, comfortably
+        // representable in `f32`.
+        let m = StrategyMetrics::from_host_fitness(
+            0,
+            &[1.0, f32::INFINITY, f32::INFINITY, 3.0],
+            f32::NEG_INFINITY,
+        );
+        assert_eq!(
+            m.broken_count(),
+            0,
+            "clamped +∞ members are finite, so none is broken"
+        );
+        assert!(
+            m.mean_fitness().is_finite(),
+            "two f32::MAX members must not saturate the mean; got {}",
+            m.mean_fitness()
+        );
+        approx::assert_relative_eq!(m.best_fitness(), f32::MAX);
     }
 
     #[test]

--- a/docs/user-book/src/part-1-foundations/evolutionary-computation/23-fitness.md
+++ b/docs/user-book/src/part-1-foundations/evolutionary-computation/23-fitness.md
@@ -183,8 +183,16 @@ So the same chokepoint that canonicalises also **sanitises**, in one rule
 - `NaN → −∞` — the worst value under the maximise convention, so a broken
   individual can never seed or displace a real best;
 - `+∞ → f32::MAX` — a genuinely optimal individual still ranks top, but as a
-  *finite* value, so it cannot blow `mean_fitness` or a reward up to `+∞`;
+  *finite* value, so it never reads as a sentinel and never propagates `+∞` into
+  a reward;
 - `−∞` passes through unchanged (it is the worst-value sentinel).
+
+Note what that second rule does *not* buy you on its own. Clamping to
+`f32::MAX` keeps a single value finite, but \\(\texttt{f32::MAX} +
+\texttt{f32::MAX}\\) overflows back to `+∞`, so two optimal individuals in one
+generation would still saturate an `f32` running total. We therefore accumulate
+`mean_fitness` in `f64` and narrow once, after the division — it is the
+accumulator's width, not the clamp, that keeps the reported mean finite.
 
 The upshot for you as a caller: **the fitness a strategy's `tell` receives on a
 harness-driven run is always finite or `−∞`** — you never have to guard your
@@ -349,7 +357,10 @@ still scattered. A small gap means the whole population has settled near the sam
 optimum. For landscapes with a known optimum (Ackley → 0), `best_fitness_ever`
 doubles as a direct "how close did we get" readout. Averaging `mean_fitness` over
 the finite members keeps one broken individual from collapsing the whole statistic
-to `−∞`; `broken_count` surfaces that individual instead of hiding it.
+to `−∞`; `broken_count` surfaces that individual instead of hiding it. We sum
+those finite members in `f64` before narrowing back to `f32`, which both keeps a
+population of clamped `+∞` individuals from saturating the mean and removes the
+drift an `f32` running total accrues across a large population.
 
 ## Putting it together
 


### PR DESCRIPTION
Closes #132.

ADR 0034 landed the fitness-hygiene chokepoint and the six code-review rows for #132 were all marked `closed`. An executed probe across all seven algorithms #132 names confirms the harness path genuinely is fixed — `best`/`worst`/`best_fitness_ever` stay finite-or-`−∞` under both senses. Two defects survived that verification.

## D1 — `mean_fitness` overflowed to `+inf` (harness path, every strategy family)

`StrategyMetrics::from_host_fitness` accumulated in `f32`. ADR 0034 maps `+∞ → f32::MAX` and states the clamped value is finite so it "cannot blow a `mean`". It does: `f32::MAX` passes `is_finite()`, joins the sum, and `f32::MAX + f32::MAX == f32::INFINITY`. Two individuals legitimately pegging the objective in one generation reported an infinite mean.

The accumulator now runs in `f64` and narrows once, after the division — the width, not the clamp, is what carries the guarantee. This also removes the ~1 ULP-per-addition drift over a large population.

This is the dropped half of the GA review row: §1.1 shipped the NaN policy, §1.2's `f64` accumulator did not, and the row still read `closed`. Because the chokepoint is shared, the defect reached **every** strategy family, not just the EA-root algorithms #132 names.

*Why existing tests missed it:* the one `+∞` regression test used a slice with a **single** infinite member — exactly the case that does not overflow. Two are required.

## D2 — permanent champion desync (bypass path)

`update_best` in `ga.rs`, `ga_binary.rs` and `ep.rs` seeded `best_f = fitness[0]` and compared with `>`. Comparisons against a `NaN` seed are all false, so the scan kept index 0 and the champion guard never fired — `best_genome` was never assigned, while the caller ratcheted `best_fitness` up from the sanitizing metrics. `Strategy::best()` returned `None` for the rest of the run.

Executed, driving `tell` directly with `[NaN, 1000.0, 1.0, 2.0, 3.0, 4.0]`:

```
gen1: state.best_fitness=1e3  best_genome=None  best()=None
gen2 (all-finite [10..60]): best_fitness=1e3  best_genome=None  best()=None
CONTROL, NaN moved to index 2: best() = Some(1e3)
```

All three now mirror `gp_cgp.rs::update_best` — sanitize into a local buffer, order with `total_cmp` — satisfying ADR 0034 decision 3.

Reviews repeatedly scored this benign: GA §1.1 says "the NaN individual can never become 'best in generation' (good)". Not becoming best is not the failure mode. A reviewer checking that claim will find the code agrees with it and may wrongly close a real bug, so the review doc now carries a dated correction rather than a silent rewrite.

*Why existing tests missed it:* every one went through the harness, which sanitizes before `tell`.

## Deliberately not changed

`es_classical.rs` and `de.rs`. Both delegate to `argmax_host`, which seeds at `f32::NEG_INFINITY` and uses `>`, so a `NaN` can neither win nor shadow a later finite maximum. QA attacked this scope claim with direct-`tell` probes and could not refute it — both returned `Some(1000.0)`.

ADR 0034 itself is untouched; ADRs are immutable, and the code fix is what restores its stated guarantee.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy -p rlevo-evolution --all-targets -- -D warnings` | 0 warnings |
| `cargo test -p rlevo-evolution` | 596 passed, 0 failed (592 baseline, +4 new) |
| doctests | 41 passed, 9 ignored |
| `cargo check --workspace --all-targets` | clean |
| `mdbook build` | clean, KaTeX delimiters intact |

All four new tests were confirmed non-vacuous by reverting each production change, observing the test go red, and restoring byte-identically.

## Ripple

Triage of the linked issues turned up an **unfiled sibling of D1 that this PR does not fix**: `neuroevolution/species.rs:297` accumulates already-sanitized fitness in `f32`, so two `+∞` members in one species overflow `adjusted_fitness_sum`, and `allocate_offspring` then collapses fitness-proportional apportionment to an even split **population-wide**. Unlike D2 it is reachable on NEAT's normal path. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)