### PR TITLE
fix(rl): Drop unconstructed agent error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   changes. (Other types in `replay/` — `ReplayConfig`, `PrioritizedReplaySettings`,
   `Priority`, `ImportanceExponent` — do derive it, and are untouched.)
 
+- **All eight agent error enums lose their unconstructed variants and become
+  `#[non_exhaustive]`** (resolves #1070, and subsumes #467 and #484). The six
+  off-policy enums — `DqnAgentError`, `C51AgentError`, `QrDqnAgentError`,
+  `DdpgAgentError`, `Td3AgentError`, `SacAgentError` — drop
+  `TensorConversionFailed(String)`, `Buffer(#[from] ReplayBufferError)` and
+  `Io(#[from] std::io::Error)`, keeping `InvalidAction` and `Polyak`.
+  `PpoAgentError` and `PpgAgentError` drop `TensorConversionFailed(String)`,
+  `InvalidConfig(String)` and `Io(#[from] std::io::Error)`, keeping
+  `Environment` and so becoming one variant wide. Twenty-four variants in
+  total, none of which any code in this workspace ever constructed. Migration:
+  as above, an exhaustive `match` needs a wildcard arm, which
+  `#[non_exhaustive]` now requires anyway and which buys future variants for
+  free. The three `#[from]` impls go with their variants, so a `?` that
+  converted a `ReplayBufferError` or an `std::io::Error` into an agent error no
+  longer compiles — no such site exists in this workspace, and for
+  `ReplayBufferError` none is possible (see below). No persisted data is
+  involved: none of the eight derives `serde`.
+
 ### `rlevo-evolution`
 
 **Fixed**
@@ -223,6 +241,55 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   unconstructed on all eight agent error enums — is **not** fixed here and is
   tracked as #1070. It is deliberately a separate call: agents *are* where
   staging happens, so deletion is not automatically the right remedy there.
+
+- **Twenty-four agent error variants that advertised failure modes the agents
+  cannot reach** (resolves #1070 — the deferral recorded in the entry above —
+  and subsumes #467 and #484, which are per-agent slices of the same finding).
+  The issue was filed against `TensorConversionFailed(String)` on all eight
+  enums; verifying it turned up two more dead shapes on the same family, plus a
+  third on PPO and PPG. Three arguments, one per shape.
+
+  `TensorConversionFailed(String)` is unconstructible by signature, not by
+  accident. `act`, `act_greedy`, `act_with` and `act_greedy_with` all return a
+  bare action, not a `Result`, so the host-read that could fail has no channel
+  to return through. What is there instead is
+  `.expect("actor output is f32")` — an `.expect` on a named invariant, which
+  is the form `docs/rules.md` §4 sanctions for a read that cannot fail by
+  construction. So the issue's second candidate remedy, wiring the staging
+  sites to return the variant, is not a fix to this enum at all: it is a change
+  to four public signatures, which #317 explicitly defers. The first candidate,
+  `#[from]`-ing the core error, fails for the same reason — there is nothing to
+  convert *into a return value* from a function that does not return one. Each
+  enum's rustdoc now records that when #317 lands the variant must come back as
+  `#[from] rlevo_core::base::TensorConversionError`, not as a `String`, since
+  §4 prefers structured variants and names that type as the tensor-op domain; a
+  re-introduced `String` payload would reproduce exactly the defect this entry
+  closes.
+
+  `Buffer(#[from] ReplayBufferError)` was unreachable by design. Every
+  `learn_step` writes
+  `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and after
+  the removal above the only variant `sample` can produce is
+  `InsufficientData` — which means "skip this learn step", not "the step
+  failed". Propagating it would misreport a warm-up buffer as an error.
+
+  `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+  there is no `save`, `load`, `Recorder` or `std::fs` anywhere under
+  `algorithms/`, and ADR 0014 defers checkpointing to Tier D. On PPO and PPG,
+  `InvalidConfig(String)` duplicated validation another type already performs —
+  `new` returns `rlevo_core::config::ConfigError`, so a bad config is rejected
+  before an agent exists and never reaches the agent's own error type.
+
+  As with `ReplayBufferError`, no test could have caught this and none was
+  missing: nothing behaved incorrectly. The defect was the API surface. Read as
+  an error domain, these enums told a caller that action selection may fail,
+  which the signatures say it cannot. `PpoAgentError` and `PpgAgentError` are
+  left one variant wide, which is the honest width — `Environment` is the only
+  failure their train loops surface. No new ADR is written; the rationale lives
+  in each enum's rustdoc, so the absence reads as a decision rather than an
+  oversight, and `#[non_exhaustive]` keeps the door open at no cost. The bar
+  for reopening it is a real construction site, not an anticipated failure
+  mode.
 
 ---
 

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_agent.rs
@@ -18,7 +18,7 @@ use burn::tensor::{ElementConversion, Int, Tensor, TensorData};
 use rand::{Rng, RngExt};
 
 use crate::metrics::{AgentStats, PerformanceRecord};
-use crate::replay::{DiscreteTransition, ReplayBufferError, ReplayKind, ReplayStrategy};
+use crate::replay::{DiscreteTransition, ReplayKind, ReplayStrategy};
 use rlevo_core::action::DiscreteAction;
 use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
@@ -37,24 +37,63 @@ use crate::algorithms::shared::{
 use crate::utils::PolyakError;
 
 /// Error variants returned by [`C51Agent`] operations.
+///
+/// Two things can go wrong, and each has a construction site.
+/// [`InvalidAction`](C51AgentError::InvalidAction) is built in
+/// [`crate::algorithms::c51::train`], where an environment `reset`/`step`
+/// rejection is converted into this domain. [`Polyak`](C51AgentError::Polyak)
+/// arrives through `?` in [`C51Agent::learn_step`] — the agent's only fallible
+/// method — when the policy and target networks have mismatched parameter
+/// topologies.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// ever constructed and nothing could: the tensor host-reads on the action path
+/// live in [`act`](C51Agent::act), [`act_greedy`](C51Agent::act_greedy) and
+/// [`act_greedy_with`](C51Agent::act_greedy_with), all of which return a bare
+/// `A` rather than a `Result`. With no error channel in the signature there is
+/// nowhere for the variant to be returned from, so those reads use the
+/// infallible form that `docs/rules.md` §4 sanctions for a read that "cannot
+/// fail by construction (e.g. a tensor the same function just built)".
+///
+/// Making action selection fallible is a breaking change, deferred and tracked
+/// as #317. When it lands, the variant that returns must carry
+/// [`rlevo_core::base::TensorConversionError`] as a `#[from]` payload, not a
+/// `String`: §4 prefers structured error types over string-based ones, and
+/// names `TensorConversionError` as the domain type for tensor ops.
+///
+/// # Why there is no buffer or I/O variant
+///
+/// `Buffer(#[from] ReplayBufferError)` was unreachable by design.
+/// [`learn_step`](C51Agent::learn_step) samples with
+/// `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and the
+/// only variant `sample` can produce is
+/// [`ReplayBufferError::InsufficientData`](crate::replay::ReplayBufferError::InsufficientData),
+/// which means "skip this learn step", not "the step failed". `Ok(None)` is the
+/// correct channel for a warm-up buffer; propagating it would misreport an
+/// ordinary warm-up as an error.
+///
+/// `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+/// there is no `save`, no `load`, no `Recorder` and no `std::fs` anywhere under
+/// `algorithms/`, and ADR 0014 §6 defers checkpointing producer wiring to
+/// Tier D.
+///
+/// The enum is `#[non_exhaustive]`, so adding a variant later is not a breaking
+/// change — checkpointing is the shape that would plausibly need one. The bar
+/// for adding it is a real construction site, not an anticipated failure mode;
+/// an unconstructible variant is what this section exists to keep from
+/// recurring.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum C51AgentError {
-    /// A tensor-to-action or action-to-tensor conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
     /// The sampled or requested action is outside the valid action space.
     #[error("Invalid action: {0}")]
     InvalidAction(String),
-    /// A replay buffer operation failed.
-    #[error(transparent)]
-    Buffer(#[from] ReplayBufferError),
     /// The target soft-update failed because the policy and target networks
     /// have mismatched parameter topologies.
     #[error(transparent)]
     Polyak(#[from] PolyakError),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
 }
 
 /// Per-episode statistics emitted by the C51 training loop.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_agent.rs
@@ -18,7 +18,7 @@ use rand::Rng;
 use rand::RngExt;
 
 use crate::metrics::{AgentStats, PerformanceRecord};
-use crate::replay::{ContinuousTransition, ReplayBufferError, ReplayStrategy, UniformReplay};
+use crate::replay::{ContinuousTransition, ReplayStrategy, UniformReplay};
 use rlevo_core::action::BoundedAction;
 use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
@@ -35,24 +35,66 @@ use crate::algorithms::shared::{
 use crate::utils::{PolyakError, compute_target_q_values};
 
 /// Error variants returned by [`DdpgAgent`] operations.
+///
+/// Two variants, and each has a real construction site in this crate.
+/// [`InvalidAction`](DdpgAgentError::InvalidAction) is built by
+/// [`train`](super::train::train) when `env.reset()` or `env.step()` rejects an
+/// action the agent proposed. [`Polyak`](DdpgAgentError::Polyak) arrives through
+/// `?` on the target soft-updates at the end of
+/// [`learn_step`](DdpgAgent::learn_step), where a live network and its target
+/// twin can disagree on parameter topology.
+///
+/// The enum is `#[non_exhaustive]`: downstream `match` expressions must carry a
+/// wildcard arm, so a future variant is not a breaking change.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// constructed and nothing could. The tensor host-reads on the act path are the
+/// `as_slice::<f32>()` calls in [`act`](DdpgAgent::act) and
+/// [`act_with`](DdpgAgent::act_with), and both methods return a bare `A` rather
+/// than a `Result` — there is no error channel for a variant to travel down. The
+/// read is an `.expect` on a named invariant, which is precisely the form
+/// `docs/rules.md` §4 sanctions for a host-read that "cannot fail by
+/// construction": the tensor is one the same function just built from its own
+/// actor. Issue #317 tracks making that path fallible and is an explicitly
+/// deferred breaking change.
+///
+/// When #317 lands, the variant returns as
+/// `#[from]` [`rlevo_core::base::TensorConversionError`] — not as a `String`.
+/// §4 prefers structured variants over string-based errors and names that type
+/// as the tensor-op error domain, so re-introducing a `String` payload would
+/// rebuild the discarded variant in a merely-live form.
+///
+/// # Why there is no buffer or I/O variant
+///
+/// `Buffer(#[from] ReplayBufferError)` was unreachable by design.
+/// [`learn_step`](DdpgAgent::learn_step) samples with
+/// `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and the
+/// only variant `sample` can produce is
+/// [`ReplayBufferError::InsufficientData`](crate::replay::ReplayBufferError::InsufficientData),
+/// which means "the buffer is still warming up, skip this learn step" — not
+/// "this learn step failed". Propagating it would misreport an ordinary warm-up
+/// as an error.
+///
+/// `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+/// there is no `save`, `load`, `Recorder`, or `std::fs` use anywhere under
+/// `algorithms/`, and ADR 0014 §6 defers the checkpoint write path to Tier D.
+///
+/// Because the enum is `#[non_exhaustive]`, adding a variant when either of
+/// those lands is not a breaking change. The bar for adding one is an actual
+/// construction site, not an anticipated failure mode — a declared but
+/// unconstructible variant is what this section exists to keep from recurring.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DdpgAgentError {
-    /// A tensor-to-action or action-to-tensor conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
     /// The sampled or requested action is outside the valid action space.
     #[error("Invalid action: {0}")]
     InvalidAction(String),
-    /// A replay-buffer operation failed.
-    #[error(transparent)]
-    Buffer(#[from] ReplayBufferError),
     /// A target soft-update failed because a live network and its target twin
     /// have mismatched parameter topologies.
     #[error(transparent)]
     Polyak(#[from] PolyakError),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
 }
 
 /// Per-episode statistics emitted by the DDPG training loop.
@@ -391,7 +433,11 @@ where
     /// Panics if the actor slot is poisoned — see
     /// [`Slot::get`](crate::algorithms::shared::Slot::get). This requires a
     /// prior panic *inside* the actor's optimizer step; a panic anywhere else
-    /// in [`learn_step`](Self::learn_step) leaves this method working.
+    /// in [`learn_step`](Self::learn_step) leaves this method working. Also
+    /// panics if the actor's output tensor is not `f32`: that host-read is an
+    /// `.expect` on a named invariant, the form `docs/rules.md` §4 sanctions
+    /// here because `act` returns a bare action and so has no error channel to
+    /// report the failure through — issue #317 tracks making the path fallible.
     pub fn act<R: Rng + ?Sized>(&self, obs: &O, training: bool, rng: &mut R) -> A {
         if training && self.step < self.config.learning_starts {
             let sample: Vec<f32> = (0..A::COMPONENTS)
@@ -462,7 +508,8 @@ where
     ///
     /// Panics if the actor's output tensor is not `f32`, or if it yields fewer
     /// than `A::COMPONENTS` values. Both indicate the supplied `net` does not
-    /// match the action type this agent was built for.
+    /// match the action type this agent was built for. Issue #317 tracks making
+    /// this path fallible so the first of those becomes an `Err` instead.
     pub fn act_with(&self, net: &Actor::InnerModule, obs: &O) -> A {
         // Function-local for the same `&self` / `Sync` reason as `act`.
         let mut scratch: Vec<f32> = Vec::new();

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_agent.rs
@@ -17,7 +17,7 @@ use burn::tensor::{ElementConversion, Int, Tensor, TensorData};
 use rand::{Rng, RngExt};
 
 use crate::metrics::{AgentStats, PerformanceRecord};
-use crate::replay::{DiscreteTransition, ReplayBufferError, ReplayKind, ReplayStrategy};
+use crate::replay::{DiscreteTransition, ReplayKind, ReplayStrategy};
 use rlevo_core::action::DiscreteAction;
 use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
@@ -32,24 +32,63 @@ use crate::algorithms::shared::{
 use crate::utils::{PolyakError, compute_target_q_values};
 
 /// Error variants returned by [`DqnAgent`] operations.
+///
+/// Two things can go wrong, and each has a construction site.
+/// [`InvalidAction`](DqnAgentError::InvalidAction) is built in
+/// [`crate::algorithms::dqn::train`], where an environment `reset`/`step`
+/// rejection is converted into this domain. [`Polyak`](DqnAgentError::Polyak)
+/// arrives through `?` in [`DqnAgent::learn_step`] — the agent's only fallible
+/// method — when the policy and target networks have mismatched parameter
+/// topologies.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// ever constructed and nothing could: the tensor host-reads on the action path
+/// live in [`act`](DqnAgent::act), [`act_greedy`](DqnAgent::act_greedy) and
+/// [`act_greedy_with`](DqnAgent::act_greedy_with), all of which return a bare
+/// `A` rather than a `Result`. With no error channel in the signature there is
+/// nowhere for the variant to be returned from, so those reads use the
+/// infallible form that `docs/rules.md` §4 sanctions for a read that "cannot
+/// fail by construction (e.g. a tensor the same function just built)".
+///
+/// Making action selection fallible is a breaking change, deferred and tracked
+/// as #317. When it lands, the variant that returns must carry
+/// [`rlevo_core::base::TensorConversionError`] as a `#[from]` payload, not a
+/// `String`: §4 prefers structured error types over string-based ones, and
+/// names `TensorConversionError` as the domain type for tensor ops.
+///
+/// # Why there is no buffer or I/O variant
+///
+/// `Buffer(#[from] ReplayBufferError)` was unreachable by design.
+/// [`learn_step`](DqnAgent::learn_step) samples with
+/// `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and the
+/// only variant `sample` can produce is
+/// [`ReplayBufferError::InsufficientData`](crate::replay::ReplayBufferError::InsufficientData),
+/// which means "skip this learn step", not "the step failed". `Ok(None)` is the
+/// correct channel for a warm-up buffer; propagating it would misreport an
+/// ordinary warm-up as an error.
+///
+/// `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+/// there is no `save`, no `load`, no `Recorder` and no `std::fs` anywhere under
+/// `algorithms/`, and ADR 0014 §6 defers checkpointing producer wiring to
+/// Tier D.
+///
+/// The enum is `#[non_exhaustive]`, so adding a variant later is not a breaking
+/// change — checkpointing is the shape that would plausibly need one. The bar
+/// for adding it is a real construction site, not an anticipated failure mode;
+/// an unconstructible variant is what this section exists to keep from
+/// recurring.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum DqnAgentError {
-    /// A tensor-to-action or action-to-tensor conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
     /// The sampled or requested action is outside the valid action space.
     #[error("Invalid action: {0}")]
     InvalidAction(String),
-    /// A replay buffer operation failed.
-    #[error(transparent)]
-    Buffer(#[from] ReplayBufferError),
     /// The target soft-update failed because the policy and target networks
     /// have mismatched parameter topologies.
     #[error(transparent)]
     Polyak(#[from] PolyakError),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
 }
 
 /// Per-episode statistics emitted by the DQN training loop.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/ppg_agent.rs
@@ -47,17 +47,79 @@ use crate::algorithms::ppo::ppo_value::PpoValue;
 use crate::algorithms::ppo::rollout::{RolloutBuffer, StepEnd};
 
 /// Error variants returned by [`PpgAgent`] operations.
+///
+/// This enum is deliberately one variant wide. The PPG train loop
+/// ([`crate::algorithms::ppg::train`]) surfaces exactly one failure — an
+/// environment `reset`/`step` that returns `Err` — so the enum carries exactly
+/// one variant, [`Environment`](PpgAgentError::Environment), constructed at the
+/// single `env_error` helper in that module. This is the same shape, and the
+/// same reasoning, as
+/// [`ReplayBufferError`](crate::replay::ReplayBufferError) one layer down: the
+/// width of an error enum is the number of ways its owner can actually fail,
+/// not the number of ways one might imagine it failing.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// ever constructed and nothing could. The agent's host-reading methods have no
+/// error channel by signature: [`PpgAgent::act`] returns a bare [`ActOutcome`]
+/// and [`PpgAgent::act_greedy`] / [`PpgAgent::act_greedy_env_row_with`] return
+/// `Vec<f32>`. None is a `Result`, so a failing host-read has nowhere to go.
+/// Those reads use the `.expect("<named invariant>")` form that
+/// `docs/rules.md` §4 sanctions for a host-read that cannot fail by
+/// construction — the tensor being read is one the same function just built on
+/// the same device.
+///
+/// Making those signatures fallible is tracked as issue #317 (see ADR 0057,
+/// which resolved the off-policy half and left `act` and the on-policy agents
+/// panic-based as the explicit residual). When #317 lands, the variant returns
+/// carrying [`rlevo_core::base::TensorConversionError`] via `#[from]` — a
+/// structured payload, **not** a `String`. `docs/rules.md` §4 prefers
+/// structured variants over string-based errors and names
+/// [`TensorConversionError`](rlevo_core::base::TensorConversionError) as the
+/// domain type for tensor ops, so re-adding a `String` payload would reintroduce
+/// the smell along with the variant.
+///
+/// # Why there is no config variant
+///
+/// This enum previously carried `InvalidConfig(String)`, duplicating a job
+/// another type already does. [`PpgAgent::new`] validates its [`PpgConfig`]
+/// through [`Validate`] and returns `Result<Self, E>` with `E` =
+/// [`rlevo_core::config::ConfigError`], so an inconsistent setting —
+/// `aux_batch_size == 0`, say, or anything the delegated
+/// [`PpoTrainingConfig`](crate::algorithms::ppo::ppo_config::PpoTrainingConfig)
+/// check rejects — is caught *before* an agent exists. No `PpgAgent` can be
+/// holding a config bad enough to produce this variant, because such a config
+/// never yields a `PpgAgent`.
+///
+/// # Why there is no I/O variant
+///
+/// This enum previously carried `Io(#[from] std::io::Error)` for "saving or
+/// loading model weights". No such code exists: nothing under
+/// [`crate::algorithms`] defines a `save`, a `load`, a `Recorder`, or touches
+/// `std::fs`. ADR 0014 defers checkpointing and resume-from-checkpoint to
+/// Tier D. The variant returns with the feature that needs it, not before.
+///
+/// # Known limitation: the `Environment` payload is a `String`
+///
+/// The surviving variant carries a `String` where
+/// [`rlevo_core::environment::EnvironmentError`] is the domain type;
+/// `docs/rules.md` §4 would prefer `Environment(#[from] EnvironmentError)`.
+/// `train.rs` currently calls `err.to_string()`, discarding the structured
+/// error and its [`source`](std::error::Error::source) chain. This is **known
+/// and tracked as #171**, which scopes the same fix across all eight
+/// algorithms — it is a breaking change to the payload type and is
+/// deliberately out of scope here. Do not read the `String` as endorsed.
+///
+/// # Adding a variant
+///
+/// The enum is `#[non_exhaustive]`, so adding a variant later is not a breaking
+/// change and downstream `match` expressions must already carry a wildcard arm.
+/// The bar for adding one is a real construction site — an anticipated failure
+/// mode is what the three sections above exist to keep out.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PpgAgentError {
-    /// A tensor-to-action conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
-    /// The config is internally inconsistent.
-    #[error("Invalid config: {0}")]
-    InvalidConfig(String),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
     /// Env-side failure surfaced through the train loop.
     #[error("Environment error: {0}")]
     Environment(String),
@@ -1052,6 +1114,12 @@ mod tests {
             .build()
             .expect("valid config");
         TestAgent::new(policy, value, config, device, 1).expect("valid config")
+    }
+
+    #[test]
+    fn error_display_uses_thiserror_messages() {
+        let err = PpgAgentError::Environment("boom".into());
+        assert_eq!(err.to_string(), "Environment error: boom");
     }
 
     /// Regression (issue #183): PPG builds its optimizers from

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppg/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppg/train.rs
@@ -94,7 +94,7 @@ where
 {
     let rollout_len = agent.config().ppo.num_steps;
 
-    let mut snapshot = env.reset().map_err(io_from_env)?;
+    let mut snapshot = env.reset().map_err(env_error)?;
     let mut episode_reward = 0.0_f32;
     let mut episode_steps = 0_usize;
     let mut last_update_stats = PpoUpdateStats::default();
@@ -116,7 +116,7 @@ where
             let act = agent.act(&obs_now, rng);
 
             let typed_action = A::from_index(act.env_row[0] as usize);
-            let next_snapshot = env.step(typed_action).map_err(io_from_env)?;
+            let next_snapshot = env.step(typed_action).map_err(env_error)?;
             let reward_f32: f32 = (*next_snapshot.reward()).into();
             let status = next_snapshot.status();
             let done = status.is_done();
@@ -161,7 +161,7 @@ where
                 // the rollout's final step is recorded as done, so
                 // `finalize_rollout` never reads the observation at all.
                 if global_step < total_timesteps {
-                    snapshot = env.reset().map_err(io_from_env)?;
+                    snapshot = env.reset().map_err(env_error)?;
                 }
             } else {
                 snapshot = next_snapshot;
@@ -265,6 +265,6 @@ fn emit_progress<B, P, V, O, const DO: usize, const DB: usize>(
 // `EnvironmentError`. Taking `&EnvironmentError` to satisfy the lint would force
 // a `|e| ..(&e)` closure at every call site for no benefit.
 #[allow(clippy::needless_pass_by_value)]
-fn io_from_env(err: rlevo_core::environment::EnvironmentError) -> PpgAgentError {
+fn env_error(err: rlevo_core::environment::EnvironmentError) -> PpgAgentError {
     PpgAgentError::Environment(err.to_string())
 }

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_agent.rs
@@ -31,17 +31,79 @@ use crate::algorithms::ppo::ppo_value::PpoValue;
 use crate::algorithms::ppo::rollout::{RolloutBuffer, StepEnd};
 
 /// Error variants returned by [`PpoAgent`] operations.
+///
+/// This enum is deliberately one variant wide. The PPO train loop
+/// ([`crate::algorithms::ppo::train`]) surfaces exactly one failure — an
+/// environment `reset`/`step` that returns `Err` — so the enum carries exactly
+/// one variant, [`Environment`](PpoAgentError::Environment), constructed at the
+/// single `env_error` helper in that module. This is the same shape, and the
+/// same reasoning, as
+/// [`ReplayBufferError`](crate::replay::ReplayBufferError) one layer down: the
+/// width of an error enum is the number of ways its owner can actually fail,
+/// not the number of ways one might imagine it failing.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// ever constructed and nothing could. The agent's host-reading methods have no
+/// error channel by signature: [`PpoAgent::act`] returns a bare [`ActOutcome`]
+/// and [`PpoAgent::act_greedy_env_row_with`] returns `Vec<f32>`. Neither is a
+/// `Result`, so a failing host-read has nowhere to go. Those reads use the
+/// `.expect("<named invariant>")` form that `docs/rules.md` §4 sanctions for a
+/// host-read that cannot fail by construction — the tensor being read is one
+/// the same function just built on the same device.
+///
+/// Making those signatures fallible is tracked as issue #317 (see ADR 0057,
+/// which resolved the off-policy half and left `act` and the on-policy agents
+/// panic-based as the explicit residual). When #317 lands, the variant returns
+/// carrying [`rlevo_core::base::TensorConversionError`] via `#[from]` — a
+/// structured payload, **not** a `String`. `docs/rules.md` §4 prefers
+/// structured variants over string-based errors and names
+/// [`TensorConversionError`](rlevo_core::base::TensorConversionError) as the
+/// domain type for tensor ops, so re-adding a `String` payload would reintroduce
+/// the smell along with the variant.
+///
+/// # Why there is no config variant
+///
+/// This enum previously carried `InvalidConfig(String)`, duplicating a job
+/// another type already does. [`PpoAgent::new`] validates its
+/// [`PpoTrainingConfig`] through [`Validate`] and returns `Result<Self, E>`
+/// with `E` = [`rlevo_core::config::ConfigError`], so an inconsistent setting —
+/// `num_minibatches == 0`, say — is rejected *before* an agent exists. No
+/// `PpoAgent` can be holding a config bad enough to produce this variant,
+/// because such a config never yields a `PpoAgent`. (The deleted variant's own
+/// doc cited `minibatch_size > batch_size`, a state that cannot arise:
+/// [`PpoTrainingConfig::minibatch_size`] is *derived* from `num_steps`,
+/// `num_envs`, and `num_minibatches` and floored at `1`.)
+///
+/// # Why there is no I/O variant
+///
+/// This enum previously carried `Io(#[from] std::io::Error)` for "saving or
+/// loading model weights". No such code exists: nothing under
+/// [`crate::algorithms`] defines a `save`, a `load`, a `Recorder`, or touches
+/// `std::fs`. ADR 0014 defers checkpointing and resume-from-checkpoint to
+/// Tier D. The variant returns with the feature that needs it, not before.
+///
+/// # Known limitation: the `Environment` payload is a `String`
+///
+/// The surviving variant carries a `String` where
+/// [`rlevo_core::environment::EnvironmentError`] is the domain type;
+/// `docs/rules.md` §4 would prefer `Environment(#[from] EnvironmentError)`.
+/// `train.rs` currently calls `err.to_string()`, discarding the structured
+/// error and its [`source`](std::error::Error::source) chain. This is **known
+/// and tracked as #171**, which scopes the same fix across all eight
+/// algorithms — it is a breaking change to the payload type and is
+/// deliberately out of scope here. Do not read the `String` as endorsed.
+///
+/// # Adding a variant
+///
+/// The enum is `#[non_exhaustive]`, so adding a variant later is not a breaking
+/// change and downstream `match` expressions must already carry a wildcard arm.
+/// The bar for adding one is a real construction site — an anticipated failure
+/// mode is what the three sections above exist to keep out.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PpoAgentError {
-    /// A tensor-to-action conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
-    /// The config is internally inconsistent (e.g. `minibatch_size` > `batch_size`).
-    #[error("Invalid config: {0}")]
-    InvalidConfig(String),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
     /// Env-side failure surfaced through the train loop.
     #[error("Environment error: {0}")]
     Environment(String),
@@ -829,6 +891,12 @@ mod tests {
             .build()
             .expect("valid config");
         TestAgent::new(policy, value, config, device, 1).expect("valid config")
+    }
+
+    #[test]
+    fn error_display_uses_thiserror_messages() {
+        let err = PpoAgentError::Environment("boom".into());
+        assert_eq!(err.to_string(), "Environment error: boom");
     }
 
     /// Regression (issue #183): `clip_grad` must reach *both* optimizers.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs
@@ -154,7 +154,7 @@ where
 {
     let rollout_len = agent.config().num_steps;
 
-    let mut snapshot = env.reset().map_err(io_from_env)?;
+    let mut snapshot = env.reset().map_err(env_error)?;
     let mut episode_reward = 0.0_f32;
     let mut episode_steps = 0_usize;
     let mut last_update_stats = PpoUpdateStats::default();
@@ -173,7 +173,7 @@ where
             let act = agent.act(&obs_now, rng);
 
             let typed_action = action_from_row(&act.env_row);
-            let next_snapshot = env.step(typed_action).map_err(io_from_env)?;
+            let next_snapshot = env.step(typed_action).map_err(env_error)?;
             let reward_f32: f32 = (*next_snapshot.reward()).into();
             let status = next_snapshot.status();
             let done = status.is_done();
@@ -216,7 +216,7 @@ where
                 // the rollout's final step is recorded as done, so
                 // `finalize_rollout` never reads the observation at all.
                 if global_step < total_timesteps {
-                    snapshot = env.reset().map_err(io_from_env)?;
+                    snapshot = env.reset().map_err(env_error)?;
                 }
             } else {
                 snapshot = next_snapshot;
@@ -393,10 +393,12 @@ impl EpisodeReturnStats {
     }
 }
 
+/// Maps an [`EnvironmentError`](rlevo_core::environment::EnvironmentError)
+/// into [`PpoAgentError::Environment`] for use with `?` in the training loop.
 // Passed by name to `.map_err(..)`, which hands the closure an owned
 // `EnvironmentError`. Taking `&EnvironmentError` to satisfy the lint would force
 // a `|e| ..(&e)` closure at every call site for no benefit.
 #[allow(clippy::needless_pass_by_value)]
-fn io_from_env(err: rlevo_core::environment::EnvironmentError) -> PpoAgentError {
+fn env_error(err: rlevo_core::environment::EnvironmentError) -> PpoAgentError {
     PpoAgentError::Environment(err.to_string())
 }

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
@@ -18,7 +18,7 @@ use burn::tensor::{ElementConversion, Int, Tensor, TensorData};
 use rand::{Rng, RngExt};
 
 use crate::metrics::{AgentStats, PerformanceRecord};
-use crate::replay::{DiscreteTransition, ReplayBufferError, ReplayKind, ReplayStrategy};
+use crate::replay::{DiscreteTransition, ReplayKind, ReplayStrategy};
 use rlevo_core::action::DiscreteAction;
 use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
@@ -34,24 +34,63 @@ use crate::algorithms::shared::{
 use crate::utils::PolyakError;
 
 /// Error variants returned by [`QrDqnAgent`] operations.
+///
+/// Two things can go wrong, and each has a construction site.
+/// [`InvalidAction`](QrDqnAgentError::InvalidAction) is built in
+/// [`crate::algorithms::qrdqn::train`], where an environment `reset`/`step`
+/// rejection is converted into this domain.
+/// [`Polyak`](QrDqnAgentError::Polyak) arrives through `?` in
+/// [`QrDqnAgent::learn_step`] — the agent's only fallible method — when the
+/// policy and target networks have mismatched parameter topologies.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// ever constructed and nothing could: the tensor host-reads on the action path
+/// live in [`act`](QrDqnAgent::act), [`act_greedy`](QrDqnAgent::act_greedy) and
+/// [`act_greedy_with`](QrDqnAgent::act_greedy_with), all of which return a bare
+/// `A` rather than a `Result`. With no error channel in the signature there is
+/// nowhere for the variant to be returned from, so those reads use the
+/// infallible form that `docs/rules.md` §4 sanctions for a read that "cannot
+/// fail by construction (e.g. a tensor the same function just built)".
+///
+/// Making action selection fallible is a breaking change, deferred and tracked
+/// as #317. When it lands, the variant that returns must carry
+/// [`rlevo_core::base::TensorConversionError`] as a `#[from]` payload, not a
+/// `String`: §4 prefers structured error types over string-based ones, and
+/// names `TensorConversionError` as the domain type for tensor ops.
+///
+/// # Why there is no buffer or I/O variant
+///
+/// `Buffer(#[from] ReplayBufferError)` was unreachable by design.
+/// [`learn_step`](QrDqnAgent::learn_step) samples with
+/// `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and the
+/// only variant `sample` can produce is
+/// [`ReplayBufferError::InsufficientData`](crate::replay::ReplayBufferError::InsufficientData),
+/// which means "skip this learn step", not "the step failed". `Ok(None)` is the
+/// correct channel for a warm-up buffer; propagating it would misreport an
+/// ordinary warm-up as an error.
+///
+/// `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+/// there is no `save`, no `load`, no `Recorder` and no `std::fs` anywhere under
+/// `algorithms/`, and ADR 0014 §6 defers checkpointing producer wiring to
+/// Tier D.
+///
+/// The enum is `#[non_exhaustive]`, so adding a variant later is not a breaking
+/// change — checkpointing is the shape that would plausibly need one. The bar
+/// for adding it is a real construction site, not an anticipated failure mode;
+/// an unconstructible variant is what this section exists to keep from
+/// recurring.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum QrDqnAgentError {
-    /// A tensor-to-action or action-to-tensor conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
     /// The sampled or requested action is outside the valid action space.
     #[error("Invalid action: {0}")]
     InvalidAction(String),
-    /// A replay buffer operation failed.
-    #[error(transparent)]
-    Buffer(#[from] ReplayBufferError),
     /// The target soft-update failed because the policy and target networks
     /// have mismatched parameter topologies.
     #[error(transparent)]
     Polyak(#[from] PolyakError),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
 }
 
 /// Per-episode statistics emitted by the QR-DQN training loop.

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_agent.rs
@@ -24,7 +24,7 @@ use rand::Rng;
 use rand::RngExt;
 
 use crate::metrics::{AgentStats, PerformanceRecord};
-use crate::replay::{ContinuousTransition, ReplayBufferError, ReplayStrategy, UniformReplay};
+use crate::replay::{ContinuousTransition, ReplayStrategy, UniformReplay};
 use rlevo_core::action::BoundedAction;
 use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
@@ -41,24 +41,65 @@ use crate::algorithms::shared::{
 use crate::utils::{PolyakError, compute_target_q_values};
 
 /// Error variants returned by [`SacAgent`] operations.
+///
+/// Two variants, and each has a real construction site in this crate.
+/// [`InvalidAction`](SacAgentError::InvalidAction) is built by
+/// [`train`](super::train::train) when `env.reset()` or `env.step()` rejects an
+/// action the agent proposed. [`Polyak`](SacAgentError::Polyak) arrives through
+/// `?` on the target soft-updates at the end of
+/// [`learn_step`](SacAgent::learn_step), where a live critic and its target
+/// twin can disagree on parameter topology.
+///
+/// The enum is `#[non_exhaustive]`: downstream `match` expressions must carry a
+/// wildcard arm, so a future variant is not a breaking change.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// constructed and nothing could. The one tensor host-read on the act path is
+/// the `as_slice::<f32>()` call in [`act`](SacAgent::act), and that method
+/// returns a bare `A` rather than a `Result` — there is no error channel for a
+/// variant to travel down. The read is an `.expect` on a named invariant, which
+/// is precisely the form `docs/rules.md` §4 sanctions for a host-read that
+/// "cannot fail by construction": the tensor is one the same function just
+/// built from its own actor. Issue #317 tracks making that path fallible and is
+/// an explicitly deferred breaking change.
+///
+/// When #317 lands, the variant returns as
+/// `#[from]` [`rlevo_core::base::TensorConversionError`] — not as a `String`.
+/// §4 prefers structured variants over string-based errors and names that type
+/// as the tensor-op error domain, so re-introducing a `String` payload would
+/// rebuild the discarded variant in a merely-live form.
+///
+/// # Why there is no buffer or I/O variant
+///
+/// `Buffer(#[from] ReplayBufferError)` was unreachable by design.
+/// [`learn_step`](SacAgent::learn_step) samples with
+/// `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and the
+/// only variant `sample` can produce is
+/// [`ReplayBufferError::InsufficientData`](crate::replay::ReplayBufferError::InsufficientData),
+/// which means "the buffer is still warming up, skip this learn step" — not
+/// "this learn step failed". Propagating it would misreport an ordinary warm-up
+/// as an error.
+///
+/// `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+/// there is no `save`, `load`, `Recorder`, or `std::fs` use anywhere under
+/// `algorithms/`, and ADR 0014 §6 defers the checkpoint write path to Tier D.
+///
+/// Because the enum is `#[non_exhaustive]`, adding a variant when either of
+/// those lands is not a breaking change. The bar for adding one is an actual
+/// construction site, not an anticipated failure mode — a declared but
+/// unconstructible variant is what this section exists to keep from recurring.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SacAgentError {
-    /// A tensor-to-action or action-to-tensor conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
     /// The sampled or requested action is outside the valid action space.
     #[error("Invalid action: {0}")]
     InvalidAction(String),
-    /// A replay-buffer operation failed.
-    #[error(transparent)]
-    Buffer(#[from] ReplayBufferError),
     /// A target soft-update failed because a live critic and its target twin
     /// have mismatched parameter topologies.
     #[error(transparent)]
     Polyak(#[from] PolyakError),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
 }
 
 /// Per-episode statistics emitted by the SAC training loop.
@@ -478,7 +519,11 @@ where
     /// Panics if the actor slot is poisoned — i.e. a previous
     /// [`learn_step`](Self::learn_step) unwound *inside* the actor's optimizer
     /// step. The agent cannot recover and must be rebuilt; see
-    /// [`Slot`](crate::algorithms::shared::Slot).
+    /// [`Slot`](crate::algorithms::shared::Slot). Also panics if the actor's
+    /// output tensor is not `f32`: that host-read is an `.expect` on a named
+    /// invariant, the form `docs/rules.md` §4 sanctions here because `act`
+    /// returns a bare action and so has no error channel to report the failure
+    /// through — issue #317 tracks making the path fallible.
     pub fn act<R: Rng + ?Sized>(&self, obs: &O, training: bool, rng: &mut R) -> A {
         if training && self.step < self.config.learning_starts {
             let sample: Vec<f32> = (0..A::COMPONENTS)

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_agent.rs
@@ -24,7 +24,7 @@ use rand::Rng;
 use rand::RngExt;
 
 use crate::metrics::{AgentStats, PerformanceRecord};
-use crate::replay::{ContinuousTransition, ReplayBufferError, ReplayStrategy, UniformReplay};
+use crate::replay::{ContinuousTransition, ReplayStrategy, UniformReplay};
 use rlevo_core::action::BoundedAction;
 use rlevo_core::base::{Observation, TensorConvertible};
 use rlevo_core::config::Validate;
@@ -42,24 +42,66 @@ use crate::algorithms::td3::td3_model::{ContinuousQ, DeterministicPolicy};
 use crate::utils::{PolyakError, compute_target_q_values};
 
 /// Error variants returned by [`Td3Agent`] operations.
+///
+/// Two variants, and each has a real construction site in this crate.
+/// [`InvalidAction`](Td3AgentError::InvalidAction) is built by
+/// [`train`](super::train::train) when `env.reset()` or `env.step()` rejects an
+/// action the agent proposed. [`Polyak`](Td3AgentError::Polyak) arrives through
+/// `?` on the target soft-updates at the end of
+/// [`learn_step`](Td3Agent::learn_step), where a live network and its target
+/// twin can disagree on parameter topology.
+///
+/// The enum is `#[non_exhaustive]`: downstream `match` expressions must carry a
+/// wildcard arm, so a future variant is not a breaking change.
+///
+/// # Why there is no tensor-conversion variant
+///
+/// This enum previously carried `TensorConversionFailed(String)`, which nothing
+/// constructed and nothing could. The tensor host-reads on the act path are the
+/// `as_slice::<f32>()` calls in [`act`](Td3Agent::act) and
+/// [`act_with`](Td3Agent::act_with), and both methods return a bare `A` rather
+/// than a `Result` — there is no error channel for a variant to travel down. The
+/// read is an `.expect` on a named invariant, which is precisely the form
+/// `docs/rules.md` §4 sanctions for a host-read that "cannot fail by
+/// construction": the tensor is one the same function just built from its own
+/// actor. Issue #317 tracks making that path fallible and is an explicitly
+/// deferred breaking change.
+///
+/// When #317 lands, the variant returns as
+/// `#[from]` [`rlevo_core::base::TensorConversionError`] — not as a `String`.
+/// §4 prefers structured variants over string-based errors and names that type
+/// as the tensor-op error domain, so re-introducing a `String` payload would
+/// rebuild the discarded variant in a merely-live form.
+///
+/// # Why there is no buffer or I/O variant
+///
+/// `Buffer(#[from] ReplayBufferError)` was unreachable by design.
+/// [`learn_step`](Td3Agent::learn_step) samples with
+/// `let Ok(batch) = self.buffer.sample(..) else { return Ok(None) };`, and the
+/// only variant `sample` can produce is
+/// [`ReplayBufferError::InsufficientData`](crate::replay::ReplayBufferError::InsufficientData),
+/// which means "the buffer is still warming up, skip this learn step" — not
+/// "this learn step failed". Propagating it would misreport an ordinary warm-up
+/// as an error.
+///
+/// `Io(#[from] std::io::Error)` anticipated checkpointing that does not exist:
+/// there is no `save`, `load`, `Recorder`, or `std::fs` use anywhere under
+/// `algorithms/`, and ADR 0014 §6 defers the checkpoint write path to Tier D.
+///
+/// Because the enum is `#[non_exhaustive]`, adding a variant when either of
+/// those lands is not a breaking change. The bar for adding one is an actual
+/// construction site, not an anticipated failure mode — a declared but
+/// unconstructible variant is what this section exists to keep from recurring.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Td3AgentError {
-    /// A tensor-to-action or action-to-tensor conversion failed.
-    #[error("Tensor conversion failed: {0}")]
-    TensorConversionFailed(String),
     /// The sampled or requested action is outside the valid action space.
     #[error("Invalid action: {0}")]
     InvalidAction(String),
-    /// A replay-buffer operation failed.
-    #[error(transparent)]
-    Buffer(#[from] ReplayBufferError),
     /// A target soft-update failed because a live network and its target twin
     /// have mismatched parameter topologies.
     #[error(transparent)]
     Polyak(#[from] PolyakError),
-    /// An I/O error occurred while saving or loading model weights.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
 }
 
 /// Per-episode statistics emitted by the TD3 training loop.
@@ -442,7 +484,11 @@ where
     ///
     /// Panics if the actor slot was poisoned by a panic inside an earlier
     /// actor optimizer step (see the type-level docs); the agent must then be
-    /// rebuilt.
+    /// rebuilt. Also panics if the actor's output tensor is not `f32`: that
+    /// host-read is an `.expect` on a named invariant, the form
+    /// `docs/rules.md` §4 sanctions here because `act` returns a bare action and
+    /// so has no error channel to report the failure through — issue #317 tracks
+    /// making the path fallible.
     pub fn act<R: Rng + ?Sized>(&self, obs: &O, training: bool, rng: &mut R) -> A {
         if training && self.step < self.config.learning_starts {
             let sample: Vec<f32> = (0..A::COMPONENTS)
@@ -514,7 +560,8 @@ where
     ///
     /// Panics if the actor's output tensor is not `f32`, or if it yields fewer
     /// than `A::COMPONENTS` values. Both indicate the supplied `net` does not
-    /// match the action type this agent was built for.
+    /// match the action type this agent was built for. Issue #317 tracks making
+    /// this path fallible so the first of those becomes an `Err` instead.
     pub fn act_with(&self, net: &Actor::InnerModule, obs: &O) -> A {
         // Function-local for the same `&self` / `Sync` reason as `act`.
         let mut scratch: Vec<f32> = Vec::new();


### PR DESCRIPTION
## Summary

Deletes 24 error-enum variants across the eight per-algorithm agent error enums that no code in
this workspace ever constructed, and makes all eight `#[non_exhaustive]`. #1070 named
`TensorConversionFailed(String)` on all eight; verifying that claim turned up two more dead shapes
on the same family (`Io`, `Buffer`) and a third on PPO/PPG (`InvalidConfig`). Nothing behaved
incorrectly — the defect was API surface. Read as an error domain, these enums told a caller that
action selection may fail, which the signatures say it cannot. Follows the precedent set by #411 /
`a2c615b` one layer down in `replay/error.rs`.

## Change Type

- [x] Other — _describe and justify scope below_

This is **not** a plain bug fix: it is a breaking removal of public enum variants, so the "Bug fix
(non-breaking, includes regression test)" box would be false on both counts. It is also not a
refactor of the kind the alpha scope excludes — no algorithm, environment, dependency, or CI change
is involved, and no runtime behavior changes at all. It is the resolution of a filed, discussed
issue (#1070), applying a remedy the maintainer already ratified for the identical shape in #1071
(merged). Scope justification: doing this per-agent later would mean eight separate breaking
changes to the same enum family instead of one.

## Linked Issue

Closes #1070

Also subsumes and closes #467 and #484, which are per-agent slices of the same finding.

## What Was Changed

- `algorithms/{dqn,c51,qrdqn}/*_agent.rs` — deleted `TensorConversionFailed(String)`,
  `Buffer(#[from] ReplayBufferError)`, `Io(#[from] std::io::Error)`; added `#[non_exhaustive]`;
  pruned `ReplayBufferError` from the `use crate::replay::{..}` list; replaced the one-line enum
  rustdoc with a block recording why each absent variant is absent.
- `algorithms/{ddpg,td3,sac}/*_agent.rs` — same three deletions, same attribute, same import prune
  and rustdoc. Additionally appended to `act`'s existing `# Panics` section the
  `.expect("actor output is f32")` behavior that `act_with`'s section already documented, with a
  pointer to #317 — closing a pre-existing doc asymmetry.
- `algorithms/{ppo,ppg}/*_agent.rs` — deleted `TensorConversionFailed(String)`,
  `InvalidConfig(String)`, `Io(#[from] std::io::Error)`; added `#[non_exhaustive]`. Both enums are
  now one variant wide (`Environment(String)`), which is the honest width. Their rustdoc flags that
  survivor's `String` payload as a known limitation owned by #171.
- `algorithms/{ppo,ppg}/train.rs` — renamed the private `io_from_env` to `env_error`. It builds
  `Environment`, not `Io`, so its name pointed at a variant this PR deletes; `ppg/train.rs`'s own
  doc comment already contradicted the name.
- `algorithms/{ppo,ppg}/*_agent.rs` (tests) — added the `error_display_uses_thiserror_messages`
  test the other six algorithms already had.
- `CHANGELOG.md` — a `### Breaking changes` bullet with migration guidance, and a `**Removed**`
  entry under `rlevo-reinforcement-learning` placed directly after the #411 entry that
  forward-referenced #1070.

Deliberately **not** changed: any `act*` signature, and the `.expect("actor output is f32")` sites
themselves. Both belong to #317.

## How It Was Tested

There is no regression test, and there could not be: no behavior changed. The deleted variants had
zero construction sites, so no test's reach was removed either — verified per variant. The
compile-time gate is the real test here, plus `cargo doc` under the `broken_intra_doc_links = "deny"`
gate added in `17e8fd3`, which is what validates the new rustdoc's intra-doc links.

```
cargo build --workspace                          # clean
cargo test --workspace                           # 64 test binaries ok, 0 failures
cargo clippy --all-targets --all-features        # clean, warnings-as-errors
```

Also run, because `rlevo-examples` is not in `default-members` and so is invisible to a
workspace-root `--all-features` clippy:

```
cargo fmt --all --check
just clippy-vis-examples
just build-vis-examples
cargo clippy -p rlevo-environments --all-targets --no-default-features --features box2d      -- -D warnings
cargo clippy -p rlevo-environments --all-targets --no-default-features --features locomotion -- -D warnings
cargo doc --workspace --no-deps
cargo doc --workspace --no-deps --all-features
```

The eight `error_display_uses_thiserror_messages` tests (six pre-existing, two added here) all pass
and construct only surviving variants. Stated plainly: those tests assert a `thiserror` format
string and nothing about agent behavior.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU). No GPU backend was exercised — this change touches no tensor
  code path, so backend coverage is not load-bearing for it.
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): _Claude Code (Opus 5)_. Scope: _issue triage and verification,
  the variant deletions and rustdoc across all eight enums, the `io_from_env` rename, the two added
  tests, the CHANGELOG entries, and this PR description. Every claim asserted in the rustdoc and
  CHANGELOG was re-derived by executing greps and builds against the tree rather than accepted from
  the issue text — which is how the scope grew from the 8 variants #1070 named to 24._

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR.
      **Not applicable and left unchecked deliberately** — no behavior changed, so no test can fail
      on the previous code. The removed variants were unconstructed, so nothing regressed.
- [x] This PR addresses a single concern. (One defect shape across one enum family.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**The one judgment call, not just a cleanup.** Deleting `Buffer` removes the
`#[from] ReplayBufferError` impl, so the
`let Ok(batch) = self.buffer.sample(..) else { return Ok(None) }` in all six off-policy
`learn_step`s is correct *only* while `InsufficientData` is the sole variant `sample` can produce.
Add a second variant to `ReplayBufferError` and that `else` silently swallows it as a skipped
learn step rather than failing to compile. This is the reverse of the lesson in `a2c615b`, where
deleting a match arm made a future variant a compile error. **A new `ReplayBufferError` variant
must revisit those six call sites.**

**Follow-ups, none blocking:**

- #317 owns making `act`/`learn_step` fallible. When it lands, the variant it reintroduces must be
  `#[from] rlevo_core::base::TensorConversionError`, not the `String` deleted here — `rules.md` §4
  prefers structured variants and names that type as the tensor-op domain. `#[non_exhaustive]`
  makes that addition non-breaking. Recorded in each enum's rustdoc so the constraint survives.
- #171 owns replacing PPO/PPG's surviving `Environment(String)` with `#[from] EnvironmentError`.
  Note that `code-review-30-06-2026-rl-c51.md` claimed PPO/PPG "already have" the `#[from]` form —
  that is false, and the review row has been corrected.
- #1072 records that `EnvironmentError::IoError` has the same grep signature one layer up but
  **not** the same justification, and should not be deleted by pattern match.

**Migration.** An exhaustive `match` on any of the eight now needs a wildcard arm — which
`#[non_exhaustive]` requires anyway, and in exchange future variants stop being breaking. The three
`#[from]` impls go with their variants, so a `?` converting a `ReplayBufferError` or `std::io::Error`
into an agent error no longer compiles; no such site exists in this workspace. No persisted data is
affected — none of the eight derives `serde`.
