### PR TITLE
docs(rlevo-core): Drop agent module version stamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   existing enum and nothing in the workspace matches `ConstraintKind`
   exhaustively, so no caller breaks.
 
+**Changed**
+
+- **The `agent` module's documentation no longer names the version it is empty
+  in** (resolves #936). Every doc site describing the placeholder module carried
+  a version stamp, and between them they gave three different answers: the
+  crate-level module map in `lib.rs` said `v0.1.x`, the `pub mod agent` doc
+  comment said `v0.3.x`, and both the module's own header in `agent.rs` and the
+  crate `README.md` said `v0.1.0` — while the workspace has been on `0.4.0` for
+  some time, so every one of them was stale regardless of which you believed.
+  The stamps are deleted rather than corrected to `0.4.x`: a version number in
+  prose about an unimplemented module carries no information a reader can act
+  on, and keeping one only guarantees the next release bump re-falsifies each
+  copy. All of them now read "while the unified agent trait hierarchy
+  stabilizes", which is the condition that actually governs when the module
+  fills in. `docs/rules.md` loses a hardcoded `0.1.0` for the same reason,
+  stating the workspace-inheritance mechanism instead of the value it currently
+  carries.
+
 ### `rlevo-environments`
 
 **Fixed**

--- a/crates/rlevo-core/README.md
+++ b/crates/rlevo-core/README.md
@@ -118,10 +118,7 @@ Small, dependency-free newtypes and helpers shared across config validation in e
 
 ### `agent` — Agent Traits (reserved)
 
-Placeholder module reserved for a future unified agent trait hierarchy
-(`act` / `learn` / checkpoint). Empty in v0.1.0 — concrete algorithms currently
-live in `rlevo-reinforcement-learning` and `rlevo-evolution` and will migrate behind these traits
-once the API stabilizes.
+Placeholder module reserved for a future unified agent trait hierarchy (`act` / `learn` / checkpoint). Empty while the unified agent trait hierarchy stabilizes — concrete algorithms currently live in `rlevo-reinforcement-learning` and `rlevo-evolution` and will migrate behind these traits once the API stabilizes.
 
 ### `render` — Rendering Abstractions
 

--- a/crates/rlevo-core/src/agent.rs
+++ b/crates/rlevo-core/src/agent.rs
@@ -1,9 +1,9 @@
 //! Agent traits — reserved for a future release.
 //!
-//! This module is intentionally empty in v0.1.0. The planned trait hierarchy
-//! will distinguish gradient-based reinforcement-learning agents from
-//! population-based evolutionary agents, with a shared surface for
-//! `act` / `learn` / checkpoint operations.
+//! This module is intentionally empty while the unified agent trait hierarchy
+//! stabilizes. The planned trait hierarchy will distinguish gradient-based
+//! reinforcement-learning agents from population-based evolutionary agents,
+//! with a shared surface for `act` / `learn` / checkpoint operations.
 //!
 //! Concrete algorithm implementations currently live in the `rlevo-reinforcement-learning` and
 //! `rlevo-evolution` crates. They will migrate behind the traits defined

--- a/crates/rlevo-core/src/lib.rs
+++ b/crates/rlevo-core/src/lib.rs
@@ -22,7 +22,7 @@
 //! | [`probability`] | [`Probability`] — a `[0, 1]` rate valid by construction (rejects `NaN`, `Inf`, out-of-range) |
 //! | [`rate`] | [`NonNegativeRate`] — a finite non-negative magnitude valid by construction (BLX-α, σ) |
 //! | [`render`] | [`AsciiRenderable`], [`Renderer`](crate::render::Renderer), styled/palette/payload sub-modules — optional debug and TUI visualization layer |
-//! | [`agent`] | Reserved; empty in v0.1.x while the unified agent trait hierarchy stabilizes |
+//! | [`agent`] | Reserved; empty while the unified agent trait hierarchy stabilizes |
 //! | [`util`] | Shared utility helpers |
 //!
 //! # Const-generic `RANK`
@@ -123,22 +123,10 @@ pub mod action;
 
 /// Reserved for a future unified agent trait hierarchy.
 ///
-/// Empty in v0.3.x. Concrete RL and evolutionary agents currently live in
-/// `rlevo-reinforcement-learning` and `rlevo-evolution` respectively.
+/// Empty while the unified agent trait hierarchy stabilizes. Concrete RL and
+/// evolutionary agents currently live in `rlevo-reinforcement-learning` and
+/// `rlevo-evolution` respectively.
 pub mod agent;
-
-/// Shared configuration-validation convention.
-///
-/// Provides [`Validate`], the trait every `*Config` implements to check its
-/// invariants at construction, plus the structured [`ConfigError`] /
-/// [`ConstraintKind`] it returns and ergonomic check helpers. Construction that
-/// consumes a caller-supplied config returns `Result<_, ConfigError>` rather
-/// than panicking (ADR 0026).
-///
-/// [`Validate`]: crate::config::Validate
-/// [`ConfigError`]: crate::config::ConfigError
-/// [`ConstraintKind`]: crate::config::ConstraintKind
-pub mod config;
 
 /// Validated closed-range primitive.
 ///
@@ -152,6 +140,19 @@ pub mod config;
 /// [`Bounds`]: crate::bounds::Bounds
 /// [`BoundsError`]: crate::bounds::BoundsError
 pub mod bounds;
+
+/// Shared configuration-validation convention.
+///
+/// Provides [`Validate`], the trait every `*Config` implements to check its
+/// invariants at construction, plus the structured [`ConfigError`] /
+/// [`ConstraintKind`] it returns and ergonomic check helpers. Construction that
+/// consumes a caller-supplied config returns `Result<_, ConfigError>` rather
+/// than panicking (ADR 0026).
+///
+/// [`Validate`]: crate::config::Validate
+/// [`ConfigError`]: crate::config::ConfigError
+/// [`ConstraintKind`]: crate::config::ConstraintKind
+pub mod config;
 
 /// Agent/environment interaction protocol.
 ///

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -28,7 +28,7 @@ Hard constraints and conventions that apply to every contribution. Read this bef
 - Never add implementation logic to `rlevo-core`; it is a contract crate. The `util` module is the single exception (a math helper folded in from the deleted `rlevo-utils` crate per ADR 0003).
 - All shared dependencies must be declared in the root `Cargo.toml` `[workspace.dependencies]` table. Crates inherit via `{ workspace = true }`.
 - Workspace resolver must remain `resolver = "3"`.
-- All crates share version `0.1.0` and license `MIT OR Apache-2.0` via workspace inheritance.
+- All crates share a single version and license `MIT OR Apache-2.0` via workspace inheritance (`[workspace.package]` in the root `Cargo.toml`).
 
 ## 2. Naming Conventions
 


### PR DESCRIPTION
## Summary

Four doc sites described `rlevo-core`'s empty `agent` placeholder module, and every one carried a version stamp giving three different answers between them — the crate-level module map said `v0.1.x`, the `pub mod agent` doc comment said `v0.3.x`, and both `agent.rs`'s own header and the crate README said `v0.1.0`. The workspace has been on `0.4.0` for some time, so all four were stale regardless of which one a reader believed. The stamps are deleted rather than corrected to `0.4.x`: a version number in prose about an unimplemented module carries nothing a reader can act on, and keeping one only guarantees the next release bump re-falsifies every copy. All four now state the condition that actually governs when the module fills in.

## Change Type

- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #936

## What Was Changed

- `crates/rlevo-core/src/lib.rs:25` — module-map row: dropped `in v0.1.x`
- `crates/rlevo-core/src/lib.rs:126` — `pub mod agent` doc: `Empty in v0.3.x` → `Empty while the unified agent trait hierarchy stabilizes`
- `crates/rlevo-core/src/agent.rs:3` — module header: `intentionally empty in v0.1.0` → same version-free phrasing
- `crates/rlevo-core/README.md:122` — `Empty in v0.1.0` → same phrasing. **This fourth site was missed by the original triage**, which grepped `--glob '*.rs'` and so never saw markdown; it was caught by review
- `docs/rules.md:31` — dropped a hardcoded `0.1.0`, now states the `[workspace.package]` inheritance mechanism instead of the value it currently carries
- `crates/rlevo-core/src/lib.rs` — moved the `bounds` doc+decl block above `config`, restoring `base`-first-then-alphabetical `pub mod` order (per the follow-up comment on #936). Pure block move, doc bodies unchanged
- `CHANGELOG.md` — entry under `[Unreleased]` → `### rlevo-core` → `**Changed**`

All four doc sites now use the identical phrase *"while the unified agent trait hierarchy stabilizes"*.

## How It Was Tested

```
cargo build --workspace                          # clean
cargo clippy --all-targets --all-features        # clean, no warnings
cargo test --workspace                           # 3164 passed, 0 failed, 32 ignored
```

Additionally, for a docs change specifically:

```
cargo fmt --all --check                                  # clean
cargo doc -p rlevo-core --no-deps                        # zero rustdoc warnings
rg -n 'v0\.[0-9]' crates/rlevo-core/ docs/rules.md       # zero matches
```

The `bounds`/`config` reordering was verified text-preserving by md5 of both blocks pre- and post-move (identical), plus a forced `cargo doc` rebuild confirming the `[`config`]` intra-doc link inside the `bounds` doc still resolves. That link is the one thing a careless block move could break without failing any test.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`), `rustc 1.94.1 (e408947bf 2026-03-25)`
- Burn backend tested: n/a — no tensor or backend code touched
- OS: macOS 26.5.2, arm64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change — triage against the source, the doc edits, the CHANGELOG entry, and the verification runs above, under maintainer direction and review.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*. — n/a, no API change; this PR only edits existing doc prose.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR. — n/a, documentation-only, no behavior change. The closest thing to a regression guard is the `rg 'v0\.[0-9]'` sweep above.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**This does not close #901**, despite rewriting the exact `agent.rs` line #901 quotes verbatim. #901's substantive ask is a tracking-issue pointer required by `docs/rules.md` §12, and `agent.rs` still has none — removing a falsifiable claim does not discharge the obligation to add a missing one. #901 has been commented with the fresh verbatim text so its quoted block is accurate again.

Two follow-ups filed from what this work surfaced, neither addressed here:

- #1098 — the same defect class in `rlevo-environments`: 8 `v0.1`/`v0.2` prose stamps, split into doc-comment prose and `#[allow(dead_code)]` deferred-work markers (the latter fail both rules §9 and §12). An unscoped repo-wide sweep confirms those 8 are all that remain; `rlevo-core` is clean after this PR.
- #1099 — 59 residual rustdoc warnings (`private_intra_doc_links`, `redundant_explicit_link`) that no lint level gates. None are broken intra-doc links. About half are one real defect: the six off-policy agents' public docs link the private `Slot` newtype.

Also closed #937 during this work as already-implemented — its claim that no CI doc-link check exists is false; `.github/workflows/crate-tests.yml:127` has run one since `17e8fd3`.