### PR TITLE
fix(rl): Encapsulate AgentStats behind accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `ReplayBufferError` none is possible (see below). No persisted data is
   involved: none of the eight derives `serde`.
 
+- **`AgentStats<T>`'s four `pub` fields become private, behind `#[must_use]`
+  accessors** (resolves #407). `total_episodes`, `total_steps`, `best_score` and
+  `recent_history` are now read through `total_episodes()`, `total_steps()`,
+  `best_score()` and `recent_history()`, and `recent_history.len()` becomes
+  `recent_len()`; the bound itself is readable as `window_size()`, which was not
+  reachable before at all. One wrinkle worth calling out, because the compiler
+  reports it as a type error rather than a missing field:
+  `let history = &agent.stats().recent_history;` becomes
+  `let history = agent.stats().recent_history();` — the `&` is dropped, since
+  the accessor already returns a reference.
+
+  The invariant at stake is `recent_history.len() <= window_size`. `record()`
+  has always maintained it, popping the front before pushing once the window is
+  full — but a `pub` field let any external caller `push_back` past the window,
+  or advance `total_episodes` without touching the history and desync the
+  lifetime counters from it. `docs/rules.md` §3 lists precisely this shape of
+  bound for `History` and `ReplayStrategy` ("`len()` never exceeds capacity")
+  among the invariants a type must enforce rather than merely document; §2's
+  Struct Field Encapsulation rule (ADR 0055) names the remedy this entry
+  applies — private fields, `#[must_use]` read accessors named after the field.
+
+  No test could have caught this, and the reason is the point. All 25 call sites
+  across 11 files — nine integration suites, the `ch03_dqn_cartpole` book
+  example, and production code at `algorithms/ppo/train.rs:295` — only ever
+  *read* these fields, which the accessors still permit; nothing anywhere in the
+  workspace ever wrote to one. A test can only observe a missing guard by
+  tripping it, so the defect was unreachable from inside this repository and
+  reachable only by a downstream user of the published crate. (The issue itself
+  understates the surface as a single three-line test site; the verified figure
+  is the 25/11 above, and the migration is read-only at every one of them.)
+
 ### `rlevo-core`
 
 **Added**
@@ -314,6 +345,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   it is public for the same reason its rank-1 sibling is, and its docs carry
   the terminal-bootstrap convention, the masking rationale, and the C51
   exclusion so both forms of the convention are findable from one place.
+
+**Changed**
+
+- **`AgentStats` now demonstrates its window contract instead of asserting it in
+  prose** (for #407). The type carried no doc example, so the one behaviour a
+  caller has to internalise — the recent window evicts, the lifetime counters
+  never do — was discoverable only by reading `record()`. It gains a runnable
+  example showing both halves, and in-source unit tests for the two edges the
+  existing suite left open: an empty `AgentStats` (no average, no best) and
+  eviction at *exactly* `window_size`, the off-by-one the previous tests
+  straddled without pinning.
 
 **Removed**
 

--- a/crates/rlevo-examples/examples/book/ch03_dqn_cartpole.rs
+++ b/crates/rlevo-examples/examples/book/ch03_dqn_cartpole.rs
@@ -172,12 +172,15 @@ fn main() {
 
     let stats = agent.stats();
     println!("\n=== CartPole DQN — training complete ===");
-    println!("episodes     : {}", stats.total_episodes);
-    println!("env steps    : {}", stats.total_steps);
-    println!("best episode : {:.1}", stats.best_score.unwrap_or(f32::NAN));
+    println!("episodes     : {}", stats.total_episodes());
+    println!("env steps    : {}", stats.total_steps());
+    println!(
+        "best episode : {:.1}",
+        stats.best_score().unwrap_or(f32::NAN)
+    );
     println!(
         "avg (last {:>3}): {:.1}",
-        stats.recent_history.len(),
+        stats.recent_len(),
         stats.avg_score().unwrap_or(f32::NAN)
     );
 }
@@ -207,7 +210,7 @@ mod tests {
             agent.buffer_len() > 0,
             "replay buffer should have transitions"
         );
-        for (i, m) in agent.stats().recent_history.iter().enumerate() {
+        for (i, m) in agent.stats().recent_history().iter().enumerate() {
             assert!(m.reward.is_finite(), "non-finite reward at episode {i}");
         }
     }

--- a/crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs
+++ b/crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs
@@ -292,7 +292,7 @@ fn emit_progress<B, P, V, O, const DO: usize, const DB: usize>(
     // Per-iteration episode-return statistics over the recent-episode window.
     // Cheap: a handful of arithmetic ops on a bounded VecDeque, and only ever
     // reached behind the periodic-log guard so the hot path is untouched.
-    let ret_stats = EpisodeReturnStats::from_window(&agent.stats().recent_history);
+    let ret_stats = EpisodeReturnStats::from_window(agent.stats().recent_history());
     let elapsed = loop_start.elapsed().as_secs_f64();
     let steps_per_sec = if elapsed > 0.0 {
         global_step as f64 / elapsed

--- a/crates/rlevo-reinforcement-learning/src/metrics.rs
+++ b/crates/rlevo-reinforcement-learning/src/metrics.rs
@@ -19,16 +19,43 @@ pub trait PerformanceRecord: std::fmt::Debug + Clone {
 ///
 /// Tracks global counters, best observed score, and a fixed-size sliding
 /// window of recent episodes for computing moving averages.
+///
+/// All state is private: the sliding window upholds the invariant
+/// `recent_history().len() <= window_size()`, which only [`Self::record`] is
+/// allowed to maintain. Read the accumulated statistics through the accessors.
+///
+/// # Example
+/// ```
+/// use rlevo_reinforcement_learning::metrics::{AgentStats, PerformanceRecord};
+/// # #[derive(Debug, Clone)]
+/// # struct Ep { score: f32, duration: usize }
+/// # impl PerformanceRecord for Ep {
+/// #   fn score(&self) -> f32 { self.score }
+/// #   fn duration(&self) -> usize { self.duration }
+/// # }
+/// let mut stats = AgentStats::<Ep>::new(16);
+/// assert_eq!(stats.avg_score(), None);
+///
+/// stats.record(Ep { score: 1.0, duration: 10 });
+/// stats.record(Ep { score: 3.0, duration: 20 });
+///
+/// assert_eq!(stats.avg_score(), Some(2.0));
+/// assert_eq!(stats.best_score(), Some(3.0));
+/// assert_eq!(stats.total_episodes(), 2);
+/// assert_eq!(stats.total_steps(), 30);
+/// assert_eq!(stats.recent_len(), 2);
+/// assert_eq!(stats.window_size(), 16);
+/// ```
 #[derive(Debug, Clone)]
 pub struct AgentStats<T: PerformanceRecord> {
     /// Global counter of episodes recorded so far.
-    pub total_episodes: usize,
+    total_episodes: usize,
     /// Total environment steps taken across all episodes.
-    pub total_steps: usize,
+    total_steps: usize,
     /// The highest score observed across all episodes.
-    pub best_score: Option<f32>,
+    best_score: Option<f32>,
     /// Fixed-size sliding window of the most recent episodes.
-    pub recent_history: VecDeque<T>,
+    recent_history: VecDeque<T>,
     /// Maximum capacity of the sliding window.
     window_size: usize,
 }
@@ -80,18 +107,75 @@ impl<T: PerformanceRecord> AgentStats<T> {
     }
 
     /// Records a completed episode, updating all counters and the sliding window.
-    pub fn record(&mut self, record: T) {
+    pub fn record(&mut self, entry: T) {
         self.total_episodes += 1;
-        self.total_steps += record.duration();
+        self.total_steps += entry.duration();
 
-        let score = record.score();
+        let score = entry.score();
         self.best_score = Some(self.best_score.map_or(score, |b| b.max(score)));
 
         // Maintain Sliding Window (O(1) with VecDeque)
         if self.recent_history.len() >= self.window_size {
             self.recent_history.pop_front();
         }
-        self.recent_history.push_back(record);
+        self.recent_history.push_back(entry);
+    }
+
+    /// Returns the number of episodes recorded since construction.
+    ///
+    /// This is a global counter over all of history; it is unaffected by the
+    /// sliding window and so may exceed [`Self::window_size`].
+    #[must_use]
+    pub fn total_episodes(&self) -> usize {
+        self.total_episodes
+    }
+
+    /// Returns the sum of [`PerformanceRecord::duration`] over every recorded
+    /// episode.
+    ///
+    /// Like [`Self::total_episodes`], this accumulates over all of history
+    /// rather than the sliding window.
+    #[must_use]
+    pub fn total_steps(&self) -> usize {
+        self.total_steps
+    }
+
+    /// Returns the highest [`PerformanceRecord::score`] observed across all
+    /// recorded episodes, or `None` when no episodes have been recorded yet.
+    ///
+    /// Unlike [`Self::avg_score`], the best score is never evicted by the
+    /// sliding window.
+    #[must_use]
+    pub fn best_score(&self) -> Option<f32> {
+        self.best_score
+    }
+
+    /// Returns the sliding window of the most recent episodes, oldest first.
+    ///
+    /// The returned deque holds at most [`Self::window_size`] entries
+    /// (`recent_history().len() <= window_size()`); once the window is full,
+    /// each [`Self::record`] evicts the front (oldest) entry before appending
+    /// the new one at the back.
+    #[must_use]
+    pub fn recent_history(&self) -> &VecDeque<T> {
+        &self.recent_history
+    }
+
+    /// Returns the current occupancy of the sliding window.
+    ///
+    /// Always `<= `[`Self::window_size`], and equal to it once at least
+    /// `window_size` episodes have been recorded.
+    #[must_use]
+    pub fn recent_len(&self) -> usize {
+        self.recent_history.len()
+    }
+
+    /// Returns the configured maximum size of the sliding window.
+    ///
+    /// This is the `window_size` passed to [`Self::new`] and never changes.
+    #[must_use]
+    pub fn window_size(&self) -> usize {
+        self.window_size
     }
 
     /// Returns the mean [`PerformanceRecord::score`] over the sliding window of
@@ -134,6 +218,13 @@ mod tests {
         fn new(score: f32) -> Self {
             Self { score, duration: 1 }
         }
+
+        /// Builds a record whose duration differs from 1, so that
+        /// `total_steps` can never coincide with `total_episodes` and a
+        /// transposed accessor is observable.
+        fn with_duration(score: f32, duration: usize) -> Self {
+            Self { score, duration }
+        }
     }
 
     impl PerformanceRecord for TestRecord {
@@ -175,17 +266,17 @@ mod tests {
         // pin `len` at 1 and fail here on the second push.
         for i in 0..N {
             stats.record(TestRecord::new(i as f32));
-            assert_eq!(stats.recent_history.len(), i + 1);
+            assert_eq!(stats.recent_history().len(), i + 1);
         }
 
-        let scores: Vec<f32> = stats.recent_history.iter().map(|r| r.score).collect();
+        let scores: Vec<f32> = stats.recent_history().iter().map(|r| r.score).collect();
         assert_eq!(scores, vec![0.0, 1.0, 2.0]);
 
         // The N+1th record evicts the oldest, leaving length pinned at N.
         stats.record(TestRecord::new(3.0));
-        assert_eq!(stats.recent_history.len(), N);
+        assert_eq!(stats.recent_history().len(), N);
 
-        let scores: Vec<f32> = stats.recent_history.iter().map(|r| r.score).collect();
+        let scores: Vec<f32> = stats.recent_history().iter().map(|r| r.score).collect();
         assert_eq!(scores, vec![1.0, 2.0, 3.0]);
     }
 
@@ -205,11 +296,176 @@ mod tests {
     #[test]
     fn window_of_one_keeps_only_the_latest_record() {
         let mut stats = AgentStats::<TestRecord>::new(1);
-        stats.record(TestRecord::new(1.0));
-        stats.record(TestRecord::new(2.0));
+        stats.record(TestRecord::with_duration(1.0, 7));
+        stats.record(TestRecord::with_duration(2.0, 11));
 
-        assert_eq!(stats.recent_history.len(), 1);
-        assert_eq!(stats.recent_history[0], TestRecord::new(2.0));
-        assert_eq!(stats.total_episodes, 2);
+        assert_eq!(stats.recent_history().len(), 1);
+        assert_eq!(
+            stats.recent_history()[0],
+            TestRecord::with_duration(2.0, 11)
+        );
+
+        // Distinct counters: 2 episodes but 18 steps, so a transposed
+        // `total_episodes`/`total_steps` pair cannot satisfy both assertions.
+        assert_eq!(stats.total_episodes(), 2);
+        assert_eq!(stats.total_steps(), 18);
+    }
+
+    /// A freshly constructed `AgentStats` reports empty statistics rather than
+    /// zero-valued ones: `avg_score`/`best_score` are `None`, not `Some(0.0)`.
+    #[test]
+    fn empty_stats_report_no_average_or_best() {
+        let stats = AgentStats::<TestRecord>::new(4);
+
+        assert_eq!(stats.avg_score(), None);
+        assert_eq!(stats.best_score(), None);
+        assert_eq!(stats.total_episodes(), 0);
+        assert_eq!(stats.total_steps(), 0);
+        assert_eq!(stats.recent_len(), 0);
+        // `window_size` is the configured capacity, not the occupancy, so it is
+        // non-zero on an empty instance.
+        assert_eq!(stats.window_size(), 4);
+    }
+
+    /// Drives the eviction boundary purely through the public accessors, with
+    /// every observable quantity distinct (window 3, 4 episodes, 4/5/6/7-step
+    /// durations, ascending-then-descending scores) so no pair of accessors can
+    /// be swapped without failing an assertion.
+    #[test]
+    fn window_evicts_at_exact_capacity_via_accessors() {
+        const WINDOW: usize = 3;
+        let mut stats = AgentStats::<TestRecord>::new(WINDOW);
+
+        stats.record(TestRecord::with_duration(2.0, 4));
+        stats.record(TestRecord::with_duration(9.0, 5));
+        stats.record(TestRecord::with_duration(4.0, 6));
+
+        // Exactly at capacity: nothing has been evicted yet.
+        assert_eq!(stats.recent_len(), WINDOW);
+        assert_eq!(stats.window_size(), WINDOW);
+        assert_eq!(stats.total_episodes(), 3);
+        assert_eq!(stats.total_steps(), 15);
+        let scores: Vec<f32> = stats.recent_history().iter().map(|r| r.score).collect();
+        assert_eq!(scores, vec![2.0, 9.0, 4.0]);
+
+        // One past capacity: the oldest entry (score 2.0) leaves the window,
+        // but the global counters keep growing and `best_score` (9.0, from the
+        // still-resident middle entry) is unchanged.
+        stats.record(TestRecord::with_duration(1.0, 7));
+
+        assert_eq!(stats.recent_len(), WINDOW);
+        assert_eq!(stats.total_episodes(), 4);
+        assert_eq!(stats.total_steps(), 22);
+        let scores: Vec<f32> = stats.recent_history().iter().map(|r| r.score).collect();
+        assert_eq!(scores, vec![9.0, 4.0, 1.0]);
+        assert_eq!(stats.recent_history().front().map(|r| r.score), Some(9.0));
+        assert_eq!(stats.recent_history().back().map(|r| r.score), Some(1.0));
+
+        // best (9.0) != avg (14/3 ~= 4.667): the two cannot be transposed.
+        assert_eq!(stats.best_score(), Some(9.0));
+        let avg = stats.avg_score().expect("window is non-empty");
+        assert!((avg - 14.0 / 3.0).abs() < 1e-6, "avg_score was {avg}");
+    }
+
+    /// Pins review row 1.2 ("NaN poisons `best_score` **permanently**") as
+    /// **refuted**: `record` folds with `f32::max`, which returns the non-NaN
+    /// operand when exactly one side is NaN, so a NaN score is simply skipped
+    /// and the next finite score still advances the best. Swapping the fold for
+    /// `f32::maximum` (NaN-propagating) would invert this, hence the exact-value
+    /// assertions rather than a mere `is_finite` check.
+    ///
+    /// The final assertion records what is deliberately *not* guarded: review
+    /// row 1.2b ("NaN transits `avg_score`") is open and rated Low, because the
+    /// NaN clears itself once the window rolls past it. `avg_score` admitting
+    /// the NaN is therefore the known, accepted contract — do not "fix" it here.
+    ///
+    /// This test only exercises the *argument* position of the fold (finite
+    /// accumulator, NaN argument). Its sibling
+    /// [`nan_as_first_record_does_not_latch_best_score`] covers the *receiver*
+    /// position (NaN accumulator, finite argument), which is the only position
+    /// where `b.max(score)` and a naive `if score > b` comparison diverge.
+    /// Neither test subsumes the other; keep both.
+    #[test]
+    fn nan_score_does_not_poison_best_score() {
+        // Window of 4 so all three records stay resident and `avg_score` is
+        // observed over the window that actually contains the NaN.
+        let mut stats = AgentStats::<TestRecord>::new(4);
+
+        stats.record(TestRecord::with_duration(5.0, 3));
+        assert_eq!(stats.best_score(), Some(5.0));
+
+        // The NaN episode must not become — or destroy — the best score.
+        stats.record(TestRecord::with_duration(f32::NAN, 4));
+        assert_eq!(stats.best_score(), Some(5.0));
+
+        // The self-healing half: a later, higher finite score still wins, which
+        // it could not if the NaN had latched into `best_score`.
+        stats.record(TestRecord::with_duration(9.0, 5));
+        assert_eq!(stats.best_score(), Some(9.0));
+
+        // Row 1.2b, open by design: the mean is *not* NaN-filtered, so the NaN
+        // transits it for as long as that episode sits in the window. `NaN !=
+        // NaN`, so this cannot be written as an `assert_eq!`.
+        assert!(
+            stats.avg_score().is_some_and(f32::is_nan),
+            "avg_score should still admit the NaN (row 1.2b is open), got {:?}",
+            stats.avg_score()
+        );
+
+        // The counters are untouched by the NaN: 3 episodes, 12 steps.
+        assert_eq!(stats.total_episodes(), 3);
+        assert_eq!(stats.total_steps(), 12);
+    }
+
+    /// The receiver-position half of [`nan_score_does_not_poison_best_score`]:
+    /// the NaN episode arrives **first**, so `best_score` is seeded through
+    /// `map_or`'s `score` branch — the accumulator itself becomes NaN, and the
+    /// fold is never given a chance to discard the NaN on the way in.
+    ///
+    /// This ordering is what makes the test non-redundant. `b.max(score)`
+    /// returns the non-NaN operand from *either* side, so `NaN.max(5.0) == 5.0`
+    /// and the accumulator heals on the very next finite episode. A naive
+    /// `if score > b { score } else { b }` looks equivalent but is not: every
+    /// comparison against NaN is `false`, so `5.0 > NaN` keeps the NaN and
+    /// `best_score` latches at NaN forever — review row 1.2's original claim,
+    /// re-instated. With a finite accumulator (the sibling test) the two forms
+    /// agree, which is precisely why that test cannot catch this.
+    #[test]
+    fn nan_as_first_record_does_not_latch_best_score() {
+        let mut stats = AgentStats::<TestRecord>::new(4);
+
+        // NaN first: `best_score` is now `Some(NaN)`, seeded directly rather
+        // than folded through `max`.
+        stats.record(TestRecord::with_duration(f32::NAN, 3));
+
+        // The healing assertion. `max` yields 5.0; the naive comparison leaves
+        // NaN, and `Some(NaN) != Some(5.0)`, so this is the line that kills it.
+        stats.record(TestRecord::with_duration(5.0, 4));
+        assert_eq!(stats.best_score(), Some(5.0));
+
+        // Once healed, the accumulator behaves normally and still advances.
+        stats.record(TestRecord::with_duration(9.0, 5));
+        assert_eq!(stats.best_score(), Some(9.0));
+
+        assert_eq!(stats.total_episodes(), 3);
+        assert_eq!(stats.total_steps(), 12);
+    }
+
+    /// Eviction must not lower `best_score`: the maximum is global, while
+    /// `avg_score` tracks only the window.
+    #[test]
+    fn best_score_survives_eviction_while_average_does_not() {
+        let mut stats = AgentStats::<TestRecord>::new(2);
+
+        stats.record(TestRecord::with_duration(10.0, 3));
+        stats.record(TestRecord::with_duration(1.0, 4));
+        stats.record(TestRecord::with_duration(3.0, 5));
+
+        // 10.0 has been evicted from the window but remains the best score.
+        assert_eq!(stats.recent_len(), 2);
+        assert_eq!(stats.best_score(), Some(10.0));
+        assert_eq!(stats.avg_score(), Some(2.0));
+        assert_eq!(stats.total_episodes(), 3);
+        assert_eq!(stats.total_steps(), 12);
     }
 }

--- a/crates/rlevo/tests/c51_integration.rs
+++ b/crates/rlevo/tests/c51_integration.rs
@@ -145,7 +145,7 @@ fn run_cartpole(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 
@@ -167,7 +167,7 @@ fn c51_cartpole_produces_finite_rewards() {
     let mut agent = fresh_agent(seed);
     train(&mut agent, &mut env, &mut rng, 2_500, 0).expect("training");
     assert!(agent.buffer_len() > 0, "buffer should have transitions");
-    let history = &agent.stats().recent_history;
+    let history = agent.stats().recent_history();
     assert_all_finite(
         "reward",
         &history.iter().map(|m| m.reward).collect::<Vec<_>>(),

--- a/crates/rlevo/tests/ddpg_integration.rs
+++ b/crates/rlevo/tests/ddpg_integration.rs
@@ -188,7 +188,7 @@ fn run_linear(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 

--- a/crates/rlevo/tests/dqn_integration.rs
+++ b/crates/rlevo/tests/dqn_integration.rs
@@ -141,7 +141,7 @@ fn run_cartpole(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 
@@ -185,7 +185,7 @@ fn dqn_cartpole_produces_finite_rewards() {
     assert!(agent.buffer_len() > 0, "buffer should have transitions");
     let rewards: Vec<f32> = agent
         .stats()
-        .recent_history
+        .recent_history()
         .iter()
         .map(|m| m.reward)
         .collect();
@@ -340,7 +340,7 @@ fn dqn_cartpole_hard_target_copies_inside_train() {
     assert!(agent.buffer_len() > 0, "buffer should have transitions");
     let rewards: Vec<f32> = agent
         .stats()
-        .recent_history
+        .recent_history()
         .iter()
         .map(|m| m.reward)
         .collect();

--- a/crates/rlevo/tests/integration_test.rs
+++ b/crates/rlevo/tests/integration_test.rs
@@ -413,13 +413,13 @@ fn agent_stats_tracks_episodes_and_sliding_window() {
         duration: 7,
     });
 
-    assert_eq!(stats.total_episodes, 3);
-    assert_eq!(stats.total_steps, 32);
-    assert_eq!(stats.best_score, Some(8.0));
+    assert_eq!(stats.total_episodes(), 3);
+    assert_eq!(stats.total_steps(), 32);
+    assert_eq!(stats.best_score(), Some(8.0));
 
     // window_size = 2 means the first record is evicted; average is over the
     // last two episodes: (8.0 + 3.0) / 2 = 5.5.
     let avg = stats.avg_score().expect("avg_score present after records");
     assert!((avg - 5.5).abs() < 1e-6, "expected 5.5, got {avg}");
-    assert_eq!(stats.recent_history.len(), 2);
+    assert_eq!(stats.recent_len(), 2);
 }

--- a/crates/rlevo/tests/ppg_integration.rs
+++ b/crates/rlevo/tests/ppg_integration.rs
@@ -145,7 +145,7 @@ fn run_cartpole(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 
@@ -277,7 +277,7 @@ fn ppg_cartpole_produces_finite_rewards() {
         &mut agent, &mut env, &mut rng, total, 0,
     )
     .expect("training");
-    let history = &agent.stats().recent_history;
+    let history = agent.stats().recent_history();
     assert_all_finite(
         "reward",
         &history.iter().map(|m| m.reward).collect::<Vec<_>>(),

--- a/crates/rlevo/tests/ppo_integration.rs
+++ b/crates/rlevo/tests/ppo_integration.rs
@@ -141,7 +141,7 @@ fn run_cartpole(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 
@@ -206,7 +206,7 @@ fn ppo_cartpole_produces_finite_rewards() {
         &mut agent, &mut env, &mut rng, total, 0,
     )
     .expect("training");
-    let history = &agent.stats().recent_history;
+    let history = agent.stats().recent_history();
     assert_all_finite(
         "reward",
         &history.iter().map(|m| m.reward).collect::<Vec<_>>(),
@@ -298,7 +298,7 @@ fn run_pendulum(seed: u64, total: usize) -> TrainOutcome {
     eprintln!("CALIBRATION: PPO Pendulum avg = {avg:.2}");
     TrainOutcome {
         avg_score: avg,
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 

--- a/crates/rlevo/tests/qrdqn_integration.rs
+++ b/crates/rlevo/tests/qrdqn_integration.rs
@@ -147,7 +147,7 @@ fn run_cartpole(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 
@@ -169,7 +169,7 @@ fn qrdqn_cartpole_produces_finite_rewards() {
     let mut agent = fresh_agent(seed);
     train(&mut agent, &mut env, &mut rng, 2_500, 0).expect("training");
     assert!(agent.buffer_len() > 0, "buffer should have transitions");
-    let history = &agent.stats().recent_history;
+    let history = agent.stats().recent_history();
     assert_all_finite(
         "reward",
         &history.iter().map(|m| m.reward).collect::<Vec<_>>(),

--- a/crates/rlevo/tests/sac_integration.rs
+++ b/crates/rlevo/tests/sac_integration.rs
@@ -258,7 +258,7 @@ fn run_linear(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 

--- a/crates/rlevo/tests/td3_integration.rs
+++ b/crates/rlevo/tests/td3_integration.rs
@@ -190,7 +190,7 @@ fn run_linear(seed: u64, total: usize) -> TrainOutcome {
     let stats = agent.stats();
     TrainOutcome {
         avg_score: stats.avg_score().unwrap_or(0.0),
-        rewards: stats.recent_history.iter().map(|m| m.reward).collect(),
+        rewards: stats.recent_history().iter().map(|m| m.reward).collect(),
     }
 }
 

--- a/docs/user-book/src/part-2-guided-tour/20-classic-control.md
+++ b/docs/user-book/src/part-2-guided-tour/20-classic-control.md
@@ -179,7 +179,7 @@ example calls it directly:
 
 The last argument is `log_every`: emit a progress line every *N* steps (`0`
 disables logging). At the end you read results off `agent.stats()` —
-`total_episodes`, `best_score`, and `avg_score()` over the recent window.
+`total_episodes()`, `best_score()`, and `avg_score()` over the recent window.
 
 This is *not* an ask/tell loop in the evolutionary sense — the agent acts
 sequentially and updates after every few steps, not after a full population


### PR DESCRIPTION
## Summary

`AgentStats<T>` maintained the invariant `recent_history.len() <= window_size` inside `record()` — popping the front before pushing once the window is full — while leaving four of its five fields `pub`. Any external caller could `push_back` past the window, or advance `total_episodes` without touching the history and desync the lifetime counters from it. This privatizes the four fields behind `#[must_use]` accessors, applying `docs/rules.md` §2 (Struct Field Encapsulation, ADR 0055). `window_size()` is newly readable; it had no accessor at all before.

## Change Type

- [x] Other — **breaking API change** (public fields become private), not a non-breaking bug fix

Deliberately *not* ticking "Bug fix (non-breaking, includes regression test)": this breaks downstream callers, and — see **Notes** — the defect is not regression-testable from inside this repository. Flagging it rather than picking the closest-fitting box.

On scope: the template lists refactors as out of scope during alpha. This is issue-driven (labeled `bug`), applies an existing accepted rule rather than proposing a new pattern, and changes no runtime behavior — but it is a public-API change, so it is called out here rather than filed under "bug fix" silently.

## Linked Issue

Closes #407

## What Was Changed

- **`crates/rlevo-reinforcement-learning/src/metrics.rs`** — dropped `pub` from `total_episodes`, `total_steps`, `best_score`, `recent_history`. Added `#[must_use]` accessors `total_episodes()`, `total_steps()`, `best_score()`, `recent_history() -> &VecDeque<T>`, plus new `recent_len()` and `window_size()`. Renamed the `record()` parameter `record` → `entry` (it shadowed the method name). Added a runnable doc example.
- **`crates/rlevo-reinforcement-learning/src/algorithms/ppo/train.rs:295`** — `&agent.stats().recent_history` → `agent.stats().recent_history()`. The `&` is dropped; the accessor already returns a reference.
- **`crates/rlevo-examples/examples/book/ch03_dqn_cartpole.rs`** — 5 sites. All below the `ANCHOR_END: train` marker, so no rendered user-book code block changes.
- **`crates/rlevo/tests/`** — 19 sites across `integration_test.rs` and the eight per-algorithm suites (dqn, ppo, ppg, c51, qrdqn, td3, sac, ddpg).
- **`CHANGELOG.md`** — `### Breaking changes` entry with the migration, plus a `**Changed**` note for the doc example and new tests.
- **`docs/user-book/src/part-2-guided-tour/20-classic-control.md:182`** — prose only; `total_episodes` → `total_episodes()`, `best_score` → `best_score()`.

### Migration for downstream callers

| Before | After |
|---|---|
| `stats.total_episodes` | `stats.total_episodes()` |
| `stats.total_steps` | `stats.total_steps()` |
| `stats.best_score` | `stats.best_score()` |
| `stats.recent_history.len()` | `stats.recent_len()` |
| `let h = &agent.stats().recent_history;` | `let h = agent.stats().recent_history();` |

The last row is the one worth reading twice: the `&` is **dropped**, and the compiler reports it as a type error rather than a missing field.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
cargo fmt --all --check
cargo test --doc -p rlevo-reinforcement-learning
mdbook build docs/user-book
```

All pass. 64 test suites green; `metrics` module is 10 tests, 0 failures.

**New tests in `metrics.rs`:**

- `empty_stats_report_no_average_or_best`
- `window_evicts_at_exact_capacity_via_accessors`
- `best_score_survives_eviction_while_average_does_not`
- `nan_score_does_not_poison_best_score`
- `nan_as_first_record_does_not_latch_best_score`

Every pre-existing test was rewritten onto the accessors. They live in the same module, so they would otherwise have kept compiling against the private fields and silently stopped guarding the public API.

**Mutation-checked, not merely green.** Each accessor is a trivial one-liner, so "the test passes" proves little. Mutations were applied in a throwaway worktree and confirmed to fail:

| Mutation | Caught by |
|---|---|
| `total_episodes()` ↔ `total_steps()` transposed | 3 tests |
| `best_score()` → returns `self.avg_score()` | 2 tests |
| `recent_len()` ↔ `window_size()` transposed | `empty_stats_report_no_average_or_best` only — once the window saturates the two are equal by construction, which is why the empty case earns its own test |
| `b.max(score)` → `f32::maximum` semantics (NaN-propagating) | both NaN tests |
| `b.max(score)` → naive `if score > b { score } else { b }` | `nan_as_first_record_does_not_latch_best_score` **only** |

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: CPU (NdArray) — no backend-specific code paths touched
- OS: macOS 26.5.2 (Apple Silicon)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the entire change** — implementation, tests, changelog, and user-book prose, orchestrated across delegated agents with the claims below verified by execution rather than by reading.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] ~~Bug fixes include a regression test that fails on the previous code and passes on this PR.~~ **Not possible here — see Notes.**
- [x] This PR addresses a single concern.
- [x] Ready for Review.

## Notes

**Why there is no regression test for the headline defect.** The four fields were only ever *read* in this repository — all 25 sites, across 11 files — and the accessors still permit every one of those reads. Nothing anywhere ever wrote to them. A test can observe a missing guard only by tripping it, so the defect was unreachable from inside this repo and reachable only by a downstream user of the published crate. A `trybuild` compile-fail test would be the only way to pin it; that would be the crate's first, so it is not introduced here. The five behavioral tests above pin the invariant `record()` maintains, which is the part that *is* testable.

**Two claims in #407's body are refuted by this PR**, [corrected on the issue](https://github.com/anthonytorlucci/rlevo/issues/407#issuecomment-5231800767) rather than by rewriting the body:

1. "The only direct field access is `integration_test.rs:416-418`" — actually 25 sites across 11 files. It also missed `:424` in the file it cited.
2. "All 8 production agents never touch fields directly" — `algorithms/ppo/train.rs:295` did. Private fields are scoped to the defining *module*, not the crate, so that in-crate site broke exactly like an external caller.

**The two NaN tests are not duplicate coverage.** Review row 1.2 ("NaN poisons `best_score` permanently") is on record as *refuted*, but that refutation rested on reasoning about `f32::max` alone. `b.max(score)` and a naive `if score > b` agree whenever the accumulator is finite; they diverge only when the NaN episode arrives **first**, where `map_or` seeds `best_score` to NaN directly — `max` heals on the next record, while `5.0 > NaN` is false and the value latches at NaN forever, re-instating row 1.2 verbatim. Only the NaN-first test catches that. Both tests carry cross-referencing doc comments so neither is later deleted as redundant.

`nan_score_does_not_poison_best_score` also asserts `avg_score().is_some_and(f32::is_nan)` — deliberately pinning the *un-filtered* mean as the currently accepted contract (review row 1.2b, still open and rated Low). Whoever closes 1.2b must update that assertion; it will fail by design.

**Follow-ups, not in this PR:**

- Review row 7.1 remains **partial** — zero-duration episodes and negative scores are still untested. Both look benign.
- #408 (`saturating_add` on these counters) is narrowed by this PR: the two `+=` sites are now reachable only through `record()`, and the direct-write vector (`stats.total_steps = usize::MAX - 1`, which used to compile) is closed. [Commented there.](https://github.com/anthonytorlucci/rlevo/issues/408#issuecomment-5231830016)
- #410's row 4.3 is consumed by this PR; rows 1.3 and 4.2 remain. [Commented there](https://github.com/anthonytorlucci/rlevo/issues/410#issuecomment-5231831521), flagging that this PR's new `best_score()` doc could mislead a reviewer into closing row 1.3 — it documents the *aggregation*, not the `PerformanceRecord::score` contract.
- Sibling sweep found nothing: `History`, `UniformReplay`, `PrioritizedReplay`, and `SumTree` already had private fields with accessors. `AgentStats` was the outlier, not the first of a pattern.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
