### PR TITLE
feat(grids): Fallible mirrors for Grid::set and GridAction::from_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,45 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `usize` cell indices, not `CELL_COUNT`, so that issue is only partly closed.
   New public API, so nothing breaks.
 
+- **`Grid::try_set` and `GridError`**, a non-panicking way to write a cell whose
+  coordinates come from data rather than from a literal (resolves #864, #862).
+  `Grid::set` panics out of bounds, which is the right contract for the literal
+  and derived coordinates every in-tree environment uses — each one calls
+  `Grid::new(config.size, …)` with the same config field its coordinates derive
+  from, so a larger config builds a larger grid and the write stays in range.
+  But `Grid` is publicly re-exported, so that reasoning protects only callers
+  inside this workspace; a downstream layout loader had no total write path at
+  all. `set` now delegates to `try_set`, giving the bounds check one home, and
+  `GridError` converts into `ConfigError` and `EnvironmentError` so a `reset()`
+  can `?` straight through it. The issue proposed `-> bool`; that was rejected
+  because `try_*` means `Result` everywhere else in the workspace, `bool` here
+  is reserved for predicates like `in_bounds`, and widening `bool` to `Result`
+  on public API later would be a breaking change. Both the enum and its variant
+  are `#[non_exhaustive]`, which reserves the right to add variants and fields
+  and stops downstream struct-literal construction — but note it does *not*
+  make the existing `x`/`y` fields malleable: a downstream
+  `OutOfBounds { x, y, .. }` binds them by name, so the position-newtype
+  collapse #863 proposes stays a semver-major change. `Grid::new` now rejects a
+  `width * height` that *wraps* — which would otherwise build a backing store
+  shorter than the grid's own extent, leaving `index` free to run past it. A
+  single absurd dimension (`Grid::new(1, usize::MAX)`) does not wrap and still
+  fails later inside the allocation; bounding grid size is the caller's job.
+  Both `Grid::new`'s and `Grid::set`'s panic contracts are now listed in the
+  panic-contracts table in `docs/rules.md`.
+
+- **`GridAction::try_from_index` and `impl TryFrom<usize> for GridAction`**, the
+  fallible counterpart to the trait's panicking `from_index` (resolves #813,
+  #829, #831). Every current caller pre-clamps its index, so nothing was
+  reachable — but the only constructor was one that panics, which is the wrong
+  default for an index arriving from a policy network's argmax. `from_index`
+  now routes through `try_from_index` and keeps its documented panic verbatim,
+  and gained the `# Panics` section it was missing. A `const` assertion ties the
+  explicit discriminants to `ACTION_COUNT`, so adding a variant without bumping
+  the constant is now a compile error rather than a runtime surprise — the
+  previous round-trip test was self-referential and passed under a shuffled
+  variant order (#815, #819, #835 add the literal-binding, literal-`to_index`,
+  and `usize::MAX` cases that pin it).
+
 ### `rlevo-evolution`
 
 **Fixed**

--- a/crates/rlevo-environments/src/grids/core/action.rs
+++ b/crates/rlevo-environments/src/grids/core/action.rs
@@ -1,6 +1,6 @@
 //! The 7-action discrete action space shared by every grid environment.
 
-use rlevo_core::action::DiscreteAction;
+use rlevo_core::action::{DiscreteAction, InvalidActionError};
 use rlevo_core::base::Action;
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +24,67 @@ pub enum GridAction {
     Done = 6,
 }
 
+// The explicit discriminants above are a wire format: they are the indices a
+// policy head emits and the values `to_index` returns. Pin them at compile
+// time so a reordering of the variants cannot silently renumber the action
+// space. The final assertion ties the enum's cardinality to `ACTION_COUNT`, so
+// adding a variant without bumping the constant fails to compile.
+const _: () = {
+    assert!(GridAction::TurnLeft as usize == 0);
+    assert!(GridAction::TurnRight as usize == 1);
+    assert!(GridAction::Forward as usize == 2);
+    assert!(GridAction::Pickup as usize == 3);
+    assert!(GridAction::Drop as usize == 4);
+    assert!(GridAction::Toggle as usize == 5);
+    assert!(GridAction::Done as usize == 6);
+    assert!(GridAction::Done as usize + 1 == <GridAction as DiscreteAction<1>>::ACTION_COUNT);
+};
+
+impl GridAction {
+    /// Constructs an action from its zero-based index, returning an error if
+    /// `index` is out of range.
+    ///
+    /// This is the fallible counterpart to
+    /// [`DiscreteAction::from_index`], for callers whose index comes from data
+    /// (a config file, a replay log, a deserialized trajectory) rather than
+    /// from a trusted in-range computation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`; the message
+    /// names the offending index and the valid range.
+    pub fn try_from_index(index: usize) -> Result<Self, InvalidActionError> {
+        match index {
+            0 => Ok(Self::TurnLeft),
+            1 => Ok(Self::TurnRight),
+            2 => Ok(Self::Forward),
+            3 => Ok(Self::Pickup),
+            4 => Ok(Self::Drop),
+            5 => Ok(Self::Toggle),
+            6 => Ok(Self::Done),
+            _ => Err(InvalidActionError {
+                message: format!(
+                    "GridAction index {index} out of range [0, {})",
+                    Self::ACTION_COUNT
+                ),
+            }),
+        }
+    }
+}
+
+impl TryFrom<usize> for GridAction {
+    type Error = InvalidActionError;
+
+    /// Delegates to [`GridAction::try_from_index`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`.
+    fn try_from(index: usize) -> Result<Self, Self::Error> {
+        Self::try_from_index(index)
+    }
+}
+
 impl Action<1> for GridAction {
     fn shape() -> [usize; 1] {
         [Self::ACTION_COUNT]
@@ -37,17 +98,27 @@ impl Action<1> for GridAction {
 impl DiscreteAction<1> for GridAction {
     const ACTION_COUNT: usize = 7;
 
+    /// Constructs an action from its zero-based index.
+    ///
+    /// Use [`Self::try_from_index`] (or the equivalent [`TryFrom<usize>`]
+    /// implementation) when the index originates from data rather than from a
+    /// trusted in-range computation such as an argmax over `ACTION_COUNT`
+    /// logits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= ACTION_COUNT`, per the
+    /// [`DiscreteAction::from_index`] contract.
     fn from_index(index: usize) -> Self {
-        match index {
-            0 => Self::TurnLeft,
-            1 => Self::TurnRight,
-            2 => Self::Forward,
-            3 => Self::Pickup,
-            4 => Self::Drop,
-            5 => Self::Toggle,
-            6 => Self::Done,
-            _ => panic!("GridAction index out of bounds: {index}"),
-        }
+        // The error's own `Display` repeats the index and prefixes "Invalid
+        // action:", both of which would read as noise after this panic's
+        // pinned prefix; only the valid range is new information.
+        Self::try_from_index(index).unwrap_or_else(|_| {
+            panic!(
+                "GridAction index out of bounds: {index}, valid range is [0, {})",
+                Self::ACTION_COUNT
+            )
+        })
     }
 
     fn to_index(&self) -> usize {
@@ -73,6 +144,31 @@ mod tests {
     }
 
     #[test]
+    fn index_bindings_are_canonical() {
+        // Literal, not a loop: `index_roundtrip_all_variants` is self-referential
+        // and still passes if the variant order is shuffled. These pin each
+        // index to a named variant.
+        assert_eq!(GridAction::from_index(0), GridAction::TurnLeft);
+        assert_eq!(GridAction::from_index(1), GridAction::TurnRight);
+        assert_eq!(GridAction::from_index(2), GridAction::Forward);
+        assert_eq!(GridAction::from_index(3), GridAction::Pickup);
+        assert_eq!(GridAction::from_index(4), GridAction::Drop);
+        assert_eq!(GridAction::from_index(5), GridAction::Toggle);
+        assert_eq!(GridAction::from_index(6), GridAction::Done);
+    }
+
+    #[test]
+    fn to_index_values_are_canonical() {
+        assert_eq!(GridAction::TurnLeft.to_index(), 0);
+        assert_eq!(GridAction::TurnRight.to_index(), 1);
+        assert_eq!(GridAction::Forward.to_index(), 2);
+        assert_eq!(GridAction::Pickup.to_index(), 3);
+        assert_eq!(GridAction::Drop.to_index(), 4);
+        assert_eq!(GridAction::Toggle.to_index(), 5);
+        assert_eq!(GridAction::Done.to_index(), 6);
+    }
+
+    #[test]
     fn enumerate_returns_all_actions() {
         let all = GridAction::enumerate();
         assert_eq!(all.len(), GridAction::ACTION_COUNT);
@@ -89,6 +185,44 @@ mod tests {
     #[should_panic(expected = "GridAction index out of bounds")]
     fn from_index_out_of_bounds_panics() {
         let _ = GridAction::from_index(7);
+    }
+
+    // A separate test from the one above: a `#[should_panic]` body unwinds at
+    // the first panic, so one body cannot exercise both inputs.
+    #[test]
+    #[should_panic(expected = "GridAction index out of bounds")]
+    fn from_index_usize_max_panics() {
+        let _ = GridAction::from_index(usize::MAX);
+    }
+
+    #[test]
+    fn try_from_index_accepts_every_valid_index() {
+        for i in 0..GridAction::ACTION_COUNT {
+            assert_eq!(GridAction::try_from_index(i), Ok(GridAction::from_index(i)));
+        }
+    }
+
+    #[test]
+    fn try_from_index_rejects_out_of_range() {
+        let err = GridAction::try_from_index(7).expect_err("index 7 is out of range");
+        assert!(err.to_string().contains("index 7"), "message was {err}");
+
+        let err = GridAction::try_from_index(usize::MAX).expect_err("usize::MAX is out of range");
+        assert!(
+            err.to_string().contains(&usize::MAX.to_string()),
+            "message was {err}"
+        );
+    }
+
+    #[test]
+    fn try_from_matches_inherent_method() {
+        assert_eq!(GridAction::try_from(3usize), GridAction::try_from_index(3));
+        assert_eq!(GridAction::try_from(3usize), Ok(GridAction::Pickup));
+        assert_eq!(
+            GridAction::try_from(usize::MAX),
+            GridAction::try_from_index(usize::MAX)
+        );
+        assert!(GridAction::try_from(7usize).is_err());
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/core/grid.rs
+++ b/crates/rlevo-environments/src/grids/core/grid.rs
@@ -1,10 +1,108 @@
 //! Rectangular grid of [`Entity`] cells, an egocentric view extractor, and the
 //! shadow-casting pass that turns that view into a visibility-masked one.
 
+use rlevo_core::config::{ConfigError, ConstraintKind};
+use rlevo_core::environment::EnvironmentError;
+
 use super::agent::AgentState;
 use super::entity::Entity;
 use super::observation::VIEW_SIZE;
 use crate::direction::Direction;
+
+/// A write to a [`Grid`] cell that the grid's own geometry rejected.
+///
+/// # Why this is not a `PlacementError` variant
+///
+/// [`placement`](super::placement) already depends on this module
+/// (`use super::grid::Grid`), so the dependency runs *placement → grid* and
+/// only that way. Adding an out-of-bounds variant to
+/// [`PlacementError`](super::PlacementError) and importing it back here would
+/// close that edge into a cycle, and would also hang a grid-geometry failure
+/// off a type whose whole vocabulary — regions, rejection filters, exhausted
+/// searches — is about *choosing* a cell rather than *writing* one. The two
+/// errors converge anyway one layer up: both land on
+/// [`EnvironmentError::Config`] through [`ConfigError`], so a `reset()` that
+/// samples a position and then writes it can `?` through either with no
+/// bridging code.
+///
+/// # Reaching the environment error path
+///
+/// An out-of-bounds write is a config-domain failure — a layout the
+/// environment's own parameters produced — so it converts into [`ConfigError`]
+/// and from there into [`EnvironmentError::Config`], mirroring
+/// [`PlacementError`](super::PlacementError):
+///
+/// ```
+/// use rlevo_core::environment::EnvironmentError;
+/// use rlevo_environments::grids::core::{Entity, Grid};
+///
+/// let mut grid = Grid::new(4, 4);
+/// let err = grid.try_set(9, 0, Entity::Goal).unwrap_err();
+/// let as_env: EnvironmentError = err.into();
+/// assert!(matches!(as_env, EnvironmentError::Config(_)));
+/// ```
+///
+/// The conversion is lossy in one direction only: `ConfigError` is
+/// allocation-free (`&'static str` payloads), so the coordinates and the grid
+/// extent survive only on the `GridError` itself. Log or match the `GridError`
+/// where that detail matters, then convert.
+///
+/// # What `#[non_exhaustive]` buys here, and what it does not
+///
+/// Both the enum and its `OutOfBounds` variant are `#[non_exhaustive]`. That
+/// reserves exactly two freedoms: adding a *new* variant, and adding a *new*
+/// field to `OutOfBounds`, without either being a breaking change. It also
+/// stops downstream crates constructing the variant by struct literal, so its
+/// fields can only ever be produced by this module.
+///
+/// It does **not** make the existing fields malleable. A downstream
+/// `GridError::OutOfBounds { x, y, .. }` still binds `x` and `y` by name, so
+/// renaming or removing a field is a breaking change (`E0026`) whether or not
+/// the variant is non-exhaustive. Collapsing the loose `(x, y)` pair into the
+/// single `Pos` newtype of issue #863 is therefore a semver-major change here,
+/// and should be planned as one — the attribute does not buy a quiet migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum GridError {
+    /// A write targeted a cell outside the grid.
+    #[error("cell ({x}, {y}) is outside the {width}×{height} grid")]
+    #[non_exhaustive]
+    OutOfBounds {
+        /// The requested x coordinate.
+        x: i32,
+        /// The requested y coordinate.
+        y: i32,
+        /// The grid's width in cells.
+        width: usize,
+        /// The grid's height in cells.
+        height: usize,
+    },
+}
+
+impl From<GridError> for ConfigError {
+    fn from(err: GridError) -> Self {
+        // `ConstraintKind` has no variant for "a coordinate fell outside a
+        // derived extent", and `Custom` is the documented home for a one-off
+        // invariant with a static explanation. The message states the policy
+        // that was violated without asserting a mechanism, per `rules.md` §4.
+        let kind = match err {
+            GridError::OutOfBounds { .. } => {
+                ConstraintKind::Custom("grid cell coordinates lie outside the grid")
+            }
+        };
+        Self {
+            config: "Grid",
+            field: "cell",
+            kind,
+        }
+    }
+}
+
+impl From<GridError> for EnvironmentError {
+    fn from(err: GridError) -> Self {
+        Self::Config(ConfigError::from(err))
+    }
+}
 
 /// Rectangular grid of [`Entity`] cells, row-major in `y` then `x`.
 #[derive(Debug, Clone)]
@@ -19,14 +117,30 @@ impl Grid {
     ///
     /// # Panics
     ///
-    /// Panics if either dimension is zero.
+    /// Panics if either dimension is zero, or if `width * height` overflows
+    /// `usize`.
+    ///
+    /// The overflow check guards the *product* only, and it exists for one
+    /// specific failure: a wrapped `width * height` would build a backing store
+    /// shorter than the grid's own extent, leaving `index` free to run past it.
+    /// Catching it here turns that into an immediate, named panic.
+    ///
+    /// It is not a size ceiling. A single absurd dimension whose product does
+    /// not wrap — `Grid::new(1, usize::MAX)` — passes this check and then fails
+    /// inside the allocation instead, either with the allocator's own
+    /// `"capacity overflow"` panic or, for large-but-representable requests, by
+    /// exhausting memory. Callers that need a bounded grid size must impose
+    /// that bound themselves.
     #[must_use]
     pub fn new(width: usize, height: usize) -> Self {
         assert!(width > 0 && height > 0, "grid dimensions must be positive");
+        let cell_count = width.checked_mul(height).unwrap_or_else(|| {
+            panic!("grid dimensions overflow usize: {width} × {height} exceeds usize::MAX cells")
+        });
         Self {
             width,
             height,
-            cells: vec![Entity::Empty; width * height],
+            cells: vec![Entity::Empty; cell_count],
         }
     }
 
@@ -62,15 +176,69 @@ impl Grid {
         }
     }
 
+    /// Overwrite the cell at `(x, y)`, reporting an out-of-bounds write instead
+    /// of panicking.
+    ///
+    /// This is the fallible half of [`set`](Self::set) and the one to reach for
+    /// whenever the coordinates come from *data* rather than from a literal —
+    /// a config field, a sampled position, a decoded layout. `set` is the right
+    /// call only when the caller has already established the coordinates are in
+    /// range (as [`draw_walls`](Self::draw_walls) has), because there a failure
+    /// is a bug in this module rather than bad input.
+    ///
+    /// The grid is left untouched when the write is rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GridError::OutOfBounds`] if `(x, y)` lies outside the grid,
+    /// carrying both the requested coordinates and the grid extent. The error
+    /// converts into [`EnvironmentError`], so a `reset()` can `?` on it
+    /// directly.
+    ///
+    /// ```
+    /// use rlevo_environments::grids::core::{Entity, Grid, GridError};
+    ///
+    /// let mut grid = Grid::new(4, 3);
+    /// grid.try_set(1, 2, Entity::Goal)?;
+    /// assert_eq!(grid.get(1, 2), Entity::Goal);
+    ///
+    /// // A row past the bottom edge is rejected, not written.
+    /// assert!(matches!(
+    ///     grid.try_set(1, 3, Entity::Goal),
+    ///     Err(GridError::OutOfBounds { y: 3, height: 3, .. })
+    /// ));
+    /// # Ok::<(), GridError>(())
+    /// ```
+    pub fn try_set(&mut self, x: i32, y: i32, entity: Entity) -> Result<(), GridError> {
+        if !self.in_bounds(x, y) {
+            return Err(GridError::OutOfBounds {
+                x,
+                y,
+                width: self.width,
+                height: self.height,
+            });
+        }
+        let idx = self.index(x, y);
+        self.cells[idx] = entity;
+        Ok(())
+    }
+
     /// Overwrite the cell at `(x, y)`.
+    ///
+    /// The infallible spelling of [`try_set`](Self::try_set), for callers whose
+    /// coordinates are already known to be in range. The bounds check itself
+    /// lives in `try_set` and is not duplicated here.
     ///
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of bounds.
     pub fn set(&mut self, x: i32, y: i32, entity: Entity) {
-        assert!(self.in_bounds(x, y), "Grid::set out of bounds: ({x}, {y})");
-        let idx = self.index(x, y);
-        self.cells[idx] = entity;
+        // Destructured rather than interpolated whole: `GridError`'s own
+        // `Display` repeats the coordinates the prefix already carries, and
+        // only the extent is new information here.
+        if let Err(GridError::OutOfBounds { width, height, .. }) = self.try_set(x, y, entity) {
+            panic!("Grid::set out of bounds: ({x}, {y}) in a {width}×{height} grid");
+        }
     }
 
     /// Fill the outermost rows and columns with [`Entity::Wall`], producing
@@ -392,6 +560,120 @@ mod tests {
         g.set(1, 1, Entity::Goal);
         assert_eq!(g.get(1, 1), Entity::Goal);
         assert_eq!(g.get(0, 0), Entity::Empty);
+    }
+
+    #[test]
+    #[should_panic(expected = "Grid::set out of bounds")]
+    fn set_out_of_bounds_panics() {
+        let mut g = Grid::new(3, 3);
+        g.set(-1, 0, Entity::Goal);
+    }
+
+    #[test]
+    fn try_set_in_bounds_writes_the_cell() {
+        let mut g = Grid::new(3, 4);
+        assert_eq!(g.try_set(2, 3, Entity::Lava), Ok(()));
+        assert_eq!(g.get(2, 3), Entity::Lava);
+    }
+
+    #[test]
+    fn try_set_rejects_every_edge_and_leaves_the_grid_alone() {
+        let (width, height) = (3usize, 4usize);
+        #[allow(clippy::cast_possible_wrap)]
+        let (w, h) = (width as i32, height as i32);
+
+        // One cell of non-default content, so "unmodified" is a claim about the
+        // whole grid rather than about an all-Empty grid that a failed write
+        // could not have disturbed visibly.
+        let mut g = Grid::new(width, height);
+        g.set(1, 1, Entity::Goal);
+        let before = g.clone();
+
+        for (x, y) in [(-1, 0), (0, -1), (w, 0), (0, h)] {
+            let err = g.try_set(x, y, Entity::Lava).unwrap_err();
+            assert_eq!(
+                err,
+                GridError::OutOfBounds {
+                    x,
+                    y,
+                    width,
+                    height
+                },
+                "({x}, {y}) is outside a {width}×{height} grid"
+            );
+            assert_eq!(
+                g.cells, before.cells,
+                "a rejected write at ({x}, {y}) must not touch any cell"
+            );
+        }
+    }
+
+    #[test]
+    fn try_set_rejects_the_extremes_of_i32() {
+        // `in_bounds` short-circuits on `x >= 0` before the `usize::try_from`,
+        // so `i32::MIN` is rejected by the sign test and `i32::MAX` by the
+        // extent test. Pinned because a future rewrite to a raw `as usize`
+        // cast would sign-extend `i32::MIN` into a huge in-range-looking index
+        // on a 64-bit target and index straight past the backing store.
+        let (width, height) = (3usize, 4usize);
+        let mut g = Grid::new(width, height);
+        g.set(1, 1, Entity::Goal);
+        let before = g.clone();
+
+        for (x, y) in [
+            (i32::MIN, 0),
+            (0, i32::MIN),
+            (i32::MAX, 0),
+            (0, i32::MAX),
+            (i32::MIN, i32::MIN),
+            (i32::MAX, i32::MAX),
+        ] {
+            assert!(!g.in_bounds(x, y), "({x}, {y}) must not be in bounds");
+            assert_eq!(
+                g.try_set(x, y, Entity::Lava),
+                Err(GridError::OutOfBounds {
+                    x,
+                    y,
+                    width,
+                    height
+                }),
+                "({x}, {y}) must be rejected with the requested coordinates intact"
+            );
+            assert_eq!(
+                g.cells, before.cells,
+                "a rejected write at ({x}, {y}) must not touch any cell"
+            );
+        }
+    }
+
+    #[test]
+    fn grid_error_display_names_the_cell_and_the_extent() {
+        // Deliberately asymmetric on both axes — `width != height` and
+        // `x != y` — so transposing either pair in the `#[error(...)]` format
+        // string fails this assertion instead of rendering identically.
+        let mut g = Grid::new(4, 7);
+        let err = g.try_set(9, 2, Entity::Goal).unwrap_err();
+        assert_eq!(err.to_string(), "cell (9, 2) is outside the 4×7 grid");
+    }
+
+    #[test]
+    fn grid_error_converts_into_an_environment_config_error() {
+        let mut g = Grid::new(2, 2);
+        let err = g.try_set(5, 5, Entity::Goal).unwrap_err();
+        let as_env: rlevo_core::environment::EnvironmentError = err.into();
+        assert!(matches!(
+            as_env,
+            rlevo_core::environment::EnvironmentError::Config(_)
+        ));
+    }
+
+    #[test]
+    // The message must discriminate against Rust's own debug-build
+    // "attempt to multiply with overflow", which a bare `width * height` would
+    // raise here and which also contains the word "overflow".
+    #[should_panic(expected = "grid dimensions overflow usize")]
+    fn new_rejects_overflowing_dimensions() {
+        let _ = Grid::new(usize::MAX, 2);
     }
 
     #[test]

--- a/crates/rlevo-environments/src/grids/core/mod.rs
+++ b/crates/rlevo-environments/src/grids/core/mod.rs
@@ -65,7 +65,7 @@ pub use entity::{DoorState, Entity};
 // unoccluded window, which is only a correct emission model for an environment
 // that chose `Visibility::SeeThrough`. `observe_grid` is the public entry point
 // so the visibility policy cannot be bypassed from outside the crate.
-pub use grid::Grid;
+pub use grid::{Grid, GridError};
 pub use observation::{GridObservation, OBS_CHANNELS, UNSEEN_TYPE, VIEW_SIZE};
 pub use placement::{
     PlacementError, Rect, is_free, no_reject, place_agent, place_obj, random_direction, sample_pos,

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -284,6 +284,8 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
 | Builder `with_alpha(x)` | `x ∉ [0.0, 1.0]` |
 | `History::index(i)` | `i >= len()` |
 | `History::new(n)` | `n == 0` or `n > MAX_BUFFER_CAPACITY` |
+| `Grid::new(w, h)` | `w == 0`, `h == 0`, or `w * h` overflows `usize` |
+| `Grid::set(x, y, e)` | `(x, y)` out of bounds — use `Grid::try_set` for data-driven writes |
 | `SimulatedAnnealingParams::with_max_iters` | `max_iters == 0` |
 | `SimulatedAnnealingParams::with_initial_temp` | value not finite or not `> 0` |
 | `SimulatedAnnealingParams::with_cooling` | `Geometric` `factor ∉ (0, 1)`; `Linear` `delta` not finite or not `> 0` |


### PR DESCRIPTION
## Summary

Gives `grids/core` a fallible mirror for both of its panicking write paths, and pins the contracts that were previously unexercised. `Grid::set` and `GridAction::from_index` both panic on out-of-range input with no total alternative — correct for the literal and config-derived coordinates every in-tree caller uses, but `Grid` and `GridAction` are publicly re-exported, so a downstream layout loader or a policy head's argmax had no recoverable path at all. Both now delegate to a `try_*` sibling and keep their documented panics verbatim. Eight filed issues, two files, one question they all share: *does `grids/core` expose a fallible mirror for every panicking constructor/setter, and what does it return?* Answering that once, consistently, is why they are batched rather than landed separately — six of them touch the same file and would conflict line-for-line.

## Change Type

- [x] Other — hardening of existing API surface: two additive fallible constructors, one overflow guard, and the tests/docs pinning contracts that already existed. No new environments, algorithms, or dependencies. Every item was filed as its own issue by the maintainer.

## Linked Issue

Closes #864
Closes #862
Closes #813
Closes #815
Closes #819
Closes #829
Closes #831
Closes #835

## What Was Changed

**`crates/rlevo-environments/src/grids/core/grid.rs`**
- Added `GridError` (`#[non_exhaustive]`, `Copy`, `thiserror`) with `OutOfBounds { x, y, width, height }`, plus `From<GridError>` for `ConfigError` and `EnvironmentError` so a `reset()` can `?` straight through it.
- Added `pub fn try_set(&mut self, x: i32, y: i32, entity: Entity) -> Result<(), GridError>`; `set` now delegates to it, giving the bounds check a single home. `draw_walls` and all ~28 environment call sites are untouched.
- `Grid::new` guards `width * height` with `checked_mul` before allocating.
- Tests: `set`'s OOB panic (previously untested), `try_set` round-trip, all four edges rejected with the grid left unmodified, `i32::MIN`/`i32::MAX` coordinates, `EnvironmentError` conversion, `GridError`'s rendered `Display`, and the overflow guard. Two doctests.

**`crates/rlevo-environments/src/grids/core/action.rs`**
- Added `GridAction::try_from_index` and `impl TryFrom<usize>`, both returning `InvalidActionError`; `from_index` delegates.
- Added the `# Panics` section `from_index` was missing, and a `const _: ()` assertion tying the explicit discriminants to `ACTION_COUNT`.
- Tests: canonical index→variant bindings, literal `to_index` values, `usize::MAX`, and the `try_from_index`/`TryFrom` agreement cases.

**`crates/rlevo-environments/src/grids/core/mod.rs`** — re-export `GridError` alongside `Grid`, matching how `PlacementError` is already exposed.

**`docs/rules.md`** — two rows added to the Documented Panic Contracts table (`Grid::new`, `Grid::set`); both were absent.

**`CHANGELOG.md`** — two entries under `[Unreleased]` → `rlevo-environments` → **Added**.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace --exclude rlevo-examples     61 binaries ok, 0 failed
cargo clippy --all-targets --all-features           clean
cargo fmt --all -- --check                          clean
cargo doc -p rlevo-environments --no-deps [--all-features]   no grids/core warnings
```

`grids` is ungated at `lib.rs:108`, so the feature-orthogonality job lints it in isolation too. Both combos run clean:

```
cargo clippy -p rlevo-environments --all-targets --no-default-features --features box2d -- -D warnings
cargo clippy -p rlevo-environments --all-targets --no-default-features --features locomotion -- -D warnings
```

Every new test was mutation-checked rather than merely observed to pass:

| Mutation | Result |
|---|---|
| Swap two `try_from_index` match arms | `index_bindings_are_canonical` fails |
| `ACTION_COUNT: 7 → 8` | `E0080` at the const block — compile error, not a test failure |
| Invert `try_set`'s bounds check | 269 tests fail across the grid-consuming surface |
| `checked_mul` → `*` | `new_rejects_overflowing_dimensions` fails |
| Transpose `{width}`/`{height}` in `GridError`'s format string | `grid_error_display_...` fails |

- Rust toolchain: `1.94.1` (pinned in `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU) — no tensor code in this diff
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change** — issue verification, design, implementation, tests, and docs, across delegated subagents. Reviewed and verified by the maintainer.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings.
- [x] Public API additions include doc comments explaining *what* and *why*.
- [x] Regression tests included; each verified to fail against the unfixed code (table above).
- [x] This PR addresses a single concern. Eight issues, but one decision — see Summary. Split into two commits along the file boundary if that reviews better.
- [x] Ready for Review.

## Notes

Three claims in the filed issues did not survive verification. Recording them here because acting on any of the three would have produced a worse change:

1. **#864's premise is false.** It says `draw_walls` is the only in-crate caller of `Grid::set`. There are ~28 non-test call sites across 12 environment modules. The conclusion — no `validate()`-passing config panics today — still holds, but because each env calls `Grid::new(config.size, …)` with the same field its coordinates derive from, so a larger config builds a larger grid. That safety is non-local and undocumented at the call site: `unlock.rs:362` writes a literal `(2, 1)`, correct only because `MIN_SIZE = 4` lives 277 lines away in a different `impl`.

2. **The proposed `-> bool` signature was rejected.** `try_*` returns `Result` everywhere else in the workspace (`rules.md` §88, §97), `bool` here is reserved for predicates like `in_bounds`, and `Grid` is public — widening `bool` to `Result` later would break callers.

3. **#864 and #831 both claim `PixelGridAction::from_index` shares the `# Panics` gap.** It does not; it has carried the doc since `9335c07`. Left unswept deliberately.

Two design points worth a reviewer's eye:

- **`#[non_exhaustive]` does less than it looks like.** It is on both the enum and the `OutOfBounds` variant, which reserves future additions and blocks downstream struct literals — but it does *not* make `x`/`y` renameable. A downstream `OutOfBounds { x, y, .. }` binds them by name, so #863's `(x, y)` → `Pos` collapse is semver-major regardless. Settled with a two-crate compile check (`E0026`); the source doc says so explicitly, since an earlier draft claimed the opposite.
- **`checked_mul` guards the product, not the dimensions.** `Grid::new(1, usize::MAX)` does not wrap and still dies inside the allocation. The `# Panics` doc states this rather than overclaiming. Bounding grid size is left to callers — a ceiling is out of scope for #862 and wants its own issue.

Follow-ups, not addressed here:

- **#868 is wrong as filed** and would turn a passing test red: it proposes `assert_eq!(wall_count, 47)`, but the executed value is **45**. Its derivation assumes at most 2 view cells fall inside the grid; for `Direction::East` all 4 cells of the 2×2 fixture do. Commented on the issue.
- **#836 is still blocked** after #813 lands — ADR 0036 scopes `proptest` to `rlevo-evolution` dev-deps only.
- **#863** now has two more raw-`(i32, i32)` surfaces in its blast radius (`try_set`, `GridError::OutOfBounds`); both are confined to `grid.rs` so far.
