### PR TITLE
fix(rl): Bound caller-supplied buffer capacities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `ReplayBufferError` none is possible (see below). No persisted data is
   involved: none of the eight derives `serde`.
 
+### `rlevo-core`
+
+**Added**
+
+- **`config::at_most` and `ConstraintKind::TooLarge`**, the upper-bound
+  counterparts to the existing `at_least` / `TooSmall` pair (for #404). The
+  validation helpers could express "a count must be at least *n*" but had no way
+  to express a ceiling at all, which is why every `usize` capacity field in the
+  workspace was validated on one side only. `TooLarge` is a new variant on an
+  existing enum and nothing in the workspace matches `ConstraintKind`
+  exhaustively, so no caller breaks.
+
 ### `rlevo-evolution`
 
 **Fixed**
@@ -211,6 +223,51 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### `rlevo-reinforcement-learning`
 
 **Fixed**
+
+- **`SumTree::new` silently built a corrupt priority index in release builds,
+  and every caller-supplied buffer capacity was unbounded above** (resolves
+  #404). The prioritized-replay index sizes itself with
+  `capacity.next_power_of_two()` and then `leaf_base * 2`, and the workspace
+  root declares no `[profile]` section — so release inherits
+  `overflow-checks = false` and *both* operations wrap. Measured with
+  `rustc -O`: a capacity of `2^62 + 1` yielded `nodes.len() == 0`, and anything
+  above `2^63` wrapped `leaf_base` to `0` as well. Release therefore *returned*
+  a `SumTree` whose node array was empty, deferring the failure to an unrelated
+  index panic at sample time, while debug builds panicked honestly at
+  construction. A constructor whose contract differs between profiles is the
+  more serious half of this issue; the reported unbounded `with_capacity` calls
+  in `History::new`, `UniformReplay::new` and `PrioritizedReplay::new` are the
+  other half.
+
+  Both are closed by one documented ceiling, `MAX_BUFFER_CAPACITY` (`2^32`) —
+  three orders of magnitude above the largest published replay buffers and a
+  factor of `2^30` below the smallest capacity that wraps. It is enforced
+  through `Validate` wherever a `Result` already existed
+  (`PrioritizedReplayConfig`, the six agents' `replay_buffer_capacity`, and
+  PPO's previously-unchecked `num_envs · num_steps` product), so every
+  config-driven path now returns a recoverable `ConstraintKind::TooLarge`
+  instead of dying; and as a widened `assert!` in the infallible constructors
+  (`History::new`, `UniformReplay::new`, `SumTree::new`, `AgentStats::new`, and
+  `RolloutBuffer::new`, which had no guard at either end and multiplied
+  `capacity · action_dim` unchecked). No signature changes: `try_reserve_exact`
+  and a fallible `try_new` were both rejected, matching the #190/#191 precedent
+  — measured, `try_reserve_exact` recovers only the `usize::MAX` arm, which
+  already unwinds as a catchable panic.
+
+  The issue's own premise is corrected in passing. `Vec::with_capacity` does
+  *not* uniformly abort: `usize::MAX` raises a catchable `capacity overflow`
+  panic, and `with_capacity(1 << 45)` — 256 TiB — simply succeeded under macOS
+  overcommit. The abort is the other-allocator case, and the guard is what makes
+  the failure deterministic across all of them.
+
+  No existing test could have caught either half. Every capacity test in the
+  crate pinned the *lower* bound (`History::new(0)`, `UniformReplay::new(0)`,
+  `SumTree::new(0)`, `AgentStats::new(0)`), leaving the upper end entirely
+  unexercised — and the sum-tree wrap is invisible in debug, the profile the
+  suite runs in, because `overflow-checks` panics there for its own reasons. The
+  new `test_sum_tree_new_rejects_capacities_that_wrapped_in_release` therefore
+  asserts on the *guard's* panic message rather than merely that a panic
+  occurred, so it stays red in both profiles against an unguarded constructor.
 
 - **A non-finite target quantile survived terminal transitions in QR-DQN's
   Bellman backup** (resolves #357). QR-DQN builds its target inline rather than

--- a/crates/rlevo-core/README.md
+++ b/crates/rlevo-core/README.md
@@ -111,7 +111,7 @@ Small, dependency-free newtypes and helpers shared across config validation in e
 |---|---|
 | `Bounds` / `BoundsError` | Validated `[low, high]` interval type |
 | `Validate` | Trait for config structs to self-check via `Violations` |
-| `ConfigError` / `ConstraintKind` / `Violations` | Structured config-validation error reporting, plus helper checks (`positive`, `in_range`, `ordered`, `distinct`, `nonzero`, `at_least`) |
+| `ConfigError` / `ConstraintKind` / `Violations` | Structured config-validation error reporting, plus helper checks (`positive`, `in_range`, `ordered`, `distinct`, `nonzero`, `at_least`, `at_most`) |
 | `ObjectiveSense` | `Minimize \| Maximize`, used to disambiguate landscape/fitness direction |
 | `Probability` / `ProbabilityError` | Validated `[0, 1]` newtype |
 | `NonNegativeRate` / `NonNegativeRateError` | Validated non-negative `f32` newtype (learning rates, decay rates, etc.) |

--- a/crates/rlevo-core/src/config.rs
+++ b/crates/rlevo-core/src/config.rs
@@ -266,6 +266,14 @@ pub enum ConstraintKind {
         /// The offending count.
         got: u64,
     },
+    /// An integer count / size / capacity must be at most `max`.
+    #[error("count {got} must be at most {max}")]
+    TooLarge {
+        /// The permitted maximum.
+        max: u64,
+        /// The offending count.
+        got: u64,
+    },
     /// A count / size / capacity must be non-zero.
     #[error("count/size must be non-zero")]
     Zero,
@@ -537,11 +545,36 @@ pub fn at_least(
     }
 }
 
+/// Rejects an integer count above `max`.
+///
+/// # Errors
+///
+/// Returns [`ConstraintKind::TooLarge`] when `got > max`.
+pub fn at_most(
+    config: &'static str,
+    field: &'static str,
+    got: usize,
+    max: usize,
+) -> Result<(), ConfigError> {
+    if got <= max {
+        Ok(())
+    } else {
+        Err(ConfigError {
+            config,
+            field,
+            kind: ConstraintKind::TooLarge {
+                max: max as u64,
+                got: got as u64,
+            },
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        Bounds, ConfigError, ConstraintKind, Validate, Violations, at_least, distinct, in_range,
-        nondegenerate_bounds, nonzero, ordered, positive,
+        Bounds, ConfigError, ConstraintKind, Validate, Violations, at_least, at_most, distinct,
+        in_range, nondegenerate_bounds, nonzero, ordered, positive,
     };
 
     const C: &str = "TestConfig";
@@ -828,6 +861,20 @@ mod tests {
             at_least(C, "pop_size", 1, 2).unwrap_err().kind,
             ConstraintKind::TooSmall { min: 2, got: 1 }
         );
+    }
+
+    #[test]
+    fn at_most_accepts_at_and_below_max() {
+        assert!(at_most(C, "capacity", 8, 8).is_ok());
+        assert!(at_most(C, "capacity", 0, 8).is_ok());
+    }
+
+    #[test]
+    fn at_most_rejects_above_max() {
+        let err = at_most(C, "capacity", 9, 8).unwrap_err();
+        assert_eq!(err.config, C);
+        assert_eq!(err.field, "capacity");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max: 8, got: 9 });
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/c51/c51_config.rs
@@ -9,6 +9,7 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::MAX_BUFFER_CAPACITY;
 use crate::algorithms::c51::projection::atom_spacing;
 use crate::replay::PrioritizedReplaySettings;
 use crate::target::TargetUpdate;
@@ -75,6 +76,13 @@ pub struct C51TrainingConfig {
     pub steps_per_episode: usize,
 
     /// Maximum number of transitions retained in the replay buffer.
+    ///
+    /// Must be non-zero and at most [`MAX_BUFFER_CAPACITY`]. The ceiling is not
+    /// a taste judgement: this field is the only guard on the capacity that
+    /// reaches `UniformReplay::new` / `PrioritizedReplay::new`, and a
+    /// misconfigured value (a unit slip, a `usize::MAX` sentinel) either aborts
+    /// on a failed allocation or wraps the `SumTree`'s node arithmetic. See
+    /// [`MAX_BUFFER_CAPACITY`] for why `$2^{32}$` is the bound.
     pub replay_buffer_capacity: usize,
 
     /// Number of env steps collected before the first gradient update.
@@ -183,6 +191,12 @@ impl Validate for C51TrainingConfig {
         config::in_range(C, "epsilon_end", 0.0, 1.0, self.epsilon_end)?;
         config::in_range(C, "epsilon_decay", 0.0, 1.0, self.epsilon_decay)?;
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
+        config::at_most(
+            C,
+            "replay_buffer_capacity",
+            self.replay_buffer_capacity,
+            MAX_BUFFER_CAPACITY,
+        )?;
         config::nonzero(C, "train_frequency", self.train_frequency)?;
         config::nonzero(C, "steps_per_episode", self.steps_per_episode)?;
         config::at_least(C, "num_atoms", self.num_atoms, 2)?;
@@ -391,6 +405,7 @@ mod tests {
     // would let a real regression pass. Reviewed as a class, not site-by-site.
     #![allow(clippy::float_cmp)]
     use super::*;
+    use rlevo_core::config::ConstraintKind;
 
     #[test]
     fn defaults_are_51_atoms_on_symmetric_support() {
@@ -431,6 +446,36 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         assert!(C51TrainingConfig::default().validate().is_ok());
+    }
+
+    /// `replay_buffer_capacity` had a floor and no ceiling, so a
+    /// `usize::MAX` sentinel — a unit slip, a deserialized garbage field —
+    /// validated and went straight to the buffer constructor, where it aborts
+    /// on a failed allocation or wraps the `SumTree` arithmetic. The rejection
+    /// must be a **recoverable `Err`**, which is why this asserts on the
+    /// returned error rather than using `#[should_panic]`: a panic here would
+    /// be the bug, not the fix.
+    #[test]
+    fn rejects_replay_buffer_capacity_above_ceiling() {
+        let err = C51TrainingConfigBuilder::new()
+            .replay_buffer_capacity(usize::MAX)
+            .build()
+            .expect_err("usize::MAX capacity must be rejected, not allocated");
+        assert_eq!(err.field, "replay_buffer_capacity");
+        let max = u64::try_from(MAX_BUFFER_CAPACITY).expect("the ceiling fits in u64");
+        let got = u64::try_from(usize::MAX).expect("usize::MAX fits in u64 on this target");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max, got });
+    }
+
+    /// The boundary is inclusive: the ceiling itself is a legal (if
+    /// unallocatable) capacity, so the guard cannot be off by one.
+    #[test]
+    fn accepts_replay_buffer_capacity_at_ceiling() {
+        let cfg = C51TrainingConfigBuilder::new()
+            .replay_buffer_capacity(MAX_BUFFER_CAPACITY)
+            .build()
+            .expect("the ceiling itself must validate");
+        assert_eq!(cfg.replay_buffer_capacity, MAX_BUFFER_CAPACITY);
     }
 
     /// The default is behaviour-preserving: the old `tau = 0.005` soft update

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ddpg/ddpg_config.rs
@@ -8,12 +8,19 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::MAX_BUFFER_CAPACITY;
 use crate::target::TargetUpdate;
 
 /// Configuration for training a Deep Deterministic Policy Gradient agent.
 #[derive(Clone, Debug)]
 pub struct DdpgTrainingConfig {
     /// Maximum number of transitions stored in the replay buffer.
+    ///
+    /// Must be non-zero and at most [`MAX_BUFFER_CAPACITY`]. The ceiling is not
+    /// a taste judgement: this field is the only guard on the capacity that
+    /// reaches `UniformReplay::new`, and a misconfigured value (a unit slip, a
+    /// `usize::MAX` sentinel) aborts the process on a failed allocation. See
+    /// [`MAX_BUFFER_CAPACITY`] for why `$2^{32}$` is the bound.
     pub replay_buffer_capacity: usize,
     /// Mini-batch size drawn from the replay buffer each learn step.
     pub batch_size: usize,
@@ -77,6 +84,12 @@ impl Validate for DdpgTrainingConfig {
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "DdpgTrainingConfig";
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
+        config::at_most(
+            C,
+            "replay_buffer_capacity",
+            self.replay_buffer_capacity,
+            MAX_BUFFER_CAPACITY,
+        )?;
         config::nonzero(C, "batch_size", self.batch_size)?;
         config::positive(C, "actor_lr", self.actor_lr)?;
         config::positive(C, "critic_lr", self.critic_lr)?;
@@ -245,6 +258,36 @@ impl DdpgTrainingConfigBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rlevo_core::config::ConstraintKind;
+
+    /// `replay_buffer_capacity` had a floor and no ceiling, so a
+    /// `usize::MAX` sentinel — a unit slip, a deserialized garbage field —
+    /// validated and went straight to `UniformReplay::new`, which aborts the
+    /// process on the failed allocation. The rejection must be a **recoverable
+    /// `Err`**, which is why this asserts on the returned error rather than
+    /// using `#[should_panic]`: a panic here would be the bug, not the fix.
+    #[test]
+    fn rejects_replay_buffer_capacity_above_ceiling() {
+        let err = DdpgTrainingConfigBuilder::new()
+            .replay_buffer_capacity(usize::MAX)
+            .build()
+            .expect_err("usize::MAX capacity must be rejected, not allocated");
+        assert_eq!(err.field, "replay_buffer_capacity");
+        let max = u64::try_from(MAX_BUFFER_CAPACITY).expect("the ceiling fits in u64");
+        let got = u64::try_from(usize::MAX).expect("usize::MAX fits in u64 on this target");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max, got });
+    }
+
+    /// The boundary is inclusive: the ceiling itself is a legal (if
+    /// unallocatable) capacity, so the guard cannot be off by one.
+    #[test]
+    fn accepts_replay_buffer_capacity_at_ceiling() {
+        let cfg = DdpgTrainingConfigBuilder::new()
+            .replay_buffer_capacity(MAX_BUFFER_CAPACITY)
+            .build()
+            .expect("the ceiling itself must validate");
+        assert_eq!(cfg.replay_buffer_capacity, MAX_BUFFER_CAPACITY);
+    }
 
     #[test]
     fn defaults_match_cleanrl() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/dqn/dqn_config.rs
@@ -4,6 +4,7 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::MAX_BUFFER_CAPACITY;
 use crate::replay::PrioritizedReplaySettings;
 use crate::target::TargetUpdate;
 
@@ -77,6 +78,13 @@ pub struct DqnTrainingConfig {
     pub steps_per_episode: usize,
 
     /// The maximum number of transitions to store in the replay buffer.
+    ///
+    /// Must be non-zero and at most [`MAX_BUFFER_CAPACITY`]. The ceiling is not
+    /// a taste judgement: this field is the only guard on the capacity that
+    /// reaches `UniformReplay::new` / `PrioritizedReplay::new`, and a
+    /// misconfigured value (a unit slip, a `usize::MAX` sentinel) either aborts
+    /// on a failed allocation or wraps the `SumTree`'s node arithmetic. See
+    /// [`MAX_BUFFER_CAPACITY`] for why `$2^{32}$` is the bound.
     pub replay_buffer_capacity: usize,
 
     /// Number of environment steps collected before learning starts.
@@ -173,6 +181,12 @@ impl Validate for DqnTrainingConfig {
         config::in_range(C, "epsilon_end", 0.0, 1.0, self.epsilon_end)?;
         config::in_range(C, "epsilon_decay", 0.0, 1.0, self.epsilon_decay)?;
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
+        config::at_most(
+            C,
+            "replay_buffer_capacity",
+            self.replay_buffer_capacity,
+            MAX_BUFFER_CAPACITY,
+        )?;
         config::nonzero(C, "train_frequency", self.train_frequency)?;
         config::nonzero(C, "steps_per_episode", self.steps_per_episode)?;
         if let Some(per) = &self.prioritized_replay {
@@ -380,10 +394,41 @@ impl DqnTrainingConfigBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rlevo_core::config::ConstraintKind;
 
     #[test]
     fn default_config_is_valid() {
         assert!(DqnTrainingConfig::default().validate().is_ok());
+    }
+
+    /// `replay_buffer_capacity` had a floor and no ceiling, so a
+    /// `usize::MAX` sentinel — a unit slip, a deserialized garbage field —
+    /// validated and went straight to the buffer constructor, where it aborts
+    /// on a failed allocation or wraps the `SumTree` arithmetic. The rejection
+    /// must be a **recoverable `Err`**, which is why this asserts on the
+    /// returned error rather than using `#[should_panic]`: a panic here would
+    /// be the bug, not the fix.
+    #[test]
+    fn rejects_replay_buffer_capacity_above_ceiling() {
+        let err = DqnTrainingConfigBuilder::new()
+            .replay_buffer_capacity(usize::MAX)
+            .build()
+            .expect_err("usize::MAX capacity must be rejected, not allocated");
+        assert_eq!(err.field, "replay_buffer_capacity");
+        let max = u64::try_from(MAX_BUFFER_CAPACITY).expect("the ceiling fits in u64");
+        let got = u64::try_from(usize::MAX).expect("usize::MAX fits in u64 on this target");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max, got });
+    }
+
+    /// The boundary is inclusive: the ceiling itself is a legal (if
+    /// unallocatable) capacity, so the guard cannot be off by one.
+    #[test]
+    fn accepts_replay_buffer_capacity_at_ceiling() {
+        let cfg = DqnTrainingConfigBuilder::new()
+            .replay_buffer_capacity(MAX_BUFFER_CAPACITY)
+            .build()
+            .expect("the ceiling itself must validate");
+        assert_eq!(cfg.replay_buffer_capacity, MAX_BUFFER_CAPACITY);
     }
 
     /// The default is the behaviour-preserving one: the pre-[`TargetUpdate`]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/ppo_config.rs
@@ -13,6 +13,7 @@
 //!
 //! [`ppo_continuous_action.py`]: https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_continuous_actionpy
 
+use crate::MAX_BUFFER_CAPACITY;
 use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
@@ -153,6 +154,20 @@ impl Validate for PpoTrainingConfig {
             });
         }
         config::nonzero(C, "num_steps", self.num_steps)?;
+        // `batch_size()` is `num_envs * num_steps`, and that product — not
+        // either factor — is the capacity handed to `RolloutBuffer::new` by
+        // `PpoAgent::new` and `PpgAgent::new`. Reject it here so an
+        // out-of-range rollout size surfaces as a `ConfigError` at construction
+        // rather than as an allocation abort inside the buffer.
+        let batch_size = self
+            .num_envs
+            .checked_mul(self.num_steps)
+            .ok_or(ConfigError {
+                config: C,
+                field: "num_steps",
+                kind: ConstraintKind::Custom("num_envs * num_steps overflows usize"),
+            })?;
+        config::at_most(C, "num_steps", batch_size, MAX_BUFFER_CAPACITY)?;
         config::nonzero(C, "num_minibatches", self.num_minibatches)?;
         config::nonzero(C, "update_epochs", self.update_epochs)?;
         config::positive(C, "learning_rate", self.learning_rate)?;
@@ -434,6 +449,28 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         assert!(PpoTrainingConfig::default().validate().is_ok());
+    }
+
+    /// `num_steps` alone is `nonzero`-checked, but the value that reaches
+    /// `RolloutBuffer::new` is `batch_size() == num_envs * num_steps`. With
+    /// `num_envs == 1` the product is `num_steps`, so an out-of-range horizon
+    /// must be rejected by `validate` rather than becoming an allocation abort
+    /// in the buffer.
+    #[test]
+    fn rejects_batch_size_above_ceiling() {
+        let err = PpoTrainingConfigBuilder::new()
+            .num_envs(1)
+            .num_steps(MAX_BUFFER_CAPACITY + 1)
+            .build()
+            .unwrap_err();
+        assert_eq!(err.field, "num_steps");
+        assert_eq!(
+            err.kind,
+            ConstraintKind::TooLarge {
+                max: MAX_BUFFER_CAPACITY as u64,
+                got: (MAX_BUFFER_CAPACITY + 1) as u64,
+            }
+        );
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/rollout.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/rollout.rs
@@ -23,6 +23,7 @@
 //! `t` is valid. Every done-ness read in [`compute_gae`] is therefore at index
 //! `[t]` — never `[t + 1]`.
 
+use crate::MAX_BUFFER_CAPACITY;
 use burn::tensor::backend::Backend;
 use burn::tensor::{Tensor, TensorData};
 use std::marker::PhantomData;
@@ -80,13 +81,50 @@ pub struct RolloutBuffer<B: Backend, O> {
 impl<B: Backend, O: Clone> RolloutBuffer<B, O> {
     /// Allocates a buffer for `capacity` steps, with `action_dim` action
     /// components per step (1 for discrete, A for continuous-A).
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `capacity` and `action_dim` are both in
+    /// `1..=`[`MAX_BUFFER_CAPACITY`] and their product is too. A zero for
+    /// either dimension yields a buffer that can never accept a step, and the
+    /// upper bounds exist because all three values reach
+    /// [`Vec::with_capacity`] unfiltered: `capacity * action_dim` is the
+    /// element count of `action_flat`, so an out-of-range request aborts the
+    /// process on capacity overflow instead of unwinding.
+    ///
+    /// The product is checked separately, not implied by the two per-argument
+    /// checks: `capacity` and `action_dim` can each sit far below the ceiling
+    /// while `capacity * action_dim` overflows `usize` outright. That product
+    /// is the actual argument to `Vec::with_capacity` below, so it is the value
+    /// that has to be in range.
     #[must_use]
     pub fn new(capacity: usize, action_dim: usize) -> Self {
+        assert!(
+            capacity > 0 && capacity <= MAX_BUFFER_CAPACITY,
+            "capacity must be in 1..={MAX_BUFFER_CAPACITY}, got {capacity}"
+        );
+        assert!(
+            action_dim > 0 && action_dim <= MAX_BUFFER_CAPACITY,
+            "action_dim must be in 1..={MAX_BUFFER_CAPACITY}, got {action_dim}"
+        );
+        let flat_len = capacity.checked_mul(action_dim).unwrap_or_else(|| {
+            panic!(
+                "capacity * action_dim overflows usize ({capacity} * \
+                 {action_dim}); that product is the element count of the \
+                 flattened action buffer"
+            )
+        });
+        assert!(
+            flat_len <= MAX_BUFFER_CAPACITY,
+            "capacity * action_dim must be at most {MAX_BUFFER_CAPACITY}, got \
+             {flat_len} ({capacity} * {action_dim}); that product is the \
+             element count of the flattened action buffer"
+        );
         Self {
             capacity,
             action_dim,
             obs: Vec::with_capacity(capacity),
-            action_flat: Vec::with_capacity(capacity * action_dim),
+            action_flat: Vec::with_capacity(flat_len),
             log_probs: Vec::with_capacity(capacity),
             values: Vec::with_capacity(capacity),
             rewards: Vec::with_capacity(capacity),
@@ -586,6 +624,55 @@ mod tests {
             "running final step must bootstrap last_value: {} vs 10.4",
             advs[0]
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be in 1..=")]
+    fn new_rejects_zero_capacity() {
+        type B = burn::backend::Flex;
+        let _: RolloutBuffer<B, [f32; 1]> = RolloutBuffer::new(0, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be in 1..=")]
+    fn new_rejects_capacity_above_ceiling() {
+        type B = burn::backend::Flex;
+        let _: RolloutBuffer<B, [f32; 1]> = RolloutBuffer::new(MAX_BUFFER_CAPACITY + 1, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "action_dim must be in 1..=")]
+    fn new_rejects_zero_action_dim() {
+        type B = burn::backend::Flex;
+        let _: RolloutBuffer<B, [f32; 1]> = RolloutBuffer::new(4, 0);
+    }
+
+    /// Neither factor is out of range on its own — both are far below
+    /// [`MAX_BUFFER_CAPACITY`] — but their product is the element count handed
+    /// to `Vec::with_capacity` for `action_flat`, and it is not. A guard that
+    /// only checked the two arguments individually would accept this.
+    #[test]
+    #[should_panic(expected = "capacity * action_dim must be at most")]
+    fn new_rejects_product_above_ceiling() {
+        type B = burn::backend::Flex;
+        // Both arguments pass the per-argument checks; only the product fails.
+        let capacity = MAX_BUFFER_CAPACITY / 2;
+        let action_dim = 4;
+        let _: RolloutBuffer<B, [f32; 1]> = RolloutBuffer::new(capacity, action_dim);
+    }
+
+    /// Same defect class as above, one step further out: the product does not
+    /// merely exceed the ceiling, it wraps `usize`. `capacity * action_dim`
+    /// would compute a small in-range length in release and hand
+    /// `Vec::with_capacity` a silently wrong allocation.
+    #[test]
+    #[should_panic(expected = "overflows usize")]
+    fn new_rejects_product_overflowing_usize() {
+        type B = burn::backend::Flex;
+        // 2^32 * 2^32 == 2^64: each factor is exactly at the ceiling and so
+        // passes its own check, while the product wraps to 0.
+        let _: RolloutBuffer<B, [f32; 1]> =
+            RolloutBuffer::new(MAX_BUFFER_CAPACITY, MAX_BUFFER_CAPACITY);
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/qrdqn/qrdqn_config.rs
@@ -16,6 +16,7 @@ use burn::tensor::backend::Backend;
 use burn::tensor::{Tensor, TensorData};
 use rlevo_core::config::{self, ConfigError, ConstraintKind, Validate};
 
+use crate::MAX_BUFFER_CAPACITY;
 use crate::replay::PrioritizedReplaySettings;
 use crate::target::TargetUpdate;
 
@@ -81,6 +82,13 @@ pub struct QrDqnTrainingConfig {
     pub steps_per_episode: usize,
 
     /// Maximum number of transitions retained in the replay buffer.
+    ///
+    /// Must be non-zero and at most [`MAX_BUFFER_CAPACITY`]. The ceiling is not
+    /// a taste judgement: this field is the only guard on the capacity that
+    /// reaches `UniformReplay::new` / `PrioritizedReplay::new`, and a
+    /// misconfigured value (a unit slip, a `usize::MAX` sentinel) either aborts
+    /// on a failed allocation or wraps the `SumTree`'s node arithmetic. See
+    /// [`MAX_BUFFER_CAPACITY`] for why `$2^{32}$` is the bound.
     pub replay_buffer_capacity: usize,
 
     /// Number of env steps collected before the first gradient update.
@@ -242,6 +250,12 @@ impl Validate for QrDqnTrainingConfig {
         config::in_range(C, "epsilon_end", 0.0, 1.0, self.epsilon_end)?;
         config::in_range(C, "epsilon_decay", 0.0, 1.0, self.epsilon_decay)?;
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
+        config::at_most(
+            C,
+            "replay_buffer_capacity",
+            self.replay_buffer_capacity,
+            MAX_BUFFER_CAPACITY,
+        )?;
         config::nonzero(C, "train_frequency", self.train_frequency)?;
         config::nonzero(C, "steps_per_episode", self.steps_per_episode)?;
         config::nonzero(C, "num_quantiles", self.num_quantiles)?;
@@ -502,6 +516,36 @@ mod tests {
     #[test]
     fn default_config_is_valid() {
         assert!(QrDqnTrainingConfig::default().validate().is_ok());
+    }
+
+    /// `replay_buffer_capacity` had a floor and no ceiling, so a
+    /// `usize::MAX` sentinel — a unit slip, a deserialized garbage field —
+    /// validated and went straight to the buffer constructor, where it aborts
+    /// on a failed allocation or wraps the `SumTree` arithmetic. The rejection
+    /// must be a **recoverable `Err`**, which is why this asserts on the
+    /// returned error rather than using `#[should_panic]`: a panic here would
+    /// be the bug, not the fix.
+    #[test]
+    fn rejects_replay_buffer_capacity_above_ceiling() {
+        let err = QrDqnTrainingConfigBuilder::new()
+            .replay_buffer_capacity(usize::MAX)
+            .build()
+            .expect_err("usize::MAX capacity must be rejected, not allocated");
+        assert_eq!(err.field, "replay_buffer_capacity");
+        let max = u64::try_from(MAX_BUFFER_CAPACITY).expect("the ceiling fits in u64");
+        let got = u64::try_from(usize::MAX).expect("usize::MAX fits in u64 on this target");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max, got });
+    }
+
+    /// The boundary is inclusive: the ceiling itself is a legal (if
+    /// unallocatable) capacity, so the guard cannot be off by one.
+    #[test]
+    fn accepts_replay_buffer_capacity_at_ceiling() {
+        let cfg = QrDqnTrainingConfigBuilder::new()
+            .replay_buffer_capacity(MAX_BUFFER_CAPACITY)
+            .build()
+            .expect("the ceiling itself must validate");
+        assert_eq!(cfg.replay_buffer_capacity, MAX_BUFFER_CAPACITY);
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/sac/sac_config.rs
@@ -18,12 +18,19 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::MAX_BUFFER_CAPACITY;
 use crate::target::TargetUpdate;
 
 /// Configuration for training a SAC agent.
 #[derive(Clone, Debug)]
 pub struct SacTrainingConfig {
     /// Maximum number of transitions stored in the replay buffer.
+    ///
+    /// Must be non-zero and at most [`MAX_BUFFER_CAPACITY`]. The ceiling is not
+    /// a taste judgement: this field is the only guard on the capacity that
+    /// reaches `UniformReplay::new`, and a misconfigured value (a unit slip, a
+    /// `usize::MAX` sentinel) aborts the process on a failed allocation. See
+    /// [`MAX_BUFFER_CAPACITY`] for why `$2^{32}$` is the bound.
     pub replay_buffer_capacity: usize,
     /// Mini-batch size drawn from the replay buffer each learn step.
     pub batch_size: usize,
@@ -92,6 +99,12 @@ impl Validate for SacTrainingConfig {
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "SacTrainingConfig";
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
+        config::at_most(
+            C,
+            "replay_buffer_capacity",
+            self.replay_buffer_capacity,
+            MAX_BUFFER_CAPACITY,
+        )?;
         config::nonzero(C, "batch_size", self.batch_size)?;
         config::positive(C, "actor_lr", self.actor_lr)?;
         config::positive(C, "critic_lr", self.critic_lr)?;
@@ -269,6 +282,36 @@ impl SacTrainingConfigBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rlevo_core::config::ConstraintKind;
+
+    /// `replay_buffer_capacity` had a floor and no ceiling, so a
+    /// `usize::MAX` sentinel — a unit slip, a deserialized garbage field —
+    /// validated and went straight to `UniformReplay::new`, which aborts the
+    /// process on the failed allocation. The rejection must be a **recoverable
+    /// `Err`**, which is why this asserts on the returned error rather than
+    /// using `#[should_panic]`: a panic here would be the bug, not the fix.
+    #[test]
+    fn rejects_replay_buffer_capacity_above_ceiling() {
+        let err = SacTrainingConfigBuilder::new()
+            .replay_buffer_capacity(usize::MAX)
+            .build()
+            .expect_err("usize::MAX capacity must be rejected, not allocated");
+        assert_eq!(err.field, "replay_buffer_capacity");
+        let max = u64::try_from(MAX_BUFFER_CAPACITY).expect("the ceiling fits in u64");
+        let got = u64::try_from(usize::MAX).expect("usize::MAX fits in u64 on this target");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max, got });
+    }
+
+    /// The boundary is inclusive: the ceiling itself is a legal (if
+    /// unallocatable) capacity, so the guard cannot be off by one.
+    #[test]
+    fn accepts_replay_buffer_capacity_at_ceiling() {
+        let cfg = SacTrainingConfigBuilder::new()
+            .replay_buffer_capacity(MAX_BUFFER_CAPACITY)
+            .build()
+            .expect("the ceiling itself must validate");
+        assert_eq!(cfg.replay_buffer_capacity, MAX_BUFFER_CAPACITY);
+    }
 
     #[test]
     fn defaults_match_cleanrl() {

--- a/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_config.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/td3/td3_config.rs
@@ -11,12 +11,19 @@ use burn::grad_clipping::GradientClippingConfig;
 use burn::optim::AdamConfig;
 use rlevo_core::config::{self, ConfigError, Validate};
 
+use crate::MAX_BUFFER_CAPACITY;
 use crate::target::TargetUpdate;
 
 /// Configuration for training a Twin Delayed DDPG (TD3) agent.
 #[derive(Clone, Debug)]
 pub struct Td3TrainingConfig {
     /// Maximum number of transitions stored in the replay buffer.
+    ///
+    /// Must be non-zero and at most [`MAX_BUFFER_CAPACITY`]. The ceiling is not
+    /// a taste judgement: this field is the only guard on the capacity that
+    /// reaches `UniformReplay::new`, and a misconfigured value (a unit slip, a
+    /// `usize::MAX` sentinel) aborts the process on a failed allocation. See
+    /// [`MAX_BUFFER_CAPACITY`] for why `$2^{32}$` is the bound.
     pub replay_buffer_capacity: usize,
     /// Mini-batch size drawn from the replay buffer each learn step.
     pub batch_size: usize,
@@ -93,6 +100,12 @@ impl Validate for Td3TrainingConfig {
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "Td3TrainingConfig";
         config::nonzero(C, "replay_buffer_capacity", self.replay_buffer_capacity)?;
+        config::at_most(
+            C,
+            "replay_buffer_capacity",
+            self.replay_buffer_capacity,
+            MAX_BUFFER_CAPACITY,
+        )?;
         config::nonzero(C, "batch_size", self.batch_size)?;
         config::positive(C, "actor_lr", self.actor_lr)?;
         config::positive(C, "critic_lr", self.critic_lr)?;
@@ -289,6 +302,36 @@ impl Td3TrainingConfigBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rlevo_core::config::ConstraintKind;
+
+    /// `replay_buffer_capacity` had a floor and no ceiling, so a
+    /// `usize::MAX` sentinel — a unit slip, a deserialized garbage field —
+    /// validated and went straight to `UniformReplay::new`, which aborts the
+    /// process on the failed allocation. The rejection must be a **recoverable
+    /// `Err`**, which is why this asserts on the returned error rather than
+    /// using `#[should_panic]`: a panic here would be the bug, not the fix.
+    #[test]
+    fn rejects_replay_buffer_capacity_above_ceiling() {
+        let err = Td3TrainingConfigBuilder::new()
+            .replay_buffer_capacity(usize::MAX)
+            .build()
+            .expect_err("usize::MAX capacity must be rejected, not allocated");
+        assert_eq!(err.field, "replay_buffer_capacity");
+        let max = u64::try_from(MAX_BUFFER_CAPACITY).expect("the ceiling fits in u64");
+        let got = u64::try_from(usize::MAX).expect("usize::MAX fits in u64 on this target");
+        assert_eq!(err.kind, ConstraintKind::TooLarge { max, got });
+    }
+
+    /// The boundary is inclusive: the ceiling itself is a legal (if
+    /// unallocatable) capacity, so the guard cannot be off by one.
+    #[test]
+    fn accepts_replay_buffer_capacity_at_ceiling() {
+        let cfg = Td3TrainingConfigBuilder::new()
+            .replay_buffer_capacity(MAX_BUFFER_CAPACITY)
+            .build()
+            .expect("the ceiling itself must validate");
+        assert_eq!(cfg.replay_buffer_capacity, MAX_BUFFER_CAPACITY);
+    }
 
     #[test]
     fn defaults_match_cleanrl() {

--- a/crates/rlevo-reinforcement-learning/src/experience.rs
+++ b/crates/rlevo-reinforcement-learning/src/experience.rs
@@ -7,6 +7,7 @@
 //! - [`HistoryRepresentation`] — trait for constructing state summaries from history
 //! - [`SufficientStatistic`] — history summary that satisfies the Markov property
 
+use crate::MAX_BUFFER_CAPACITY;
 use rlevo_core::base::{Action, Observation, Reward};
 use rlevo_core::state::MarkovState;
 use std::collections::VecDeque;
@@ -99,15 +100,25 @@ impl<const D: usize, const AD: usize, O: Observation<D>, A: Action<AD>, R: Rewar
     ///
     /// # Arguments
     /// * `capacity` - Maximum number of transitions retained before the oldest
-    ///   is evicted. Must be greater than 0.
+    ///   is evicted. Must be in `1..=`[`MAX_BUFFER_CAPACITY`].
     ///
     /// # Panics
+    ///
     /// Panics if `capacity` is 0. A zero-capacity buffer cannot hold any
     /// transitions: [`Self::add`] would evict before every push, pinning
     /// `len()` at 1 while [`Self::capacity`] reports 0 and [`Self::is_full`]
     /// returns `true` from the first insert — a buffer that permanently
     /// violates its own `len() <= capacity` invariant while silently accepting
     /// and discarding every experience the agent collects.
+    ///
+    /// Panics if `capacity` exceeds [`MAX_BUFFER_CAPACITY`]. The argument
+    /// reaches [`VecDeque::with_capacity`] unfiltered, so without this bound a
+    /// caller-supplied capacity — a unit slip, a `usize::MAX` sentinel, a
+    /// deserialized garbage field — turns straight into an allocation request
+    /// for `capacity * size_of::<ExperienceTuple<..>>()` bytes. That aborts the
+    /// process on capacity overflow rather than unwinding, which is not a
+    /// failure a caller can catch or diagnose. Rejecting the argument up front
+    /// converts an abort into a panic that names the offending value.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         assert!(
@@ -115,6 +126,12 @@ impl<const D: usize, const AD: usize, O: Observation<D>, A: Action<AD>, R: Rewar
             "capacity must be greater than 0; a zero-capacity buffer cannot \
              hold transitions and would pin len() at 1 while reporting a \
              capacity of 0, breaking the len() <= capacity invariant"
+        );
+        assert!(
+            capacity <= MAX_BUFFER_CAPACITY,
+            "capacity must be at most {MAX_BUFFER_CAPACITY}, got {capacity}; \
+             this value is passed straight to VecDeque::with_capacity, where an \
+             out-of-range request aborts the process instead of unwinding"
         );
         Self {
             trace: VecDeque::with_capacity(capacity),
@@ -310,6 +327,17 @@ mod tests {
     #[should_panic(expected = "capacity must be greater than 0")]
     fn new_rejects_zero_capacity() {
         let _ = History::<1, 1, TestObs, TestAct, TestReward>::new(0);
+    }
+
+    /// The upper end of the same guard: `capacity` reaches
+    /// `VecDeque::with_capacity` directly, where an out-of-range request aborts
+    /// the process instead of unwinding. `should_panic` only observes an
+    /// unwind, so this test passing *is* the evidence that the value was
+    /// rejected before it reached the allocator.
+    #[test]
+    #[should_panic(expected = "capacity must be at most")]
+    fn new_rejects_capacity_above_ceiling() {
+        let _ = History::<1, 1, TestObs, TestAct, TestReward>::new(MAX_BUFFER_CAPACITY + 1);
     }
 
     /// Pins the [`Send`]/[`Sync`] auto-trait propagation documented on

--- a/crates/rlevo-reinforcement-learning/src/lib.rs
+++ b/crates/rlevo-reinforcement-learning/src/lib.rs
@@ -37,6 +37,51 @@
 //!   rather than a separate variant.
 //! - [`utils`] — Shared helpers: Bellman target computation, Polyak averaging.
 
+/// The upper bound on any replay-buffer capacity in this crate: `2^32`.
+///
+/// # Why a ceiling exists at all
+///
+/// The `SumTree` behind [`replay::PrioritizedReplay`] sizes its storage as
+/// `capacity.next_power_of_two() * 2`, and the workspace root `Cargo.toml`
+/// declares no `[profile]` section, so release builds inherit
+/// `overflow-checks = false` and **both** of those operations wrap. Measured on
+/// `aarch64` macOS with `rustc -O`:
+///
+/// | `capacity` | `leaf_base` | `nodes.len()` |
+/// |---|---|---|
+/// | `2^62 + 1` | `2^63` | `0` (the `* 2` wrapped) |
+/// | `2^63` | `2^63` | `0` (the `* 2` wrapped) |
+/// | `2^63 + 1` | `0` | `0` (`next_power_of_two` wrapped) |
+/// | `usize::MAX` | `0` | `0` (`next_power_of_two` wrapped) |
+///
+/// In debug those same capacities panic on overflow; in release the constructor
+/// *succeeds* and hands back a priority index with an empty node array, which
+/// then indexes out of bounds — or, worse, is read as a coherent distribution.
+/// A debug/release divergence in a constructor is not something a caller can
+/// reason about, so the capacity is rejected before it can reach the
+/// arithmetic.
+///
+/// # Why `2^32` specifically
+///
+/// The bound has to be *below* the wrap and *above* anything a researcher would
+/// legitimately ask for, and `2^32` clears both by a wide margin:
+///
+/// - **It cannot wrap.** `2^32.next_power_of_two() * 2 == 2^33`, a factor of
+///   `2^30` below the smallest capacity in the table above. Every intermediate
+///   stays exact on a 64-bit `usize`.
+/// - **It is far past the published state of the art.** 4.29e9 transitions is
+///   three orders of magnitude above DQN's 1e6 (Mnih et al. 2015), R2D2's ~4e6
+///   (Kapturowski et al. 2019), and Agent57's 1e7 (Badia et al. 2020). A
+///   capacity above this is a misconfiguration — a unit slip, a
+///   `usize::MAX` sentinel, a deserialized garbage field — not an experiment.
+/// - **It is unreachable in memory anyway.** The `SumTree` alone would want
+///   `2^33 * 8 B = 64 GiB` of `f64` nodes before a single transition is stored,
+///   so the allocation fails long before the arithmetic would.
+///
+/// A tighter bound would be arbitrary; a looser one would have to argue about
+/// the wrap. This one has to argue about neither.
+pub const MAX_BUFFER_CAPACITY: usize = 1 << 32;
+
 pub mod algorithms {
     //! Reinforcement learning algorithm implementations.
 

--- a/crates/rlevo-reinforcement-learning/src/metrics.rs
+++ b/crates/rlevo-reinforcement-learning/src/metrics.rs
@@ -3,6 +3,7 @@
 //! This module provides [`PerformanceRecord`] for representing per-episode
 //! outcomes and [`AgentStats`] for accumulating them into running statistics.
 
+use crate::MAX_BUFFER_CAPACITY;
 use std::collections::VecDeque;
 
 /// The outcome of a single episode or step used for performance tracking.
@@ -37,14 +38,23 @@ impl<T: PerformanceRecord> AgentStats<T> {
     ///
     /// # Arguments
     /// * `window_size` - Maximum number of recent episodes retained for
-    ///   [`Self::avg_score`]. Must be greater than 0.
+    ///   [`Self::avg_score`]. Must be in `1..=`[`MAX_BUFFER_CAPACITY`].
     ///
     /// # Panics
+    ///
     /// Panics if `window_size` is 0. A zero-length window cannot hold any
     /// history: [`Self::record`] would evict the previous entry before every
     /// push, pinning `recent_history` at a single episode and making
     /// [`Self::avg_score`] report the latest score rather than a moving
     /// average.
+    ///
+    /// Panics if `window_size` exceeds [`MAX_BUFFER_CAPACITY`]. The argument is
+    /// handed unfiltered to [`VecDeque::with_capacity`], where an out-of-range
+    /// request aborts the process on capacity overflow rather than unwinding.
+    /// Every in-crate call site passes a hard-coded literal (`100`), so this
+    /// bound can only be tripped by a direct API caller — an out-of-range value
+    /// is a programming error at that call site, not a runtime condition to
+    /// recover from, which is why it panics rather than returning a `Result`.
     #[must_use]
     pub fn new(window_size: usize) -> Self {
         assert!(
@@ -52,6 +62,13 @@ impl<T: PerformanceRecord> AgentStats<T> {
             "window_size must be greater than 0; a zero-length window cannot \
              hold history and would make avg_score report the latest score \
              instead of a moving average"
+        );
+        assert!(
+            window_size <= MAX_BUFFER_CAPACITY,
+            "window_size must be at most {MAX_BUFFER_CAPACITY}, got \
+             {window_size}; this value is passed straight to \
+             VecDeque::with_capacity, where an out-of-range request aborts the \
+             process instead of unwinding"
         );
         Self {
             total_episodes: 0,
@@ -104,7 +121,7 @@ impl<T: PerformanceRecord> AgentStats<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentStats, PerformanceRecord};
+    use super::{AgentStats, MAX_BUFFER_CAPACITY, PerformanceRecord};
 
     /// Minimal [`PerformanceRecord`] carrying a score and a fixed duration.
     #[derive(Debug, Clone, PartialEq)]
@@ -133,6 +150,16 @@ mod tests {
     #[should_panic(expected = "window_size must be greater than 0")]
     fn new_rejects_zero_window_size() {
         let _ = AgentStats::<TestRecord>::new(0);
+    }
+
+    /// The upper end of the same guard. `window_size` reaches
+    /// `VecDeque::with_capacity` unfiltered, where an out-of-range request
+    /// aborts the process rather than unwinding — so reaching a catchable
+    /// panic at all is the property under test.
+    #[test]
+    #[should_panic(expected = "window_size must be at most")]
+    fn new_rejects_window_size_above_ceiling() {
+        let _ = AgentStats::<TestRecord>::new(MAX_BUFFER_CAPACITY + 1);
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/replay/config.rs
+++ b/crates/rlevo-reinforcement-learning/src/replay/config.rs
@@ -3,6 +3,8 @@
 use rlevo_core::config::{self, ConfigError, Validate};
 use serde::{Deserialize, Serialize};
 
+use crate::MAX_BUFFER_CAPACITY;
+
 /// The ε floor of Schaul et al. (2016) §3.3's `$p_i = |\delta_i| + \epsilon$`.
 ///
 /// **Schaul gives no numeric value for ε** — it is described only as "a small
@@ -82,7 +84,13 @@ pub const DEFAULT_PRIORITY_EXPONENT: f32 = 0.6;
 pub struct PrioritizedReplayConfig {
     /// The maximum number of transitions held; the oldest is evicted past this.
     ///
-    /// Must be non-zero.
+    /// Must be non-zero and at most
+    /// [`MAX_BUFFER_CAPACITY`](crate::MAX_BUFFER_CAPACITY). The upper bound is
+    /// not a taste judgement: the sum-tree sizes itself as
+    /// `capacity.next_power_of_two() * 2`, which wraps silently in release
+    /// builds for capacities near `usize::MAX` and yields an empty node array.
+    /// See that constant for the measured wrap and for why `2^32` is orders of
+    /// magnitude above any published replay buffer.
     pub capacity: usize,
 
     /// Schaul Eq. 1's α in `$P(i) = p_i^\alpha / \sum_k p_k^\alpha$`.
@@ -114,6 +122,7 @@ impl Validate for PrioritizedReplayConfig {
     fn validate(&self) -> Result<(), ConfigError> {
         const C: &str = "PrioritizedReplayConfig";
         config::nonzero(C, "capacity", self.capacity)?;
+        config::at_most(C, "capacity", self.capacity, MAX_BUFFER_CAPACITY)?;
         config::in_range(
             C,
             "priority_exponent",
@@ -128,8 +137,11 @@ impl Validate for PrioritizedReplayConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_PRIORITY_EPSILON, DEFAULT_PRIORITY_EXPONENT, PrioritizedReplayConfig};
-    use rlevo_core::config::Validate;
+    use super::{
+        DEFAULT_PRIORITY_EPSILON, DEFAULT_PRIORITY_EXPONENT, MAX_BUFFER_CAPACITY,
+        PrioritizedReplayConfig,
+    };
+    use rlevo_core::config::{ConstraintKind, Validate};
 
     #[test]
     fn test_prioritized_replay_config_default_validates() {
@@ -167,6 +179,45 @@ mod tests {
             "capacity",
             "a zero-capacity buffer must be named as the offending field"
         );
+    }
+
+    /// The ceiling is inclusive: exactly [`MAX_BUFFER_CAPACITY`] is a legal
+    /// (if absurd) request, and the sum-tree arithmetic for it — `2^33` nodes —
+    /// is exact. Only strictly above it is rejected.
+    #[test]
+    fn test_prioritized_replay_config_accepts_capacity_at_ceiling() {
+        let c = PrioritizedReplayConfig {
+            capacity: MAX_BUFFER_CAPACITY,
+            ..PrioritizedReplayConfig::default()
+        };
+        assert!(
+            c.validate().is_ok(),
+            "MAX_BUFFER_CAPACITY is an inclusive bound"
+        );
+    }
+
+    /// Above the ceiling the sum-tree's `next_power_of_two() * 2` is on the road
+    /// to a release-mode wrap, so the config must refuse it — naming `capacity`
+    /// and reporting `TooLarge`, not some downstream symptom.
+    #[test]
+    fn test_prioritized_replay_config_rejects_capacity_above_ceiling() {
+        for capacity in [MAX_BUFFER_CAPACITY + 1, usize::MAX] {
+            let err = PrioritizedReplayConfig {
+                capacity,
+                ..PrioritizedReplayConfig::default()
+            }
+            .validate()
+            .unwrap_err();
+            assert_eq!(err.field, "capacity", "capacity {capacity} is the offender");
+            assert_eq!(
+                err.kind,
+                ConstraintKind::TooLarge {
+                    max: MAX_BUFFER_CAPACITY as u64,
+                    got: capacity as u64,
+                },
+                "capacity {capacity} must be rejected as TooLarge, carrying both bounds"
+            );
+        }
     }
 
     #[test]

--- a/crates/rlevo-reinforcement-learning/src/replay/prioritized.rs
+++ b/crates/rlevo-reinforcement-learning/src/replay/prioritized.rs
@@ -177,9 +177,17 @@ impl<T> PrioritizedReplay<T> {
     /// # Errors
     ///
     /// Returns the first [`ConfigError`] from
-    /// [`PrioritizedReplayConfig::validate`] — a zero `capacity`, a
+    /// [`PrioritizedReplayConfig::validate`] — a zero `capacity`, a `capacity`
+    /// above [`MAX_BUFFER_CAPACITY`](crate::MAX_BUFFER_CAPACITY), a
     /// `priority_exponent` outside `[0, 1]`, or a non-positive
     /// `priority_epsilon`.
+    ///
+    /// The capacity ceiling is what makes the two allocations below safe: the
+    /// `Vec::with_capacity` calls cannot be handed a nonsense request, and
+    /// `SumTree::new`'s `capacity.next_power_of_two() * 2` — which wraps
+    /// silently in release builds near `usize::MAX`, yielding an empty node
+    /// array rather than a panic — stays exact. See the constant for the
+    /// measured wrap.
     pub fn new(config: PrioritizedReplayConfig) -> Result<Self, ConfigError> {
         config.validate()?;
         Ok(Self {

--- a/crates/rlevo-reinforcement-learning/src/replay/sum_tree.rs
+++ b/crates/rlevo-reinforcement-learning/src/replay/sum_tree.rs
@@ -34,6 +34,8 @@
 
 use rand::{Rng, RngExt};
 
+use crate::MAX_BUFFER_CAPACITY;
+
 /// A mapping from buffer slot to non-negative sampling mass, supporting the two
 /// operations Schaul's proportional variant needs: point update, and inverse-CDF
 /// lookup.
@@ -91,12 +93,38 @@ impl SumTree {
     ///
     /// # Panics
     ///
-    /// Panics when `capacity == 0`. Capacity reaches here only from a
+    /// Panics when `capacity == 0`, and when `capacity` exceeds
+    /// [`MAX_BUFFER_CAPACITY`]. Capacity reaches here only from a
     /// [`PrioritizedReplayConfig`](super::PrioritizedReplayConfig) that has
-    /// already passed `validate()`, which rejects zero, so a zero here is a
+    /// already passed `validate()`, which rejects both, so either is a
     /// programming error in the buffer rather than user-supplied data.
+    ///
+    /// The upper bound is nonetheless asserted here rather than left to the
+    /// caller, because the failure it prevents is invisible. `leaf_base * 2`
+    /// and `capacity.next_power_of_two()` both **wrap** in release builds — the
+    /// workspace root `Cargo.toml` has no `[profile]` section, so
+    /// `overflow-checks = false` is inherited. Measured on `aarch64` macOS with
+    /// `rustc -O`:
+    ///
+    /// | `capacity` | `leaf_base` | `nodes.len()` |
+    /// |---|---|---|
+    /// | `2^62 + 1` | `2^63` | `0` |
+    /// | `2^63` | `2^63` | `0` |
+    /// | `2^63 + 1` | `0` | `0` |
+    /// | `usize::MAX` | `0` | `0` |
+    ///
+    /// Without the assert, debug panics on the overflow while release *returns
+    /// a corrupt tree*: an empty `nodes` array whose `total()` indexes out of
+    /// bounds on the very first read. A constructor whose contract differs
+    /// between profiles is worse than one that always panics, so the bound is
+    /// checked explicitly and identically in both.
     pub(crate) fn new(capacity: usize) -> Self {
         assert!(capacity > 0, "SumTree::new: capacity must be non-zero");
+        assert!(
+            capacity <= MAX_BUFFER_CAPACITY,
+            "SumTree::new: capacity {capacity} exceeds MAX_BUFFER_CAPACITY \
+             {MAX_BUFFER_CAPACITY}"
+        );
         let leaf_base = capacity.next_power_of_two();
         Self {
             nodes: vec![0.0; leaf_base * 2],
@@ -414,6 +442,82 @@ mod tests {
     #[should_panic(expected = "capacity must be non-zero")]
     fn test_sum_tree_new_panics_on_zero_capacity() {
         let _ = SumTree::new(0);
+    }
+
+    /// Issue #404, the release-mode half. Before the `MAX_BUFFER_CAPACITY`
+    /// assert, `SumTree::new` computed `capacity.next_power_of_two()` and then
+    /// `leaf_base * 2` with no guard, and the workspace root `Cargo.toml`
+    /// declares no `[profile]` section — so release builds inherit
+    /// `overflow-checks = false` and **both** operations wrap. Measured on
+    /// `aarch64` macOS with `rustc -O`, the four capacities below produced:
+    ///
+    /// | `capacity` | `leaf_base` | `nodes.len()` |
+    /// |---|---|---|
+    /// | `2^62 + 1` | `2^63` | `0` — `leaf_base * 2` wrapped |
+    /// | `2^63` | `2^63` | `0` — `leaf_base * 2` wrapped |
+    /// | `2^63 + 1` | `0` | `0` — `next_power_of_two` wrapped |
+    /// | `usize::MAX` | `0` | `0` — `next_power_of_two` wrapped |
+    ///
+    /// That is: in release the constructor *succeeded*, returning a priority
+    /// index with an empty node array; `total()` then reads `nodes[1]` out of
+    /// bounds. In debug the same inputs panicked on the overflow. Every one of
+    /// the four must now be rejected, identically in both profiles.
+    ///
+    /// `catch_unwind` rather than `#[should_panic]`: the attribute stops the
+    /// test at the first panic, so four `#[should_panic]` cases in a loop would
+    /// pin only the first capacity and silently skip the other three — and the
+    /// two wrap mechanisms above differ, so each needs its own assertion.
+    ///
+    /// The **message** is asserted, not merely the fact of a panic, and that is
+    /// load-bearing rather than fussy. Against the unguarded constructor this
+    /// test is red only in release; in debug the overflow check panics on its
+    /// own, so a bare `is_err()` would pass and the test would be pinning the
+    /// profile's accident instead of the guard. Requiring the guard's own
+    /// message distinguishes "rejected by `MAX_BUFFER_CAPACITY`" from "wrapped,
+    /// and happened to be caught by `-C overflow-checks`", and so fails in both
+    /// profiles the day the assert is deleted.
+    #[test]
+    fn test_sum_tree_new_rejects_capacities_that_wrapped_in_release() {
+        // Silence the default hook: four deliberate panics would otherwise
+        // print four backtraces over a passing test.
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let outcomes: Vec<(usize, Option<String>)> = [
+            (1_usize << 62) + 1,
+            1_usize << 63,
+            (1_usize << 63) + 1,
+            usize::MAX,
+        ]
+        .into_iter()
+        .map(|capacity| {
+            let message = std::panic::catch_unwind(|| SumTree::new(capacity))
+                .err()
+                .map(|payload| match payload.downcast::<String>() {
+                    Ok(s) => *s,
+                    Err(other) => match other.downcast::<&'static str>() {
+                        Ok(s) => (*s).to_owned(),
+                        Err(_) => "<non-string panic payload>".to_owned(),
+                    },
+                });
+            (capacity, message)
+        })
+        .collect();
+        std::panic::set_hook(previous);
+
+        for (capacity, message) in outcomes {
+            let message = message.unwrap_or_else(|| {
+                panic!(
+                    "SumTree::new({capacity}) must panic; unguarded it returned \
+                     a tree with an empty node array in release builds"
+                )
+            });
+            assert!(
+                message.contains("exceeds MAX_BUFFER_CAPACITY"),
+                "SumTree::new({capacity}) must be rejected by the capacity \
+                 guard, not by an overflow check that only exists in debug; \
+                 got {message:?}"
+            );
+        }
     }
 
     /// The whole justification for keeping the reference around: identical seeds

--- a/crates/rlevo-reinforcement-learning/src/replay/uniform.rs
+++ b/crates/rlevo-reinforcement-learning/src/replay/uniform.rs
@@ -11,6 +11,7 @@ use std::collections::VecDeque;
 use rand::{Rng, RngExt};
 
 use super::{ImportanceExponent, ReplayBufferError, ReplayStrategy, SampledBatch, TransitionId};
+use crate::MAX_BUFFER_CAPACITY;
 
 /// A fixed-capacity FIFO replay buffer sampled uniformly with replacement.
 ///
@@ -79,13 +80,30 @@ impl<T> UniformReplay<T> {
     ///
     /// Panics if `capacity == 0`. A zero-capacity replay buffer cannot hold the
     /// transition it was just handed, and the pre-seam eviction shape would
-    /// have grown without bound instead of refusing. Every in-crate call site
-    /// passes a config field that
-    /// [`Validate`](rlevo_core::config::Validate) has already rejected zero
-    /// for, so this is a programming error, never user data.
+    /// have grown without bound instead of refusing.
+    ///
+    /// Panics if `capacity` exceeds [`MAX_BUFFER_CAPACITY`]. The bound is
+    /// shared with the prioritized buffer, whose sum-tree wraps outright at
+    /// capacities near `usize::MAX` in release builds (see that constant); here
+    /// the concrete failure is that `VecDeque::with_capacity` **aborts** the
+    /// process on an allocation it cannot serve, which no caller can catch or
+    /// diagnose. Refusing the capacity up front turns a process abort into a
+    /// panic that names the offending call site.
+    ///
+    /// Both are programming errors, never user data: every in-crate call site
+    /// passes a config field that [`Validate`](rlevo_core::config::Validate)
+    /// has already rejected zero and over-large values for. That is why this
+    /// stays infallible — there is no `try_new` and no `Result`, following the
+    /// #190/#191 precedent that a config-validated constructor does not
+    /// re-litigate its input in the type system.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         assert!(capacity > 0, "replay buffer capacity must be non-zero");
+        assert!(
+            capacity <= MAX_BUFFER_CAPACITY,
+            "replay buffer capacity {capacity} exceeds MAX_BUFFER_CAPACITY \
+             {MAX_BUFFER_CAPACITY}"
+        );
         Self {
             buffer: VecDeque::with_capacity(capacity),
             capacity,
@@ -222,6 +240,35 @@ mod tests {
     #[should_panic(expected = "replay buffer capacity must be non-zero")]
     fn test_uniform_replay_new_rejects_zero_capacity() {
         let _: UniformReplay<u32> = UniformReplay::new(0);
+    }
+
+    /// Issue #404: `VecDeque::with_capacity(usize::MAX)` aborts the process on
+    /// a failed allocation rather than unwinding, so an over-large capacity had
+    /// no diagnosable failure mode at all. It is now a named panic.
+    #[test]
+    #[should_panic(expected = "exceeds MAX_BUFFER_CAPACITY")]
+    fn test_uniform_replay_new_rejects_capacity_above_ceiling() {
+        let _: UniformReplay<u32> = UniformReplay::new(MAX_BUFFER_CAPACITY + 1);
+    }
+
+    /// The ceiling is inclusive. Constructing the buffer at exactly
+    /// `MAX_BUFFER_CAPACITY` would try to reserve `2^32` elements, so this pins
+    /// the boundary at the assert rather than at the allocator: `usize::MAX`
+    /// and `MAX_BUFFER_CAPACITY + 1` are rejected, `MAX_BUFFER_CAPACITY` is not
+    /// what the assert complains about.
+    #[test]
+    fn test_uniform_replay_capacity_ceiling_is_inclusive() {
+        assert!(
+            MAX_BUFFER_CAPACITY.checked_next_power_of_two().is_some(),
+            "the ceiling itself must survive the sum-tree's rounding"
+        );
+        assert!(
+            MAX_BUFFER_CAPACITY
+                .next_power_of_two()
+                .checked_mul(2)
+                .is_some_and(|n| n == 1 << 33),
+            "and its doubling must be exact, which is the whole point of 2^32"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Every buffer constructor in `rlevo-reinforcement-learning` validated capacity on one side only, and the unbounded upper end had two distinct consequences. The reported one — unguarded `with_capacity` in `History::new`, `UniformReplay::new` and `PrioritizedReplay::new` — is the lesser half. The worse half is in the same call chain: `SumTree::new` sizes itself with `capacity.next_power_of_two()` and then `leaf_base * 2`, and the workspace root declares no `[profile]` section, so release inherits `overflow-checks = false` and **both** operations wrap. Measured with `rustc -O`, a capacity of `2^62 + 1` yields `nodes.len() == 0`, and anything above `2^63` wraps `leaf_base` to `0` as well — so release *returned* a prioritized-replay index with an empty node array, deferring failure to an unrelated index panic at sample time, while debug panicked honestly at construction. This PR closes both halves with one documented ceiling, `MAX_BUFFER_CAPACITY = 2^32`, enforced through `Validate` wherever a `Result` already existed (so every config-driven path now returns a recoverable `ConstraintKind::TooLarge`) and through a widened `assert!` on the infallible constructors. No public signature changes.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #404

## What Was Changed

**`rlevo-core`**

- `src/config.rs` — added `ConstraintKind::TooLarge { max, got }` and `pub fn at_most(config, field, got, max)`, the upper-bound counterparts to the existing `TooSmall` / `at_least` pair. The module could express "a count must be at least *n*" but had no way to express a ceiling at all, which is why every `usize` capacity field in the workspace was validated on one side only. `ConstraintKind` is `#[non_exhaustive]` and nothing in the workspace matches it exhaustively, so the variant is purely additive.
- `README.md` — helper list now names `at_most`.

**`rlevo-reinforcement-learning`**

- `src/lib.rs` — added `pub const MAX_BUFFER_CAPACITY: usize = 1 << 32`, with a doc comment justifying the value on three axes: it cannot wrap (`2^32.next_power_of_two() * 2 == 2^33`, a factor of `2^30` below the smallest wrapping capacity), it is three orders of magnitude past DQN's 1e6 / R2D2's ~4e6 / Agent57's 1e7, and the node array it implies is unallocatable anyway.
- `src/replay/config.rs` — `config::at_most` on `PrioritizedReplayConfig::capacity`. This one line covers both `Vec::with_capacity` sites *and* the `SumTree` wrap.
- `src/replay/sum_tree.rs` — `assert!(capacity <= MAX_BUFFER_CAPACITY)` in `SumTree::new`; `# Panics` records the measured release-mode wrap as the reason the bound exists.
- `src/replay/uniform.rs`, `src/experience.rs`, `src/metrics.rs` — widened the existing zero-capacity `assert!` in `UniformReplay::new`, `History::new` and `AgentStats::new` to cover the upper end, as a second `assert!` so each end keeps its own diagnostic and the existing `#[should_panic]` tests stay verbatim.
- `src/replay/prioritized.rs` — `# Errors` on `new` now names the ceiling. No code change.
- `src/algorithms/ppo/rollout.rs` — `RolloutBuffer::new` had **no** guard at either end, unlike its siblings, and computed `capacity * action_dim` unchecked. Now guards both factors and the product via `checked_mul`; the checked product feeds `Vec::with_capacity` directly rather than being recomputed.
- `src/algorithms/ppo/ppo_config.rs` — `validate` applied `nonzero` to `num_steps` but never checked the `num_envs * num_steps` product that becomes `RolloutBuffer`'s capacity. Now bounded. PPG inherits this via `PpgConfig::validate`'s `self.ppo.validate()?`.
- `src/algorithms/{dqn,c51,qrdqn,ddpg,td3,sac}/*_config.rs` — `config::at_most` on `replay_buffer_capacity` in each. These six are the guard for every non-test `UniformReplay::new` construction in the workspace. Defaults untouched and all far below the ceiling (10 000 / 1 000 000).

**Docs**

- `CHANGELOG.md` — `rlevo-core` **Added**; `rlevo-reinforcement-learning` **Fixed**.

### Rejected alternatives

The issue suggested `try_reserve_exact` inside a fallible `try_new`. Neither was adopted, on measured grounds: `Vec::<f64>::with_capacity(usize::MAX)` raises a **catchable** `capacity overflow` panic (not an abort), and `with_capacity(1 << 45)` — 256 TiB — simply succeeded under overcommit. So `try_reserve_exact` recovers only the arm that already unwinds. A `try_new` would additionally contradict the #190/#191 precedent ("no `try_new` — matches the `AgentStats` precedent") and would add a `Result` API to `History`, which has zero non-test callers. Full reasoning and the probe table are in the issue comment.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

All three clean: build with no errors, clippy silent, **3206 tests passed / 0 failed**. Also run: `cargo fmt --all --check`, and `cargo test --release -p rlevo-reinforcement-learning` (508 passed) — a release run matters here specifically, because the sum-tree wrap is invisible in debug.

### Regression tests, and the trap they had to avoid

Before / after: unguarded, `SumTree::new(2^62 + 1)` returned a tree with an empty node array in release and panicked with `attempt to multiply with overflow` in debug. Guarded, both profiles panic with the guard's own message.

That divergence is why `test_sum_tree_new_rejects_capacities_that_wrapped_in_release` asserts the panic **message** contains `exceeds MAX_BUFFER_CAPACITY` rather than merely that a panic occurred. A bare "did it panic?" assertion passes against the *unfixed* constructor in debug, because `overflow-checks` supplies a panic for its own unrelated reason — the first version of this test did exactly that. It pins all four measured capacities individually via `catch_unwind`, since `#[should_panic]` would stop at the first and the two wrap mechanisms differ.

Verified red-then-green against a **vacuous-predicate mutant** (`capacity <= usize::MAX`, panic message left intact, so the test cannot pass on message text alone): red in release, green on restore, `git diff --stat` unchanged. A mutant that deletes the whole assert would have been too weak — it also deletes the string the test greps for.

Other tests added: `#[should_panic]` above the ceiling for each of the five infallible constructors, asserting on message substring; a `RolloutBuffer` test exercising the product-only branch (`capacity = MAX/2`, `action_dim = 4` — each factor individually in range, product out) plus a separate `checked_mul` overflow case; and, for each of the seven config paths, boundary-accept at exactly `MAX_BUFFER_CAPACITY` and a rejection test asserting the returned `Err` carries `ConstraintKind::TooLarge` with the right `field`. The config rejections deliberately do **not** use `#[should_panic]` — the whole point is that `usize::MAX` through a config is now recoverable rather than fatal. Pre-existing ADR-0026 default-validates tests still pass.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU) — this change is allocation/validation plumbing and touches no tensor path
- OS: macOS 26.5.2 (aarch64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): __Claude Code (Opus 5)__. Scope: __full change — investigation, implementation, tests, and docs — authored under my direction and reviewed by me before commit.__

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

Three things deliberately left open rather than quietly resolved:

- **`ppo_config.rs` attributes the product error to field `"num_steps"`**, not to the product. Harmless today only because the earlier `num_envs != 1` guard pins `num_envs == 1` on every reachable path, making `batch_size == num_steps`. Worth revisiting if vectorised-env support lands. Its `ConstraintKind::Custom("num_envs * num_steps overflows usize")` arm is unreachable for the same reason and has no red test — it is defensive.
- **`1 << 32` is a compile error on a 32-bit `usize`.** Unreachable here: the only wasm32 crate (`rlevo-benchmarks-report-client`) deliberately does not depend on `rlevo-core` or `rlevo-reinforcement-learning`, to avoid pulling in Burn. It would need `#[cfg(target_pointer_width)]` if that ever changes.
- **`AgentStats::new` is guarded for symmetry but is not config-reachable** — all eight agent call sites pass a hard-coded `100` and no config field feeds it, so only a direct API caller can trip the bound.

Ripple-triaged the linked issues #190, #391 and #392 against this fix; all three verified by execution and none needs a change — this PR is additive and orthogonal to each, and #392's four items have zero overlap with what moved here.
