### PR TITLE
fix(qrdqn): Mask terminal bootstrap instead of scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,54 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### `rlevo-reinforcement-learning`
 
+**Fixed**
+
+- **A non-finite target quantile survived terminal transitions in QR-DQN's
+  Bellman backup** (resolves #357). QR-DQN builds its target inline rather than
+  through the shared helper, and it still computed the backup by *scaling* the
+  bootstrap term: `rewards + (1 − terminated) · θ_target · γ`. Because IEEE-754
+  gives `NaN · 0.0 == NaN` (as does `inf · 0.0`), a poisoned quantile anywhere
+  in the target network's output for the bootstrap action contaminated the
+  target on exactly the samples where the terminal convention says the
+  bootstrap must vanish — samples whose correct value, the reward alone, is
+  known with certainty. The term is now genuinely masked to `0` wherever
+  `terminated == 1.0`, so a terminal target is the reward regardless of what
+  the next-state estimate holds.
+
+  This corrects the record as well as the code. The #192 entry under 0.4.0
+  below states that "C51 and QR-DQN never used this helper (they mask in their
+  own projection step)". That is false for QR-DQN: it did not mask, it scaled,
+  and this is the fix for the gap that sentence denied. C51 genuinely is
+  unaffected, for a reason worth stating precisely so nobody patches it on a
+  pattern match — its `(1 − terminated)` factor multiplies the **fixed atom
+  support**, finite by construction from `v_min`/`v_max` and asserted so, never
+  a network output.
+
+  This is hardening, not a repair of live divergence: the expression cannot
+  *originate* a non-finite value, only preserve one, and for all-finite inputs
+  the masked form is numerically identical, so no algorithm's behaviour
+  changes. The known upstream NaN sources (#184, #173) are both closed, so
+  there is no live trigger today. No test could have caught it, and the reason
+  is the interesting part: the backup was an inline expression in the middle of
+  `train_step`, with no seam a test could reach. Lifting it into a named
+  function is what made the poisoned case testable at all, and the five new
+  tests cover it. Four sit on the helper — including that masking stays
+  *per-row*, leaving a non-finite quantile on a non-terminal row for the
+  finite-loss guard rather than silently scrubbing a real divergence. The
+  fifth runs through the agent and pins the backed-up target numerically in
+  the reported loss, because the call site passes reward and terminal mask as
+  two `(B, 1)` tensors the compiler cannot tell apart: without it, transposing
+  them was a silent change.
+
+**Added**
+
+- **`utils::compute_target_quantiles`**, the rank-2 sibling of
+  `compute_target_q_values`, backing up a whole `(B, N)` quantile vector per
+  sample instead of a single bootstrap value. Introduced by the #357 fix above;
+  it is public for the same reason its rank-1 sibling is, and its docs carry
+  the terminal-bootstrap convention, the masking rationale, and the C51
+  exclusion so both forms of the convention are findable from one place.
+
 **Removed**
 
 - **Two `ReplayBufferError` variants that advertised failure modes the replay

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs
@@ -31,7 +31,7 @@ use crate::algorithms::shared::{
     FiniteLossGuard, FiniteObsGuard, FiniteRewardGuard, Slot, UNIFORM_REPLAY_BETA,
     reduce_weighted_loss,
 };
-use crate::utils::PolyakError;
+use crate::utils::{PolyakError, compute_target_quantiles};
 
 /// Error variants returned by [`QrDqnAgent`] operations.
 ///
@@ -765,13 +765,16 @@ where
         let next_quantiles_chosen: Tensor<B::InnerBackend, 2> =
             next_quantiles_all.gather(1, a_star_3).squeeze_dim::<2>(1); // (B, N)
 
-        // Bellman backup (no projection): T θ_j = r + γ (1 − terminated) · θ_target_j.
+        // Bellman backup (no projection): T θ_j = r + γ · θ_target_j on a
+        // non-terminal transition, and T θ_j = r on a terminal one — the
+        // bootstrap is *masked away* there, not scaled by (1 − terminated).
+        // Scaling would let a non-finite target-network quantile survive the
+        // terminal transition, since NaN · 0.0 == NaN (issue #357).
         let rewards_bn: Tensor<B::InnerBackend, 2> = rewards_inner.unsqueeze_dim::<2>(1); // (B, 1)
         let terminated_bn: Tensor<B::InnerBackend, 2> = terminated_inner.unsqueeze_dim::<2>(1); // (B, 1)
-        let keep = terminated_bn.neg().add_scalar(1.0); // 1 − terminated  (B, 1)
         let gamma = self.config.gamma as f32;
         let target_inner: Tensor<B::InnerBackend, 2> =
-            rewards_bn + keep * next_quantiles_chosen.mul_scalar(gamma);
+            compute_target_quantiles(rewards_bn, next_quantiles_chosen, terminated_bn, gamma);
 
         // --- Policy forward (autodiff) ---
         //
@@ -1114,6 +1117,142 @@ mod tests {
         assert!(
             (after - before).abs() > 1e-9,
             "the quantile-Huber priority writeback must change the sampling mass: {before} -> {after}"
+        );
+    }
+
+    // -------- Bellman target reaches the loss (#357 call site) --------
+    //
+    // `learn_step` hands `(rewards, next_quantiles, terminated, gamma)` to
+    // `compute_target_quantiles`, and `rewards` and `terminated` are both
+    // `(B, 1)` `f32` tensors — the compiler cannot tell them apart. Nothing else
+    // in this suite asserts a numeric target or loss, so a swap of those two
+    // arguments used to pass every QR-DQN test. The fixture below makes the
+    // target value fully hand-computable and pins it through `LearnOutcome.loss`.
+
+    /// Weight fill for the target-arithmetic fixture.
+    ///
+    /// `TestQrDqnNet` computes `obs · W` with every element of `W` equal to this
+    /// fill, and `obs(x)` is four copies of `x`, so every one of the network's
+    /// `A × N` outputs is exactly `4 · x · fill` — `x` for `fill = 0.25`. Both
+    /// action heads therefore carry the same quantile vector, so the bootstrap
+    /// `argmax` and the taken action cannot change the arithmetic.
+    const BELLMAN_FILL: f32 = 0.25;
+    /// Reward on the fixture's single transition.
+    ///
+    /// Deliberately neither `0.0` nor `1.0`: those are the only two values the
+    /// terminated column ever holds, so a reward/terminated swap at the call
+    /// site would be numerically invisible if the reward were one of them.
+    const BELLMAN_REWARD: f32 = 3.0;
+    /// Discount for the fixture. Dyadic, so `γ · θ` is exact in `f32` and the
+    /// `f64` config knob round-trips without rounding.
+    const BELLMAN_GAMMA: f32 = 0.5;
+    /// `Σ_i τ_i` for `τ_i = (i + 0.5)/N`, which is `N/2` for any `N` — spelled
+    /// as a literal, with the `TEST_QUANTILES = 4` it assumes asserted below.
+    const TAU_SUM: f32 = 2.0;
+    const _: () = assert!(TEST_QUANTILES == 4, "TAU_SUM is N/2, written out for N = 4");
+
+    /// Builds a uniform-replay agent holding exactly **one** transition, with
+    /// `batch_size = 1`, so the sampled batch is that transition whatever the
+    /// RNG does and the reported loss is a deterministic function of the
+    /// Bellman target.
+    fn bellman_agent(terminated: bool) -> TestAgent {
+        let device: <TestBackend as burn::tensor::backend::BackendTypes>::Device =
+            Default::default();
+        let config = QrDqnTrainingConfigBuilder::new()
+            .target_update(TargetUpdate::polyak(0.005, 1))
+            .batch_size(1)
+            .learning_starts(0)
+            .gamma(f64::from(BELLMAN_GAMMA))
+            .num_quantiles(TEST_QUANTILES)
+            .build()
+            .expect("valid config");
+        let policy: TestQrDqnNet<TestBackend> = TestQrDqnNet::new(BELLMAN_FILL, &device);
+        let mut agent = TestAgent::new(policy, config, device).expect("valid config");
+        // obs(1.0) -> every predicted quantile is 1.0.
+        // obs(2.0) -> every target-network quantile is 2.0.
+        agent.remember(
+            obs(1.0),
+            &CartPoleAction::Left,
+            BELLMAN_REWARD,
+            obs(2.0),
+            terminated,
+        );
+        agent
+    }
+
+    /// Runs one learn step on the fixture and returns `(loss, q_mean)`.
+    fn bellman_learn_once(terminated: bool) -> (f32, f32) {
+        let mut agent = bellman_agent(terminated);
+        let mut rng = StdRng::seed_from_u64(357);
+        let outcome = agent
+            .learn_step(&mut rng)
+            .expect("no polyak error")
+            .expect("one transition, batch_size = 1, learning_starts = 0");
+        (outcome.loss, outcome.q_mean)
+    }
+
+    /// The closed form of this fixture's loss.
+    ///
+    /// Every predicted quantile is `1.0` and every target quantile is the same
+    /// value `target`, so `u_ij = target − 1.0` for all `(i, j)`. With
+    /// `target > 1.0` the sign indicator is `0`, the weight is `τ_i`, and
+    /// `mean_j → sum_i` collapses to `L_κ(u) · Σ_i τ_i`.
+    fn bellman_expected_loss(target: f32) -> f32 {
+        let u = target - 1.0;
+        assert!(u > 0.0, "closed form assumes a positive residual");
+        // κ = 1.0 (config default) and u > κ here, so L_κ(u) = |u| − 0.5.
+        let huber = u - 0.5;
+        huber * TAU_SUM
+    }
+
+    /// Pins the Bellman target numerically **through the agent**, on a terminal
+    /// and a non-terminal transition.
+    ///
+    /// Terminal: the bootstrap is masked away, so the target is the reward
+    /// alone, `3.0`. Non-terminal: the target is `3.0 + 0.5 · 2.0 = 4.0`. Both
+    /// land in `LearnOutcome.loss` through the quantile-Huber closed form above.
+    ///
+    /// Swapping the `rewards` and `terminated` arguments at the
+    /// `compute_target_quantiles` call site makes the terminal target `1.0 +
+    /// 0.5 · 2.0 = 2.0` and the non-terminal target `0.0 + 0.5 · 2.0 = 1.0`,
+    /// i.e. losses of `1.0` and `0.0` against the `3.0` and `5.0` asserted here.
+    #[test]
+    fn qrdqn_learn_step_pins_the_bellman_target_through_the_loss() {
+        let (terminal_loss, q_mean) = bellman_learn_once(true);
+        // Precondition: the network really is the hand-set constant net, so the
+        // closed form above applies. Every predicted quantile is 1.0, hence
+        // q_mean = 1.0.
+        assert!(
+            (q_mean - 1.0).abs() < 1e-6,
+            "fixture precondition: every predicted quantile must be 1.0 \
+             (q_mean = {q_mean})"
+        );
+
+        // Terminal: target = reward = 3.0, u = 2.0, L_1(2.0) = 1.5, loss = 3.0.
+        let want_terminal = bellman_expected_loss(BELLMAN_REWARD);
+        assert!(
+            (terminal_loss - want_terminal).abs() < 1e-5,
+            "a terminal transition must back up the reward alone: loss \
+             {terminal_loss}, want {want_terminal}"
+        );
+
+        // Non-terminal: target = 3.0 + 0.5 · 2.0 = 4.0, u = 3.0,
+        // L_1(3.0) = 2.5, loss = 5.0.
+        let (nonterminal_loss, _) = bellman_learn_once(false);
+        let want_nonterminal = bellman_expected_loss(BELLMAN_REWARD + BELLMAN_GAMMA * 2.0);
+        assert!(
+            (nonterminal_loss - want_nonterminal).abs() < 1e-5,
+            "a non-terminal transition must keep the discounted bootstrap: loss \
+             {nonterminal_loss}, want {want_nonterminal}"
+        );
+
+        // Non-vacuity: the two branches must actually differ, or the pair of
+        // assertions above could be satisfied by a target that ignores the
+        // terminal mask entirely.
+        assert!(
+            (terminal_loss - nonterminal_loss).abs() > 1e-3,
+            "the terminal mask must be observable in the loss: terminal \
+             {terminal_loss} vs non-terminal {nonterminal_loss}"
         );
     }
 

--- a/crates/rlevo-reinforcement-learning/src/utils.rs
+++ b/crates/rlevo-reinforcement-learning/src/utils.rs
@@ -38,6 +38,9 @@ use burn::tensor::{Tensor, TensorPrimitive};
 /// be exactly `0` wherever `terminated == 1.0`, whatever `next_q_max` holds
 /// there. This is defensive only; it does not alter any target computed from
 /// finite inputs.
+///
+/// See [`compute_target_quantiles`] for the rank-2 sibling used by
+/// distributional algorithms that back up a whole quantile vector per sample.
 pub fn compute_target_q_values<B: Backend>(
     rewards: Tensor<B, 1>,
     next_q_max: Tensor<B, 1>,
@@ -46,6 +49,92 @@ pub fn compute_target_q_values<B: Backend>(
 ) -> Tensor<B, 1> {
     let is_terminal = terminated.equal_elem(1.0);
     let bootstrap = next_q_max.mul_scalar(gamma).mask_fill(is_terminal, 0.0);
+    rewards + bootstrap
+}
+
+/// Computes the distributional Bellman backup for a batch of quantile vectors.
+///
+/// This is the rank-2 sibling of [`compute_target_q_values`]: instead of a
+/// single bootstrap value per sample it backs up a whole quantile vector,
+/// `$\mathcal{T}\theta_j = r + \gamma \cdot \theta^{\text{target}}_j$` for every
+/// quantile index `$j$`, with the bootstrap term dropped entirely on a terminal
+/// transition. There is no projection step — the quantile locations are the
+/// learned quantity, so the shifted atoms need no redistribution (Dabney et al.,
+/// "Distributional Reinforcement Learning with Quantile Regression", AAAI 2018,
+/// Eq. 9).
+///
+/// # Arguments
+///
+/// - `rewards` — `(B, 1)` per-sample reward.
+/// - `next_quantiles` — `(B, N)` target-network quantile estimates for the
+///   bootstrap action in the successor state.
+/// - `terminated` — `(B, 1)` mask in `{0.0, 1.0}` that is `1.0` **only** for an
+///   *environmental termination*, never for a *truncation*. The same
+///   partial-episode-bootstrapping caveat documented on
+///   [`compute_target_q_values`] applies verbatim: zeroing the bootstrap on a
+///   time-limit cutoff biases every quantile downward.
+/// - `gamma` — discount factor.
+///
+/// Returns the `(B, N)` target quantile vectors. The `rewards` `(B, 1)` term is
+/// broadcast across the quantile axis; that broadcast is intended.
+///
+/// # Non-finite hardening
+///
+/// The bootstrap is **masked**, not scaled by `$(1 - \text{terminated})$`
+/// (issue #357). The two agree exactly for finite inputs, but scaling
+/// propagates poison: IEEE-754 gives `NaN · 0.0 == NaN` and `inf · 0.0 == NaN`,
+/// so one non-finite entry anywhere in `next_quantiles` — a target-network
+/// output, and therefore data, not configuration — would survive a terminal
+/// transition and contaminate a target whose correct value (the reward alone)
+/// is known with certainty. Selecting on the terminal mask forces the bootstrap
+/// to be exactly `0` wherever `terminated == 1.0`, whatever `next_quantiles`
+/// holds on that row.
+///
+/// This is *not* a NaN scrubber. Masking is per-row: a non-finite quantile on a
+/// **non**-terminal row is left in place and must still be caught downstream by
+/// the agent's finite-loss guard. Silently repairing it there would hide a real
+/// divergence.
+///
+/// `terminated` reaches this function as exactly `0.0` or `1.0`, converted from
+/// a `bool` at the batch-staging site (`qrdqn_agent.rs`, `terminated.push(if
+/// t.terminated { 1.0 } else { 0.0 })`), so `equal_elem(1.0)` is an exact
+/// comparison against a value that is representable without rounding — not a
+/// threshold test on a continuous quantity.
+///
+/// # Why C51 does not call this
+///
+/// C51's Bellman shift in `algorithms::c51::projection` is syntactically the
+/// same expression, but its `$(1 - \text{terminated})$` factor multiplies the
+/// **fixed atom support** — finite by construction from `v_min`/`v_max`, and
+/// asserted so — never a network output. It therefore has no poison to
+/// propagate, and its result feeds a clamp-and-project step that this signature
+/// does not model. Do not fold that call site into this helper.
+pub fn compute_target_quantiles<B: Backend>(
+    rewards: Tensor<B, 2>,        // (B, 1)
+    next_quantiles: Tensor<B, 2>, // (B, N)
+    terminated: Tensor<B, 2>,     // (B, 1)
+    gamma: f32,
+) -> Tensor<B, 2> {
+    let [_, num_quantiles] = next_quantiles.dims();
+    // The `repeat_dim` is deliberate insurance, not a correctness requirement
+    // on the backends this repo tests. Burn 0.21's `mask_fill` DOES broadcast a
+    // (B, 1) mask over a (B, N) tensor — measured correct on both `Flex` (CPU)
+    // and `Wgpu` (Metal) — and the broadcast is explicit in the vendored
+    // sources: `burn-ndarray-0.21.0/src/ops/base.rs:94`
+    // (`mask.broadcast(output.dim())`) and `burn-flex-0.21.0/src/ops/mask.rs:32`
+    // (`broadcast_binary`). Dropping the `repeat_dim` would not break either.
+    //
+    // It is kept because the cubecl/wgpu path
+    // (`burn-cubecl-0.21.0/src/kernel/mask/mask_fill.rs`) reaches the same
+    // result through `mask.into_linear_view_like(&input)` with no explicit
+    // broadcast call, and the behaviour is documented nowhere in the trait — so
+    // relying on it would make this helper depend on an undocumented,
+    // backend-varying implementation detail, in a code path with a #1044-shaped
+    // history (a Metal-only `clamp` NaN divergence in the C51 projection).
+    // Expanding to (B, N) here costs one cheap op and removes that dependency.
+    let is_terminal = terminated.equal_elem(1.0).repeat_dim(1, num_quantiles);
+    let bootstrap = next_quantiles.mul_scalar(gamma).mask_fill(is_terminal, 0.0);
+    // (B, 1) + (B, N): the reward broadcast across quantiles is intended.
     rewards + bootstrap
 }
 
@@ -330,6 +419,180 @@ mod tests {
                 "finite inputs must give a finite target; sample {i} got {g}"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_target_quantiles (issue #357)
+    // -----------------------------------------------------------------------
+
+    /// Builds a rank-2 `f32` tensor of shape `(ROWS, COLS)` on the default test
+    /// device. Rank-1 `floats` cannot express the `(B, N)` quantile batch or the
+    /// `(B, 1)` reward / terminal columns these tests need.
+    fn floats_2d<const ROWS: usize, const COLS: usize>(
+        values: [[f32; COLS]; ROWS],
+    ) -> Tensor<TestBackend, 2> {
+        Tensor::from_floats(values, &TestDevice::default())
+    }
+
+    /// Reads a rank-2 tensor back to host floats in row-major order.
+    fn host_2d(tensor: &Tensor<TestBackend, 2>) -> Vec<f32> {
+        tensor
+            .to_data()
+            .to_vec::<f32>()
+            .expect("target tensor is f32 by construction")
+    }
+
+    /// The pre-hardening rank-2 formula, kept verbatim as the reference oracle
+    /// for the "finite inputs are unchanged" test. This is exactly what
+    /// `qrdqn_agent` computed inline before issue #357.
+    fn scaled_reference_2d(
+        rewards: Tensor<TestBackend, 2>,
+        next_quantiles: Tensor<TestBackend, 2>,
+        terminated: Tensor<TestBackend, 2>,
+        gamma: f32,
+    ) -> Tensor<TestBackend, 2> {
+        let keep = terminated.neg().add_scalar(1.0); // 1 − terminated  (B, 1)
+        rewards + keep * next_quantiles.mul_scalar(gamma)
+    }
+
+    #[test]
+    fn test_compute_target_quantiles_masks_non_finite_bootstrap_on_terminal() {
+        // Row 0 is terminal with a NaN quantile vector, row 1 terminal with
+        // +inf, row 2 terminal with -inf. Under the old
+        // `keep * next_quantiles` scaling every element of all three rows came
+        // back NaN, because `NaN * 0.0` and `inf * 0.0` are both NaN. Each
+        // element must instead be exactly that row's reward.
+        let rewards = floats_2d([[1.5], [-2.0], [0.25]]);
+        let next_quantiles = floats_2d([
+            [f32::NAN, f32::NAN, f32::NAN, f32::NAN],
+            [f32::INFINITY; 4],
+            [f32::NEG_INFINITY; 4],
+        ]);
+        let terminated = floats_2d([[1.0], [1.0], [1.0]]);
+
+        let got = host_2d(&compute_target_quantiles(
+            rewards,
+            next_quantiles,
+            terminated,
+            0.99,
+        ));
+        let want = [1.5_f32, -2.0, 0.25];
+
+        assert_eq!(got.len(), 12, "masking must preserve the (3, 4) shape");
+        for (flat, &g) in got.iter().enumerate() {
+            let (row, col) = (flat / 4, flat % 4);
+            assert!(
+                g.is_finite(),
+                "a terminal transition must never inherit a non-finite bootstrap; \
+                 quantile [{row}][{col}] got {g}"
+            );
+            assert_abs_diff_eq!(g, want[row], epsilon = EPS);
+        }
+    }
+
+    #[test]
+    fn test_compute_target_quantiles_bootstraps_when_not_terminated() {
+        const REWARDS: [[f32; 1]; 2] = [[1.0], [-0.5]];
+        // Row 0: 1.0 + 0.9*[2.0, 4.0, -3.0] = [2.8, 4.6, -1.7]
+        // Row 1: -0.5 + 0.9*[0.5, -1.0, 10.0] = [-0.05, -1.4, 8.5]
+        const WANT: [[f32; 3]; 2] = [[2.8, 4.6, -1.7], [-0.05, -1.4, 8.5]];
+
+        // Masking must not disturb the non-terminal path: every quantile here
+        // keeps the full `reward + gamma * next_quantile` target.
+        let gamma = 0.9_f32;
+
+        let got = host_2d(&compute_target_quantiles(
+            floats_2d(REWARDS),
+            floats_2d([[2.0, 4.0, -3.0], [0.5, -1.0, 10.0]]),
+            floats_2d([[0.0], [0.0]]),
+            gamma,
+        ));
+
+        for (flat, &g) in got.iter().enumerate() {
+            let (row, col) = (flat / 3, flat % 3);
+            assert_abs_diff_eq!(g, WANT[row][col], epsilon = EPS);
+            assert!(
+                (g - REWARDS[row][0]).abs() > EPS,
+                "quantile [{row}][{col}] must actually bootstrap, not collapse to the \
+                 reward; got {g}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_target_quantiles_matches_scaled_formula_on_finite_inputs() {
+        // Mixed terminal / non-terminal batch, all finite: the masked form must
+        // reproduce the old `keep * next_quantiles` result exactly.
+        let gamma = 0.97_f32;
+        let rewards = [[0.0_f32], [1.25], [-3.5], [2.0]];
+        let next_quantiles = [
+            [5.0_f32, -5.0, 0.0, 123.5],
+            [-0.125, 1.0, 2.5, -7.0],
+            [0.5, 0.25, -0.75, 4.0],
+            [10.0, -10.0, 0.0625, 3.5],
+        ];
+        let terminated = [[0.0_f32], [1.0], [0.0], [1.0]];
+
+        let want = host_2d(&scaled_reference_2d(
+            floats_2d(rewards),
+            floats_2d(next_quantiles),
+            floats_2d(terminated),
+            gamma,
+        ));
+        let got = host_2d(&compute_target_quantiles(
+            floats_2d(rewards),
+            floats_2d(next_quantiles),
+            floats_2d(terminated),
+            gamma,
+        ));
+
+        assert_eq!(
+            got.len(),
+            want.len(),
+            "masking must preserve the batch and quantile counts"
+        );
+        for (flat, (&g, &w)) in got.iter().zip(want.iter()).enumerate() {
+            let (row, col) = (flat / 4, flat % 4);
+            assert_abs_diff_eq!(g, w, epsilon = EPS);
+            assert!(
+                g.is_finite(),
+                "finite inputs must give a finite target; quantile [{row}][{col}] got {g}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_target_quantiles_masks_per_row_and_preserves_non_terminal_nan() {
+        // The mask is per-row, and this helper is not a NaN scrubber. Row 0 is
+        // terminal and must come back clean; row 1 is *not* terminated and
+        // carries a NaN quantile, which must survive so the agent's
+        // `FiniteLossGuard` still sees the divergence it exists to catch.
+        let gamma = 0.99_f32;
+        let got = host_2d(&compute_target_quantiles(
+            floats_2d([[1.5], [-2.0]]),
+            floats_2d([[f32::NAN, 3.0], [f32::NAN, 4.0]]),
+            floats_2d([[1.0], [0.0]]),
+            gamma,
+        ));
+
+        // Terminal row: both quantiles are exactly the reward, NaN included.
+        for (col, &g) in got[..2].iter().enumerate() {
+            assert!(
+                g.is_finite(),
+                "the terminal row must be clean even though its quantile vector \
+                 held a NaN; quantile [0][{col}] got {g}"
+            );
+            assert_abs_diff_eq!(g, 1.5_f32, epsilon = EPS);
+        }
+
+        // Non-terminal row: the NaN propagates, the finite quantile bootstraps.
+        assert!(
+            got[2].is_nan(),
+            "a NaN on a non-terminal row must reach the downstream finite guard, \
+             not be silently repaired; got {}",
+            got[2]
+        );
+        assert_abs_diff_eq!(got[3], -2.0 + gamma * 4.0, epsilon = EPS);
     }
 
     // Hand-set constant weights. `active` and `target` differ in *every*


### PR DESCRIPTION
## Summary

QR-DQN built its Bellman target inline and computed the backup by *scaling* the bootstrap term, `rewards + (1 − terminated) · θ_target · γ`. Because IEEE-754 gives `NaN · 0.0 == NaN` (as does `inf · 0.0`), a non-finite quantile anywhere in the target network's output for the bootstrap action survived a terminal transition and contaminated a target whose correct value — the reward alone — is known with certainty. This is the same defect #192 removed from the shared rank-1 helper `compute_target_q_values`; QR-DQN carried its own copy, which that issue's `0.4.0` changelog entry wrongly recorded as already masked. The term is now genuinely masked to `0` wherever `terminated == 1.0`.

This is hardening, not a repair of live divergence: the expression cannot *originate* a non-finite value, only preserve one, and for all-finite inputs the masked form is numerically identical, so no algorithm's behaviour changes. The known upstream NaN sources (#184, #173) are both closed, so there is no live trigger today.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #357

Also corrects the record on #192 — see [this comment](https://github.com/anthonytorlucci/rlevo/issues/192#issuecomment-5231431244).

## What Was Changed

- `crates/rlevo-reinforcement-learning/src/utils.rs` — added `compute_target_quantiles`, the rank-2 sibling of `compute_target_q_values`, backing up a whole `(B, N)` quantile vector per sample instead of a single bootstrap value. Reciprocal cross-links added to both. Its rustdoc carries the terminal-bootstrap convention, the masking-vs-scaling rationale, the exact `0.0`/`1.0` provenance of `terminated`, an explicit "this is not a NaN scrubber — masking is per-row" note, and a `# Why C51 does not call this` section.
- `crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs` — the inline scaling backup in `train_step` now calls the helper; the `keep = terminated_bn.neg().add_scalar(1.0)` line is gone.
- `crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_agent.rs` — new agent-level regression test (below).
- `CHANGELOG.md` — `**Fixed**` entry under Unreleased → `rlevo-reinforcement-learning`, plus an `**Added**` entry for the new public helper. The `**Fixed**` entry also corrects the false QR-DQN claim in the released `0.4.0` entry for #192.

`crates/rlevo-reinforcement-learning/src/algorithms/c51/projection.rs` is **deliberately untouched**. Its `(1 − terminated)` factor is syntactically identical but multiplies `support_bn`, the fixed atom support — finite by construction from `v_min`/`v_max`, and asserted so — never a network output. `next_probs` is used separately and never touches `keep`. Recorded in the helper's docs so nobody patches it on a pattern match.

## How It Was Tested

Five new tests. Four unit tests on the helper, in `utils.rs`'s existing `mod tests`:

- `test_compute_target_quantiles_masks_non_finite_bootstrap_on_terminal` — `NaN`/`+Inf`/`-Inf` in distinct rows, all terminal; every output element must be finite and equal that row's reward. **Fails on the previous code**, which yields `NaN`.
- `test_compute_target_quantiles_bootstraps_when_not_terminated` — asserts the value *and* that it differs from the bare reward, so a helper that always zeroed the bootstrap fails.
- `test_compute_target_quantiles_matches_scaled_formula_on_finite_inputs` — mixed batch, all finite, against a verbatim scaled reference. Pins numerical identity with the old form.
- `test_compute_target_quantiles_masks_per_row_and_preserves_non_terminal_nan` — a `NaN` on a *non*-terminal row must survive for the finite-loss guard. The helper is not a scrubber; silently repairing there would hide a real divergence.

Plus one agent-level test in `qrdqn_agent.rs`:

- `qrdqn_learn_step_pins_the_bellman_target_through_the_loss` — drives one `train_step` through a closed-form fixture (weight fill `0.25`, `obs(x)` four copies of `x`, so every network output is `x`; `reward = 3.0`, `γ = 0.5`, `κ = 1.0`, `N = 4`) and pins the reported loss: **3.0** terminal, **5.0** non-terminal.

This last test exists because of a coverage gap found during review, and it is the load-bearing one. `rewards_bn` and `terminated_bn` are both `Tensor<_, 2>` of shape `(B, 1)`, so transposing them at the call site compiles — and the swap passed all 34 pre-existing QR-DQN tests unchanged. The two that sound relevant (`test_train_termination_sets_bootstrap_mask`, `test_train_truncation_leaves_bootstrap_mask_clear`) only assert on `replay_terminated_flags()`, i.e. rollout bookkeeping; nothing in the suite asserted a numeric target or loss. With the swap applied, only the new test fails:

```
test ...qrdqn_learn_step_pins_the_bellman_target_through_the_loss ... FAILED
panicked at qrdqn_agent.rs:1230:9:
  a terminal transition must back up the reward alone: loss 1, want 3
test result: FAILED. 34 passed; 1 failed
```

Mutation testing on the helper: inverted mask (`equal_elem(0.0)`), threshold instead of exact comparison (`lower_equal_elem(0.5)`), masking the reward instead of the bootstrap, and omitting `mul_scalar(gamma)` are each killed by 3–4 of the four unit tests.

Workspace commands, all clean:

```
cargo build --workspace          # Finished, no errors
cargo test --workspace           # 0 failed across all targets (rl crate: 483 lib + 28 doctests)
cargo clippy --all-targets --all-features   # no warnings
cargo fmt --all --check          # clean
```

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: CPU (`Flex`, the crate's `TestBackend`) for the test suite; `Wgpu`/Metal additionally exercised by hand for the `mask_fill` broadcast probe described under Notes
- OS: macOS 26.5.2 (Apple silicon)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the whole change** — helper, call site, all five tests, changelog, and this description, produced by delegated agents under maintainer direction, with independent verification runs and a review pass that found and closed the two defects described here.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**The new helper is `pub`, not `pub(crate)`.** `compute_target_q_values` is `pub` and `utils` is a public module, so the sibling matches it; hence the `**Added**` changelog entry. Nothing is removed or renamed, so this is not a breaking change.

**On the explicit `repeat_dim` expanding the `(B, 1)` mask to `(B, N)`.** An earlier revision of this PR justified it by claiming Burn 0.21's `mask_fill` does not broadcast. That claim was disproved by execution during review: `mask_fill` broadcasts a `(2,1)` mask over a `(2,4)` tensor bit-identically to an explicitly-expanded mask, on both `Flex`/CPU and `Wgpu`/Metal, implemented via `mask.broadcast(...)` in `burn-ndarray-0.21.0/src/ops/base.rs:94` and `broadcast_binary` in `burn-flex-0.21.0/src/ops/mask.rs:32`. The expansion is nonetheless **kept**, and the comment now says so honestly: the cubecl path (`burn-cubecl-0.21.0/src/kernel/mask/mask_fill.rs`) reaches the same result through `into_linear_view_like` with no explicit broadcast call, and this area has a #1044-shaped history of GPU-only divergence. It is cheap insurance against depending on an undocumented, backend-varying detail — not a correctness requirement on the measured backends.

**No user-book change.** The fix is numerically identical on finite inputs; nothing user-observable moves. No new ADR either — #192's decision already establishes the convention; this applies it to the one site that was missed.
