### PR TITLE
fix(evolution): Sanitize tell fitness at the host pull (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Fixed**
 
+- **A `NaN` fitness permanently froze one individual in the metaheuristic
+  family, silently shrinking the population by one** (resolves #131). ABC, Bat,
+  Cuckoo Search and PSO keep a persistent per-slot fitness cache and accept a
+  candidate only when it beats the cached value. The raw `NaN` was latched into
+  that cache at the gen-0 bootstrap, and every subsequent comparison against it
+  is false — so the slot became a zombie the algorithm could never replace. Bat
+  and PSO have no reset mechanism at all, so the freeze was
+  permanent-until-restart; ABC escaped only via the scout `limit`
+  (`pop_size · genome_dim / 2` — hundreds of generations for realistic configs);
+  Cuckoo escaped via abandonment, but never at `p_a = 0`, a valid configuration
+  the suite already exercises. All nine metaheuristic `tell` impls now sanitize
+  the fitness vector once, where it is pulled to host, so the bootstrap seed and
+  the accept-store are both covered by one call.
+
+  The issue was filed as leader/global-best poisoning; it is not that.
+  `argmax_host` seeds from `−∞` and compares with `>`, so a `NaN` can neither
+  win a champion scan nor seed one, and `best()` was correct throughout — which
+  is precisely why the frozen slot went unnoticed: the run's *reported* optimum
+  stayed right while the search quietly ran a member short. Two files were
+  missed by the original triage in the other direction. `gwo.rs` sanitized on
+  the read (`argtop3_max`) but stored the raw value, and `aco_r.rs` sanitized
+  for its archive ranking but then re-read the *unsanitized* vector when
+  materializing `archive_fitness`, so a `NaN` survived at the archive tail. Both
+  had been declared clean on the strength of their read-side guard alone.
+
+  No existing test could have caught this. The NaN-safety coverage all runs
+  through `EvolutionaryHarness::step`, which sanitizes before `tell`, and the
+  convergence-style assertions that do exercise these algorithms pass happily
+  while a slot is frozen. The new `nan_fitness_does_not_latch_without_harness`
+  tests — one per algorithm, the bypass twin of the existing
+  `nan_fitness_survives_harness` — drive `init → ask → tell` directly and assert
+  on the cache rather than on convergence.
+
+  Only callers who drive `Strategy::tell` directly were exposed; harness-driven
+  runs were never affected, and on that path the change is a provable no-op
+  (`sanitize_fitness` is idempotent). `Strategy` is public and re-exported in the
+  umbrella prelude, so this is the ADR 0034 decision-3 bypass hole, now closed at
+  the per-site floor rather than left to the chokepoint above it.
+
+  One route remains open and is tracked separately as #1064: this sanitizes the
+  fitness *entering* `tell`, not the cache it is compared against, so a `NaN`
+  placed directly into a state's fitness vector via the `pub` `*State::try_new`
+  constructors (or `PsoState`'s `pub` fields) still freezes that slot.
+
 - **`mean_fitness` still reported `+∞` for a population of optimal
   individuals** (resolves the metrics half of #132). ADR 0034 maps a `+∞`
   fitness to `f32::MAX` and states that, because the clamped value is finite, it

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
@@ -904,6 +904,18 @@ mod tests {
             "raw NaN latched into the bee-0 fitness cache: {:?}",
             state.fitness()
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would rank bee 0 *above* the finite -1/-2/-3
+        // scores and make the NaN-scoring bee the reported population best —
+        // the leader poisoning this regression exists to catch.
+        assert!(
+            state.fitness()[0].is_infinite() && state.fitness()[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the bee-0 fitness cache: {:?}",
+            state.fitness()
+        );
 
         // Generations 1 and 2: every candidate is finite and strictly better,
         // so a live bee 0 must adopt them.
@@ -915,5 +927,64 @@ mod tests {
             state = advanced;
         }
         approx::assert_relative_eq!(state.fitness()[0], 20.0, epsilon = 1e-6);
+    }
+
+    // Regression for issue #131, `+∞` half. The
+    // `nan_fitness_does_not_latch_without_harness` family above covers
+    // `NaN → −∞`; `sanitize_fitness` has a second rule, `+∞ → f32::MAX`, which
+    // the same bypass `tell` now applies. That rule is *observable* to a direct
+    // `ask`/`tell` driver: an individual scoring a genuine `+∞` is reported as
+    // a finite `f32::MAX` in both the fitness cache and `StrategyMetrics`,
+    // never as raw `+∞`. This is intended (ADR 0034 decision 1) — it keeps the
+    // top-ranked member top-ranked while stopping a single unbounded score from
+    // blowing the population mean/variance to `+∞`. One shared test covers the
+    // rule; the nine per-algorithm NaN tests already prove every `tell` routes
+    // its host pull through `sanitize_fitness`, so the `+∞` branch reaches all
+    // of them by the same path.
+    #[test]
+    fn inf_fitness_clamps_finite_without_harness() {
+        let device = Default::default();
+        let strategy = ArtificialBeeColony::<TestBackend>::new();
+        let params = AbcConfig::default_for(4, 2);
+        let mut rng = StdRng::seed_from_u64(31);
+
+        // Generation 0 (bootstrap): bee 0 scores `+∞`, the rest finite.
+        let state = strategy.init(&params, &mut rng, &device);
+        let (colony, state) = strategy.ask(&params, &state, &mut rng, &device);
+        let fitness = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::INFINITY, -1.0, -2.0, -3.0], [4]),
+            &device,
+        );
+        let (state, m) = strategy.tell(&params, colony, fitness, state, &mut rng);
+
+        // The cache holds the clamped, finite `f32::MAX` — not raw `+∞`.
+        assert!(
+            state.fitness()[0].is_finite(),
+            "raw +inf latched into the bee-0 fitness cache: {:?}",
+            state.fitness()
+        );
+        approx::assert_relative_eq!(state.fitness()[0], f32::MAX);
+
+        // Clamping preserves the ranking: bee 0 is still the best, and every
+        // reported statistic stays finite (the point of the clamp — `+∞` would
+        // poison `mean_fitness` for the whole population).
+        approx::assert_relative_eq!(m.best_fitness(), f32::MAX);
+        assert!(
+            m.mean_fitness().is_finite(),
+            "mean_fitness went non-finite under a +inf member: {}",
+            m.mean_fitness()
+        );
+        assert!(
+            m.best_fitness_ever().is_finite(),
+            "best_fitness_ever went non-finite under a +inf member: {}",
+            m.best_fitness_ever()
+        );
+        // A clamped `+∞` is a *usable* member, unlike a sanitized `NaN`: it is
+        // finite, so it is averaged in rather than counted broken.
+        assert_eq!(
+            m.broken_count(),
+            0,
+            "a clamped +inf member must not be counted broken"
+        );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs
@@ -408,10 +408,25 @@ where
         mut state: AbcState<B>,
         rng: &mut dyn Rng,
     ) -> (AbcState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitise on the host pull, per the maximise convention (`rules.md`
+        // §3, ADR 0034): `NaN → −∞` (worst), `+∞ → f32::MAX`. This is the
+        // per-site correctness floor for callers that bypass
+        // `EvolutionaryHarness::step` — `Strategy` is public and re-exported,
+        // so a hand-rolled `ask`/`tell` driver reaches this line with raw
+        // values (ADR 0034 decision 3, issue #131). One sanitise here covers
+        // both the bootstrap seed of `state.fitness` and the accept-store
+        // below; a raw `NaN` latched into a bee's cache loses every later
+        // `cand_fit >= state.fitness[t]` comparison, freezing that bee until
+        // the scout `limit` happens to rescue it. `sanitize_fitness` is
+        // idempotent, so on the harness path (which pre-sanitises) this is a
+        // provable no-op — do not delete it as redundant.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         let device = candidates.device();
         let pop = params.pop_size;
         let genome_dim = params.genome_dim;
@@ -850,5 +865,55 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() > 0, "expected a broken (NaN) member");
+    }
+
+    // Regression for issue #131. `nan_fitness_survives_harness` above covers
+    // the harness path; this covers the documented bypass hole (ADR 0034
+    // decision 3) — a direct `init` → `ask` → `tell` driver. A raw `NaN`
+    // latched into `state.fitness` loses every later
+    // `cand_fit >= state.fitness[t]` comparison, so bee 0 freezes: it accepts
+    // nothing, and only the scout `limit` eventually rescues it. The assertion
+    // is on the *cache*, not on convergence — a "reaches < ε on Sphere" check
+    // passes straight through this bug because of that self-heal.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = ArtificialBeeColony::<TestBackend>::new();
+        let mut params = AbcConfig::default_for(4, 2);
+        // Push the scout trigger out of reach so the reinit self-heal cannot
+        // mask a frozen slot within this test's horizon.
+        params.limit = 1_000;
+        let mut rng = StdRng::seed_from_u64(31);
+        let fit = |vals: Vec<f32>| {
+            let n = vals.len();
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [n]), &device)
+        };
+
+        // Generation 0 (bootstrap): bee 0 scores `NaN`, the rest finite.
+        let state = strategy.init(&params, &mut rng, &device);
+        let (colony, state) = strategy.ask(&params, &state, &mut rng, &device);
+        let (mut state, _m) = strategy.tell(
+            &params,
+            colony,
+            fit(vec![f32::NAN, -1.0, -2.0, -3.0]),
+            state,
+            &mut rng,
+        );
+        assert!(
+            !state.fitness()[0].is_nan(),
+            "raw NaN latched into the bee-0 fitness cache: {:?}",
+            state.fitness()
+        );
+
+        // Generations 1 and 2: every candidate is finite and strictly better,
+        // so a live bee 0 must adopt them.
+        for score in [10.0_f32, 20.0] {
+            let (candidates, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let n = candidates.dims()[0];
+            let (advanced, _m) =
+                strategy.tell(&params, candidates, fit(vec![score; n]), next, &mut rng);
+            state = advanced;
+        }
+        approx::assert_relative_eq!(state.fitness()[0], 20.0, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -348,10 +348,21 @@ where
         mut state: AcoRState<B>,
         _rng: &mut dyn Rng,
     ) -> (AcoRState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitize at the pull (NaN → −inf, +inf → f32::MAX). This is the
+        // per-site correctness floor for a caller driving `ask`/`tell`
+        // directly instead of `EvolutionaryHarness::step`, which already
+        // sanitizes (the ADR 0034 decision-3 bypass hole, issue #131):
+        // the local `sane` derivations below only fix the *ranking*, while the
+        // stored `state.archive_fitness` would still carry the raw NaN.
+        // `sanitize_fitness` is idempotent, so on the harness path this is a
+        // provable no-op — not redundant, load-bearing.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         let device = population.device();
         let k = params.archive_size;
 
@@ -785,5 +796,34 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() > 0, "expected a broken (NaN) member");
+    }
+
+    /// Cache hygiene (not a freeze): `tell` already sanitizes for the archive
+    /// *ranking*, so a `NaN` sorts worst and is evicted rather than latching.
+    /// What this pins is the **store** — driving `init → ask → tell` directly,
+    /// the ADR-0034 decision-3 bypass of `EvolutionaryHarness::step`, must not
+    /// leave a raw `NaN` in the public `archive_fitness` a caller reads back.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device: FlexDevice = Default::default();
+        let strategy = AntColonyReal::<TestBackend>::new();
+        let params = AcoRConfig::default_for(6, 4, 3);
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = strategy.init(&params, &mut rng, &device);
+        // The first `ask` hands back the initial archive, so gen-0 scores the
+        // `archive_size` rows the first-tell branch sorts into the archive.
+        let (pop, state) = strategy.ask(&params, &state, &mut rng, &device);
+        // Gen-0 fitness supplied by the test, never by a landscape: [NaN, finite…].
+        let n = params.archive_size;
+        #[allow(clippy::cast_precision_loss)]
+        let mut vals: Vec<f32> = (0..n).map(|i| -(i as f32) - 1.0).collect();
+        vals[0] = f32::NAN;
+        let fitness = Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [n]), &device);
+        let (state, _m) = strategy.tell(&params, pop, fitness, state, &mut rng);
+        assert!(
+            state.archive_fitness.iter().all(|f| !f.is_nan()),
+            "raw NaN reached the public archive fitness: {:?}",
+            state.archive_fitness
+        );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/aco_r.rs
@@ -825,5 +825,29 @@ mod tests {
             "raw NaN reached the public archive fitness: {:?}",
             state.archive_fitness
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. ACO_R differs from its siblings in *where*
+        // the value lands: the first-tell branch sorts the archive descending,
+        // so the sanitized row is demoted from index 0 to the tail. Any other
+        // finite substitute (e.g. `0.0`) clears `is_nan` yet would sort the
+        // NaN-scoring ant *above* every finite -2/-3/… row, into archive slot 0
+        // and straight into `best_fitness` — the leader poisoning this
+        // regression exists to catch.
+        let tail = state.archive_fitness[n - 1];
+        assert!(
+            tail.is_infinite() && tail.is_sign_negative(),
+            "sanitized NaN must land as -inf at the archive tail: {:?}",
+            state.archive_fitness
+        );
+        // The demotion is the observable consequence: the surviving best is the
+        // finite -2.0 (the NaN overwrote the -1.0 row), never the sanitized one.
+        assert!(
+            state.archive_fitness[0].is_finite() && state.best_fitness.is_finite(),
+            "sanitized NaN must not head the archive: archive={:?} best={}",
+            state.archive_fitness,
+            state.best_fitness
+        );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -453,10 +453,26 @@ where
         mut state: BatState<B>,
         _rng: &mut dyn Rng,
     ) -> (BatState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitise on the host pull, per the maximise convention (`rules.md`
+        // §3, ADR 0034): `NaN → −∞` (worst), `+∞ → f32::MAX`. This is the
+        // per-site correctness floor for callers that bypass
+        // `EvolutionaryHarness::step` — `Strategy` is public and re-exported,
+        // so a hand-rolled `ask`/`tell` driver reaches this line with raw
+        // values (ADR 0034 decision 3, issue #131). One sanitise here covers
+        // both the bootstrap seed of `state.fitness` and the accept-store
+        // below; a raw `NaN` latched into a bat's cache loses every later
+        // `fitness_host[i] >= state.fitness[i]` comparison, and BA has no
+        // scout or abandonment mechanism to rescue the frozen slot.
+        // `sanitize_fitness` is idempotent, so on the harness path (which
+        // pre-sanitises) this is a provable no-op — do not delete it as
+        // redundant.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         let device = candidates.device();
         let pop = params.pop_size;
         let genome_dim = params.genome_dim;
@@ -855,5 +871,56 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() > 0, "expected a broken (NaN) member");
+    }
+
+    // Regression for issue #131. `nan_fitness_survives_harness` above covers
+    // the harness path; this covers the documented bypass hole (ADR 0034
+    // decision 3) — a direct `init` → `ask` → `tell` driver. A raw `NaN`
+    // latched into `state.fitness` loses every later
+    // `fitness_host[i] >= state.fitness[i]` comparison, so bat 0 freezes
+    // permanently: BA has no scout or abandonment mechanism to rescue a dead
+    // slot. The assertion is on the *cache*, not on convergence.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = BatAlgorithm::<TestBackend>::new();
+        let mut params = BatConfig::default_for(4, 2);
+        // Loudness pinned at 1 with no decay keeps the `pending_accept` draw
+        // (uniform in [0, 1)) always under `A_i`, isolating the fitness
+        // comparison from the probabilistic acceptance gate.
+        params.a0 = 1.0;
+        params.alpha = 1.0;
+        let mut rng = StdRng::seed_from_u64(37);
+        let fit = |vals: Vec<f32>| {
+            let n = vals.len();
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [n]), &device)
+        };
+
+        // Generation 0 (bootstrap): bat 0 scores `NaN`, the rest finite.
+        let state = strategy.init(&params, &mut rng, &device);
+        let (positions, state) = strategy.ask(&params, &state, &mut rng, &device);
+        let (mut state, _m) = strategy.tell(
+            &params,
+            positions,
+            fit(vec![f32::NAN, -1.0, -2.0, -3.0]),
+            state,
+            &mut rng,
+        );
+        assert!(
+            !state.fitness()[0].is_nan(),
+            "raw NaN latched into the bat-0 fitness cache: {:?}",
+            state.fitness()
+        );
+
+        // Generations 1 and 2: every candidate is finite and strictly better,
+        // so a live bat 0 must adopt them.
+        for score in [10.0_f32, 20.0] {
+            let (candidates, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let n = candidates.dims()[0];
+            let (advanced, _m) =
+                strategy.tell(&params, candidates, fit(vec![score; n]), next, &mut rng);
+            state = advanced;
+        }
+        approx::assert_relative_eq!(state.fitness()[0], 20.0, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/bat.rs
@@ -911,6 +911,18 @@ mod tests {
             "raw NaN latched into the bat-0 fitness cache: {:?}",
             state.fitness()
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would rank bat 0 *above* the finite -1/-2/-3
+        // scores and make the NaN-scoring bat the reported population best —
+        // the leader poisoning this regression exists to catch.
+        assert!(
+            state.fitness()[0].is_infinite() && state.fitness()[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the bat-0 fitness cache: {:?}",
+            state.fitness()
+        );
 
         // Generations 1 and 2: every candidate is finite and strictly better,
         // so a live bat 0 must adopt them.

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -849,6 +849,18 @@ mod tests {
             "raw NaN latched into the nest-0 fitness cache: {:?}",
             state.fitness()
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would rank nest 0 *above* the finite -1/-2/-3
+        // scores and make the NaN-scoring nest the reported population best —
+        // the leader poisoning this regression exists to catch.
+        assert!(
+            state.fitness()[0].is_infinite() && state.fitness()[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the nest-0 fitness cache: {:?}",
+            state.fitness()
+        );
 
         // Generations 1 and 2: every egg is finite and strictly better, so a
         // live nest 0 must adopt them.

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/cuckoo.rs
@@ -368,6 +368,10 @@ where
     ///    re-initialized from `bounds` via [`seed_stream`]; abandoned
     ///    slots carry sentinel `+∞` fitness so the next generation's Lévy
     ///    proposal always lands on them.
+    // Mirrors the same allow on `ArtificialBeeColony::tell`: the body is a
+    // straight-line accept → abandon → best-update pipeline, and splitting it
+    // would only move the device-tensor plumbing behind a name.
+    #[allow(clippy::too_many_lines)]
     fn tell(
         &self,
         params: &CuckooConfig,
@@ -376,10 +380,26 @@ where
         mut state: CuckooState<B>,
         rng: &mut dyn Rng,
     ) -> (CuckooState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitise on the host pull, per the maximise convention (`rules.md`
+        // §3, ADR 0034): `NaN → −∞` (worst), `+∞ → f32::MAX`. This is the
+        // per-site correctness floor for callers that bypass
+        // `EvolutionaryHarness::step` — `Strategy` is public and re-exported,
+        // so a hand-rolled `ask`/`tell` driver reaches this line with raw
+        // values (ADR 0034 decision 3, issue #131). One sanitise here covers
+        // both the bootstrap seed of `state.fitness` and the accept-store
+        // below; a raw `NaN` latched into a nest's cache loses every later
+        // `fitness_host[i] >= state.fitness[i]` comparison, and `p_a = 0` is a
+        // valid config that disables the abandonment eviction which would
+        // otherwise clear it. `sanitize_fitness` is idempotent, so on the
+        // harness path (which pre-sanitises) this is a provable no-op — do not
+        // delete it as redundant.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         let device = population.device();
         let pop = params.pop_size;
         let d = params.genome_dim;
@@ -792,5 +812,52 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() > 0, "expected a broken (NaN) member");
+    }
+
+    // Regression for issue #131. `nan_fitness_survives_harness` above covers
+    // the harness path; this covers the documented bypass hole (ADR 0034
+    // decision 3) — a direct `init` → `ask` → `tell` driver. A raw `NaN`
+    // latched into `state.fitness` loses every later
+    // `fitness_host[i] >= state.fitness[i]` comparison, so nest 0 freezes. The
+    // §3-sanitized abandonment ranking below the accept loop would eventually
+    // evict such a nest, but `p_a = 0` is a valid config that disables it —
+    // hence `p_a = 0` here, and an assertion on the *cache*, not convergence.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = CuckooSearch::<TestBackend>::new();
+        let mut params = CuckooConfig::default_for(4, 2);
+        params.p_a = 0.0;
+        let mut rng = StdRng::seed_from_u64(41);
+        let fit = |vals: Vec<f32>| {
+            let n = vals.len();
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [n]), &device)
+        };
+
+        // Generation 0 (bootstrap): nest 0 scores `NaN`, the rest finite.
+        let state = strategy.init(&params, &mut rng, &device);
+        let (nests, state) = strategy.ask(&params, &state, &mut rng, &device);
+        let (mut state, _m) = strategy.tell(
+            &params,
+            nests,
+            fit(vec![f32::NAN, -1.0, -2.0, -3.0]),
+            state,
+            &mut rng,
+        );
+        assert!(
+            !state.fitness()[0].is_nan(),
+            "raw NaN latched into the nest-0 fitness cache: {:?}",
+            state.fitness()
+        );
+
+        // Generations 1 and 2: every egg is finite and strictly better, so a
+        // live nest 0 must adopt them.
+        for score in [10.0_f32, 20.0] {
+            let (eggs, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let n = eggs.dims()[0];
+            let (advanced, _m) = strategy.tell(&params, eggs, fit(vec![score; n]), next, &mut rng);
+            state = advanced;
+        }
+        approx::assert_relative_eq!(state.fitness()[0], 20.0, epsilon = 1e-6);
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -781,6 +781,18 @@ mod tests {
             "raw NaN reached the public fitness cache: {:?}",
             state.fitness()
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would rank firefly 0 *above* every finite
+        // -1/-2/… row and make the NaN-scoring firefly the brightest — the
+        // leader poisoning this regression exists to catch.
+        assert!(
+            state.fitness()[0].is_infinite() && state.fitness()[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the firefly-0 fitness cache: {:?}",
+            state.fitness()
+        );
     }
 
     // Gap (b') cont. / issue #233: a full `genome_dim = 1` run drives the harness

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/firefly.rs
@@ -391,10 +391,21 @@ where
         mut state: FireflyState<B>,
         _rng: &mut dyn Rng,
     ) -> (FireflyState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitize at the pull (NaN → −inf, +inf → f32::MAX). This is the
+        // per-site correctness floor for a caller driving `ask`/`tell`
+        // directly instead of `EvolutionaryHarness::step`, which already
+        // sanitizes (the ADR 0034 decision-3 bypass hole, issue #131):
+        // otherwise a raw NaN lands in the public `state.fitness` cache and
+        // silently disables the `fitness[j] > fitness[i]` brightness ordering
+        // in the next `ask`. `sanitize_fitness` is idempotent, so on the
+        // harness path this is a provable no-op — not redundant, load-bearing.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         let device = population.device();
         state.fitness.clone_from(&fitness_host);
         state.positions.clone_from(&population);
@@ -741,6 +752,35 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() > 0, "expected a broken (NaN) member");
+    }
+
+    /// Cache hygiene (not a freeze): `tell` overwrites `state.fitness`
+    /// wholesale every generation, so a `NaN` can never latch here. What this
+    /// pins is the **store** — driving `init → ask → tell` directly, the
+    /// ADR-0034 decision-3 bypass of `EvolutionaryHarness::step`, must not
+    /// leave a raw `NaN` in the public fitness cache. `ask` feeds that cache
+    /// to the brightness ordering (`fitness[j] > fitness[i]`), where a `NaN`
+    /// would silently disable one firefly's attraction for a generation.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = FireflyAlgorithm::<TestBackend>::new();
+        let params = FireflyConfig::default_for(6, 3);
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = strategy.init(&params, &mut rng, &device);
+        let (pop, state) = strategy.ask(&params, &state, &mut rng, &device);
+        // Gen-0 fitness supplied by the test, never by a landscape: [NaN, finite…].
+        #[allow(clippy::cast_precision_loss)]
+        let mut vals: Vec<f32> = (0..params.pop_size).map(|i| -(i as f32) - 1.0).collect();
+        vals[0] = f32::NAN;
+        let fitness =
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [params.pop_size]), &device);
+        let (state, _m) = strategy.tell(&params, pop, fitness, state, &mut rng);
+        assert!(
+            state.fitness().iter().all(|f| !f.is_nan()),
+            "raw NaN reached the public fitness cache: {:?}",
+            state.fitness()
+        );
     }
 
     // Gap (b') cont. / issue #233: a full `genome_dim = 1` run drives the harness

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -338,10 +338,22 @@ where
         mut state: GwoState<B>,
         _rng: &mut dyn Rng,
     ) -> (GwoState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitise on the host pull (`rules.md` §3, ADR 0034 decision 3,
+        // issue #131): the harness chokepoint already applies
+        // `sanitize_fitness_tensor` before `tell`, but `Strategy` is public, so
+        // a direct `ask`/`tell` driver can hand us a raw `NaN`. `argtop3_max`
+        // sanitises on the *read*, which keeps leader selection safe; this
+        // closes the *write* half, so the `GwoState` fitness cache a caller
+        // observes via `fitness()` never holds a `NaN`. `sanitize_fitness` is
+        // idempotent, so this is a provable no-op on the harness path: do not
+        // delete it as redundant.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         state.fitness.clone_from(&fitness_host);
         state.pack.clone_from(&population);
         let best_idx = argmax_host(&fitness_host);
@@ -648,6 +660,53 @@ mod tests {
         let (pack, _state) = strategy.ask(&params, &state, &mut rng, &device);
         let got = pack.into_data().into_vec::<f32>().unwrap();
         assert_eq!(expected, got);
+    }
+
+    /// Regression for the ADR 0034 decision-3 bypass hole (issue #131): a
+    /// driver calling `init → ask → tell` directly gets no harness sanitize, so
+    /// `tell` used to store a raw `NaN` into the `GwoState` fitness cache that
+    /// `fitness()` hands back to callers.
+    ///
+    /// GWO keeps no per-slot best, so nothing freezes and leader selection was
+    /// already safe (`argtop3_max` sanitises on the read). This is a
+    /// cache-hygiene assertion — the write half of the same rule — not a
+    /// freeze assertion.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = GreyWolfOptimizer::<TestBackend>::new();
+        let params = GwoConfig::default_for(4, 3);
+        let mut rng = StdRng::seed_from_u64(131);
+        let state = strategy.init(&params, &mut rng, &device);
+
+        // Generation 0: row 0 is NaN, the rest finite.
+        let (pack, state) = strategy.ask(&params, &state, &mut rng, &device);
+        let f0 = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NAN, 0.0, 0.0, 0.0], [4]),
+            &device,
+        );
+        let (mut state, _m) = strategy.tell(&params, pack, f0, state, &mut rng);
+        assert!(
+            state.fitness().iter().all(|f| !f.is_nan()),
+            "tell stored a raw NaN in the fitness cache: {:?}",
+            state.fitness()
+        );
+
+        // Two more generations of finite, strictly-better fitness supplied by
+        // the test (never a landscape): the cache tracks what it was given and
+        // stays NaN-free.
+        for value in [1.0_f32, 2.0] {
+            let (pack, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let f =
+                Tensor::<TestBackend, 1>::from_data(TensorData::new(vec![value; 4], [4]), &device);
+            let (next, _m) = strategy.tell(&params, pack, f, next, &mut rng);
+            state = next;
+            assert!(
+                state.fitness().iter().all(|f| (f - value).abs() < 1e-6),
+                "fitness cache did not track the supplied {value}: {:?}",
+                state.fitness()
+            );
+        }
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/gwo.rs
@@ -691,6 +691,18 @@ mod tests {
             "tell stored a raw NaN in the fitness cache: {:?}",
             state.fitness()
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would tie wolf 0 with the finite 0.0 rows and let
+        // it be elected alpha — the leader poisoning this regression exists to
+        // catch.
+        assert!(
+            state.fitness()[0].is_infinite() && state.fitness()[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the wolf-0 fitness cache: {:?}",
+            state.fitness()
+        );
 
         // Two more generations of finite, strictly-better fitness supplied by
         // the test (never a landscape): the cache tracks what it was given and

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
@@ -339,10 +339,23 @@ where
         mut state: PsoState<B>,
         _rng: &mut dyn Rng,
     ) -> (PsoState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitise on the host pull (`rules.md` §3, ADR 0034 decision 3,
+        // issue #131): the harness chokepoint already applies
+        // `sanitize_fitness_tensor` before `tell`, but `Strategy` is public, so
+        // a direct `ask`/`tell` driver can hand us a raw `NaN`. PSO latches
+        // fitness into the persistent `personal_best_fitness` cache and
+        // compares against it next generation — an unsanitised `NaN` there
+        // loses every `>` comparison and freezes that particle's personal best
+        // permanently, with no reset path. `sanitize_fitness` is idempotent, so
+        // this is a provable no-op on the harness path: do not delete it as
+        // redundant.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         let device = population.device();
 
         // First tell: seed personal-bests.
@@ -627,6 +640,50 @@ mod tests {
             m.best_fitness_ever()
         );
         assert!(m.broken_count() >= 1, "the NaN row must be counted broken");
+    }
+
+    /// Regression for the ADR 0034 decision-3 bypass hole (issue #131): a
+    /// driver calling `init → ask → tell` directly gets no harness sanitize, so
+    /// a raw `NaN` used to latch into `personal_best_fitness[0]` and freeze
+    /// that particle's personal best permanently — `x > NaN` is false for every
+    /// `x`, and PSO has no reset path for the cache.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = ParticleSwarm::<TestBackend>::new();
+        let params = PsoConfig::default_for(4, 3);
+        let mut rng = StdRng::seed_from_u64(131);
+        let state = strategy.init(&params, &mut rng, &device);
+
+        // Generation 0: row 0 is NaN, the rest finite. The bootstrap `tell`
+        // seeds `personal_best_fitness` straight from this vector.
+        let (pop, state) = strategy.ask(&params, &state, &mut rng, &device);
+        let f0 = Tensor::<TestBackend, 1>::from_data(
+            TensorData::new(vec![f32::NAN, 0.0, 0.0, 0.0], [4]),
+            &device,
+        );
+        let (mut state, _m) = strategy.tell(&params, pop, f0, state, &mut rng);
+        assert!(
+            !state.personal_best_fitness[0].is_nan(),
+            "bootstrap tell latched a raw NaN into the personal-best cache: {:?}",
+            state.personal_best_fitness
+        );
+
+        // Two more generations of finite, strictly-better fitness supplied by
+        // the test (never a landscape). Particle 0 must adopt each value rather
+        // than staying pinned behind an unbeatable cached entry.
+        for value in [1.0_f32, 2.0] {
+            let (pop, next) = strategy.ask(&params, &state, &mut rng, &device);
+            let f =
+                Tensor::<TestBackend, 1>::from_data(TensorData::new(vec![value; 4], [4]), &device);
+            let (next, _m) = strategy.tell(&params, pop, f, next, &mut rng);
+            state = next;
+            assert!(
+                (state.personal_best_fitness[0] - value).abs() < 1e-6,
+                "personal_best_fitness[0] = {} did not adopt the finite {value}",
+                state.personal_best_fitness[0]
+            );
+        }
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/pso.rs
@@ -668,6 +668,19 @@ mod tests {
             "bootstrap tell latched a raw NaN into the personal-best cache: {:?}",
             state.personal_best_fitness
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would let particle 0 tie or beat the finite rows
+        // and seed the global best from a NaN-scoring particle — the leader
+        // poisoning this regression exists to catch.
+        assert!(
+            state.personal_best_fitness[0].is_infinite()
+                && state.personal_best_fitness[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the personal-best cache: {:?}",
+            state.personal_best_fitness
+        );
 
         // Two more generations of finite, strictly-better fitness supplied by
         // the test (never a landscape). Particle 0 must adopt each value rather

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
@@ -523,6 +523,18 @@ mod tests {
             "raw NaN reached the public fitness cache: {:?}",
             state.fitness
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would rank salp 0 *above* every finite -1/-2/…
+        // row and elect the NaN-scoring salp as the food source — the leader
+        // poisoning this regression exists to catch.
+        assert!(
+            state.fitness[0].is_infinite() && state.fitness[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the salp-0 fitness cache: {:?}",
+            state.fitness
+        );
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/salp.rs
@@ -285,10 +285,20 @@ where
         mut state: SalpState<B>,
         _rng: &mut dyn Rng,
     ) -> (SalpState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitize at the pull (NaN → −inf, +inf → f32::MAX). This is the
+        // per-site correctness floor for a caller driving `ask`/`tell`
+        // directly instead of `EvolutionaryHarness::step`, which already
+        // sanitizes (the ADR 0034 decision-3 bypass hole, issue #131):
+        // otherwise a raw NaN lands in the public `state.fitness` cache.
+        // `sanitize_fitness` is idempotent, so on the harness path this is a
+        // provable no-op — not redundant, load-bearing.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         state.fitness.clone_from(&fitness_host);
         state.positions.clone_from(&population);
         let best_idx = argmax_host(&fitness_host);
@@ -486,6 +496,33 @@ mod tests {
         .expect("valid params");
         harness.reset();
         assert!(harness.latest_metrics().is_none());
+    }
+
+    /// Cache hygiene (not a freeze): `tell` overwrites `state.fitness`
+    /// wholesale every generation, so a `NaN` can never latch here. What this
+    /// pins is the **store** — driving `init → ask → tell` directly, the
+    /// ADR-0034 decision-3 bypass of `EvolutionaryHarness::step`, must not
+    /// leave a raw `NaN` in the public fitness cache a caller can read back.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = SalpSwarm::<TestBackend>::new();
+        let params = SalpConfig::default_for(6, 3);
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = strategy.init(&params, &mut rng, &device);
+        let (pop, state) = strategy.ask(&params, &state, &mut rng, &device);
+        // Gen-0 fitness supplied by the test, never by a landscape: [NaN, finite…].
+        #[allow(clippy::cast_precision_loss)]
+        let mut vals: Vec<f32> = (0..params.pop_size).map(|i| -(i as f32) - 1.0).collect();
+        vals[0] = f32::NAN;
+        let fitness =
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [params.pop_size]), &device);
+        let (state, _m) = strategy.tell(&params, pop, fitness, state, &mut rng);
+        assert!(
+            state.fitness.iter().all(|f| !f.is_nan()),
+            "raw NaN reached the public fitness cache: {:?}",
+            state.fitness
+        );
     }
 
     #[test]

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -657,5 +657,17 @@ mod tests {
             "raw NaN reached the public fitness cache: {:?}",
             state.fitness()
         );
+        // Pin the *value*, not just "not NaN": under the canonical maximise
+        // convention (ADR 0023 / ADR 0034) `−∞` is the worst representable
+        // fitness, and that is precisely what makes a sanitized member unable
+        // to win a champion scan. Any other finite substitute (e.g. `0.0`)
+        // clears `is_nan` yet would rank whale 0 *above* every finite -1/-2/…
+        // row and make the NaN-scoring whale the prey the pack encircles — the
+        // leader poisoning this regression exists to catch.
+        assert!(
+            state.fitness()[0].is_infinite() && state.fitness()[0].is_sign_negative(),
+            "sanitized NaN must land as -inf in the whale-0 fitness cache: {:?}",
+            state.fitness()
+        );
     }
 }

--- a/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
+++ b/crates/rlevo-evolution/src/algorithms/metaheuristic/woa.rs
@@ -404,10 +404,20 @@ where
         mut state: WoaState<B>,
         _rng: &mut dyn Rng,
     ) -> (WoaState<B>, StrategyMetrics) {
-        let fitness_host = fitness
+        // Sanitize at the pull (NaN → −inf, +inf → f32::MAX). This is the
+        // per-site correctness floor for a caller driving `ask`/`tell`
+        // directly instead of `EvolutionaryHarness::step`, which already
+        // sanitizes (the ADR 0034 decision-3 bypass hole, issue #131):
+        // otherwise a raw NaN lands in the public `state.fitness` cache.
+        // `sanitize_fitness` is idempotent, so on the harness path this is a
+        // provable no-op — not redundant, load-bearing.
+        let fitness_host: Vec<f32> = fitness
             .into_data()
             .into_vec::<f32>()
-            .expect("fitness tensor must be readable as f32");
+            .expect("fitness tensor must be readable as f32")
+            .into_iter()
+            .map(crate::fitness::sanitize_fitness)
+            .collect();
         state.fitness.clone_from(&fitness_host);
         state.positions.clone_from(&population);
         let best_idx = argmax_host(&fitness_host);
@@ -619,6 +629,33 @@ mod tests {
                 .unwrap()
                 .best_fitness_ever()
                 .is_finite()
+        );
+    }
+
+    /// Cache hygiene (not a freeze): `tell` overwrites `state.fitness`
+    /// wholesale every generation, so a `NaN` can never latch here. What this
+    /// pins is the **store** — driving `init → ask → tell` directly, the
+    /// ADR-0034 decision-3 bypass of `EvolutionaryHarness::step`, must not
+    /// leave a raw `NaN` in the public fitness cache a caller can read back.
+    #[test]
+    fn nan_fitness_does_not_latch_without_harness() {
+        let device = Default::default();
+        let strategy = WhaleOptimization::<TestBackend>::new();
+        let params = WoaConfig::default_for(6, 3);
+        let mut rng = StdRng::seed_from_u64(7);
+        let state = strategy.init(&params, &mut rng, &device);
+        let (pop, state) = strategy.ask(&params, &state, &mut rng, &device);
+        // Gen-0 fitness supplied by the test, never by a landscape: [NaN, finite…].
+        #[allow(clippy::cast_precision_loss)]
+        let mut vals: Vec<f32> = (0..params.pop_size).map(|i| -(i as f32) - 1.0).collect();
+        vals[0] = f32::NAN;
+        let fitness =
+            Tensor::<TestBackend, 1>::from_data(TensorData::new(vals, [params.pop_size]), &device);
+        let (state, _m) = strategy.tell(&params, pop, fitness, state, &mut rng);
+        assert!(
+            state.fitness().iter().all(|f| !f.is_nan()),
+            "raw NaN reached the public fitness cache: {:?}",
+            state.fitness()
         );
     }
 }

--- a/crates/rlevo-evolution/src/strategy.rs
+++ b/crates/rlevo-evolution/src/strategy.rs
@@ -145,10 +145,22 @@ pub trait Strategy<B: Backend>: Send + Sync {
     /// **canonical (maximise) and sanitized** (ADR 0034): every element is finite
     /// or `f32::NEG_INFINITY` — no `NaN`, no `+∞`. A `tell` impl may therefore
     /// build leaders / personal-best / global-best directly from it without a
-    /// finite check. Callers that invoke `tell` **directly, bypassing the
-    /// harness**, do *not* get this guarantee and must apply
-    /// `sanitize_fitness` at every
-    /// ordering/aggregation site (`rules.md` §3).
+    /// finite check.
+    ///
+    /// The guarantee is the harness's, so on a **bypass path** — a unit test or a
+    /// custom driver calling `ask`/`tell` by hand — it is the **implementor** that
+    /// owes it: a `tell` pulling `fitness` to host applies `sanitize_fitness`
+    /// **once at the pull**, after which every ordering / argmax / champion-write
+    /// site downstream *in that function* may assume it (`rules.md` §3).
+    ///
+    /// Every shipping strategy in [`algorithms::metaheuristic`] does this
+    /// internally, so a direct `ask`/`tell` caller of that family need not
+    /// pre-sanitize. Coverage stops at the tensor argument, though: a `NaN` written
+    /// straight into a state's fitness cache via the `pub` `*State::try_new`
+    /// constructors (or `PsoState`'s `pub` fields) is never re-sanitized and still
+    /// freezes that slot for the run (issue #1064).
+    ///
+    /// [`algorithms::metaheuristic`]: crate::algorithms::metaheuristic
     fn tell(
         &self,
         params: &Self::Params,

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -210,6 +210,15 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
   For a whole `Tensor<B, 1>` on the hot path use `sanitize_fitness_tensor`
   (one device op) instead of a host round-trip.
 
+  **A `Strategy::tell` that pulls fitness to host sanitizes once at the pull**,
+  and the ordering/argmax/champion-write sites downstream *in that function* may
+  then assume it. One `.map(sanitize_fitness)` on the `Vec<f32>` the pull already
+  produces is cheaper and more greppable than re-deriving a `sane` buffer at each
+  site — and it stops the raw value reaching a *persistent* per-slot cache, where
+  a `NaN` freezes that individual for the rest of the run (#131: `state.fitness`
+  in the metaheuristic family). Sanitizing only the compared value is an
+  under-fix: the accept-store writes the raw value back.
+
 ---
 
 ## 4. Error Handling


### PR DESCRIPTION
## Summary

Fixes a per-slot fitness-cache freeze in the metaheuristic family: a `NaN` fitness handed to `Strategy::tell` by a caller bypassing `EvolutionaryHarness` was latched raw into a persistent per-slot cache, and every subsequent acceptance comparison against it is false — so that individual became a zombie the algorithm could never replace, silently shrinking the population by one. Bat and PSO have no reset mechanism, so the freeze was permanent-until-restart. All nine metaheuristic `tell` impls now sanitize the fitness vector once, at the point it is pulled to host, so the gen-0 bootstrap seed and the accept-store are both covered by a single call.

The run's *reported* optimum stayed correct throughout, which is exactly why this survived review.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)
- [x] Documentation correction (misleading `Strategy::tell` doc contract, corrected as a consequence of the fix)

## Linked Issue

Closes #131

Follow-ups filed, not addressed here: #1064 (residual `try_new` entry point), #1065 (ADR 0034 `CanonicalFitness<B>` fast-follow).

## What Was Changed

- `crates/rlevo-evolution/src/algorithms/metaheuristic/{abc,bat,cuckoo,pso,gwo,firefly,salp,woa,aco_r}.rs` — each `Strategy::tell` maps `crate::fitness::sanitize_fitness` over the `Vec<f32>` at its single host pull, with a comment citing ADR 0034 decision 3 and #131 so it is not later deleted as redundant. No comparison operator changed. Pre-existing local `sane` derivations (`gwo.rs` `argtop3_max`, `cuckoo.rs` abandonment ranking, `aco_r.rs` ×2) deliberately kept — they are the `rules.md` §3 floor.
- Same nine files — added `nan_fitness_does_not_latch_without_harness`, an in-source seeded example test per algorithm (ADR 0012 tier 1), the bypass twin of the existing `nan_fitness_survives_harness`.
- `crates/rlevo-evolution/src/algorithms/metaheuristic/abc.rs` — added `inf_fitness_clamps_finite_without_harness` covering the `+∞ → f32::MAX` half, which had no bypass coverage at all.
- `crates/rlevo-evolution/src/strategy.rs` — corrected the `Strategy::tell` `# Invariants` doc. It told bypass *callers* they must sanitize; the obligation is the *implementor's*, the shipped metaheuristic family now discharges it internally, and the residual (`*State::try_new`) is stated explicitly.
- `docs/rules.md` §3 — added the enforceable rule this implements: *a `tell` that pulls fitness to host sanitizes once at the pull, and downstream sites in that function may assume it.*
- `CHANGELOG.md` — entry under `[Unreleased]` → `rlevo-evolution` → **Fixed**.

**No new ADR.** This implements ADR 0034 decision 3 against the failure its own "Negative / accepted costs" section predicted ("if the hole recurs in practice"). A new ADR would have to decide something 0034 does not.

**Two files were affected that #131 did not correctly identify.** `gwo.rs` sanitized on the *read* (`argtop3_max`) but stored the raw value on the *write* — that split is why the class stayed invisible, and commit `5830e74` generalized its clean read side into an "audit of every metaheuristic" claim that was false for four siblings. `aco_r.rs` sanitizes for archive *ranking* but re-reads the unsanitized vector when materializing `archive_fitness`, so a `NaN` survives at the archive tail. Both had been declared clean on their read-side guard alone.

## How It Was Tested

```
cargo build --workspace                        # clean
cargo test --workspace                         # green; 606 lib tests in rlevo-evolution
cargo clippy --all-targets --all-features      # clean, no warnings
```

**Regression tests, before/after.** All nine `nan_fitness_does_not_latch_without_harness` tests fail on the previous code and pass on this PR. Driving `init → ask → tell` directly (no harness) with a gen-0 `NaN` and finite improving fitness thereafter:

| | before | after |
|---|---|---|
| `abc` | `[NaN×5, -inf, 5000.0, …]` (heals only via scout `limit`) | `[-inf, 5000.0, …]` |
| `bat` | `[NaN×10]` — never heals | `[-inf, 5000.0, …]` |
| `cuckoo` (`p_a = 0.0`) | `[NaN×10]` — never heals | `[-inf, 5000.0, …]` |
| `pso` | `[NaN×10]` — never heals | `[-inf, 5000.0, …]` |

**These tests are mutation-checked, not just red/green.** An earlier version asserted only `!x.is_nan()` and passed against a `sanitize_fitness` mutated to map `NaN → 0.0` — under which the `NaN`-scoring individual becomes the reported population best, the exact bug. They now assert the sanitized `−∞` directly at generation 0 (`is_infinite() && is_sign_negative()`; `rules.md` §5/§8 forbids float equality), and all nine fail under that mutant. `inf_fitness_clamps_finite_without_harness` likewise fails under a pass-through `+∞`.

Tests assert on the **cache**, never on convergence — a `reaches < ε on sphere` assertion passes while a slot is frozen, since ABC self-heals via the scout `limit`. That assertion shape is why the defect survived the original review.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned in `rust-toolchain.toml`, `channel = "1.94.1"`)
- Burn backend tested: `Flex` (the crate's test backend)
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **all of it** — triage, the design decision, the nine-file implementation, the tests, and the docs, orchestrated across architect-reviewer, rust-engineer, and qa-expert subagents. Every claim in this PR was verified by execution against the tree, including the mutation checks, which were re-run independently rather than taken from a subagent report.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*. (No API additions; the `Strategy::tell` contract doc was corrected.)
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (One rule, applied family-wide.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**One route stays open, tracked as #1064.** This sanitizes the fitness *entering* `tell`, not the cache it is compared against. Under normal `init → ask → tell` those are equivalent, since the cache is only ever populated from an already-sanitized value. They are not equivalent when a `NaN` reaches the cache another way — and the `pub` `*State::try_new` constructors (and `PsoState`'s `pub` fields) are such a route. The original freeze reproduces there.

Worth flagging for the reviewer: **#131's own prescribed fix — sanitize the compared value at each `>=`/`>` — would have closed that route.** It was still the wrong call, because it leaves the accept-store writing the raw value back, so the public `fitness()` accessors keep leaking and the slot self-heals in one generation rather than never. But the trade is real and #1064 owns the remainder.

`cuckoo.rs` gained `#[allow(clippy::too_many_lines)]` — the added lines pushed `tell` past the threshold. `abc.rs` already carried the same allow pre-PR (9 files in the crate do), so this matches house practice rather than introducing a pattern. `tell` growth is worth watching as a maintainability item.

Harness-driven runs are unaffected and need no benchmark re-baselining: `EvolutionaryHarness::step` already sanitizes before `tell`, and `sanitize_fitness` is idempotent, verified bitwise across `NaN`, `±∞`, `−0.0`, `f32::MAX`/`MIN`, and `MIN_POSITIVE`.
