### PR TITLE
docs(rlevo-environments): drop stale version stamps from prose and dead-code markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,19 +315,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `Environment` impls landing; `Suite<E>` being monomorphic; a non-scalar-reward
   env actually existing).
 
-  The four `#[allow(dead_code)]` stubs are unchanged in effect but now point at
-  live tracking issues rather than a milestone that has passed, as `docs/rules.md`
-  §9 and §12 require: the `games` module allow (which carried no pointer at all)
-  and `chess::observations::current_board` name #1101, and the two `Rapier3DWorld`
-  accessors — `add_ground_collider` and `bodies`, both reachable only from
-  `#[cfg(test)]` today — name #1102. The allows themselves stay: every call site
-  is still test-only or commented out. Three of the four are independently
-  load-bearing — dropping any one of the `games` module allow,
-  `add_ground_collider`'s or `bodies`' fails a `-D warnings` build. The fourth,
-  on `current_board`, is redundant defense-in-depth: the module-level allow
-  already covers it, so it suppresses nothing on its own. It is kept rather than
-  deleted because it and the module allow are meant to come off together when
-  #1101 lands, but the redundancy is noted there.
+  The `#[allow(dead_code)]` stubs now point at live tracking issues rather than
+  a milestone that has passed, as `docs/rules.md` §9 and §12 require: the `games`
+  module allow, which carried no pointer at all, names #1101, and the two
+  `Rapier3DWorld` accessors — `add_ground_collider` and `bodies`, both reachable
+  only from `#[cfg(test)]` today — name #1102. Those three stay: each is
+  independently load-bearing, and dropping any one of them fails a `-D warnings`
+  build.
+
+  A fourth allow, on `chess::observations::current_board`, is **removed**. It
+  suppressed nothing — the module-level allow already covered that method, so
+  deleting it leaves the crate clean. Note that verifying this needs
+  `cargo clippy -p rlevo-environments -- -D warnings` *without* `--all-targets`:
+  the latter compiles the test cfg, where `dead_code` does not fire at all, and
+  so reports success no matter which allows are present.
 
 ### `rlevo-evolution`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   orders, so a well-meaning cross-file "harmonization" would silently corrupt an
   action space.
 
+**Changed**
+
+- **The crate's documentation no longer names the version its unfinished work
+  arrives in** (resolves #1098). Six doc sites promised the `games` module,
+  the monomorphic `Suite<E>` limitation, and the `BenchAdapter` `ScalarReward`
+  bound in terms of "v0.1" / "v0.2" / "a future milestone" — `lib.rs`'s `games`
+  module doc, the crate `README.md`'s Games heading and body, the `bench::suites`
+  and `bench::adapter` module headers, and the `chess::environment` and
+  `connect_four` placeholders. The workspace has been on `0.4.0` since the last
+  release, so all of them were already false. As in the `rlevo-core` `agent`
+  fix (#936), the numbers are deleted rather than corrected: a version stamp in
+  prose about unimplemented work carries nothing a reader can act on, and every
+  release bump re-falsifies each copy — which is exactly what happened. Each
+  site now states the condition that actually governs when the gap closes (the
+  `Environment` impls landing; `Suite<E>` being monomorphic; a non-scalar-reward
+  env actually existing).
+
+  The four `#[allow(dead_code)]` stubs are unchanged in effect but now point at
+  live tracking issues rather than a milestone that has passed, as `docs/rules.md`
+  §9 and §12 require: the `games` module allow (which carried no pointer at all)
+  and `chess::observations::current_board` name #1101, and the two `Rapier3DWorld`
+  accessors — `add_ground_collider` and `bodies`, both reachable only from
+  `#[cfg(test)]` today — name #1102. The allows themselves stay: every call site
+  is still test-only or commented out. Three of the four are independently
+  load-bearing — dropping any one of the `games` module allow,
+  `add_ground_collider`'s or `bodies`' fails a `-D warnings` build. The fourth,
+  on `current_board`, is redundant defense-in-depth: the module-level allow
+  already covers it, so it suppresses nothing on its own. It is kept rather than
+  deleted because it and the module allow are meant to come off together when
+  #1101 lands, but the redundancy is noted there.
+
 ### `rlevo-evolution`
 
 **Fixed**

--- a/crates/rlevo-environments/README.md
+++ b/crates/rlevo-environments/README.md
@@ -106,11 +106,12 @@ MuJoCo-style locomotion environments in pure Rust via [Rapier3D](https://rapier.
 
 ---
 
-### Games (planned for v0.2)
+### Games (stub, no `Environment` impls yet)
 
-`Chess` and `ConnectFour` are planned for a future release. Stub modules exist
-in-source (`src/games/chess/` and `src/games/connect_four.rs`) but do not yet
-implement the `Environment` trait and are hidden from the public API docs.
+`Chess` and `ConnectFour` exist in-source as stub modules (`src/games/chess/`
+and `src/games/connect_four.rs`). They compile but do not yet implement the
+`Environment` trait, and are hidden from the public API docs until the
+`Environment` impls land.
 
 ---
 

--- a/crates/rlevo-environments/src/bench/adapter.rs
+++ b/crates/rlevo-environments/src/bench/adapter.rs
@@ -1,9 +1,9 @@
 //! `BenchAdapter` — translates a typed [`Environment`] into the
 //! object-friendly [`BenchEnv`] interface.
 //!
-//! Bounded to [`ScalarReward`] for v0.1: every env in this crate uses it,
-//! and lifting the bound (e.g. via `BenchReward: Into<f64>`) is deferred
-//! until a non-scalar-reward env actually lands.
+//! Bounded to [`ScalarReward`]: every env in this crate uses it, and lifting
+//! the bound (e.g. via `BenchReward: Into<f64>`) is deferred until a
+//! non-scalar-reward env actually lands.
 //!
 //! [`EnvironmentError`] is preserved as the source of [`BenchError`]
 //! (the bench trait surface lives in `rlevo-core`).

--- a/crates/rlevo-environments/src/bench/suites.rs
+++ b/crates/rlevo-environments/src/bench/suites.rs
@@ -1,8 +1,8 @@
 //! Preset [`Suite`] factories for the canonical environments in this crate.
 //!
 //! Each factory returns a single-env [`Suite`] keyed on a deterministic
-//! per-trial seed. Stitching multiple suites of different env types is a
-//! v0.1 limitation — [`Suite<E>`] is monomorphic, so a heterogeneous
+//! per-trial seed. Stitching multiple suites of different env types is not
+//! supported — [`Suite<E>`] is monomorphic, so a heterogeneous
 //! "all of classic control" suite needs a `Box<dyn BenchEnv<…>>` design
 //! (deferred).
 //!

--- a/crates/rlevo-environments/src/games/chess/environment.rs
+++ b/crates/rlevo-environments/src/games/chess/environment.rs
@@ -2,4 +2,4 @@
 //!
 //! This module is a placeholder. The full `Environment` impl — wrapping
 //! [`super::board`] state, [`super::moves`] encoding, and episode lifecycle —
-//! will be completed in a future milestone.
+//! lands with the board-game environments tracked in issue #1101.

--- a/crates/rlevo-environments/src/games/chess/observations.rs
+++ b/crates/rlevo-environments/src/games/chess/observations.rs
@@ -272,7 +272,9 @@ impl ChessState {
 
     /// Returns the current board snapshot (most recent position).
     #[inline]
-    #[allow(dead_code)] // v0.2: used once Environment impl lands
+    // TODO(#1101): no caller until the Chess `Environment` impl lands; its only
+    // use site today is commented out in this module's tests.
+    #[allow(dead_code)]
     fn current_board(&self) -> &BoardSnapshot {
         &self.history[0]
     }

--- a/crates/rlevo-environments/src/games/chess/observations.rs
+++ b/crates/rlevo-environments/src/games/chess/observations.rs
@@ -272,9 +272,6 @@ impl ChessState {
 
     /// Returns the current board snapshot (most recent position).
     #[inline]
-    // TODO(#1101): no caller until the Chess `Environment` impl lands; its only
-    // use site today is commented out in this module's tests.
-    #[allow(dead_code)]
     fn current_board(&self) -> &BoardSnapshot {
         &self.history[0]
     }

--- a/crates/rlevo-environments/src/games/connect_four.rs
+++ b/crates/rlevo-environments/src/games/connect_four.rs
@@ -1,4 +1,4 @@
 //! Connect Four environment (work in progress).
 //!
 //! This module is a placeholder. The Connect Four `Environment` implementation
-//! will be added in a future milestone.
+//! lands with the board-game environments tracked in issue #1101.

--- a/crates/rlevo-environments/src/lib.rs
+++ b/crates/rlevo-environments/src/lib.rs
@@ -93,13 +93,16 @@ pub mod classic;
 /// backward compatibility.
 pub mod direction;
 pub mod episode;
-/// Board-game environments — **stub, planned for v0.2**.
+/// Board-game environments — **stub, no `Environment` impls yet**.
 ///
 /// The submodules compile but do not yet implement the [`rlevo_core::environment::Environment`]
 /// trait. They are hidden from the rendered docs until the `Environment` impls land.
 /// Internal dead-code and doc-lint warnings are suppressed here because the
-/// contained code is scaffolding for the v0.2 implementation.
+/// contained code is scaffolding for those impls.
 #[doc(hidden)]
+// TODO(#1101): the board-state and move-encoding scaffolding under this module
+// has no non-test caller until the Chess and ConnectFour `Environment` impls
+// land; drop these allows once it does.
 #[allow(dead_code, clippy::doc_lazy_continuation, clippy::needless_range_loop)]
 pub mod games {
     pub mod chess;

--- a/crates/rlevo-environments/src/locomotion/backend/rapier3d.rs
+++ b/crates/rlevo-environments/src/locomotion/backend/rapier3d.rs
@@ -170,7 +170,9 @@ impl Rapier3DWorld {
     }
 
     /// Insert a free-standing collider (e.g. the ground plane) with no rigid-body parent.
-    #[allow(dead_code)] // v0.2: used by locomotion skeleton builders
+    // TODO(#1102): called only from `#[cfg(test)]` today; the first
+    // production consumer is a ground-contact 3-D locomotion env.
+    #[allow(dead_code)]
     pub(crate) fn add_ground_collider(&mut self, desc: ColliderBuilder) -> ColliderHandle {
         self.colliders.insert(desc)
     }
@@ -204,7 +206,9 @@ impl Rapier3DWorld {
     }
 
     /// Read-only access to the world's rigid-body set.
-    #[allow(dead_code)] // v0.2: used by locomotion skeleton builders
+    // TODO(#1102): called only from `#[cfg(test)]` today; the first production
+    // consumer is a ground-contact 3-D locomotion env reading body state.
+    #[allow(dead_code)]
     pub(crate) fn bodies(&self) -> &RigidBodySet {
         &self.bodies
     }


### PR DESCRIPTION
## Summary

Eight doc sites in `rlevo-environments` promised unfinished work "in v0.1" or "v0.2". The workspace has been on `0.4.0` for some time, so every one of them was already false — v0.2 passed without the promised work landing. This deletes the version numbers rather than correcting them to `0.4.x`, following the `rlevo-core` precedent set by d7b8f56 (#936): a version stamp in prose about unimplemented work carries nothing a reader can act on, and keeping one only guarantees the next release bump re-falsifies every copy. Each site now states the condition that actually governs when the gap closes. The three `#[allow(dead_code)]` markers additionally gain the `TODO(#NNN)` tracking pointer `docs/rules.md` §9/§12 requires, which they lacked.

## Change Type

- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #1098

Two tracking issues were filed as prerequisites, because rules §12 requires the issue to exist *before* a stub's pointer can name it and neither piece of deferred work had one:

- #1101 — implement `Environment` for Chess and ConnectFour
- #1102 — rapier3d ground/body accessors are test-only

## What Was Changed

**Version-stamped prose → condition-based** (6 sites):

- `src/lib.rs:96,101` — the `games` module doc: "**stub, planned for v0.2**" → "**stub, no `Environment` impls yet**"; "scaffolding for the v0.2 implementation" → "scaffolding for those impls".
- `README.md:109` — "### Games (planned for v0.2)" → "### Games (stub, no `Environment` impls yet)", with the body rewritten to mirror the module doc. The issue explicitly asked for these two to move together and share wording.
- `src/bench/suites.rs:5` — "is a v0.1 limitation" → "is not supported"; the real condition (`Suite<E>` is monomorphic, so the heterogeneous case needs a `Box<dyn BenchEnv<…>>` design) was already in the text and now carries the sentence alone.
- `src/bench/adapter.rs:4` — "Bounded to `ScalarReward` for v0.1" → "Bounded to `ScalarReward`"; the existing "deferred until a non-scalar-reward env actually lands" clause is the governing condition.
- `src/games/chess/environment.rs:5` and `src/games/connect_four.rs:4` — "will be completed / added in a future milestone" → "lands with the board-game environments tracked in issue #1101".

**Dead-code markers → condition + issue pointer** (3 sites): the trailing `// v0.2: …` comments become `TODO(#1101)` / `TODO(#1102)` comments directly above each attribute, per rules §9 (a comment explaining *why*) and §12 (naming the tracking issue).

- `src/lib.rs` — the `games` module allow → #1101. This site carried **no** pointer at all and was not in the issue's list; it is the same §9/§12 violation and is fixed here.
- `src/locomotion/backend/rapier3d.rs` (`add_ground_collider`, `bodies`) → #1102.

These three `#[allow(dead_code)]` attributes are **retained** — every call site is inside `#[cfg(test)]` (`rapier3d.rs:529+`, `reacher/env.rs:453+`, `swimmer/env.rs:522+`), so `dead_code` genuinely still fires, and removing any one of them fails the build. A fourth, on `chess::observations::current_board`, is **removed** instead — see Notes.

**`CHANGELOG.md`** — one entry under `## [Unreleased]` → `### rlevo-environments` → `**Changed**`.

Scope note: two of the ten sites (the `lib.rs` module allow, and the two "future milestone" placeholders) were not in the issue's list. Both were added deliberately after checking with the maintainer — the first is the same rules violation as the sites that were listed, and the second are the module docs for the very stubs the listed sites describe, so leaving them would have made the games story internally inconsistent.

## How It Was Tested

```
cargo build --workspace                          # Finished, no errors
cargo test --workspace                           # 0 failed across all crates
cargo clippy --all-targets --all-features        # Finished, no warnings
cargo fmt --all --check                          # clean
```

Docs-only, so there is no regression test. The defect is falsifiable by grep, and both the issue's acceptance check and a broader defect-shape sweep were run **unscoped to file type** — the `.rs`-only grep is exactly what let `README.md:109` escape the original sweep, and what let `rlevo-core/README.md:122` escape the #936 fix:

```
rg -n 'v0\.[0-9]' crates/rlevo-environments --glob '!Cargo.toml'                       # empty
rg -ni 'planned for|next release|future release|future milestone|in 0\.[0-9]' \
   crates/rlevo-environments --glob '!Cargo.toml'                                      # empty
rg -n -B3 'allow\([^)]*dead_code' crates/rlevo-environments                            # 3 sites, 3 TODO(#N)
```

Intra-doc links needed separate treatment: several edits reflowed lines carrying them, and rustdoc's link pass never runs under `cargo test`, so a broken link tests green (rules §9). Verified by building docs before and after the diff under both default and `--all-features` — the `bench/` sites are feature-gated and invisible to a default-feature doc build. The warning sets are byte-identical: 14 pre-existing warnings (9 `private_intra_doc_links`, 5 `redundant_explicit_links`), **zero** `broken_intra_doc_links`, in all four builds.

- Rust toolchain: `1.94.1-aarch64-apple-darwin` (pinned by `rust-toolchain.toml`)
- Burn backend tested: n/a — documentation-only, no tensor code paths touched
- OS: macOS 26.5.2 (arm64)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): **Claude Code (Opus 5)**. Scope: **the full change — site triage against the live tree, the prose rewrites, the CHANGELOG entry, and the verification runs above. Reviewed by the author.**

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*. — no API change; the doc comments themselves are the change.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. — n/a, documentation-only. The grep-based acceptance checks above serve this role.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**One QA finding, acted on.** The `#[allow(dead_code)]` on `current_board` turned out to be redundant — the module-level allow in `lib.rs` already suppressed it, so it was defense-in-depth against a lint that never reached the method. It is **deleted** in the second commit rather than annotated; rules §9 permits an item-level allow only where the lint is a genuine false positive in that context, and here it did not fire at all. The remaining three allows were each re-confirmed load-bearing by removing them in turn and observing the build fail.

Worth knowing for anyone re-checking this: the probe only works with `cargo clippy -p rlevo-environments -- -D warnings` **without** `--all-targets`. Adding it compiles the test cfg, where `dead_code` does not fire on these items at all, so the build passes regardless of which allows are present — a green `--all-targets` run is not evidence either way.

**A neighbouring issue was reopened.** Ripple triage found #901 closed by d7b8f56 — the very commit whose message states *"This does not resolve #901 … `agent.rs` still has none."* `rg -n 'TODO\(#' crates/rlevo-core` confirms the rules §12 pointer is still absent, so the close was collateral rather than a decision that the ask was met. #901 is reopened with that evidence; the file-the-issue-then-point-at-it pattern this PR establishes is what it needs.
