### PR TITLE
docs(rlevo-core): Pin two deliberate Probability choices (#929, #925)

### DIFF
--- a/crates/rlevo-core/src/probability.rs
+++ b/crates/rlevo-core/src/probability.rs
@@ -77,6 +77,8 @@ impl Probability {
     /// Panics when `p` is outside `[0, 1]` (including `NaN` or infinite).
     #[must_use]
     pub const fn new(p: f32) -> Self {
+        // `(0.0..=1.0).contains(&p)` is not const-callable, so the manual comparison
+        // stands in; clippy skips `manual_range_contains` in const contexts.
         assert!(
             p >= 0.0 && p <= 1.0,
             "Probability::new: value outside [0, 1] (or NaN)"

--- a/crates/rlevo-core/src/probability.rs
+++ b/crates/rlevo-core/src/probability.rs
@@ -58,6 +58,14 @@ use serde::{Deserialize, Serialize};
 /// `Deserialize` routes through [`try_new`] via [`TryFrom`], so a rate loaded
 /// from a file cannot deserialize into an out-of-range `Probability`.
 ///
+/// There is deliberately no `Default`. No probability is canonical — 0.0, 0.5,
+/// and 1.0 are each defensible — so a default would be an arbitrary rate
+/// silently inherited by every config field that omits one, which is the class
+/// of unexamined value this type exists to eliminate. ADR 0031 fixes this
+/// surface (`new`, `try_new`, `get`, the serde/`TryFrom`/`From` conversions, and
+/// the error struct); extending it is an ADR-superseding decision, not a
+/// drive-by convenience.
+///
 /// [`try_new`]: Self::try_new
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "f32", into = "f32")]


### PR DESCRIPTION
## Summary

Resolves two `probability.rs` findings from the 2026-07-19 `rlevo-core` support review, both of which turn out to be **documentation** changes rather than the code changes they proposed. #929 asked whether `Probability::new`'s manual range check trips `clippy::manual_range_contains` and proposed an `#[allow]` if so — it does not fire, so the `#[allow]` would have been a dead attribute. #925 asked for the deliberate absence of `Default` to be documented (done) and for a `complement()` helper (declined — zero call sites, and ADR 0031 already fixes the API surface). Net diff is 10 added lines of comments and docs, no behavior change.

## Change Type

- [x] Documentation correction (typo, broken link, misleading doc comment)

## Linked Issue

Closes #929
Closes #925

## What Was Changed

- `crates/rlevo-core/src/probability.rs` — added a two-line comment above the `assert!` in `Probability::new` recording why the range check is hand-rolled: `(0.0..=1.0).contains(&p)` is not const-callable, and clippy skips `manual_range_contains` in const contexts, so no `#[allow]` is warranted.
- `crates/rlevo-core/src/probability.rs` — added a paragraph to the type doc on `pub struct Probability` pinning the deliberate absence of `Default`, and recording that ADR 0031 fixes the surface so extending it is an ADR-superseding decision.

No other files touched. No `#[allow]` added, no `Default` impl, no `complement()`, no API change, no `CHANGELOG.md` entry (nothing user-observable changed).

## How It Was Tested

```
cargo build --workspace
cargo test --workspace
cargo clippy --all-targets --all-features
```

All three pass. Note that `cargo clippy` caches aggressively and a no-op run reports zero warnings in ~0.4s while compiling nothing — the runs above were forced with `touch crates/rlevo-core/src/probability.rs` first, so they are real passes and not cache hits. `cargo doc -p rlevo-core --no-deps` is also clean (relevant because `rustdoc::broken_intra_doc_links` is `deny` and this PR is all docs); `cargo fmt --all --check` is clean.

`cargo test -p rlevo-core`: 189 unit tests, 33 doctests, 0 failures.

**Evidence for the #929 refutation.** Compiled the predicate four ways through `clippy-driver` with `-W clippy::manual_range_contains` on the pinned toolchain:

| Variant | Fires? |
|---|---|
| `pub fn c(p: f32) -> bool { p >= 0.0 && p <= 1.0 }` (non-const, bare) | yes |
| `pub fn a(p: f32) { assert!(p >= 0.0 && p <= 1.0, "bad"); }` (non-const, in `assert!`) | yes |
| `pub const fn b(p: f32) -> bool { p >= 0.0 && p <= 1.0 }` (**const**) | **no** |
| const + `assert!` (the real `Probability::new` shape) | **no** |

Constness is the suppressor, not the `assert!` macro — worth stating because "it's inside a macro" is the plausible wrong explanation.

**Evidence for declining `complement()`.** A workspace sweep for the shape found zero call sites computing a complement on a `Probability`. The `1.0 - tau` / `1.0 - lr` hits in `td3_agent.rs`, `sac_agent.rs`, `ddpg_agent.rs`, and `univariate_bernoulli.rs` are raw `f32`s, not `Probability` values, so the helper would not reach them.

- Rust toolchain: `1.94.1 (e408947bf 2026-03-25)`, pinned via `rust-toolchain.toml`
- Burn backend tested: n/a — no tensor or backend code touched; workspace tests ran on the default CPU (NdArray) path
- OS: macOS (Darwin 25.5.0), aarch64

## AI-Assisted Content

- [x] AI tooling was used. Tool(s): __Claude Code (Opus 5)__. Scope: __the verification sweeps (clippy-driver variant matrix, call-site greps), both doc/comment edits, and this PR description; reviewed and verified by the author before pushing__.

## Checklist

- [x] `cargo build --workspace` passes with no errors.
- [x] `cargo test --workspace` passes with no new test failures.
- [x] `cargo clippy --all-targets --all-features` passes with no warnings (treated as errors).
- [x] Public API additions or changes include doc comments explaining *what* and *why*.
- [ ] Bug fixes include a regression test that fails on the previous code and passes on this PR. — n/a, no behavior change; there is no defect to regress against.
- [x] This PR addresses a single concern. (Both issues are the same finding batch on the same file, and both reduce to documenting a deliberate choice.)
- [x] This PR is marked **Ready for Review** (not Draft).

## Notes

- **The `#[allow]` #929 recommended must not be added later.** It would be dead: the lint does not fire in const contexts. Rules §9 permits an item-level `#[allow]` only where the lint is a live false positive.
- **Residual risk, named honestly.** Const-context suppression of `manual_range_contains` is empirically observed clippy behavior, not a documented contract. A future toolchain bump could start firing here. The failure mode is a visible CI break rather than a silent regression, and the landed comment is scoped to "in const contexts" so it will not read as a false claim if that happens. No enforcement pin was added, deliberately.
- **Reading trap in ADR 0031.** Its surface line reads "`const fn new` (panicking, for literals / `Default`s)". That `Default` means *config* `Default` impls calling `Probability::new(0.3)` — not a `Default` on `Probability` itself. Reading it the other way inverts the premise of the second commit.
- **Follow-up not taken.** `NonNegativeRate` (`rate.rs`) and `Bounds` (`bounds.rs`) share the ADR 0031/0027 surface, are likewise `Default`-free, and are likewise undocumented on that point. `NonNegativeRate` is the weaker case — 0.0 is arguably canonical there ("no mutation / no expansion") — so the argument does not transfer verbatim and was deliberately not copy-pasted here.
