### PR TITLE
feat(env): Add fallible from_index siblings across toy_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,8 +261,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `TaxiAction`, `FrozenLakeAction` and `CliffWalkingAction`** (resolves #954,
   #951, #971, #1093). Prospective hardening, not a live defect: the panic was
   and remains the documented `DiscreteAction::from_index` contract
-  (`rlevo-core/src/action.rs:117-123`), and every in-tree caller feeds it an
-  argmax over `ACTION_COUNT` logits. What was actually wrong is that all four
+  (`rlevo-core/src/action.rs:117-123`), and the sole in-tree caller
+  (`rlevo-examples/examples/toy_text/report_toy_text_with_client.rs:70`)
+  pre-clamps its index with `Uniform::new(0, ACTION_COUNT)`. What was actually wrong is that all four
   impls carried no doc comment at all — so the panic was undocumented at the
   point a reader would look for it — and there was no non-panicking path for an
   index that arrives from data (a replay log, a deserialized trajectory, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   variant order (#815, #819, #835 add the literal-binding, literal-`to_index`,
   and `usize::MAX` cases that pin it).
 
+- **`try_from_index` and `impl TryFrom<usize>` for `BlackjackAction`,
+  `TaxiAction`, `FrozenLakeAction` and `CliffWalkingAction`** (resolves #954,
+  #951, #971, #1093). Prospective hardening, not a live defect: the panic was
+  and remains the documented `DiscreteAction::from_index` contract
+  (`rlevo-core/src/action.rs:117-123`), and every in-tree caller feeds it an
+  argmax over `ACTION_COUNT` logits. What was actually wrong is that all four
+  impls carried no doc comment at all — so the panic was undocumented at the
+  point a reader would look for it — and there was no non-panicking path for an
+  index that arrives from data (a replay log, a deserialized trajectory, a
+  mis-sized policy head) rather than from a trusted computation. `from_index`
+  keeps its panic and its exact message, now routed through the fallible
+  constructor; the additions are purely additive and no caller needs to migrate.
+  The pre-existing coverage missed the gap because it was a self-referential
+  round-trip (`from_index(to_index(a)) == a`), which passes unchanged under a
+  shuffled variant order and so pinned nothing about the wire format. Literal
+  index-binding assertions now pin it, which matters most for `TaxiAction`
+  (South 0, North 1, East 2, West 3 — neither alphabetical nor compass order)
+  and for the fact that `CliffWalkingAction` (Up, Right, Down, Left) and
+  `FrozenLakeAction` (Left, Down, Right, Up) deliberately use *different*
+  orders, so a well-meaning cross-file "harmonization" would silently corrupt an
+  action space.
+
 ### `rlevo-evolution`
 
 **Fixed**

--- a/crates/rlevo-environments/src/toy_text/blackjack.rs
+++ b/crates/rlevo-environments/src/toy_text/blackjack.rs
@@ -39,7 +39,7 @@
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rlevo_core::action::DiscreteAction;
+use rlevo_core::action::{DiscreteAction, InvalidActionError};
 use rlevo_core::base::{Action, Observation, State};
 use rlevo_core::config::{ConfigError, Validate};
 use rlevo_core::environment::{
@@ -257,6 +257,46 @@ pub enum BlackjackAction {
     Hit = 1,
 }
 
+impl BlackjackAction {
+    /// Constructs an action from its zero-based index, returning an error if
+    /// `index` is out of range.
+    ///
+    /// This is the fallible counterpart to [`DiscreteAction::from_index`], for
+    /// callers whose index comes from data (a replay log, a deserialized
+    /// trajectory, a mis-sized policy head) rather than from a trusted
+    /// in-range computation such as an argmax over `ACTION_COUNT` logits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`; the message
+    /// names the offending index and the valid range.
+    pub fn try_from_index(index: usize) -> Result<Self, InvalidActionError> {
+        match index {
+            0 => Ok(BlackjackAction::Stick),
+            1 => Ok(BlackjackAction::Hit),
+            _ => Err(InvalidActionError {
+                message: format!(
+                    "BlackjackAction index {index} out of range [0, {})",
+                    Self::ACTION_COUNT
+                ),
+            }),
+        }
+    }
+}
+
+impl TryFrom<usize> for BlackjackAction {
+    type Error = InvalidActionError;
+
+    /// Delegates to [`BlackjackAction::try_from_index`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`.
+    fn try_from(index: usize) -> Result<Self, Self::Error> {
+        Self::try_from_index(index)
+    }
+}
+
 impl Action<1> for BlackjackAction {
     fn shape() -> [usize; 1] {
         [1]
@@ -269,12 +309,27 @@ impl Action<1> for BlackjackAction {
 impl DiscreteAction<1> for BlackjackAction {
     const ACTION_COUNT: usize = 2;
 
+    /// Constructs an action from its zero-based index.
+    ///
+    /// Use [`Self::try_from_index`] (or the equivalent [`TryFrom<usize>`]
+    /// implementation) when the index originates from data rather than from a
+    /// trusted in-range computation such as an argmax over `ACTION_COUNT`
+    /// logits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= ACTION_COUNT`, per the
+    /// [`DiscreteAction::from_index`] contract.
     fn from_index(index: usize) -> Self {
-        match index {
-            0 => BlackjackAction::Stick,
-            1 => BlackjackAction::Hit,
-            _ => panic!("BlackjackAction index {index} out of range [0, 2)"),
-        }
+        // The error's own `Display` prefixes "Invalid action:", which would read
+        // as noise here; the panic keeps the message this environment has always
+        // emitted, verbatim.
+        Self::try_from_index(index).unwrap_or_else(|_| {
+            panic!(
+                "BlackjackAction index {index} out of range [0, {})",
+                Self::ACTION_COUNT
+            )
+        })
     }
 
     fn to_index(&self) -> usize {
@@ -588,6 +643,78 @@ mod tests {
         for i in 0..BlackjackAction::ACTION_COUNT {
             assert_eq!(BlackjackAction::from_index(i).to_index(), i);
         }
+    }
+
+    #[test]
+    /// Verifies each index binds to its documented variant.
+    fn index_bindings_are_canonical() {
+        // Literal, not a loop: `action_roundtrip` is self-referential and still
+        // passes if the variant order is shuffled. These pin each index to a
+        // named variant.
+        assert_eq!(BlackjackAction::from_index(0), BlackjackAction::Stick);
+        assert_eq!(BlackjackAction::from_index(1), BlackjackAction::Hit);
+    }
+
+    #[test]
+    /// Verifies each variant reports its documented index.
+    fn to_index_values_are_canonical() {
+        assert_eq!(BlackjackAction::Stick.to_index(), 0);
+        assert_eq!(BlackjackAction::Hit.to_index(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "BlackjackAction index 2 out of range [0, 2)")]
+    fn from_index_out_of_range_panics() {
+        let _ = BlackjackAction::from_index(2);
+    }
+
+    // A separate test from the one above: a `#[should_panic]` body unwinds at
+    // the first panic, so one body cannot exercise both inputs.
+    #[test]
+    #[should_panic(expected = "out of range [0, 2)")]
+    fn from_index_usize_max_panics() {
+        let _ = BlackjackAction::from_index(usize::MAX);
+    }
+
+    #[test]
+    fn try_from_index_accepts_every_valid_index() {
+        for i in 0..BlackjackAction::ACTION_COUNT {
+            assert_eq!(
+                BlackjackAction::try_from_index(i),
+                Ok(BlackjackAction::from_index(i))
+            );
+        }
+    }
+
+    #[test]
+    fn try_from_index_rejects_out_of_range() {
+        let err = BlackjackAction::try_from_index(2).expect_err("index 2 is out of range");
+        assert!(err.to_string().contains("index 2"), "message was {err}");
+
+        let err =
+            BlackjackAction::try_from_index(usize::MAX).expect_err("usize::MAX is out of range");
+        assert!(
+            err.to_string().contains(&usize::MAX.to_string()),
+            "message was {err}"
+        );
+    }
+
+    #[test]
+    fn try_from_matches_inherent_method() {
+        assert_eq!(
+            BlackjackAction::try_from(1usize),
+            BlackjackAction::try_from_index(1)
+        );
+        assert_eq!(BlackjackAction::try_from(1usize), Ok(BlackjackAction::Hit));
+        assert_eq!(
+            BlackjackAction::try_from(2usize),
+            BlackjackAction::try_from_index(2)
+        );
+        assert!(BlackjackAction::try_from(2usize).is_err());
+        assert_eq!(
+            BlackjackAction::try_from(usize::MAX),
+            BlackjackAction::try_from_index(usize::MAX)
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/toy_text/cliff_walking.rs
+++ b/crates/rlevo-environments/src/toy_text/cliff_walking.rs
@@ -49,7 +49,7 @@ use crate::episode::EpisodeGuard;
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rlevo_core::action::DiscreteAction;
+use rlevo_core::action::{DiscreteAction, InvalidActionError};
 use rlevo_core::base::{Action, Observation, State};
 use rlevo_core::config::{ConfigError, Validate};
 use rlevo_core::environment::{
@@ -235,14 +235,27 @@ impl Action<1> for CliffWalkingAction {
 impl DiscreteAction<1> for CliffWalkingAction {
     const ACTION_COUNT: usize = 4;
 
+    /// Constructs an action from its zero-based index.
+    ///
+    /// Use [`Self::try_from_index`] (or the equivalent [`TryFrom<usize>`]
+    /// implementation) when the index originates from data — a replay log, a
+    /// deserialized trajectory, a mis-sized policy head — rather than from a
+    /// trusted in-range computation such as an argmax over `ACTION_COUNT`
+    /// logits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= ACTION_COUNT`, per the
+    /// [`DiscreteAction::from_index`] contract.
     fn from_index(index: usize) -> Self {
-        match index {
-            0 => CliffWalkingAction::Up,
-            1 => CliffWalkingAction::Right,
-            2 => CliffWalkingAction::Down,
-            3 => CliffWalkingAction::Left,
-            _ => panic!("CliffWalkingAction index {index} out of range [0, 4)"),
-        }
+        // The error's own `Display` prefixes "Invalid action:", which would
+        // read as noise in a panic message; the wording is otherwise identical.
+        Self::try_from_index(index).unwrap_or_else(|_| {
+            panic!(
+                "CliffWalkingAction index {index} out of range [0, {})",
+                Self::ACTION_COUNT
+            )
+        })
     }
 
     fn to_index(&self) -> usize {
@@ -251,6 +264,37 @@ impl DiscreteAction<1> for CliffWalkingAction {
 }
 
 impl CliffWalkingAction {
+    /// Constructs an action from its zero-based index, returning an error if
+    /// `index` is out of range.
+    ///
+    /// This is the fallible counterpart to [`DiscreteAction::from_index`], for
+    /// callers whose index comes from data (a replay log, a deserialized
+    /// trajectory, a mis-sized policy head) rather than from a trusted in-range
+    /// computation.
+    ///
+    /// The index order is the Gymnasium wire format — `Up` (0), `Right` (1),
+    /// `Down` (2), `Left` (3) — and deliberately differs from the sibling
+    /// `FrozenLakeAction` ordering.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`; the message
+    /// names the offending index and the valid range.
+    pub fn try_from_index(index: usize) -> Result<Self, InvalidActionError> {
+        match index {
+            0 => Ok(CliffWalkingAction::Up),
+            1 => Ok(CliffWalkingAction::Right),
+            2 => Ok(CliffWalkingAction::Down),
+            3 => Ok(CliffWalkingAction::Left),
+            _ => Err(InvalidActionError {
+                message: format!(
+                    "CliffWalkingAction index {index} out of range [0, {})",
+                    Self::ACTION_COUNT
+                ),
+            }),
+        }
+    }
+
     fn perpendiculars(self) -> [CliffWalkingAction; 2] {
         match self {
             CliffWalkingAction::Up | CliffWalkingAction::Down => {
@@ -260,6 +304,19 @@ impl CliffWalkingAction {
                 [CliffWalkingAction::Up, CliffWalkingAction::Down]
             }
         }
+    }
+}
+
+impl TryFrom<usize> for CliffWalkingAction {
+    type Error = InvalidActionError;
+
+    /// Delegates to [`CliffWalkingAction::try_from_index`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`.
+    fn try_from(index: usize) -> Result<Self, Self::Error> {
+        Self::try_from_index(index)
     }
 }
 
@@ -587,6 +644,86 @@ mod tests {
     /// Verifies the discrete action count matches the four-direction action space.
     fn action_count() {
         assert_eq!(CliffWalkingAction::ACTION_COUNT, 4);
+    }
+
+    #[test]
+    /// Pins each index to a named variant. Literal, not a loop: a
+    /// `from_index`/`to_index` roundtrip is self-referential and still passes
+    /// if the variants are shuffled. This enum uses the Gymnasium order
+    /// (Up, Right, Down, Left), which differs from its `FrozenLake` sibling
+    /// (Left, Down, Right, Up), so a "harmonizing" reorder is a live hazard.
+    fn index_bindings_are_canonical() {
+        assert_eq!(CliffWalkingAction::from_index(0), CliffWalkingAction::Up);
+        assert_eq!(CliffWalkingAction::from_index(1), CliffWalkingAction::Right);
+        assert_eq!(CliffWalkingAction::from_index(2), CliffWalkingAction::Down);
+        assert_eq!(CliffWalkingAction::from_index(3), CliffWalkingAction::Left);
+    }
+
+    #[test]
+    /// Pins the wire-format index each variant serialises to.
+    fn to_index_values_are_canonical() {
+        assert_eq!(CliffWalkingAction::Up.to_index(), 0);
+        assert_eq!(CliffWalkingAction::Right.to_index(), 1);
+        assert_eq!(CliffWalkingAction::Down.to_index(), 2);
+        assert_eq!(CliffWalkingAction::Left.to_index(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "CliffWalkingAction index 4 out of range [0, 4)")]
+    fn from_index_out_of_range_panics() {
+        let _ = CliffWalkingAction::from_index(4);
+    }
+
+    // A separate test from the one above: a `#[should_panic]` body unwinds at
+    // the first panic, so one body cannot exercise both inputs.
+    #[test]
+    #[should_panic(expected = "out of range [0, 4)")]
+    fn from_index_usize_max_panics() {
+        let _ = CliffWalkingAction::from_index(usize::MAX);
+    }
+
+    #[test]
+    fn try_from_index_accepts_every_valid_index() {
+        for i in 0..CliffWalkingAction::ACTION_COUNT {
+            assert_eq!(
+                CliffWalkingAction::try_from_index(i),
+                Ok(CliffWalkingAction::from_index(i))
+            );
+        }
+    }
+
+    #[test]
+    fn try_from_index_rejects_out_of_range() {
+        let err = CliffWalkingAction::try_from_index(4).expect_err("index 4 is out of range");
+        assert!(err.to_string().contains("index 4"), "message was {err}");
+
+        let err =
+            CliffWalkingAction::try_from_index(usize::MAX).expect_err("usize::MAX is out of range");
+        assert!(
+            err.to_string().contains(&usize::MAX.to_string()),
+            "message was {err}"
+        );
+    }
+
+    #[test]
+    fn try_from_matches_inherent_method() {
+        assert_eq!(
+            CliffWalkingAction::try_from(1usize),
+            CliffWalkingAction::try_from_index(1)
+        );
+        assert_eq!(
+            CliffWalkingAction::try_from(1usize),
+            Ok(CliffWalkingAction::Right)
+        );
+        assert_eq!(
+            CliffWalkingAction::try_from(4usize),
+            CliffWalkingAction::try_from_index(4)
+        );
+        assert!(CliffWalkingAction::try_from(4usize).is_err());
+        assert_eq!(
+            CliffWalkingAction::try_from(usize::MAX),
+            CliffWalkingAction::try_from_index(usize::MAX)
+        );
     }
 
     #[test]

--- a/crates/rlevo-environments/src/toy_text/frozen_lake.rs
+++ b/crates/rlevo-environments/src/toy_text/frozen_lake.rs
@@ -32,7 +32,7 @@ use std::collections::VecDeque;
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rlevo_core::action::DiscreteAction;
+use rlevo_core::action::{DiscreteAction, InvalidActionError};
 use rlevo_core::base::{Action, Observation, State};
 use rlevo_core::config::{self, ConfigError, Validate};
 use rlevo_core::environment::{
@@ -493,14 +493,25 @@ impl Action<1> for FrozenLakeAction {
 impl DiscreteAction<1> for FrozenLakeAction {
     const ACTION_COUNT: usize = 4;
 
+    /// Constructs an action from its zero-based index.
+    ///
+    /// Use [`Self::try_from_index`] (or the equivalent [`TryFrom<usize>`]
+    /// implementation) when the index originates from data — a replay log, a
+    /// deserialized trajectory, a mis-sized policy head — rather than from a
+    /// trusted in-range computation such as an argmax over `ACTION_COUNT`
+    /// logits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= ACTION_COUNT`, per the
+    /// [`DiscreteAction::from_index`] contract.
     fn from_index(index: usize) -> Self {
-        match index {
-            0 => FrozenLakeAction::Left,
-            1 => FrozenLakeAction::Down,
-            2 => FrozenLakeAction::Right,
-            3 => FrozenLakeAction::Up,
-            _ => panic!("FrozenLakeAction index {index} out of range [0, 4)"),
-        }
+        Self::try_from_index(index).unwrap_or_else(|_| {
+            panic!(
+                "FrozenLakeAction index {index} out of range [0, {})",
+                Self::ACTION_COUNT
+            )
+        })
     }
 
     fn to_index(&self) -> usize {
@@ -509,6 +520,37 @@ impl DiscreteAction<1> for FrozenLakeAction {
 }
 
 impl FrozenLakeAction {
+    /// Constructs an action from its zero-based index, returning an error if
+    /// `index` is out of range.
+    ///
+    /// This is the fallible counterpart to [`DiscreteAction::from_index`], for
+    /// callers whose index comes from data (a replay log, a deserialized
+    /// trajectory, a mis-sized policy head) rather than from a trusted
+    /// in-range computation.
+    ///
+    /// The index order is Gymnasium's `FrozenLake` wire format — `Left` (0),
+    /// `Down` (1), `Right` (2), `Up` (3) — which deliberately differs from the
+    /// ordering used by sibling toy-text environments.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`; the message
+    /// names the offending index and the valid range.
+    pub fn try_from_index(index: usize) -> Result<Self, InvalidActionError> {
+        match index {
+            0 => Ok(FrozenLakeAction::Left),
+            1 => Ok(FrozenLakeAction::Down),
+            2 => Ok(FrozenLakeAction::Right),
+            3 => Ok(FrozenLakeAction::Up),
+            _ => Err(InvalidActionError {
+                message: format!(
+                    "FrozenLakeAction index {index} out of range [0, {})",
+                    Self::ACTION_COUNT
+                ),
+            }),
+        }
+    }
+
     fn perpendiculars(self) -> [FrozenLakeAction; 2] {
         match self {
             FrozenLakeAction::Left | FrozenLakeAction::Right => {
@@ -518,6 +560,19 @@ impl FrozenLakeAction {
                 [FrozenLakeAction::Left, FrozenLakeAction::Right]
             }
         }
+    }
+}
+
+impl TryFrom<usize> for FrozenLakeAction {
+    type Error = InvalidActionError;
+
+    /// Delegates to [`FrozenLakeAction::try_from_index`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`.
+    fn try_from(index: usize) -> Result<Self, Self::Error> {
+        Self::try_from_index(index)
     }
 }
 
@@ -945,6 +1000,81 @@ mod tests {
         for i in 0..FrozenLakeAction::ACTION_COUNT {
             assert_eq!(FrozenLakeAction::from_index(i).to_index(), i);
         }
+    }
+
+    #[test]
+    fn index_bindings_are_canonical() {
+        // Literal, not a loop: `action_roundtrip` is self-referential and still
+        // passes if the variant order is shuffled. These pin each index to a
+        // named variant — and this enum's Gymnasium order (Left, Down, Right,
+        // Up) deliberately differs from its CliffWalking sibling's, so a
+        // "harmonizing" reorder is a live hazard.
+        assert_eq!(FrozenLakeAction::from_index(0), FrozenLakeAction::Left);
+        assert_eq!(FrozenLakeAction::from_index(1), FrozenLakeAction::Down);
+        assert_eq!(FrozenLakeAction::from_index(2), FrozenLakeAction::Right);
+        assert_eq!(FrozenLakeAction::from_index(3), FrozenLakeAction::Up);
+    }
+
+    #[test]
+    fn to_index_values_are_canonical() {
+        assert_eq!(FrozenLakeAction::Left.to_index(), 0);
+        assert_eq!(FrozenLakeAction::Down.to_index(), 1);
+        assert_eq!(FrozenLakeAction::Right.to_index(), 2);
+        assert_eq!(FrozenLakeAction::Up.to_index(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "FrozenLakeAction index 4 out of range [0, 4)")]
+    fn from_index_out_of_range_panics() {
+        let _ = FrozenLakeAction::from_index(4);
+    }
+
+    // A separate test from the one above: a `#[should_panic]` body unwinds at
+    // the first panic, so one body cannot exercise both inputs.
+    #[test]
+    #[should_panic(expected = "out of range [0, 4)")]
+    fn from_index_usize_max_panics() {
+        let _ = FrozenLakeAction::from_index(usize::MAX);
+    }
+
+    #[test]
+    fn try_from_index_accepts_every_valid_index() {
+        for i in 0..FrozenLakeAction::ACTION_COUNT {
+            assert_eq!(
+                FrozenLakeAction::try_from_index(i),
+                Ok(FrozenLakeAction::from_index(i))
+            );
+        }
+    }
+
+    #[test]
+    fn try_from_index_rejects_out_of_range() {
+        let err = FrozenLakeAction::try_from_index(4).expect_err("index 4 is out of range");
+        assert!(err.to_string().contains("index 4"), "message was {err}");
+
+        let err =
+            FrozenLakeAction::try_from_index(usize::MAX).expect_err("usize::MAX is out of range");
+        assert!(
+            err.to_string().contains(&usize::MAX.to_string()),
+            "message was {err}"
+        );
+    }
+
+    #[test]
+    fn try_from_matches_inherent_method() {
+        assert_eq!(
+            FrozenLakeAction::try_from(1usize),
+            FrozenLakeAction::try_from_index(1)
+        );
+        assert_eq!(
+            FrozenLakeAction::try_from(1usize),
+            Ok(FrozenLakeAction::Down)
+        );
+        assert_eq!(
+            FrozenLakeAction::try_from(usize::MAX),
+            FrozenLakeAction::try_from_index(usize::MAX)
+        );
+        assert!(FrozenLakeAction::try_from(4usize).is_err());
     }
 
     #[test]

--- a/crates/rlevo-environments/src/toy_text/taxi.rs
+++ b/crates/rlevo-environments/src/toy_text/taxi.rs
@@ -45,7 +45,7 @@ use crate::episode::EpisodeGuard;
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rlevo_core::action::DiscreteAction;
+use rlevo_core::action::{DiscreteAction, InvalidActionError};
 use rlevo_core::base::{Action, Observation, State};
 use rlevo_core::config::{ConfigError, Validate};
 use rlevo_core::environment::{
@@ -282,20 +282,75 @@ impl Action<1> for TaxiAction {
 impl DiscreteAction<1> for TaxiAction {
     const ACTION_COUNT: usize = 6;
 
+    /// Constructs an action from its zero-based index.
+    ///
+    /// Use [`Self::try_from_index`] (or the equivalent [`TryFrom<usize>`]
+    /// implementation) when the index originates from data — a replay log, a
+    /// deserialized trajectory, a mis-sized policy head — rather than from a
+    /// trusted in-range computation such as an argmax over `ACTION_COUNT`
+    /// logits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= ACTION_COUNT`, per the
+    /// [`DiscreteAction::from_index`] contract.
     fn from_index(index: usize) -> Self {
-        match index {
-            0 => TaxiAction::South,
-            1 => TaxiAction::North,
-            2 => TaxiAction::East,
-            3 => TaxiAction::West,
-            4 => TaxiAction::Pickup,
-            5 => TaxiAction::Dropoff,
-            _ => panic!("TaxiAction index {index} out of range [0, 6)"),
-        }
+        // The error's own `Display` prefixes "Invalid action:", which would read
+        // as noise here; the panic keeps the historical wording verbatim.
+        Self::try_from_index(index).unwrap_or_else(|_| {
+            panic!(
+                "TaxiAction index {index} out of range [0, {})",
+                Self::ACTION_COUNT
+            )
+        })
     }
 
     fn to_index(&self) -> usize {
         *self as usize
+    }
+}
+
+impl TaxiAction {
+    /// Constructs an action from its zero-based index, returning an error if
+    /// `index` is out of range.
+    ///
+    /// This is the fallible counterpart to [`DiscreteAction::from_index`], for
+    /// callers whose index comes from data (a replay log, a deserialized
+    /// trajectory, a mis-sized policy head) rather than from a trusted in-range
+    /// computation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`; the message
+    /// names the offending index and the valid range.
+    pub fn try_from_index(index: usize) -> Result<Self, InvalidActionError> {
+        match index {
+            0 => Ok(TaxiAction::South),
+            1 => Ok(TaxiAction::North),
+            2 => Ok(TaxiAction::East),
+            3 => Ok(TaxiAction::West),
+            4 => Ok(TaxiAction::Pickup),
+            5 => Ok(TaxiAction::Dropoff),
+            _ => Err(InvalidActionError {
+                message: format!(
+                    "TaxiAction index {index} out of range [0, {})",
+                    Self::ACTION_COUNT
+                ),
+            }),
+        }
+    }
+}
+
+impl TryFrom<usize> for TaxiAction {
+    type Error = InvalidActionError;
+
+    /// Delegates to [`TaxiAction::try_from_index`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidActionError`] if `index >= ACTION_COUNT`.
+    fn try_from(index: usize) -> Result<Self, Self::Error> {
+        Self::try_from_index(index)
     }
 }
 
@@ -793,6 +848,81 @@ mod tests {
         for i in 0..TaxiAction::ACTION_COUNT {
             assert_eq!(TaxiAction::from_index(i).to_index(), i);
         }
+    }
+
+    #[test]
+    /// Pins each index to a named variant: the Gymnasium wire format is
+    /// South, North, East, West — neither alphabetical nor compass order.
+    fn index_bindings_are_canonical() {
+        // Literal, not a loop: `action_roundtrip` is self-referential and still
+        // passes if the variant order is shuffled. These pin each index to a
+        // named variant.
+        assert_eq!(TaxiAction::from_index(0), TaxiAction::South);
+        assert_eq!(TaxiAction::from_index(1), TaxiAction::North);
+        assert_eq!(TaxiAction::from_index(2), TaxiAction::East);
+        assert_eq!(TaxiAction::from_index(3), TaxiAction::West);
+        assert_eq!(TaxiAction::from_index(4), TaxiAction::Pickup);
+        assert_eq!(TaxiAction::from_index(5), TaxiAction::Dropoff);
+    }
+
+    #[test]
+    /// Pins the index each variant reports, in the Gymnasium wire order.
+    fn to_index_values_are_canonical() {
+        assert_eq!(TaxiAction::South.to_index(), 0);
+        assert_eq!(TaxiAction::North.to_index(), 1);
+        assert_eq!(TaxiAction::East.to_index(), 2);
+        assert_eq!(TaxiAction::West.to_index(), 3);
+        assert_eq!(TaxiAction::Pickup.to_index(), 4);
+        assert_eq!(TaxiAction::Dropoff.to_index(), 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "TaxiAction index 6 out of range")]
+    /// Verifies the documented `DiscreteAction::from_index` panic contract.
+    fn from_index_out_of_range_panics() {
+        let _ = TaxiAction::from_index(6);
+    }
+
+    // A separate test from the one above: a `#[should_panic]` body unwinds at
+    // the first panic, so one body cannot exercise both inputs.
+    #[test]
+    #[should_panic(expected = "out of range")]
+    /// Verifies the panic contract holds at the extreme end of the index domain.
+    fn from_index_usize_max_panics() {
+        let _ = TaxiAction::from_index(usize::MAX);
+    }
+
+    #[test]
+    /// Verifies the fallible constructor accepts every in-range index.
+    fn try_from_index_accepts_every_valid_index() {
+        for i in 0..TaxiAction::ACTION_COUNT {
+            assert_eq!(TaxiAction::try_from_index(i), Ok(TaxiAction::from_index(i)));
+        }
+    }
+
+    #[test]
+    /// Verifies out-of-range indices are rejected with a message naming the index.
+    fn try_from_index_rejects_out_of_range() {
+        let err = TaxiAction::try_from_index(6).expect_err("index 6 is out of range");
+        assert!(err.to_string().contains("index 6"), "message was {err}");
+
+        let err = TaxiAction::try_from_index(usize::MAX).expect_err("usize::MAX is out of range");
+        assert!(
+            err.to_string().contains(&usize::MAX.to_string()),
+            "message was {err}"
+        );
+    }
+
+    #[test]
+    /// Verifies the `TryFrom` impl is a faithful delegate of the inherent method.
+    fn try_from_matches_inherent_method() {
+        assert_eq!(TaxiAction::try_from(3usize), TaxiAction::try_from_index(3));
+        assert_eq!(TaxiAction::try_from(3usize), Ok(TaxiAction::West));
+        assert_eq!(
+            TaxiAction::try_from(usize::MAX),
+            TaxiAction::try_from_index(usize::MAX)
+        );
+        assert!(TaxiAction::try_from(6usize).is_err());
     }
 
     #[test]

--- a/crates/rlevo-environments/src/toy_text/taxi.rs
+++ b/crates/rlevo-environments/src/toy_text/taxi.rs
@@ -877,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "TaxiAction index 6 out of range")]
+    #[should_panic(expected = "TaxiAction index 6 out of range [0, 6)")]
     /// Verifies the documented `DiscreteAction::from_index` panic contract.
     fn from_index_out_of_range_panics() {
         let _ = TaxiAction::from_index(6);
@@ -886,7 +886,7 @@ mod tests {
     // A separate test from the one above: a `#[should_panic]` body unwinds at
     // the first panic, so one body cannot exercise both inputs.
     #[test]
-    #[should_panic(expected = "out of range")]
+    #[should_panic(expected = "out of range [0, 6)")]
     /// Verifies the panic contract holds at the extreme end of the index domain.
     fn from_index_usize_max_panics() {
         let _ = TaxiAction::from_index(usize::MAX);


### PR DESCRIPTION
## Summary

Adds a fallible index→action constructor to all four `toy_text` action types and documents the panic on the existing one. `DiscreteAction::from_index` panics on an out-of-range index — correct per the trait contract (`rlevo-core/src/action.rs:117-123`) — but all four impls carried **no doc comment at all**, so the panic was undocumented at exactly the point a reader would look for it, and there was no non-panicking path for an index arriving from data (a replay log, a deserialized trajectory, a mis-sized policy head) rather than from a trusted in-range computation. Each type now has an inherent `try_from_index(usize) -> Result<Self, InvalidActionError>`, an `impl TryFrom<usize>`, and a `# Panics` section on `from_index`, which routes through the fallible constructor so the two cannot drift. This is prospective hardening, not a live defect fix — the sole in-tree caller pre-clamps its index. It replicates the `GridAction` precedent landed in `d2b423b` for #813.

## Change Type

- [x] Other — additive public API plus documentation, replicating an already-accepted design

This is not a new environment, algorithm, refactor, or dependency. It adds two items per existing type and a doc section, changes no behavior, and requires no caller migration. The design was settled by #813 and is copied here rather than invented; this PR extends that decision to the four types that were filed with the same defect shape.

## Linked Issue

Closes #954
Closes #951
Closes #971
Closes #1093

## What Was Changed

- `crates/rlevo-environments/src/toy_text/blackjack.rs` — added `BlackjackAction::try_from_index` and `impl TryFrom<usize> for BlackjackAction`; `from_index` gained a `# Panics` section and now delegates via `unwrap_or_else(|_| panic!(...))`.
- `crates/rlevo-environments/src/toy_text/taxi.rs` — same for `TaxiAction` (6 actions).
- `crates/rlevo-environments/src/toy_text/frozen_lake.rs` — same for `FrozenLakeAction` (4 actions).
- `crates/rlevo-environments/src/toy_text/cliff_walking.rs` — same for `CliffWalkingAction` (4 actions).
- `CHANGELOG.md` — one bullet under `[Unreleased]` → `### rlevo-environments` → `**Added**`.

Each type's panic message is preserved verbatim; the literal action count in the message is now built from `Self::ACTION_COUNT` rather than hardcoded. No public item was removed, renamed, or made private.

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

All three pass. `cargo test --workspace`: **3316 passed, 0 failed** across 64 test targets. `cargo clippy --all-targets --all-features`: zero warnings. `cargo fmt --all --check`: clean. `cargo test --doc -p rlevo-environments`: 111 passed.

Seven tests added per file:

- `index_bindings_are_canonical` — **literal** assertions binding each index to a named variant. Deliberately not a round-trip loop: the pre-existing `action_roundtrip` coverage was self-referential and passes unchanged under a shuffled variant order, so it pinned nothing about the wire format. This matters most for `TaxiAction` (South 0, North 1, East 2, West 3 — neither alphabetical nor compass order) and for the fact that `CliffWalkingAction` (Up, Right, Down, Left) and `FrozenLakeAction` (Left, Down, Right, Up) deliberately use *different* orders, so a well-meaning cross-file "harmonization" would silently corrupt an action space.
- `to_index_values_are_canonical` — literal inverse.
- `from_index_out_of_range_panics` and `from_index_usize_max_panics` — separate `#[should_panic]` bodies, because one body unwinds at the first panic and cannot exercise both inputs. The expectations pin the **full rendered** message (`"...index N out of range [0, N)"`), which is what makes "panic text preserved verbatim" a verified claim rather than an assertion.
- `try_from_index_accepts_every_valid_index`, `try_from_index_rejects_out_of_range` (asserting the message *contains the offending index*, not merely that it is an `Err`), and `try_from_matches_inherent_method`.

**Mutation-tested, not just red-green.** Each file's new tests were run against three deliberately broken implementations — a transposed pair of match arms, an off-by-one bound, and an error message with the index removed — and confirmed to fail, then reverted. `index_bindings_are_canonical` catches the transposition in all four files. `try_from_index_accepts_every_valid_index` correctly *survives* it, since it compares against `from_index` through the same match — which is precisely why the literal test exists alongside it.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: n/a — no tensor code touched; these are plain enum constructors
- OS: macOS (Darwin 25.5.0, aarch64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **all of it** — the four implementations, their tests, the mutation testing, the CHANGELOG entry, and this PR description, produced by delegated agents under review.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR. — n/a in the strict sense: this fixes no live defect. The equivalent evidence is the mutation testing above, which is a stronger bar than a single regression test.
- [x] This PR addresses a single concern. (One defect shape, four sibling files, one design.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**Scope: why four files and not just #954.** #954 was filed against `blackjack.rs`, but `taxi.rs`, `frozen_lake.rs` and `cliff_walking.rs` have the byte-identical shape. #951 and #971 already covered two of them; cliff_walking had no issue at all and was filed as #1093 during this work. Splitting these would have repeated the same review four times for one design.

**A claim in these commit messages is wrong, and #1095 tracks it.** Commits `8f696ec` and its siblings state that a fallible constructor "cannot be a trait default" because `DiscreteAction` declares no provided one. That conflates "does not currently declare one" with "cannot". A provided default compiles fine, and five types now hand-roll the same match. Filed as #1095 rather than fixed here, because it touches a core trait across three crates and needs an ADR. Two things narrow it: the per-type `impl TryFrom<usize>` blocks are genuinely unavoidable (a blanket impl fails coherence, E0210/E0207), and a generic default cannot reproduce the per-type error messages that this PR's `#[should_panic]` tests now pin.

**Follow-ups filed, not fixed here:**
- **#1095** — `DiscreteAction` should provide a `try_from_index` default (above).
- **#1094** — `k_armed.rs:227` documents its panic in prose without a `# Panics` heading. Worth noting for reviewers: `clippy::missing_panics_doc` fires on *inherent* methods that panic and **not** on trait-impl methods, so it never flagged any of this family. Do not expect a lint to catch the next one.

**Known and deliberately out of scope:** `Action<1>::shape()` returns `[1]` rather than `[ACTION_COUNT]` in all four types — a real family-wide inconsistency, but separate and non-additive. `GridAction`'s `shape_matches_action_count` test was deliberately *not* ported for that reason.
