### PR TITLE
fix(env): Validate pixel_grid state construction and make paint_cell total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   understates the surface as a single three-line test site; the verified figure
   is the 25/11 above, and the migration is read-only at every one of them.)
 
+- **`PixelGridState::new` becomes fallible and is no longer `const`**: it is now
+  `pub fn new(agent: u32, goal: u32) -> Result<Self, StateError>`, rejecting any
+  cell index `>= CELL_COUNT` (resolves #542, with the panic itself recorded under
+  `rlevo-environments` below). The old signature was `pub const fn -> Self` and
+  documented its own indices as unvalidated, which left the type's one real
+  invariant — the one `Observable::project` dereferences the pixel buffer with —
+  enforced nowhere. Validating at the only public construction path mirrors
+  `ContextualBanditObservation::new`, the existing precedent in this crate.
+
+  Migration is a `.expect("…")` or a `?` at each call site; the workspace's own
+  sites are literal-index test and benchmark fixtures, where an `.expect` reads
+  as the assertion it is. The loss of `const` is the sharper break: `new` can no
+  longer initialize a `const` or `static` item, and no `const fn` can call it.
+  Where the indices are construction-provably in range and the state is built
+  inside this crate, the struct literal remains available and is what
+  `PixelGridEnv::initial_state` now uses, rather than laundering an unreachable
+  error path back to the caller. No persisted data is affected:
+  `PixelGridState` derives only `Debug, Clone` — it has no `serde` derive — so
+  no checkpoint, replay buffer, or config format contains one.
+
 ### `rlevo-metrics-registry`
 
 **Added**
@@ -144,6 +164,59 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   carried. This changes observed bytes but breaks no compilation and no
   persisted format, so it is recorded here rather than under Breaking
   changes, whose entries above are all compile-time API breaks.
+
+- **Projecting a `pixel_grid` state with an out-of-range cell index aborted the
+  process** (resolves #542). `PixelGridState::new(25, 0).project()` panicked with
+  `range end index 1203 out of range for slice of length 1200`: `paint_cell`
+  computed a pixel block from a cell index nothing had range-checked and wrote
+  past the end of the frame. `State::is_valid` had encoded exactly the missing
+  predicate since the type was written, and had zero production callers —
+  `Observable::project` never consulted it, and `impl Sensor<3, 1, 1>`, added
+  later by the ADR 0047 migration, inherited the same gap, which made the panic
+  reachable through the environment's own emission path rather than only through
+  a direct `project` call.
+
+  **Why the existing tests missed it**: `is_valid_rejects_out_of_range` asserted
+  the predicate on an out-of-range state but never projected one, and every
+  `project` test used in-range indices. The predicate was covered; the code it
+  was supposed to protect was not — no test ever put the two together, which is
+  the only way the gap could have shown up. (The issue speculated the bad state
+  would arrive from "a deserialized checkpoint." It cannot: `PixelGridState`
+  derives only `Debug, Clone` and has no `serde`. The real exposure was the
+  public unvalidated `new`, which is why the fix is the fallible constructor
+  recorded under Breaking changes.)
+
+  `paint_cell` is now total in `cell`: a `debug_assert!` fires in debug builds,
+  and an early return placed *ahead of the divide* leaves the block unpainted in
+  release instead of writing out of bounds. The placement matters beyond the
+  panic — on a 32-bit-`usize` target, a large `cell` makes the row arithmetic
+  wrap and can land the write back inside the buffer, silently corrupting a
+  pixel belonging to a valid cell; per-write bounds checks would not close that.
+  `PixelGridEnv::reset` and `step` additionally assert
+  `self.state.is_valid()` in debug builds, immediately after writing the state
+  and before the sensor call, so a broken transition is reported at the
+  environment boundary rather than inside the renderer.
+
+  The cost of totality is worth stating plainly. The degraded frame omits the
+  agent block, which is an absence marker no valid state can produce (the agent
+  is painted last and unconditionally), so it is at least not mistakable for a
+  legitimate observation the way a clamped index would be — but it is still a
+  full-size frame of *finite* `u8`-derived values, so ADR 0067's non-finite
+  replay-ingestion drop does not catch it. Nothing downstream rejects it. In a
+  release build the failure is silent past `project`, and the debug assertions
+  are the only thing that makes it loud.
+
+**Added**
+
+- **`pixel_grid::CELL_COUNT_U32`**, `CELL_COUNT` as the `u32` that cell indices
+  are actually stored in (part of #545). It exists so a range check on an index
+  is a plain comparison against a compile-time constant rather than a
+  `u32::try_from(CELL_COUNT).expect(…)` re-evaluated on every call — which is
+  what `is_valid` did before, on the hot projection path. It replaces the
+  conversions in `is_valid` and in `initial_state`'s fixed-placement branch; the
+  remaining `u32::try_from` sites #545 lists convert sampled or computed
+  `usize` cell indices, not `CELL_COUNT`, so that issue is only partly closed.
+  New public API, so nothing breaks.
 
 ### `rlevo-evolution`
 

--- a/crates/rlevo-environments/src/pixel_grid.rs
+++ b/crates/rlevo-environments/src/pixel_grid.rs
@@ -67,7 +67,7 @@ use rlevo_core::environment::{
     ConstructableEnv, Environment, EnvironmentError, Sensor, Snapshot, SnapshotBase,
 };
 use rlevo_core::reward::ScalarReward;
-use rlevo_core::state::Observable;
+use rlevo_core::state::{Observable, StateError};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
@@ -86,6 +86,14 @@ pub const CHANNELS: usize = 3;
 pub const IMG_SIDE: usize = GRID_SIDE * CELL_PX;
 /// Total number of cells in the grid (`GRID_SIDE²`).
 pub const CELL_COUNT: usize = GRID_SIDE * GRID_SIDE;
+/// [`CELL_COUNT`] as a `u32`, the width cell indices are stored in.
+///
+/// Exists so the range check on a cell index is a plain comparison rather than
+/// a `u32::try_from(CELL_COUNT).expect(...)` evaluated at every call. The cast
+/// is checked here once, at compile time: `GRID_SIDE` is a small literal, so
+/// the product is far below `u32::MAX`.
+#[allow(clippy::cast_possible_truncation)]
+pub const CELL_COUNT_U32: u32 = CELL_COUNT as u32;
 /// Total number of scalar elements in the rendered image
 /// (`IMG_SIDE * IMG_SIDE * CHANNELS`).
 pub const PIXEL_COUNT: usize = IMG_SIDE * IMG_SIDE * CHANNELS;
@@ -139,7 +147,7 @@ fn success_reward(step: usize, max_steps: usize) -> f32 {
 /// use rlevo_environments::pixel_grid::PixelGridState;
 /// use rlevo_core::base::State;
 ///
-/// let state = PixelGridState::new(0, 24);
+/// let state = PixelGridState::new(0, 24).expect("both indices are in range");
 /// assert!(state.is_valid());
 /// assert_eq!(<PixelGridState as State<1>>::shape(), [2]);
 /// ```
@@ -152,21 +160,35 @@ pub struct PixelGridState {
 impl PixelGridState {
     /// Construct a state from agent and goal cell indices.
     ///
-    /// Indices are not validated here; call [`is_valid`](State::is_valid) to
-    /// check that both lie in `0..CELL_COUNT`.
+    /// This is the only public construction path; it upholds the
+    /// `agent < CELL_COUNT && goal < CELL_COUNT` invariant that
+    /// [`Observable::project`] relies on to address the pixel buffer, and that
+    /// [`is_valid`](State::is_valid) re-checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError::InvalidData`] if either index is `>= CELL_COUNT`.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use rlevo_environments::pixel_grid::PixelGridState;
     ///
-    /// let state = PixelGridState::new(0, 24);
+    /// let state = PixelGridState::new(0, 24).expect("both indices are in range");
     /// assert_eq!(state.agent(), 0);
     /// assert_eq!(state.goal(), 24);
+    ///
+    /// // `CELL_COUNT` is 25, so index 25 is one past the last cell.
+    /// assert!(PixelGridState::new(25, 0).is_err());
     /// ```
-    #[must_use]
-    pub const fn new(agent: u32, goal: u32) -> Self {
-        Self { agent, goal }
+    pub fn new(agent: u32, goal: u32) -> Result<Self, StateError> {
+        if agent < CELL_COUNT_U32 && goal < CELL_COUNT_U32 {
+            Ok(Self { agent, goal })
+        } else {
+            Err(StateError::InvalidData(format!(
+                "cell index out of range [0, {CELL_COUNT}): agent {agent}, goal {goal}"
+            )))
+        }
     }
 
     /// Returns the agent's cell index.
@@ -244,14 +266,33 @@ impl State<1> for PixelGridState {
     }
 
     fn is_valid(&self) -> bool {
-        let count = u32::try_from(CELL_COUNT).expect("cell count fits in u32");
-        self.agent < count && self.goal < count
+        self.agent < CELL_COUNT_U32 && self.goal < CELL_COUNT_U32
     }
 }
 
 impl Observable<3> for PixelGridState {
     type Observation = PixelObservation;
 
+    /// Renders the latent to the `[IMG_SIDE, IMG_SIDE, CHANNELS]` RGB frame.
+    ///
+    /// Total for every value of the fields, including ones the fallible
+    /// [`PixelGridState::new`] would reject: an out-of-range cell index paints
+    /// nothing, so its block stays background black (see `paint_cell`). The
+    /// returned buffer always has `PIXEL_COUNT` elements.
+    ///
+    /// That degraded frame is an **absence marker, not a fabricated position**.
+    /// The agent is painted last and unconditionally, so *every* frame produced
+    /// from an in-range state contains an `AGENT_RGB` block; a frame with no
+    /// agent block is therefore unreachable from any valid state and cannot be
+    /// mistaken for one. A clamped or wrapped index, by contrast, would place
+    /// the agent on a real cell and be indistinguishable from a legitimate
+    /// observation.
+    ///
+    /// Note that the degraded frame is *finite* — every element is a `u8`
+    /// scaled into `[0, 1]` — so it is **not** caught by ADR 0067's
+    /// non-finite replay-ingestion drop. Nothing downstream rejects it; the
+    /// failure is silent past this point, which is why the invariant is
+    /// asserted at the [`Environment`] boundary in debug builds.
     fn project(&self) -> Self::Observation {
         let mut pixels = vec![0u8; PIXEL_COUNT];
         paint_cell(&mut pixels, self.goal as usize, GOAL_RGB);
@@ -263,7 +304,26 @@ impl Observable<3> for PixelGridState {
 
 /// Paint a single cell's `CELL_PX × CELL_PX` block in a row-major `[H, W, C]`
 /// pixel buffer with the given RGB color.
+///
+/// Total in `cell`: an index outside `0..CELL_COUNT` paints nothing and the
+/// block is left as background. Callers should have upheld the range
+/// invariant — a violation trips the `debug_assert!` — but a release build
+/// renders the degraded frame rather than panicking on an out-of-bounds slice
+/// (issue #542).
+///
+/// The guard must stay *ahead of the divide*. On a target with 32-bit `usize`,
+/// a `cell` near `usize::MAX` makes `crow * CELL_PX + dr` wrap, which can land
+/// `base` back inside `0..PIXEL_COUNT` and silently corrupt a pixel belonging
+/// to a valid cell. Bounds-checking each write instead of rejecting the cell
+/// would not close that.
 fn paint_cell(pixels: &mut [u8], cell: usize, color: [u8; CHANNELS]) {
+    debug_assert!(
+        cell < CELL_COUNT,
+        "cell {cell} out of range [0, {CELL_COUNT})"
+    );
+    if cell >= CELL_COUNT {
+        return; // total in release: leave the block unpainted
+    }
     let crow = cell / GRID_SIDE;
     let ccol = cell % GRID_SIDE;
     for dr in 0..CELL_PX {
@@ -294,7 +354,8 @@ fn paint_cell(pixels: &mut [u8], cell: usize, color: [u8; CHANNELS]) {
 /// use rlevo_core::state::Observable;
 ///
 /// assert_eq!(<PixelObservation as Observation<3>>::shape(), [20, 20, 3]);
-/// let obs = PixelGridState::new(0, 24).project();
+/// let state = PixelGridState::new(0, 24).expect("both indices are in range");
+/// let obs = state.project();
 /// assert_eq!(obs.pixels().len(), PIXEL_COUNT);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -651,6 +712,12 @@ impl PixelGridEnv {
     /// Fixed placement puts the agent at cell `0` and the goal at the last
     /// cell; random placement samples distinct cells from `rng` (host-RNG
     /// convention — no backend/global RNG).
+    ///
+    /// Both branches build the state by struct literal rather than through the
+    /// fallible [`PixelGridState::new`]: the indices are construction-provably
+    /// in `0..CELL_COUNT` (sampled from that exact range, or the literals `0`
+    /// and `CELL_COUNT - 1`), so re-checking them here would only add an
+    /// unreachable error path for the caller to launder.
     fn initial_state(config: PixelGridConfig, rng: &mut StdRng) -> PixelGridState {
         if config.random_placement {
             let agent = rng.random_range(0..CELL_COUNT);
@@ -658,15 +725,15 @@ impl PixelGridEnv {
             while goal == agent {
                 goal = rng.random_range(0..CELL_COUNT);
             }
-            PixelGridState::new(
-                u32::try_from(agent).expect("cell index fits in u32"),
-                u32::try_from(goal).expect("cell index fits in u32"),
-            )
+            PixelGridState {
+                agent: u32::try_from(agent).expect("cell index fits in u32"),
+                goal: u32::try_from(goal).expect("cell index fits in u32"),
+            }
         } else {
-            PixelGridState::new(
-                0,
-                u32::try_from(CELL_COUNT - 1).expect("cell index fits in u32"),
-            )
+            PixelGridState {
+                agent: 0,
+                goal: CELL_COUNT_U32 - 1,
+            }
         }
     }
 
@@ -762,6 +829,16 @@ impl Environment<3, 1, 1> for PixelGridEnv {
         self.guard.reset();
         self.state = Self::initial_state(self.config, &mut self.rng);
         self.steps = 0;
+        // Assert *before* the sensor call, not at the end of the method: the
+        // projection is the code that would trip over an out-of-range cell, and
+        // its own `debug_assert!` fires first if this one runs after it —
+        // reporting the failure at the wrong layer.
+        debug_assert!(
+            self.state.is_valid(),
+            "PixelGridState invariant violated after reset: agent {}, goal {} (CELL_COUNT {CELL_COUNT})",
+            self.state.agent,
+            self.state.goal
+        );
         let observation = self.observe_reset(&self.state);
         Ok(self.snapshot(observation, 0.0, SnapshotStatus::Running))
     }
@@ -787,6 +864,14 @@ impl Environment<3, 1, 1> for PixelGridEnv {
 
         self.steps += 1;
         self.state.apply_move(action);
+        // Same placement rule as `reset`: ahead of the sensor call, so a broken
+        // move lands here rather than inside `paint_cell`.
+        debug_assert!(
+            self.state.is_valid(),
+            "PixelGridState invariant violated after step: agent {}, goal {} (CELL_COUNT {CELL_COUNT})",
+            self.state.agent,
+            self.state.goal
+        );
         let observation = self.observe(&action, &self.state);
 
         let snap = if self.state.at_goal() {
@@ -844,7 +929,7 @@ mod tests {
         env: &mut PixelGridEnv,
     ) -> SnapshotBase<3, PixelObservation, ScalarReward> {
         env.reset().expect("reset must succeed");
-        env.state = PixelGridState::new(23, 24);
+        env.state = PixelGridState::new(23, 24).expect("valid cell indices");
         env.step(PixelGridAction::Right)
             .expect("stepping onto the goal must succeed")
     }
@@ -1051,17 +1136,228 @@ mod tests {
 
     #[test]
     fn state_shape_matches_numel() {
-        let state = PixelGridState::new(0, 24);
+        let state = PixelGridState::new(0, 24).expect("valid cell indices");
         let shape_product: usize = <PixelGridState as State<1>>::shape().iter().product();
         assert_eq!(state.numel(), shape_product);
         assert_eq!(state.numel(), 2);
     }
 
+    // ── cell-index range invariant (issue #542) ──────────────────────────────
+
+    /// `new` is the only public construction path, so it is where the
+    /// `0..CELL_COUNT` invariant is enforced. The accepting side of `is_valid`
+    /// is asserted alongside it; the rejecting side needs a state `new` refuses
+    /// to build and lives in [`is_valid_rejects_out_of_range`].
+    #[test]
+    fn new_rejects_out_of_range() {
+        let good = PixelGridState::new(0, 24).expect("valid cell indices");
+        assert!(good.is_valid());
+
+        for (agent, goal) in [(25, 0), (0, 25)] {
+            let err = PixelGridState::new(agent, goal)
+                .expect_err("an index past the last cell must be rejected");
+            match err {
+                StateError::InvalidData(msg) => assert!(
+                    msg.contains("out of range"),
+                    "error must name the violated range, got {msg}"
+                ),
+                other => panic!("expected InvalidData, got {other:?}"),
+            }
+        }
+    }
+
+    /// The last legal cell is inside the range: the check is `<`, not `<=`.
+    #[test]
+    fn new_accepts_boundary_index() {
+        let last = CELL_COUNT_U32 - 1;
+        let state = PixelGridState::new(last, last).expect("the last cell is in range");
+        assert_eq!(state.agent(), last);
+        assert_eq!(state.goal(), last);
+        assert!(state.is_valid());
+    }
+
+    /// The rejecting half of `is_valid`, on fixtures `new` would refuse to
+    /// build. Both fields are exercised independently, since `project` paints
+    /// goal and agent through two separate `paint_cell` call sites.
+    ///
+    /// **Build configuration:** deliberately *not* gated on
+    /// `debug_assertions` — this runs in every build. The `project`-based
+    /// out-of-range tests below are release-only because `paint_cell`'s
+    /// `debug_assert!` fires first; asserting the predicate alone needs no such
+    /// gate, and CI runs this crate in debug. `project` is therefore never
+    /// called on these fixtures.
     #[test]
     fn is_valid_rejects_out_of_range() {
-        assert!(PixelGridState::new(0, 24).is_valid());
-        assert!(!PixelGridState::new(25, 0).is_valid());
-        assert!(!PixelGridState::new(0, 25).is_valid());
+        let last = CELL_COUNT_U32 - 1;
+        assert!(
+            PixelGridState {
+                agent: last,
+                goal: last,
+            }
+            .is_valid(),
+            "the last cell is in range on both fields"
+        );
+
+        for (agent, goal) in [
+            (CELL_COUNT_U32, last),  // agent one past the last cell
+            (last, CELL_COUNT_U32),  // goal one past the last cell
+            (CELL_COUNT_U32 + 7, 0), // agent well past the end
+            (0, CELL_COUNT_U32 + 7), // goal well past the end
+            (u32::MAX, u32::MAX),    // both saturated
+        ] {
+            let state = PixelGridState { agent, goal };
+            assert!(
+                !state.is_valid(),
+                "({agent}, {goal}) is outside [0, {CELL_COUNT}) and must be invalid"
+            );
+        }
+    }
+
+    /// `true` when any pixel in the frame carries `color`.
+    #[cfg(not(debug_assertions))]
+    fn frame_contains_block(obs: &PixelObservation, color: [u8; CHANNELS]) -> bool {
+        obs.pixels().chunks_exact(CHANNELS).any(|px| px == color)
+    }
+
+    /// `true` when any pixel in the frame carries the agent color.
+    #[cfg(not(debug_assertions))]
+    fn frame_contains_agent_block(obs: &PixelObservation) -> bool {
+        frame_contains_block(obs, AGENT_RGB)
+    }
+
+    /// Reads the RGB triple at pixel `(h, w)` of a rendered frame.
+    #[cfg(not(debug_assertions))]
+    fn pixel_at(obs: &PixelObservation, h: usize, w: usize) -> [u8; CHANNELS] {
+        let base = (h * IMG_SIDE + w) * CHANNELS;
+        [
+            obs.pixels()[base],
+            obs.pixels()[base + 1],
+            obs.pixels()[base + 2],
+        ]
+    }
+
+    /// The issue #542 reproducer: `PixelGridState::new(25, 0).project()` used to
+    /// panic with `range end index 1203 out of range for slice of length 1200`.
+    ///
+    /// `new` now rejects those indices, so the invalid state is built by
+    /// in-module struct literal — the only remaining way to produce one.
+    ///
+    /// **Build configuration:** this test is compiled only when
+    /// `debug_assertions` is OFF, i.e. it runs under `cargo test --release` and
+    /// NOT under a plain `cargo test`. The release path is the one the guard
+    /// exists for; in debug, `paint_cell`'s `debug_assert!` fires first and the
+    /// test would fail by design. Debug `cargo test` does not cover this.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn project_is_total_for_out_of_range_cell() {
+        // Construction-provably out of range; `new` would reject this pair.
+        let state = PixelGridState {
+            agent: CELL_COUNT_U32,
+            goal: CELL_COUNT_U32 - 1,
+        };
+        assert!(!state.is_valid(), "fixture must be the invalid state");
+
+        let obs = state.project();
+        assert_eq!(
+            obs.pixels().len(),
+            PIXEL_COUNT,
+            "a degraded frame must still be a full-size frame"
+        );
+        // The in-range goal is painted normally: the out-of-range agent is
+        // dropped, not clamped onto a real cell (which would overwrite the goal
+        // block with AGENT_RGB), and the frame is not blanked wholesale.
+        assert_eq!(pixel_at(&obs, 16, 16), GOAL_RGB);
+        assert_eq!(pixel_at(&obs, 19, 19), GOAL_RGB);
+        assert!(
+            !frame_contains_agent_block(&obs),
+            "an out-of-range agent must render as absent, not relocated"
+        );
+
+        // The mirror case: `project` paints goal and agent through two separate
+        // `paint_cell` call sites, so the goal site needs its own coverage.
+        let state = PixelGridState {
+            agent: 0,
+            goal: CELL_COUNT_U32,
+        };
+        assert!(!state.is_valid(), "fixture must be the invalid state");
+
+        let obs = state.project();
+        assert_eq!(
+            obs.pixels().len(),
+            PIXEL_COUNT,
+            "a degraded frame must still be a full-size frame"
+        );
+        // The in-range agent is painted normally; the out-of-range goal is
+        // dropped rather than clamped onto a real cell.
+        assert_eq!(pixel_at(&obs, 0, 0), AGENT_RGB);
+        assert_eq!(pixel_at(&obs, 3, 3), AGENT_RGB);
+        assert!(
+            !frame_contains_block(&obs, GOAL_RGB),
+            "an out-of-range goal must render as absent, not relocated"
+        );
+    }
+
+    /// The absence marker is sound: no valid state can render a frame without an
+    /// agent block, so "no agent block" unambiguously means "the latent was out
+    /// of range" rather than "the agent is at some position".
+    ///
+    /// **Build configuration:** release only (`cargo test --release`); the
+    /// invalid half of the comparison trips `paint_cell`'s `debug_assert!` in a
+    /// debug build. See [`project_is_total_for_out_of_range_cell`].
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn degraded_frame_is_distinguishable_from_every_valid_frame() {
+        // Every reachable latent renders an agent block.
+        for agent in 0..CELL_COUNT_U32 {
+            for goal in 0..CELL_COUNT_U32 {
+                let state = PixelGridState::new(agent, goal).expect("valid cell indices");
+                assert!(
+                    frame_contains_agent_block(&state.project()),
+                    "valid state ({agent}, {goal}) must render an agent block"
+                );
+            }
+        }
+
+        // The degraded frame has none, so it is outside the image of `project`
+        // over the valid domain.
+        let degraded = PixelGridState {
+            agent: CELL_COUNT_U32 + 7,
+            goal: 0,
+        }
+        .project();
+        assert!(
+            !frame_contains_agent_block(&degraded),
+            "the degraded frame must be distinguishable from every valid frame"
+        );
+    }
+
+    /// The env-side [`Sensor`] is the second caller of `project` (added by the
+    /// ADR 0047 migration) and had the same gap; both of its methods must be
+    /// total over an invalid latent.
+    ///
+    /// **Build configuration:** release only (`cargo test --release`), for the
+    /// same reason as [`project_is_total_for_out_of_range_cell`].
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn sensor_observe_is_total_for_invalid_state() {
+        let env = PixelGridEnv::with_config(PixelGridConfig::new(100, 0, false), false)
+            .expect("valid config");
+        let invalid = PixelGridState {
+            agent: CELL_COUNT_U32,
+            goal: CELL_COUNT_U32 - 1,
+        };
+
+        for obs in [
+            env.observe_reset(&invalid),
+            env.observe(&PixelGridAction::Up, &invalid),
+        ] {
+            assert_eq!(obs.pixels().len(), PIXEL_COUNT);
+            assert_eq!(pixel_at(&obs, 16, 16), GOAL_RGB);
+            assert!(
+                !frame_contains_agent_block(&obs),
+                "the sensor must inherit project's absence marker, not a clamp"
+            );
+        }
     }
 
     #[test]
@@ -1073,7 +1369,9 @@ mod tests {
     #[test]
     fn project_paints_agent_and_goal_blocks() {
         // Agent at cell 0 (top-left block), goal at cell 24 (bottom-right block).
-        let obs = PixelGridState::new(0, 24).project();
+        let obs = PixelGridState::new(0, 24)
+            .expect("valid cell indices")
+            .project();
         assert_eq!(obs.pixels().len(), PIXEL_COUNT);
 
         let pixel = |h: usize, w: usize| {
@@ -1096,7 +1394,9 @@ mod tests {
 
     #[test]
     fn agent_on_goal_renders_agent_color() {
-        let obs = PixelGridState::new(12, 12).project();
+        let obs = PixelGridState::new(12, 12)
+            .expect("valid cell indices")
+            .project();
         // Cell 12 = row 2, col 2 → pixel block rows/cols 8..12.
         let base = (8 * IMG_SIDE + 8) * CHANNELS;
         assert_eq!(
@@ -1128,7 +1428,9 @@ mod tests {
         type TestBackend = Flex;
         let device = Default::default();
 
-        let obs = PixelGridState::new(3, 21).project();
+        let obs = PixelGridState::new(3, 21)
+            .expect("valid cell indices")
+            .project();
         let tensor =
             <PixelObservation as TensorConvertible<3, TestBackend>>::to_tensor(&obs, &device);
         let round_tripped =
@@ -1179,20 +1481,20 @@ mod tests {
     #[test]
     fn wall_clamping_holds_position_at_edges() {
         // Agent at cell 0 (top-left). Up and Left are no-ops.
-        let mut state = PixelGridState::new(0, 24);
+        let mut state = PixelGridState::new(0, 24).expect("valid cell indices");
         state.apply_move(PixelGridAction::Up);
         assert_eq!(state.agent(), 0);
         state.apply_move(PixelGridAction::Left);
         assert_eq!(state.agent(), 0);
         // Down moves to row 1 (cell 5); Right moves to col 1 (cell 1).
-        let mut state = PixelGridState::new(0, 24);
+        let mut state = PixelGridState::new(0, 24).expect("valid cell indices");
         state.apply_move(PixelGridAction::Down);
         assert_eq!(state.agent(), 5);
-        let mut state = PixelGridState::new(0, 24);
+        let mut state = PixelGridState::new(0, 24).expect("valid cell indices");
         state.apply_move(PixelGridAction::Right);
         assert_eq!(state.agent(), 1);
         // Agent at cell 24 (bottom-right). Down and Right are no-ops.
-        let mut state = PixelGridState::new(24, 0);
+        let mut state = PixelGridState::new(24, 0).expect("valid cell indices");
         state.apply_move(PixelGridAction::Down);
         assert_eq!(state.agent(), 24);
         state.apply_move(PixelGridAction::Right);
@@ -1206,7 +1508,7 @@ mod tests {
         let mut env = PixelGridEnv::with_config(cfg, false).expect("valid config");
         env.reset().unwrap();
         // Override placement for a one-step solve.
-        env.state = PixelGridState::new(23, 24);
+        env.state = PixelGridState::new(23, 24).expect("valid cell indices");
         let snap = env.step(PixelGridAction::Right).unwrap();
         assert!(snap.is_done());
         assert_eq!(snap.status(), EpisodeStatus::Terminated);

--- a/crates/rlevo-reinforcement-learning/benches/learn_step_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/learn_step_bench.rs
@@ -145,7 +145,7 @@ use rand::rngs::StdRng;
 use rlevo_core::base::TensorConvertible;
 use rlevo_core::state::Observable;
 use rlevo_environments::classic::cartpole::CartPoleObservation;
-use rlevo_environments::pixel_grid::{CELL_COUNT, PixelGridState, PixelObservation};
+use rlevo_environments::pixel_grid::{CELL_COUNT_U32, PixelGridState, PixelObservation};
 use rlevo_reinforcement_learning::algorithms::dqn::dqn_model::DqnModel;
 use rlevo_reinforcement_learning::utils::{PolyakError, compute_target_q_values, polyak_update};
 
@@ -317,10 +317,13 @@ fn cartpole_transitions(n: usize, rng: &mut StdRng) -> Vec<SynthTransition<CartP
 fn pixel_transitions(n: usize, rng: &mut StdRng) -> Vec<SynthTransition<PixelObservation>> {
     (0..n)
         .map(|_| {
-            let goal = rng.random_range(0..CELL_COUNT as u32);
-            let obs = PixelGridState::new(rng.random_range(0..CELL_COUNT as u32), goal).project();
-            let next_obs =
-                PixelGridState::new(rng.random_range(0..CELL_COUNT as u32), goal).project();
+            let goal = rng.random_range(0..CELL_COUNT_U32);
+            let obs = PixelGridState::new(rng.random_range(0..CELL_COUNT_U32), goal)
+                .expect("cells sampled from 0..CELL_COUNT_U32 are in range")
+                .project();
+            let next_obs = PixelGridState::new(rng.random_range(0..CELL_COUNT_U32), goal)
+                .expect("cells sampled from 0..CELL_COUNT_U32 are in range")
+                .project();
             SynthTransition {
                 obs,
                 next_obs,

--- a/crates/rlevo-reinforcement-learning/benches/staging_bench.rs
+++ b/crates/rlevo-reinforcement-learning/benches/staging_bench.rs
@@ -93,7 +93,7 @@ use rand::rngs::StdRng;
 use rlevo_core::base::TensorConvertible;
 use rlevo_core::state::Observable;
 use rlevo_environments::classic::cartpole::CartPoleObservation;
-use rlevo_environments::pixel_grid::{CELL_COUNT, PixelGridState, PixelObservation};
+use rlevo_environments::pixel_grid::{CELL_COUNT_U32, PixelGridState, PixelObservation};
 
 use bench_backend::BenchBackend;
 
@@ -195,17 +195,14 @@ fn cartpole_batch(n: usize, rng: &mut StdRng) -> Vec<CartPoleObservation> {
         .collect()
 }
 
-// Synthetic fixture/benchmark data: the loop counter and element count are
-// bounded by small constants declared in this file, far below f32's 2^24
-// exact-integer limit. The values are inputs to a throughput measurement, not
-// quantities whose precision is asserted.
-#[allow(clippy::cast_possible_truncation)]
 fn pixel_batch(n: usize, rng: &mut StdRng) -> Vec<PixelObservation> {
     (0..n)
         .map(|_| {
-            let agent = rng.random_range(0..CELL_COUNT as u32);
-            let goal = rng.random_range(0..CELL_COUNT as u32);
-            PixelGridState::new(agent, goal).project()
+            let agent = rng.random_range(0..CELL_COUNT_U32);
+            let goal = rng.random_range(0..CELL_COUNT_U32);
+            PixelGridState::new(agent, goal)
+                .expect("cells sampled from 0..CELL_COUNT_U32 are in range")
+                .project()
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds panic in `pixel_grid`: `Observable::project` never consulted `State::is_valid` — a predicate that existed on `PixelGridState` but had zero production callers — so `PixelGridState::new(25, 0).project()` aborted the process with `range end index 1203 out of range for slice of length 1200` on the slice write in `paint_cell`. The invariant is now enforced at the only public construction path (`new` becomes fallible), and the renderer is made total so a state that slips through degrades rather than crashes.

## Change Type

- [x] Bug fix (includes regression test) — **breaking**: `PixelGridState::new` changes signature. See Notes.

## Linked Issue

Closes #542

## What Was Changed

- `crates/rlevo-environments/src/pixel_grid.rs`
  - `PixelGridState::new` is now `pub fn new(agent: u32, goal: u32) -> Result<Self, StateError>`, rejecting any index `>= CELL_COUNT`. Was `pub const fn -> Self`, whose own rustdoc documented the indices as unvalidated. Mirrors `ContextualBanditObservation::new`, the existing precedent in this crate for the same invariant shape.
  - Added `pub const CELL_COUNT_U32: u32`, used in `is_valid` and `initial_state`'s fixed branch. Completes part of #545.
  - `paint_cell` is now total in `cell`: a `debug_assert!` plus an early return, both placed *ahead of* `let crow = cell / GRID_SIDE`. Release leaves the block unpainted rather than writing past the buffer.
  - `debug_assert!(self.state.is_valid(), ...)` added to `PixelGridEnv::reset` and `step`, immediately after the state write and *before* the sensor call — at the end of the method it would fire after `project()` had already tripped its own assert, reporting the wrong layer.
  - `initial_state` uses struct literals rather than laundering an unreachable error path back to the caller; its indices are construction-provably in range.
  - Six new/restored tests (below); doc comments on `project` and `paint_cell` explaining the degraded-frame semantics.
- `crates/rlevo-reinforcement-learning/benches/{learn_step_bench,staging_bench}.rs` — call sites updated for the fallible constructor; both now consume `CELL_COUNT_U32` instead of `CELL_COUNT as u32`.
- `CHANGELOG.md` — breaking change with migration, plus `**Fixed**` and `**Added**` entries under `rlevo-environments`.

### Why not the fix the issue suggested

The issue proposed a `debug_assert!` in `paint_cell`, "without a release-mode cost." That does not fix the bug — the release symptom is an unchecked slice index, not an assert, so it survives the change unaltered. Three alternatives were considered and rejected against the ADR record:

- **Fallible `project()`** — forbidden. ADR 0019 §3 decides `project()` is infallible and rejects `Result<Observation, _>` by name; ADR 0047 §4 retires 0019's framing but not §3. Reversing it needs a superseding ADR, not a bug fix.
- **Clamping the index** — renders a plausible in-domain image of a state that never existed, the exact failure class ADR 0065 and `rules.md` §159's no-fabrication rule name.
- **`debug_assert!` as the sole guard** — rejected by name five times across ADRs 0056 → 0065 → 0070 → 0071 → 0072. It is acceptable *here* only because it sits behind real enforcement (the constructor), which is the accept criterion in ADR 0055 and the `ContextualBanditObservation` precedent.

ADR 0039 §5's "deliberately no `try_new`" carve-out does not extend to this type: it is conditioned on both incremental placeholder construction *and* the absence of a public construction path, and `PixelGridState::new` was `pub`. 0039 explicitly asks that the deviation not be normalized. No new ADR is added — both clauses one would state are already `rules.md` §2 and ADR 0019 §3.

### One correction to the issue

The issue attributed the bad state to "a deserialized checkpoint." That is impossible: `PixelGridState` derives only `Debug, Clone` and has no serde. The real exposure was the public unvalidated `new`, which is why the fix is a validating constructor rather than a decode-side guard.

## How It Was Tested

```
cargo build --workspace                          # clean
cargo test --workspace                           # 3273 passed, 0 failed
cargo clippy --all-targets --all-features        # no warnings
cargo test -p rlevo-environments                 # lib 1362 (was 1361)
cargo test -p rlevo-environments --release       # lib 1365 — the +3 are release-gated
cargo test -p rlevo-environments --doc           # 109
cargo clippy -p rlevo-environments --all-targets --release -- -D warnings
cargo check -p rlevo-reinforcement-learning --benches
```

Release clippy is not redundant here: debug clippy never compiles the `#[cfg(not(debug_assertions))]` tests.

**Regression tests.** `project_is_total_for_out_of_range_cell` is the issue's reproducer and fails on the previous code (it panicked). `degraded_frame_is_distinguishable_from_every_valid_frame` and `sensor_observe_is_total_for_invalid_state` cover the same path through `Sensor::observe`/`observe_reset`. These three are `#[cfg(not(debug_assertions))]` — `paint_cell`'s own `debug_assert!` fires first in debug — and each carries a doc paragraph naming that build configuration, so nobody mistakes a green `cargo test` for coverage of the release path. `is_valid_rejects_out_of_range`, `new_rejects_out_of_range`, and `new_accepts_boundary_index` run in every configuration.

**Mutation-tested, not just red-green.** Each test was checked against deliberate mutants rather than only against the unfixed code:

| mutant | killed by |
|---|---|
| `paint_cell` clamps `cell.min(CELL_COUNT - 1)` instead of returning | all 3 gated tests |
| `project` returns an all-black buffer | all 3 gated tests + 2 pre-existing render tests |
| `new` bound `<` → `<=` | `new_rejects_out_of_range` (debug) |
| `new` bound off-by-one downward | `new_rejects_out_of_range`, `new_accepts_boundary_index` |
| `is_valid` → `{ true }` | `is_valid_rejects_out_of_range` (debug) |

That last row is why an ungated `is_valid_rejects_out_of_range` exists. An earlier revision of this PR folded it into the constructor test, which left `!is_valid()` asserted only inside release-gated code — the `is_valid → true` mutant then survived a full debug run at 27/27 green. That was a coverage regression *introduced by this PR* against what `main` already had, caught in review and closed before merge.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: `Flex` (CPU) — the only backend these tests touch; the fix is host-side `u8` buffer arithmetic with no tensor path
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **full authorship of the diff, tests, and CHANGELOG entries under maintainer direction; the design was reviewed against the ADR record and the constructor shape was changed on review from a panicking `new` + `try_new` to a fallible `new`.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern.
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Breaking change.** `PixelGridState::new` returns `Result` and is no longer `const`. Migration is `.expect(...)` or `?` at the call site; the loss of `const` is the sharper edge, since `new` can no longer initialize a `const`/`static` and no `const fn` can call it. In-crate code with provably-in-range indices can use the struct literal, as `initial_state` now does. No persisted data is affected — the type has no serde derive, so no checkpoint, replay buffer, or config contains one.

**Known residual, documented rather than hidden.** The degraded frame omits the agent block, which is an absence marker no valid state can produce (the agent is painted last and unconditionally) — so unlike a clamped index it cannot be mistaken for a legitimate observation. But it is a full-size frame of *finite* values, so ADR 0067's non-finite replay-ingestion drop does not catch it. In release the failure is silent past `project`; the debug assertions are the only loud signal.

**Follow-ups filed during review:**
- #1089 — no CI job runs `-p rlevo-environments --release`, so the three gated tests execute nowhere. The release behavior this PR creates is verified locally and invisible to CI.
- #1090 — `paint_cell`'s guard-placement invariant only bites on 32-bit `usize`; no target in the repo can test it, so a doc comment is currently the whole enforcement.
- #545 re-scoped: this PR converts the two genuine `CELL_COUNT` sites; the remaining four convert computed indices and need the surrounding arithmetic moved to `u32`. The issue's count of "five occurrences" was stale — there are six.
