### PR TITLE
fix(rlevo-core): Compute combinations in u128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   existing enum and nothing in the workspace matches `ConstraintKind`
   exhaustively, so no caller breaks.
 
+- **`util::checked_combinations`**, a fallible counterpart to `combinations`
+  returning `Option<u64>` (for #927). `combinations` has to answer *something*
+  for arguments whose binomial coefficient is simply not representable, and the
+  only honest answers are a panic or an `Option`; callers that count
+  configurations from sizes they did not choose themselves now have the
+  non-panicking one. It returns `Some(0)` for `k > n` exactly as `combinations`
+  does, so it is a drop-in for every input the infallible helper accepts.
+
 **Changed**
 
 - **The `agent` module's documentation no longer names the version it is empty
@@ -140,6 +148,38 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   fills in. `docs/rules.md` loses a hardcoded `0.1.0` for the same reason,
   stating the workspace-inheritance mechanism instead of the value it currently
   carries.
+
+**Fixed**
+
+- **`util::combinations` returned wrong counts — silently, in release — for
+  binomial coefficients that fit comfortably in a `u64`** (resolves #927,
+  closes #933). The naive loop multiplied before dividing, so its *intermediate*
+  product overflowed long before the answer did, and in release builds that
+  overflow wrapped instead of panicking. `C(66, 33)` is
+  `7_219_428_434_016_265_740`, well under `u64::MAX`
+  (`18_446_744_073_709_551_615`), yet the helper returned
+  `128_965_714_594_187_190` — a plausible-looking number some 56× too small,
+  with nothing to distinguish it from a correct one.
+  Sweeping `n < 200`, 2603 `(n, k)` pairs whose exact value is representable
+  came back corrupted this way.
+
+  The fix accumulates in `u128` over the `C(n - k + i, i)` recurrence, whose
+  every partial result is an exact integer, and reduces by the symmetry
+  `C(n, k) == C(n, n - k)` first. Every representable coefficient is now
+  computed; `combinations` panics only when the *exact* result exceeds
+  `u64::MAX` (first at `n = 68`, where `C(68, 31)` and up no longer fit), a
+  contract now stated in its `# Panics`
+  section and in the `docs/rules.md` panic table. The signature is unchanged.
+  Note that the fix rejected in the issue thread — bolting `checked_mul` onto
+  the naive loop — would have panicked on all 2603 of those pairs rather than
+  computing them.
+
+  **Why the existing tests missed it**: the largest case they covered was
+  `C(54, 6)`, and the first intermediate overflow happens at `n = 63`. Every
+  assertion sat far inside the safe region `n <= 62`, so the coverage was not
+  merely thin near the boundary — it never approached it. A "does it panic?"
+  test would not have helped either, since release builds wrap rather than
+  panic; the new regression tests pin exact values.
 
 ### `rlevo-environments`
 

--- a/crates/rlevo-core/src/util/mod.rs
+++ b/crates/rlevo-core/src/util/mod.rs
@@ -1,10 +1,12 @@
 //! Shared utilities used across `rlevo-core` consumers.
 //!
-//! Currently houses small helpers ([`combinations`]) and the
+//! Currently houses small helpers ([`combinations`] and its fallible
+//! counterpart [`checked_combinations`]) and the
 //! [`seed`] module's deterministic seed-derivation primitives
 //! (see [`seed::SeedStream`]).
 //!
 //! [`combinations`]: crate::util::combinations
+//! [`checked_combinations`]: crate::util::checked_combinations
 //! [`seed`]: crate::util::seed
 //! [`seed::SeedStream`]: crate::util::seed::SeedStream
 
@@ -14,6 +16,14 @@ pub mod seed;
 /// `n` items taken `k` at a time).
 ///
 /// Returns `0` when `k > n`.
+///
+/// # Panics
+///
+/// Panics when the **exact** value of `C(n, k)` exceeds [`u64::MAX`] — for
+/// example `C(68, 34)`. The condition is the exact result, *not* an
+/// intermediate product: every `C(n, k)` representable in a `u64` is computed
+/// and returned. Use [`checked_combinations`] to cover the full domain without
+/// panicking.
 ///
 /// # Examples
 ///
@@ -25,14 +35,45 @@ pub mod seed;
 /// ```
 #[must_use]
 pub fn combinations(n: u64, k: u64) -> u64 {
+    checked_combinations(n, k).expect("combinations: C(n, k) exceeds u64::MAX")
+}
+
+/// Returns the binomial coefficient `n choose k`, or [`None`] when the exact
+/// value does not fit in a `u64`.
+///
+/// Returns `Some(0)` when `k > n`, matching [`combinations`].
+///
+/// # Examples
+///
+/// ```
+/// use rlevo_core::util::checked_combinations;
+/// assert_eq!(checked_combinations(66, 33), Some(7_219_428_434_016_265_740));
+/// assert_eq!(checked_combinations(3, 5), Some(0));
+/// // C(68, 34) ≈ 2.85e19 exceeds u64::MAX ≈ 1.84e19.
+/// assert_eq!(checked_combinations(68, 34), None);
+/// ```
+#[must_use]
+pub fn checked_combinations(n: u64, k: u64) -> Option<u64> {
     if k > n {
-        return 0;
+        return Some(0);
     }
-    let mut result = 1u64;
-    for i in 1..=k {
-        result = result * (n - i + 1) / i;
+    // Symmetry reduction: C(n, k) == C(n, n - k), so iterate the smaller side.
+    let k = k.min(n - k);
+    let mut result: u128 = 1;
+    for i in 1..=u128::from(k) {
+        // Partial results are exactly C(n - k + i, i), so the division is
+        // always exact and never truncates. Those partials increase
+        // monotonically in `i`, so bailing out the moment one exceeds
+        // `u64::MAX` cannot discard a final value that would have fit.
+        result = result * (u128::from(n - k) + i) / i;
+        if result > u128::from(u64::MAX) {
+            return None;
+        }
     }
-    result
+    // `result` is bounded by `u64::MAX` on entry to each step and the
+    // multiplier by `n`, so the `u128` accumulator cannot itself overflow, and
+    // the loop guard leaves this conversion infallible.
+    u64::try_from(result).ok()
 }
 
 #[cfg(test)]
@@ -51,5 +92,111 @@ mod tests {
     #[test]
     fn test_combinations_k_greater_than_n_returns_zero() {
         assert_eq!(combinations(3, 5), 0);
+    }
+
+    /// Values that fit in a `u64` but which the former naive loop corrupted by
+    /// wrapping its intermediate product (silently, in release).
+    #[test]
+    fn test_combinations_large_values_are_exact() {
+        assert_eq!(combinations(66, 33), 7_219_428_434_016_265_740);
+        assert_eq!(combinations(67, 33), 14_226_520_737_620_288_370);
+    }
+
+    /// The representability frontier: `C(67, 33)` fits, `C(68, 34)` (≈2.85e19)
+    /// does not.
+    #[test]
+    fn test_checked_combinations_frontier() {
+        assert_eq!(
+            checked_combinations(67, 33),
+            Some(14_226_520_737_620_288_370)
+        );
+        assert_eq!(checked_combinations(68, 34), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds u64::MAX")]
+    fn test_combinations_panics_when_result_exceeds_u64() {
+        let _ = combinations(68, 34);
+    }
+
+    /// Checks the `C(n, k) == C(n, n - k)` symmetry invariant only — it is
+    /// *not* a regression test for #927, since wrapping corrupts both sides
+    /// identically and this test passes against the pre-fix implementation.
+    #[test]
+    fn test_combinations_is_symmetric() {
+        for n in 0..40u64 {
+            for k in 0..=n {
+                assert_eq!(
+                    combinations(n, k),
+                    combinations(n, n - k),
+                    "asymmetry at C({n}, {k})"
+                );
+            }
+        }
+    }
+
+    /// Independent oracle: Pascal's triangle built by addition shares no code
+    /// with the multiplicative implementation, so it catches arithmetic errors
+    /// that comparing `combinations` to `checked_combinations` cannot — the
+    /// former delegates to the latter, making that comparison self-referential.
+    ///
+    /// `n <= 60` keeps every entry representable (`C(60, 30)` ≈ 1.18e17), so
+    /// the oracle itself never overflows and every cell is a live assertion.
+    #[test]
+    fn test_checked_combinations_matches_pascals_triangle() {
+        const N: usize = 60;
+        let mut row: Vec<u64> = vec![1];
+        for n in 0..=N {
+            for (k, &expected) in row.iter().enumerate() {
+                assert_eq!(
+                    checked_combinations(n as u64, k as u64),
+                    Some(expected),
+                    "mismatch at C({n}, {k})"
+                );
+            }
+            // Next row by addition: c[n+1][k] = c[n][k - 1] + c[n][k].
+            let mut next = Vec::with_capacity(row.len() + 1);
+            next.push(1);
+            for w in row.windows(2) {
+                next.push(w[0] + w[1]);
+            }
+            next.push(1);
+            row = next;
+        }
+    }
+
+    /// Boundary cases that pin the *placement* and *strictness* of the
+    /// `result > u64::MAX` guard, which no other test constrains.
+    #[test]
+    fn test_checked_combinations_guard_boundaries() {
+        // Guards the guard being INSIDE the loop. `C(9975, 4987)` is ~1e3001;
+        // partial results cross `u64::MAX` at i = 6, so the in-loop check bails
+        // immediately. "Simplify" the fix by moving that check after the loop
+        // and the `u128` accumulator overflows on its own — #927's exact
+        // failure mode one layer up, panicking under debug assertions and
+        // wrapping silently in release. No other test uses an `n` large enough
+        // to reach that. (Verified: the after-the-loop variant panics here in a
+        // debug build. In release its wrapped value still lands above
+        // `u64::MAX`, so this assertion alone does not catch it there — the
+        // debug run is what kills that mutant.)
+        assert_eq!(checked_combinations(9975, 4987), None);
+
+        // Exact fit with zero headroom: `C(u64::MAX, 1) == u64::MAX`. A `>=`
+        // guard would reject this; the correct `>` guard accepts it.
+        assert_eq!(checked_combinations(u64::MAX, 1), Some(u64::MAX));
+        assert_eq!(checked_combinations(u64::MAX, 2), None);
+
+        // `k > n` returns before `n - k` is evaluated, so no underflow.
+        assert_eq!(checked_combinations(1, u64::MAX), Some(0));
+
+        // Degenerate rows, mirroring the `combinations` known-value test.
+        assert_eq!(checked_combinations(0, 0), Some(1));
+        assert_eq!(checked_combinations(5, 5), Some(1));
+    }
+
+    #[test]
+    fn test_checked_combinations_k_greater_than_n_returns_zero() {
+        assert_eq!(checked_combinations(3, 5), Some(0));
+        assert_eq!(checked_combinations(0, 1), Some(0));
     }
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -282,6 +282,7 @@ single internal convention across the whole library (RL, evolutionary, NEAT).
 | `MultiDiscreteAction::from_indices(arr)` | any `arr[i] >= space[i]` |
 | Builder `with_capacity(n)` | `n == 0` |
 | Builder `with_alpha(x)` | `x ∉ [0.0, 1.0]` |
+| `util::combinations(n, k)` | exact `C(n, k)` exceeds `u64::MAX` — use `checked_combinations` for the full domain |
 | `History::index(i)` | `i >= len()` |
 | `History::new(n)` | `n == 0` or `n > MAX_BUFFER_CAPACITY` |
 | `Grid::new(w, h)` | `w == 0`, `h == 0`, or `w * h` overflows `usize` |


### PR DESCRIPTION
## Summary

`rlevo_core::util::combinations` computed `C(n, k)` with a naive multiplicative loop that multiplied before dividing, so its **intermediate** product overflowed `u64` long before the answer did. Debug builds panicked; release builds wrapped silently and returned a plausible-looking wrong count from a public API with no documented domain. This replaces the loop with a `u128` accumulator over the `C(n - k + i, i)` recurrence, after reducing by the `C(n, k) == C(n, n - k)` symmetry, so every coefficient representable in a `u64` is now computed exactly. `combinations` keeps its signature and panics only when the *exact* result exceeds `u64::MAX`; a new `checked_combinations` returns `Option<u64>` for the full domain.

The remedy proposed on #927 — bolting `checked_mul` onto the naive loop — was **not** used, and this is the substantive deviation from the filed fix. Executing a wrapping simulation over the whole input grid shows 2603 `(n, k)` pairs with `n < 200` whose exact value fits in a `u64` but which the old loop corrupted: `C(66, 33)` is `7_219_428_434_016_265_740`, comfortably under `u64::MAX` (`18_446_744_073_709_551_615`), yet the helper returned `128_965_714_594_187_190` — some 56× too small. `checked_mul(...).expect(...)` would have panicked on all 2603 rather than computing them, trading a wrong answer for a spurious panic across a large band of valid inputs.

## Change Type

- [x] Bug fix (non-breaking, includes regression test)

## Linked Issue

Closes #927
Closes #933

## What Was Changed

- `crates/rlevo-core/src/util/mod.rs` — added `pub fn checked_combinations(n: u64, k: u64) -> Option<u64>`: symmetry reduction `k = min(k, n - k)`, `u128` accumulator, and a `result > u64::MAX` bail **inside** the loop. Rewrote `combinations` as a delegating `.expect(...)` wrapper (signature unchanged) and gave it a `# Panics` section stating the condition is the *exact result* exceeding `u64::MAX`, not an intermediate product. Module header now names both helpers.
- `crates/rlevo-core/src/util/mod.rs` (tests) — 2 tests → 8. Value-pinning regressions (`C(66, 33)`, `C(67, 33)`), the representability frontier (`checked_combinations(67, 33)` is `Some`, `(68, 34)` is `None`), `#[should_panic(expected = "exceeds u64::MAX")]`, guard-placement and guard-strictness boundaries (`(9975, 4987)`, `(u64::MAX, 1)`, `(u64::MAX, 2)`, `(1, u64::MAX)`), and an additive Pascal's-triangle oracle over `n <= 60` that shares no code with the multiplicative implementation.
- `docs/rules.md` — new row in the §4 Documented Panic Contracts table for `util::combinations`, as §4 requires of every panic site.
- `CHANGELOG.md` — `**Added**` (`checked_combinations`) and a new `**Fixed**` block under `### rlevo-core`, recording what the defect was and why the existing tests missed it.

## How It Was Tested

```
cargo build --workspace                      # clean
cargo test --workspace                       # all suites pass, 0 failures
cargo clippy --all-targets --all-features    # no warnings
cargo fmt --all --check                      # clean
cargo test -p rlevo-core util::              # 14 passed (debug)
cargo test --release -p rlevo-core util::    # 14 passed (release)
cargo test -p rlevo-core --doc util          # 8 passed
```

The release run matters: debug builds already panicked on this defect, so a "does it overflow?" test would have gone green against the unfixed code under `--release`. The regression tests therefore pin exact **values**, not the absence of a panic.

**Before / after** — `combinations(66, 33)` returned `128_965_714_594_187_190` (release) or panicked with "attempt to multiply with overflow" (debug); it now returns `7_219_428_434_016_265_740`. `test_combinations_large_values_are_exact` is red against the previous code in both profiles.

**Independent oracle** — swept `n ∈ [0, 90]`, all `k` (4186 pairs) through the real `checked_combinations` and diffed against Python's `math.comb`: 0 mismatches, 766 correctly `None`.

- Rust toolchain: `rustc 1.94.1 (e408947bf 2026-03-25)` (pinned by `rust-toolchain.toml`)
- Burn backend tested: NdArray (CPU) — this change is backend-independent integer arithmetic
- OS: macOS 26.5.2 (Apple silicon)

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): Claude Code (Opus 5). Scope: implementation, tests, and documentation of this change, under review at each step; the design deviation from the filed fix, the 2603-pair figure, and the oracle sweep were verified by execution before being accepted.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [x] Bug fixes include a regression test that fails on the previous code and passes on this PR.
- [x] This PR addresses a single concern. (If it grew into something larger, it has been split.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

**The `u64::MAX` check must stay inside the loop.** Moved after it, the `u128` accumulator itself overflows around `n ≈ 9975` — the same silent-release-wrap failure this PR exists to remove, one layer up. `checked_combinations(9975, 4987)` pins that; the test carries a comment saying so, and noting that the debug run is what kills that particular mutant.

**#933's own examples went stale and the close comment records it.** The frontier moved from "intermediate product overflows" (first at `C(63, 29)`) to "exact result exceeds `u64::MAX`" (first at `n = 68`). `combinations(62, 31)`, which #933 named as its large-but-in-range case, is now an ordinary passing input and should not be used as a template; `C(66, 33)` / `C(67, 33)` are used instead, and unlike `C(62, 31)` they were both returned wrongly by the old code.

**`test_combinations_is_symmetric` is not a regression guard for this bug** — wrapping corrupts `C(n, k)` and `C(n, n - k)` identically, so it passes against the pre-fix implementation. It carries a doc comment saying so, to stop a future reader mistaking it for one.

**Follow-up: #930** (`combinations` has no consumers anywhere in the workspace) stays open. I re-verified that claim with a sweep that is deliberately not scoped to `*.rs` — docs, every `README.md`, the mdBook sources, `crates/rlevo-examples`, all `benches/`, and the pre-ADR-0003 `rlevo-utils::math::n` name — and it still holds. Note this PR grows the unused public surface by one function, so the delete-vs-keep decision there is now about correct, tested code rather than a latent bug.
