### PR TITLE
test(rl): Cover History eviction, is_full, and terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   eviction at *exactly* `window_size`, the off-by-one the previous tests
   straddled without pinning.
 
+- **`experience.rs` now says it is not the replay integration path** (for #392).
+  A reader landing on `ExperienceTuple` had no signal that it, `History`,
+  `HistoryRepresentation` and `SufficientStatistic` are zero-consumer ADR 0003
+  roadmap markers rather than the type family an agent writes transitions
+  into — `crate::replay::Transition` is the live stored-transition model, and
+  nothing in the module said so. That mistake is exactly the complaint #188
+  raised, and ADR 0050 §9 answered it by promising the pointer in these module
+  docs while deliberately leaving the code untouched — the doc pointer *was*
+  the deliverable, and it never landed, so the module has read as the
+  integration path ever since. The module docs now carry the signpost and
+  name #95 as the issue that decides whether the four items survive at all.
+
+  Two `History` contracts that were previously legible only from the source are
+  now written down. Indexing panics at `idx >= len()` and `get()` is the
+  fallible alternative — documented on the `index` method and listed in
+  `docs/rules.md` §4 alongside `History::new`, which §4 requires of every panic
+  site. And `trace()` is an O(n) deep clone of every stored transition, not a
+  view; read-only callers should reach for `iter()`. The suggested
+  `as_trace()`/`&VecDeque` reshaping was declined: `iter()` already serves the
+  borrowed case, and returning a reference would pin `VecDeque` into the public
+  API in exchange for renaming a method with no callers.
+
 **Removed**
 
 - **Two `ReplayBufferError` variants that advertised failure modes the replay

--- a/crates/rlevo-reinforcement-learning/src/experience.rs
+++ b/crates/rlevo-reinforcement-learning/src/experience.rs
@@ -6,6 +6,23 @@
 //! - [`History`] — a fixed-capacity FIFO buffer of transitions
 //! - [`HistoryRepresentation`] — trait for constructing state summaries from history
 //! - [`SufficientStatistic`] — history summary that satisfies the Markov property
+//!
+//! # Not the replay integration path
+//!
+//! [`crate::replay::Transition`] is the **live** stored-transition model: it is
+//! what every off-policy agent writes into a [`ReplayStrategy`], and it is the
+//! type to reach for when wiring a new agent to replay. The four items in this
+//! module have **zero consumers** in the workspace today. They are ADR 0003
+//! roadmap markers, kept under that ADR's conservative dead-code policy for the
+//! POMDP/history-conditioned work they were sketched for, and their survival is
+//! pending #95 — until that issue is settled, do not build against them.
+//!
+//! ADR 0050 §9 records this pointer as its own deliverable: `experience.rs` was
+//! deliberately left untouched by the replay-strategy seam, so the module docs
+//! carry the signpost instead of the code, and a reader cannot mistake
+//! [`ExperienceTuple`] for the integration path.
+//!
+//! [`ReplayStrategy`]: crate::replay::ReplayStrategy
 
 use crate::MAX_BUFFER_CAPACITY;
 use rlevo_core::base::{Action, Observation, Reward};
@@ -88,6 +105,17 @@ impl<const D: usize, const AD: usize, O: Observation<D>, A: Action<AD>, R: Rewar
 {
     type Output = ExperienceTuple<D, AD, O, A, R>;
 
+    /// Returns the transition stored at `idx`, counted from the oldest
+    /// retained entry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx >= self.len()`. Indexing is the infallible spelling and
+    /// treats an out-of-range index as a programming error; use
+    /// [`History::get`] for the fallible alternative, which returns `None`
+    /// instead. Note that `len()` shrinks only via [`History::clear`] —
+    /// eviction keeps `len()` pinned at `capacity()` — so a stale index taken
+    /// before a push remains in range but no longer names the same transition.
     fn index(&self, idx: usize) -> &Self::Output {
         &self.trace[idx]
     }
@@ -163,6 +191,16 @@ impl<const D: usize, const AD: usize, O: Observation<D>, A: Action<AD>, R: Rewar
     }
 
     /// Returns a clone of the full transition sequence in insertion order.
+    ///
+    /// This is an **O(n) deep clone**: every stored [`ExperienceTuple`] is
+    /// cloned, which clones two observations, an action, and a reward apiece.
+    /// Callers that only need to *read* the stored transitions should use
+    /// [`Self::iter`] (or [`Self::get`] / indexing for a single slot) and pay
+    /// nothing.
+    ///
+    /// The name intentionally mirrors the private `trace` field it copies,
+    /// rather than following the borrowing-accessor convention — the returned
+    /// value is an owned snapshot, not a view.
     #[must_use]
     pub fn trace(&self) -> VecDeque<ExperienceTuple<D, AD, O, A, R>> {
         self.trace.clone()
@@ -437,16 +475,199 @@ mod tests {
         assert_eq!(total_reward, TestReward(30.0));
     }
 
-    /// Test history operations with reward accumulation
+    /// Asserts that the reward at `history[idx]` is `expected`.
+    ///
+    /// Per-slot, never aggregate: a sum or a length cannot distinguish a
+    /// transposition or a dropped entry from a correct buffer.
+    fn assert_reward_at(
+        history: &History<1, 1, TestObs, TestAct, TestReward>,
+        idx: usize,
+        expected: f32,
+    ) {
+        let got = history[idx].reward.0;
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "slot {idx} should hold reward {expected}, got {got}"
+        );
+    }
+
+    /// Every stored slot holds the reward it was pushed with, at its own
+    /// index, in insertion order.
+    ///
+    /// The reward values are distinct primes so that swapping any two slots or
+    /// dropping any one breaks a per-slot assertion — a length check or a sum
+    /// would see neither.
     #[test]
     fn test_history_reward_accumulation() {
         let mut history = History::<1, 1, TestObs, TestAct, TestReward>::new(5);
 
-        let rewards = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let rewards = [11.0_f32, 23.0, 37.0, 41.0, 59.0];
         for &reward_val in &rewards {
             history.add(TestObs, TestAct, TestReward(reward_val), TestObs, false);
         }
 
-        assert_eq!(history.len(), 5);
+        assert_eq!(
+            history.len(),
+            rewards.len(),
+            "a below-capacity fill must retain every pushed transition"
+        );
+        for (idx, &expected) in rewards.iter().enumerate() {
+            assert_reward_at(&history, idx, expected);
+        }
+    }
+
+    /// `terminated` round-trips through `add` unchanged, per slot.
+    ///
+    /// This flag is the Bellman bootstrap mask (see
+    /// [`ExperienceTuple::terminated`] and Pardo et al., ICML 2018): a
+    /// `History` that dropped, hardcoded, or inverted it would still store
+    /// every reward in the right order and pass every other test in this
+    /// module, while biasing every Q-value downward in any agent built on it.
+    ///
+    /// The pattern `[false, true, true, false, false]` is chosen so that it is
+    /// **not** all-true (killing a `terminated: false` hardcode), **not**
+    /// all-false (killing a `true` hardcode), and **asymmetric under reversal**
+    /// (killing an order-reversing push mutant — the reverse is
+    /// `[false, false, true, true, false]`). Pairing each flag with a distinct
+    /// prime reward means a transposition of two slots breaks both assertions
+    /// when the flags differ, and the reward assertion when they agree.
+    #[test]
+    fn terminated_round_trips_per_slot() {
+        let mut history = History::<1, 1, TestObs, TestAct, TestReward>::new(5);
+
+        let pushed = [
+            (13.0_f32, false),
+            (29.0, true),
+            (43.0, true),
+            (61.0, false),
+            (71.0, false),
+        ];
+        for &(reward_val, terminated) in &pushed {
+            history.add(
+                TestObs,
+                TestAct,
+                TestReward(reward_val),
+                TestObs,
+                terminated,
+            );
+        }
+
+        assert_eq!(
+            history.len(),
+            pushed.len(),
+            "a below-capacity fill must retain every pushed transition"
+        );
+        for (idx, &(reward_val, terminated)) in pushed.iter().enumerate() {
+            assert_reward_at(&history, idx, reward_val);
+            assert_eq!(
+                history[idx].terminated, terminated,
+                "slot {idx} (reward {reward_val}) should carry terminated={terminated}"
+            );
+        }
+    }
+
+    /// At capacity, `add` evicts the **oldest** entry, and the survivors keep
+    /// their relative order.
+    ///
+    /// Pushing five distinct rewards into a capacity-3 buffer must leave the
+    /// last three, in order. Asserting slot by slot is what makes this test
+    /// sensitive to the two ways eviction goes wrong: evicting from the wrong
+    /// end (`pop_back`), and evicting one push too late (`>` instead of `>=`).
+    #[test]
+    fn add_evicts_oldest_first_at_capacity() {
+        let mut history = History::<1, 1, TestObs, TestAct, TestReward>::new(3);
+
+        for &reward_val in &[11.0_f32, 23.0, 37.0, 41.0, 59.0] {
+            history.add(TestObs, TestAct, TestReward(reward_val), TestObs, false);
+        }
+
+        assert_eq!(
+            history.len(),
+            3,
+            "len() must never exceed the configured capacity of 3"
+        );
+        assert_reward_at(&history, 0, 37.0);
+        assert_reward_at(&history, 1, 41.0);
+        assert_reward_at(&history, 2, 59.0);
+    }
+
+    /// `is_full()` is `false` below capacity, flips to `true` on reaching it,
+    /// and stays `true` across an evicting push.
+    #[test]
+    fn is_full_transitions_false_to_true() {
+        let mut history = History::<1, 1, TestObs, TestAct, TestReward>::new(3);
+
+        history.add(TestObs, TestAct, TestReward(11.0), TestObs, false);
+        history.add(TestObs, TestAct, TestReward(23.0), TestObs, false);
+        assert!(!history.is_full(), "2 of 3 slots used must not report full");
+
+        history.add(TestObs, TestAct, TestReward(37.0), TestObs, false);
+        assert!(history.is_full(), "3 of 3 slots used must report full");
+
+        history.add(TestObs, TestAct, TestReward(41.0), TestObs, false);
+        assert!(
+            history.is_full(),
+            "an evicting push must leave the buffer full, not over- or under-filled"
+        );
+        assert_eq!(
+            history.len(),
+            3,
+            "an evicting push must hold len() at capacity"
+        );
+        assert_reward_at(&history, 2, 41.0);
+    }
+
+    /// `get()` resolves the last valid index and returns `None` past the end.
+    #[test]
+    fn get_returns_none_out_of_bounds() {
+        let mut history = History::<1, 1, TestObs, TestAct, TestReward>::new(5);
+        history.add(TestObs, TestAct, TestReward(11.0), TestObs, false);
+        history.add(TestObs, TestAct, TestReward(23.0), TestObs, false);
+        history.add(TestObs, TestAct, TestReward(37.0), TestObs, false);
+
+        let last = history
+            .get(history.len() - 1)
+            .expect("the last valid index must resolve");
+        assert!(
+            (last.reward.0 - 37.0).abs() < 1e-6,
+            "get(len() - 1) must return the most recently pushed transition"
+        );
+
+        assert!(
+            history.get(history.len()).is_none(),
+            "get(len()) is one past the end and must return None"
+        );
+        assert!(
+            history.get(history.len() + 1).is_none(),
+            "get(len() + 1) is out of bounds and must return None"
+        );
+    }
+
+    /// Pins the documented `# Panics` contract on the [`Index`] impl: indexing
+    /// past the end is a programming error, and [`History::get`] is the
+    /// fallible alternative.
+    ///
+    /// Deliberately a bare `should_panic` with no `expected` string. The two
+    /// `should_panic` tests above pin messages from `assert!` calls this crate
+    /// authors in [`History::new`], which are stable by our own contract; the
+    /// panic here comes from [`VecDeque`]'s indexing, whose wording is a std
+    /// implementation detail that has been reworded before. There is nothing
+    /// to disambiguate — the only operation in this body that can panic is the
+    /// index — so pinning std's phrasing would only buy failures unrelated to
+    /// `History`'s correctness.
+    #[test]
+    // `clippy::should_panic_without_expect` asks for an `expected` string to
+    // prove the test panicked for the intended reason. That guarantee is
+    // already structural here — the body has exactly one fallible operation —
+    // and the only string available to pin belongs to `VecDeque`, not to this
+    // crate, so satisfying the lint would trade a real property for a
+    // dependency on std's phrasing. See the doc comment above.
+    #[allow(clippy::should_panic_without_expect)]
+    #[should_panic]
+    fn index_panics_out_of_bounds() {
+        let mut history = History::<1, 1, TestObs, TestAct, TestReward>::new(5);
+        history.add(TestObs, TestAct, TestReward(11.0), TestObs, false);
+
+        let _ = &history[history.len()];
     }
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -282,6 +282,8 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
 | `MultiDiscreteAction::from_indices(arr)` | any `arr[i] >= space[i]` |
 | Builder `with_capacity(n)` | `n == 0` |
 | Builder `with_alpha(x)` | `x ∉ [0.0, 1.0]` |
+| `History::index(i)` | `i >= len()` |
+| `History::new(n)` | `n == 0` or `n > MAX_BUFFER_CAPACITY` |
 | `SimulatedAnnealingParams::with_max_iters` | `max_iters == 0` |
 | `SimulatedAnnealingParams::with_initial_temp` | value not finite or not `> 0` |
 | `SimulatedAnnealingParams::with_cooling` | `Geometric` `factor ∉ (0, 1)`; `Linear` `delta` not finite or not `> 0` |


### PR DESCRIPTION
## Summary

The test suite that defined `History`'s contract asserted almost nothing about it. No test covered FIFO eviction order, the `is_full()` false→true transition, out-of-bounds `get()`, or the `Index` panic, and `test_history_reward_accumulation` never accumulated anything despite its name — it asserted `len() == 5` and would have passed against a buffer storing entirely wrong rewards. Nothing read `terminated` back after `add()` either, so a `History` that dropped or inverted the Bellman bootstrap mask passed every test in the file. This adds five tests that assert per slot, and lands three documentation contracts that were legible only from the source — including the module-doc pointer ADR 0050 §9 committed to and never wrote.

## Change Type

- [x] Bug fix (non-breaking, includes regression test) — the defect is in the test suite; the five new tests *are* the regression tests
- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #392

Refs #188 (the missing module pointer is its unresolved complaint), #95 (owns the deferred `update_with` signature), ADR 0050 §9.

## What Was Changed

- `crates/rlevo-reinforcement-learning/src/experience.rs`
  - Module docs gain a `# Not the replay integration path` section naming `crate::replay::Transition` as the live stored-transition model, and the four items in this module as zero-consumer ADR 0003 roadmap markers pending #95. ADR 0050 §9 records this pointer as its own deliverable — it was never written, so since `memory.rs` was deleted the module has read as the integration path. That is precisely the complaint #188 raised before closing.
  - `# Panics` on the `index` method: panics at `idx >= len()`, with `History::get` named as the fallible alternative.
  - `trace()` documented as an O(n) deep clone of every stored transition, directing read-only callers to `iter()`. The suggested `as_trace()` / `&VecDeque` reshaping was **declined** — `iter()` already serves the borrowed case, and returning a reference would pin `VecDeque` into the public API to rename a method with zero callers workspace-wide.
  - Five tests: `add_evicts_oldest_first_at_capacity`, `is_full_transitions_false_to_true`, `get_returns_none_out_of_bounds`, `index_panics_out_of_bounds`, `terminated_round_trips_per_slot`. `test_history_reward_accumulation` rewritten to assert every slot's reward at its index. 8 tests → 13.
- `docs/rules.md` — two rows added to §4 Documented Panic Contracts: `History::index(i)` and `History::new(n)`.
- `CHANGELOG.md` — one entry under `[Unreleased]` → `rlevo-reinforcement-learning` → `**Changed**`.

**Deliberately not changed:** `HistoryRepresentation::update_with` (issue item 2, review row 3.1). With zero implementors workspace-wide there is no consumer to validate a replacement signature against; deferred to #95 with the POMDP belief-update literature it should be checked against, and the review row re-pointed there. It is not marked resolved.

## How It Was Tested

Every test asserts **per slot**, using distinct primes so that transposing two slots or dropping one breaks an assertion — a sum or a length sees neither. That property was verified by mutation rather than assumed: each mutant below was applied, observed to fail the named test, then reverted and the file confirmed byte-identical.

| Mutant in `History::add` | Test that fails |
|---|---|
| `pop_front()` → `pop_back()` (evict wrong end) | `add_evicts_oldest_first_at_capacity` |
| `len() >= capacity` → `>` (evict one push late) | `add_evicts_oldest_first_at_capacity`, `is_full_transitions_false_to_true` |
| `terminated` → `!terminated` | `terminated_round_trips_per_slot` |
| `terminated` → `false` | `terminated_round_trips_per_slot` |

A separate review pass traced four further mutants (`get` off-by-one, `push_front`, zeroed reward, `is_full` as `len() > capacity`) and confirmed each dies. `is_full` as `len() == capacity` is an equivalent mutant given `add`'s invariant, not a coverage gap.

```
cargo build --workspace          # Finished, no errors
cargo test --workspace           # all suites ok, 0 failed
cargo clippy --all-targets --all-features   # Finished, no warnings
cargo fmt --all --check          # clean
cargo doc -p rlevo-reinforcement-learning --no-deps   # intra-doc links resolve
```

`cargo test -p rlevo-reinforcement-learning experience::` → 13 passed, 0 failed.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: none exercised — this module is backend-independent (no tensor ops)
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **claim verification against the tree, the five tests and their mutation checks, the three doc contracts, the CHANGELOG entry, and this PR description. Every claim was re-run locally; the mutation results above are observed output, not predicted.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**One deliberate lint suppression, and it is the riskiest line in the diff.** `index_panics_out_of_bounds` originally pinned `#[should_panic(expected = "Out of bounds access")]` — `VecDeque`'s internal std message, not text this crate authors, and std has reworded collection-indexing panics before. Compare the module's two other `should_panic` tests, which pin `assert!` messages from `History::new` and are stable by our own contract. Dropping to a bare `#[should_panic]` trips `clippy::should_panic_without_expect` under `-D warnings`, so the test carries an item-level `#[allow]` with a justifying comment per rules §9. The guarantee the lint asks for is structural here: the test body contains exactly one fallible operation, so there is nothing to disambiguate.

**Follow-ups filed, not fixed here:**
- #1085 — `docs/rules.md` still cites the deleted `memory.rs` at two sites (`:19`, `:358`) and still lists the `Builder with_alpha(x)` row that ADR 0050 §8 explicitly retired. Pure ADR 0050 doc drift.
- #95 — carries the deferred `update_with` signature, commented with the belief-update recursion it should be validated against (Kaelbling, Littman & Cassandra 1998; Åström 1965). The current `(obs, action, reward)` triple is wrong in both directions: it lacks `next_observation` and the terminal flag that the update needs, and carries a reward it does not.

**A provenance gap worth knowing about.** ADR 0050 §9 names **#190** — not #95 — as the owner of the keep-or-delete decision on these types. #190 closed without naming a successor; #95 picked it up in a comment the ADR does not reference. The owner is real and self-declared, but no single document links ADR 0050 → #190 → #95.
