### PR TITLE
fix(rl): Saturate AgentStats lifetime counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   two `(B, 1)` tensors the compiler cannot tell apart: without it, transposing
   them was a silent change.
 
+- **`AgentStats`'s two lifetime counters wrapped in release instead of
+  saturating** (resolves #408). `record()` accumulated `total_episodes` and
+  `total_steps` with plain `+=`, and the workspace root declares no `[profile]`
+  section — so release inherits `overflow-checks = false` and both counters wrap
+  to `0` at `usize::MAX`, while debug panics. Neither profile is acceptable at
+  this site: nothing branches on these counters — they are read for progress
+  reporting — so a wrap does not fail, it *reports*, handing whoever is watching
+  a monotone quantity that just went backwards with no signal at all. Both are
+  now `saturating_add`, and the accessor docs state the resulting contract — a
+  counter pinned at `usize::MAX` means "at least this many", not "exactly this
+  many".
+
+  This is hardening rather than a live risk, and #407 is the reason. Before it
+  landed, the four fields were `pub`: any caller could write
+  `stats.total_steps = usize::MAX - 1` and make the very next `record()`
+  overflow, no long run required. Privatizing them closed that vector, leaving
+  only honest accumulation — roughly `1.8e19` steps on a 64-bit host. The issue
+  body concedes as much.
+
+  No existing test drove a counter anywhere near the boundary, and a test that
+  merely asserted "it didn't panic" would have been vacuous: the dev profile the
+  suite runs in has `overflow-checks = on`, so it panics on the *unfixed* code
+  for a reason unrelated to the fix, and the release-only wrap is invisible to
+  `cargo test` entirely. The two new regression tests therefore assert the
+  *saturated value* at each counter, which is red in both profiles against `+=`.
+
 **Added**
 
 - **`utils::compute_target_quantiles`**, the rank-2 sibling of

--- a/crates/rlevo-reinforcement-learning/src/metrics.rs
+++ b/crates/rlevo-reinforcement-learning/src/metrics.rs
@@ -107,9 +107,18 @@ impl<T: PerformanceRecord> AgentStats<T> {
     }
 
     /// Records a completed episode, updating all counters and the sliding window.
+    ///
+    /// Both lifetime counters ([`Self::total_episodes`], [`Self::total_steps`])
+    /// saturate at `usize::MAX`: a further `record` leaves them pinned there
+    /// rather than wrapping to a small value in release builds or aborting the
+    /// run with an "attempt to add with overflow" panic under `overflow-checks`.
+    /// A long-lived agent is precisely the caller that reaches the ceiling, and
+    /// for it a monotone, clamped counter is a better failure mode than either
+    /// a silently rewound total or a crash on the hot path — nothing in this
+    /// crate branches on the counters, they are reported statistics.
     pub fn record(&mut self, entry: T) {
-        self.total_episodes += 1;
-        self.total_steps += entry.duration();
+        self.total_episodes = self.total_episodes.saturating_add(1);
+        self.total_steps = self.total_steps.saturating_add(entry.duration());
 
         let score = entry.score();
         self.best_score = Some(self.best_score.map_or(score, |b| b.max(score)));
@@ -125,6 +134,9 @@ impl<T: PerformanceRecord> AgentStats<T> {
     ///
     /// This is a global counter over all of history; it is unaffected by the
     /// sliding window and so may exceed [`Self::window_size`].
+    ///
+    /// The counter saturates in [`Self::record`], so a returned `usize::MAX`
+    /// means "at least this many episodes", not an exact count.
     #[must_use]
     pub fn total_episodes(&self) -> usize {
         self.total_episodes
@@ -134,7 +146,8 @@ impl<T: PerformanceRecord> AgentStats<T> {
     /// episode.
     ///
     /// Like [`Self::total_episodes`], this accumulates over all of history
-    /// rather than the sliding window.
+    /// rather than the sliding window, and saturates: a returned `usize::MAX`
+    /// means "at least this many steps", not an exact total.
     #[must_use]
     pub fn total_steps(&self) -> usize {
         self.total_steps
@@ -449,6 +462,49 @@ mod tests {
 
         assert_eq!(stats.total_episodes(), 3);
         assert_eq!(stats.total_steps(), 12);
+    }
+
+    /// The lifetime step counter clamps at `usize::MAX` instead of wrapping
+    /// (release) or panicking on the `overflow-checks` build (test/debug).
+    ///
+    /// The pre-saturation state is installed by assigning the private field
+    /// directly — this module is a child of `metrics`, so no test-only
+    /// constructor or setter is needed, and none should be added. Reaching
+    /// `usize::MAX` through `record` alone is not feasible.
+    ///
+    /// The assertion is on the *value* (`usize::MAX`), never on "it did not
+    /// panic": a panic-shaped test would pass against the unfixed `+=` under
+    /// `cargo test --release`, where the addition silently wraps instead.
+    #[test]
+    fn total_steps_saturates_instead_of_wrapping() {
+        let mut stats = AgentStats::<TestRecord>::new(4);
+        stats.total_steps = usize::MAX - 3;
+
+        // A 10-step episode overshoots the remaining headroom of 3.
+        stats.record(TestRecord::with_duration(1.0, 10));
+
+        assert_eq!(stats.total_steps(), usize::MAX);
+        // Distinct counters: the episode counter is nowhere near saturation, so
+        // a transposed accessor pair cannot satisfy both assertions.
+        assert_eq!(stats.total_episodes(), 1);
+    }
+
+    /// The episode-counter half of
+    /// [`total_steps_saturates_instead_of_wrapping`], and not subsumed by it:
+    /// `total_episodes` accumulates a literal `1` while `total_steps`
+    /// accumulates `entry.duration()`, so the two are separate call sites that
+    /// can be fixed — or regress — independently.
+    #[test]
+    fn total_episodes_saturates_instead_of_wrapping() {
+        let mut stats = AgentStats::<TestRecord>::new(4);
+        stats.total_episodes = usize::MAX;
+
+        stats.record(TestRecord::with_duration(1.0, 7));
+
+        assert_eq!(stats.total_episodes(), usize::MAX);
+        // The step counter starts at 0 and is unaffected: 7 != usize::MAX, so
+        // the two assertions cannot be satisfied by a single saturated value.
+        assert_eq!(stats.total_steps(), 7);
     }
 
     /// Eviction must not lower `best_score`: the maximum is global, while


### PR DESCRIPTION
## Summary

`AgentStats::record` accumulated its two lifetime counters — `total_episodes` and `total_steps` — with plain `+=`. The workspace root declares no `[profile]` section, so release inherits `overflow-checks = false`: both counters wrap to `0` at `usize::MAX`, while debug panics. Nothing in the workspace branches on these counters (they are read for progress reporting), so a wrap does not fail loudly — it *reports*, handing whoever is watching a monotone quantity that just went backwards with no signal at all. Both sites now use `saturating_add`, and the accessor docs state the resulting contract: a counter pinned at `usize::MAX` means "at least this many", not an exact count.

This is hardening rather than a live risk, and #407 is the reason. Before it landed the four fields were `pub`, so any caller could write `stats.total_steps = usize::MAX - 1` and overflow on the very next `record()` — no long run required. Privatizing them closed that vector, leaving only honest accumulation: roughly `1.8e19` steps on a 64-bit host.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #408

## What Was Changed

- `crates/rlevo-reinforcement-learning/src/metrics.rs` — `AgentStats::record`: `self.total_episodes += 1` → `self.total_episodes.saturating_add(1)`, and `self.total_steps += entry.duration()` → `self.total_steps.saturating_add(entry.duration())`. `record` keeps returning `()`; no signature or API surface changed.
- `crates/rlevo-reinforcement-learning/src/metrics.rs` — doc comments on `record`, `total_episodes()` and `total_steps()` documenting the `usize::MAX` ceiling and what a pinned value means to a reader.
- `crates/rlevo-reinforcement-learning/src/metrics.rs` — two regression tests added to the existing in-source `#[cfg(test)] mod tests`: `total_steps_saturates_instead_of_wrapping` and `total_episodes_saturates_instead_of_wrapping`. They assign the private fields directly (the test module is a child of `metrics`), so **no test-only constructor, setter, or `#[cfg(test)]` API surface was added**.
- `CHANGELOG.md` — one entry under `## [Unreleased]` → `### rlevo-reinforcement-learning` → `**Fixed**`. Not a breaking change; no public API moved.

### Deliberately not changed

The sibling `self.pushes += 1` counters in `replay/uniform.rs:143` and `replay/prioritized.rs:452` are the same *syntax* but a different bug. `pushes` is load-bearing for `TransitionId` arithmetic (`pushes - len + i`, ADR 0050 §6), where `saturating_add` would silently corrupt id resolution rather than harden it. They stay as `+=`.

## How It Was Tested

**The load-bearing detail:** the dev/test profile runs with `overflow-checks = on`, so the *unfixed* `+=` already panics under plain `cargo test` — for a reason unrelated to the fix. Any `#[should_panic]`-style or "it did not panic" test is therefore **vacuous here**: it goes green against a wrapping mutant. Both new tests assert the *saturated value* instead, which is red in both profiles against `+=`.

Mutation-checked under `cargo test --release`, one line reverted at a time:

| mutant | test killed | failure |
|---|---|---|
| `total_steps` → `+=` | `total_steps_saturates_instead_of_wrapping` | `left: 6` (the wrapped total) vs `right: 18446744073709551615` |
| `total_episodes` → `+=` | `total_episodes_saturates_instead_of_wrapping` | `left: 0` (the wrapped total) vs `right: 18446744073709551615` |

Each mutant kills exactly **one** test (17 passed / 1 failed in both cases), so the two are not cross-covering and neither would survive an independent regression of the other counter. Both failures are value assertions, not panics. Transposing the `total_episodes()` / `total_steps()` accessor bodies turns 7 tests red.

```
cargo build --workspace                        # Finished, no errors
cargo test --workspace                         # all suites ok, 0 failed
cargo clippy --all-targets --all-features      # Finished, no warnings
cargo fmt --all --check                        # clean
cargo test --release -p rlevo-reinforcement-learning metrics
                                               # 18 passed; 0 failed
```

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: CPU (NdArray) — the change is integer arithmetic on `usize` counters and touches no tensor path
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change** — the `saturating_add` swap, the doc comments, the two regression tests, and the CHANGELOG entry, all under review and direction by the author. The mutation checks in the table above were run and independently re-verified before merge.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**The issue's severity was drifted, and this PR corrects the record.** The source review rated row 5.1 `🟠 Med`, which was accurate against the *pre-#407* struct where the direct-write vector existed. With that vector closed, the honest rating is `🟢 Low / hardening` — worth landing because it is free, not because anything was at risk. The issue's cited line numbers (`metrics.rs:67-68`) were also stale; the sites had moved to `111-112` when #407 landed.

Follow-up still open, tracked separately under review row 7.1: `AgentStats` has no test for a zero-duration episode or for negative scores. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
